### PR TITLE
MML #44: Mek jump boosters and jump jets

### DIFF
--- a/megamek/resources/megamek/common/templates/tro/fluff.ftl
+++ b/megamek/resources/megamek/common/templates/tro/fluff.ftl
@@ -19,6 +19,9 @@ Maximum Speed: ${maxSpeed} kph
 Jump Jets: ${jjDesc}
      Jump Capacity: ${jumpCapacity} meters
 </#if>
+<#if jumpBoosterCapacity??>
+Jump Booster Capacity: ${jumpBoosterCapacity} meters
+</#if>
 Armor: ${armorDesc}
 Armament:
 <#list armamentList as armament>

--- a/megamek/resources/megamek/common/templates/tro/fluff.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/fluff.ftlh
@@ -6,9 +6,12 @@
 <b>Power Plant: </b>${engineDesc}<br/>
 <#if cruisingSpeed??><b>Cruising Speed: </b>${cruisingSpeed} kph<br/></#if>
 <#if cruisingSpeed??><b>Maximum Speed: </b>${maxSpeed} kph<br/></#if>
-<#if jumpDesc??>
+<#if jjDesc??>
 <b>Jump Jets: </b>${jjDesc}<br/>
 <b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Jump Capacity: </b>${jumpCapacity} meters<br/>
+</#if>
+<#if jumpBoosterCapacity??>
+    <b>Jump Booster: </b>${jumpBoosterCapacity} meters<br/>
 </#if>
 <b>Armor: </b>${armorDesc}</b><br/>
 <b>Armament:</b><br/>

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -760,7 +760,7 @@ public abstract class BotClient extends Client {
         // Calculate ideal elevation as a factor of average range of 18 being
         // highest elevation. Fast, non-jumping units should deploy towards
         // the middle elevations to avoid getting stuck up a cliff.
-        if ((deployed_ent.getJumpMP() == 0) &&
+        if ((deployed_ent.getAnyTypeMaxJumpMP() == 0) &&
                 (deployed_ent.getWalkMP() > 5)) {
             ideal_elev = lowest_elev + ((highest_elev - lowest_elev) / 3.0);
         } else {

--- a/megamek/src/megamek/client/bot/PhysicalCalculator.java
+++ b/megamek/src/megamek/client/bot/PhysicalCalculator.java
@@ -169,7 +169,7 @@ public final class PhysicalCalculator {
                     if (test_pod.getType() == INarcPod.NEMESIS) {
                         // Pod is +variable, based on movement
                         test_ranking += (entity.getWalkMP() + entity
-                                .getJumpMP()) / 2.0;
+                                .getAnyTypeMaxJumpMP()) / 2.0;
                     }
                     // If this pod is best, retain it and its ranking
                     if (test_ranking > pod_ranking) {
@@ -499,9 +499,9 @@ public final class PhysicalCalculator {
                     if (to.getWalkMP() > 0) {
                         dmg = dmg
                                 * Math.sqrt((1.0 / to.getWalkMP())
-                                                    + to.getJumpMP());
+                                                    + to.getAnyTypeMaxJumpMP());
                     } else {
-                        dmg *= Math.max(1.0, Math.sqrt(to.getJumpMP()));
+                        dmg *= Math.max(1.0, Math.sqrt(to.getAnyTypeMaxJumpMP()));
                     }
                     // Modify damage by breach factor
                     dmg *= breach;
@@ -527,9 +527,9 @@ public final class PhysicalCalculator {
                 // Modify damage to reflect how bad it is for target to be prone
                 if (to.getWalkMP() > 0) {
                     dmg = dmg
-                            * Math.sqrt((1.0 / to.getWalkMP()) + to.getJumpMP());
+                            * Math.sqrt((1.0 / to.getWalkMP()) + to.getAnyTypeMaxJumpMP());
                 } else {
-                    dmg = dmg * Math.max(1.0, Math.sqrt(to.getJumpMP()));
+                    dmg = dmg * Math.max(1.0, Math.sqrt(to.getAnyTypeMaxJumpMP()));
                 }
                 // Modify damage by breach factor
                 dmg *= breach;
@@ -611,9 +611,9 @@ public final class PhysicalCalculator {
         self_damage = calculateFallingDamage(1.0 - (Compute.oddsAbove(odds.getValue(), fromAptPiloting) / 100.0), from);
         if (from.getWalkMP() > 0) {
             self_damage = self_damage
-                    * Math.sqrt((1.0 / from.getWalkMP()) + from.getJumpMP());
+                    * Math.sqrt((1.0 / from.getWalkMP()) + from.getAnyTypeMaxJumpMP());
         } else {
-            self_damage = self_damage * Math.sqrt(from.getJumpMP());
+            self_damage = self_damage * Math.sqrt(from.getAnyTypeMaxJumpMP());
         }
         // Add together damage values for comparison
         dmg = (dmg + coll_damage) - self_damage;

--- a/megamek/src/megamek/client/bot/princess/HeatMap.java
+++ b/megamek/src/megamek/client/bot/princess/HeatMap.java
@@ -573,7 +573,7 @@ public class HeatMap {
             bvWeight = tracked.getInitialBV();
         }
 
-        bvWeight = Math.max(bvWeight - (100 * Math.max(tracked.getJumpMP(), tracked.getWalkMP())), 1);
+        bvWeight = Math.max(bvWeight - (100 * Math.max(tracked.getAnyTypeMaxJumpMP(), tracked.getWalkMP())), 1);
         bvWeight = (int) Math.floor(weightScaling * bvWeight);
 
         return bvWeight;

--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -282,8 +282,8 @@ public class PathEnumerator {
                 paths.addAll(ppf.getPronePaths());
 
                 // add jumping moves
-                if (mover.getJumpMP() > 0) {
-                    ShortestPathFinder spf = ShortestPathFinder.newInstanceOfOneToAll(mover.getJumpMP(),
+                if (mover.getAnyTypeMaxJumpMP() > 0) {
+                    ShortestPathFinder spf = ShortestPathFinder.newInstanceOfOneToAll(mover.getAnyTypeMaxJumpMP(),
                             MoveStepType.FORWARDS, getGame());
                     spf.setComparator(new MovePathMinefieldAvoidanceMinMPMaxDistanceComparator());
                     spf.run((new MovePath(game, mover, wayPoint)).addStep(MoveStepType.START_JUMP));

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -798,7 +798,7 @@ public class Princess extends BotClient {
                 ArrayList<Coords> candidates = rankedCoords.get(bestRank);
                 for (Coords c: candidates) {
                     mp.clear();
-                    mp.addStep((deployedUnit.getJumpMP() == 0) ? MoveStepType.NONE: MoveStepType.START_JUMP);
+                    mp.addStep((deployedUnit.getAnyTypeMaxJumpMP() == 0) ? MoveStepType.NONE: MoveStepType.START_JUMP);
                     mp.getLastStep().setPosition(c);
                     current = bestRank - rankKernelAroundCoords(
                             mp, deployedUnit, RADIUS, (BasicPathRanker) ranker);
@@ -1224,8 +1224,8 @@ public class Princess extends BotClient {
         try {
             // Find out how fast this unit can move.
             int fastestMove = entity.getRunMP(MPCalculationSetting.STANDARD);
-            if (entity.getJumpMP() > fastestMove) {
-                fastestMove = entity.getJumpMP();
+            if (entity.getAnyTypeMaxJumpMP() > fastestMove) {
+                fastestMove = entity.getAnyTypeMaxJumpMP();
             }
             msg.append("\n\t\tFastest Move = ").append(fastestMove);
 
@@ -1873,7 +1873,7 @@ public class Princess extends BotClient {
                 calledShotDirection = CalledShot.CALLED_HIGH;
             } else if (lowerTargets >= 1 ||
                     target.getWalkMP() >= CALLED_SHOT_MIN_MOVE ||
-                    target.getJumpMP() >= CALLED_SHOT_MIN_JUMP) {
+                    target.getAnyTypeMaxJumpMP() >= CALLED_SHOT_MIN_JUMP) {
                 calledShotDirection = CalledShot.CALLED_LOW;
             }
 

--- a/megamek/src/megamek/client/ui/SharedUtility.java
+++ b/megamek/src/megamek/client/ui/SharedUtility.java
@@ -406,7 +406,9 @@ public class SharedUtility {
                     } else if (moveType == EntityMovementType.MOVE_JUMP) {
                         int origWalkMP = entity.getWalkMP(MPCalculationSetting.NO_GRAVITY);
                         int gravWalkMP = entity.getWalkMP();
-                        if (step.getMpUsed() > entity.getJumpMP(MPCalculationSetting.NO_GRAVITY)) {
+                        int availableJumpMP = step.isUsingMekJumpBooster() ? entity.getMechanicalJumpBoosterMP(
+                              MPCalculationSetting.NO_GRAVITY) : entity.getJumpMP(MPCalculationSetting.NO_GRAVITY);
+                        if (step.getMpUsed() > availableJumpMP) {
                             rollTarget = entity.checkMovedTooFast(step, overallMoveType);
                             checkNag(rollTarget, nagReport, psrList);
                         } else if ((game.getPlanetaryConditions().getGravity() > 1)
@@ -502,7 +504,7 @@ public class SharedUtility {
             if (((step.getType() == MoveStepType.BACKWARDS)
                     || (step.getType() == MoveStepType.LATERAL_LEFT_BACKWARDS)
                     || (step.getType() == MoveStepType.LATERAL_RIGHT_BACKWARDS))
-                    && !(md.isJumping() && (entity.getJumpType() == Mek.JUMP_BOOSTER))
+                    && !(md.isJumping() && md.contains(MoveStepType.JUMP_MEK_MECHANICAL_BOOSTER))
                     && (lastHex.getLevel() + lastElevation != (curHex.getLevel() + step.getElevation()))
                     && !(entity instanceof VTOL)
                     && !(md.getFinalClimbMode()

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -3093,7 +3093,7 @@ public class ClientGUI extends AbstractClientGUI implements BoardViewListener,
      */
     public void showMovementEnvelope(Entity entity, Map<Coords, Integer> mvEnvData, int gear) {
         movementEnvelopeHandler.setMovementEnvelope(mvEnvData, entity.getWalkMP(),
-                entity.getRunMP(), entity.getJumpMP(), gear);
+              entity.getRunMP(), Math.max(entity.getMechanicalJumpBoosterMP(), entity.getJumpMP()), gear);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -3093,7 +3093,7 @@ public class ClientGUI extends AbstractClientGUI implements BoardViewListener,
      */
     public void showMovementEnvelope(Entity entity, Map<Coords, Integer> mvEnvData, int gear) {
         movementEnvelopeHandler.setMovementEnvelope(mvEnvData, entity.getWalkMP(),
-              entity.getRunMP(), Math.max(entity.getMechanicalJumpBoosterMP(), entity.getJumpMP()), gear);
+              entity.getRunMP(), entity.getAnyTypeMaxJumpMP(), gear);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/CollapseWarning.java
+++ b/megamek/src/megamek/client/ui/swing/CollapseWarning.java
@@ -92,7 +92,7 @@ public final class CollapseWarning {
             }
 
             Coords pos = e.getPosition();
-            int range = Math.max(e.getJumpMP(), e.getRunMP());
+            int range = Math.max(e.getAnyTypeMaxJumpMP(), e.getRunMP());
 
             List<Coords> hexesToCheck = new ArrayList<Coords>();
             if (pos != null) {

--- a/megamek/src/megamek/client/ui/swing/ForceGeneratorViewUi.java
+++ b/megamek/src/megamek/client/ui/swing/ForceGeneratorViewUi.java
@@ -667,7 +667,7 @@ public class ForceGeneratorViewUi implements ActionListener {
                 case COL_BV:
                     return en.calculateBattleValue();
                 case COL_MOVE:
-                    return en.getWalkMP() + "/" + en.getRunMPasString() + "/" + en.getJumpMP();
+                    return en.getWalkMP() + "/" + en.getRunMPasString() + "/" + en.getAnyTypeMaxJumpMP();
                 case COL_TECH_BASE:
                     return en.getTechBaseDescription();
                 case COL_UNIT_ROLE:

--- a/megamek/src/megamek/client/ui/swing/MapMenu.java
+++ b/megamek/src/megamek/client/ui/swing/MapMenu.java
@@ -952,7 +952,7 @@ public class MapMenu extends JPopupMenu {
 
             menu.add(item);
 
-            if (myEntity.getJumpMP() > 0) {
+            if (myEntity.getAnyTypeMaxJumpMP() > 0) {
                 item = new JMenuItem(Messages.getString("CommonMenuBar.moveJump"));
                 item.setActionCommand(MovementDisplay.MoveCommand.MOVE_JUMP.getCmd());
                 item.addActionListener(evt -> {
@@ -1030,7 +1030,7 @@ public class MapMenu extends JPopupMenu {
 
             menu.add(item);
 
-            if (myEntity.getJumpMP() > 0) {
+            if (myEntity.getAnyTypeMaxJumpMP() > 0) {
                 item = new JMenuItem(Messages.getString("CommonMenuBar.moveJump"));
                 item.setActionCommand(MovementDisplay.MoveCommand.MOVE_JUMP.getCmd());
                 item.addActionListener(evt -> {

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -710,22 +710,11 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     /**
-     * @return True when this is a Mek with Mechanical Jump Boosters and the GUI can use its MMJB MP in the place of
-     * standard jump MP, i.e. it has no jump jets. This is currently true for all canon units that have MMJB
-     * as they never have standard JJ as well (which is allowed). See TO:AUE p.105
-     */
-    private boolean useMekMechanicalJumpAsJump() {
-        return ce() instanceof Mek mek && mek.getJumpMP() == 0 && (mek.getMechanicalJumpBoosterMP() > 0)
-              && (mek.getJumpMP() == 0);
-    }
-
-    /**
      * @return True when the active unit has jump MP available, either standard jump jet MP or, in the case of Meks,
      * MP of Mechanical Jump Boosters.
      */
     private boolean hasJumpMP() {
-        return (ce() != null) &&
-              ((ce().getJumpMP() > 0) || ((ce() instanceof Mek mek) && (mek.getMechanicalJumpBoosterMP() > 0)));
+        return (ce() != null) && (ce().getAnyTypeMaxJumpMP() > 0);
     }
 
     /**
@@ -1554,13 +1543,12 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
         // Should we nag about taking fall damage with mechanical jump boosters?
         if (needNagForMechanicalJumpFallDamage()) {
-            if ((ce() != null)
-                    && cmd.shouldMechanicalJumpCauseFallDamage()) {
+            if ((ce() != null) && cmd.shouldMechanicalJumpCauseFallDamage()) {
                 String title = Messages.getString("MovementDisplay.areYouSure");
                 String body = Messages.getString("MovementDisplay.ConfirmMechanicalJumpFallDamage",
                         cmd.getJumpMaxElevationChange(),
-                        ce().getJumpMP(),
-                        cmd.getJumpMaxElevationChange() - ce().getJumpMP());
+                        ce().getMechanicalJumpBoosterMP(),
+                        cmd.getJumpMaxElevationChange() - ce().getMechanicalJumpBoosterMP());
                 if (checkNagForMechanicalJumpFallDamage(title, body)) {
                     return true;
                 }

--- a/megamek/src/megamek/client/ui/swing/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/MovementDisplay.java
@@ -55,7 +55,6 @@ import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
 import java.util.List;
 import java.util.*;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static megamek.common.MiscType.F_CHAFF_POD;
@@ -323,6 +322,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
     // what "gear" is our mek in?
     private int gear;
+    private int jumpSubGear;
 
     // is the shift key held?
     private boolean shiftheld;
@@ -348,6 +348,8 @@ public class MovementDisplay extends ActionPhaseDisplay {
     public static final int GEAR_LONGEST_WALK = 11;
     public static final int GEAR_STRAFE = 12;
     public static final String turnDetailsFormat = "%s%-3s %-14s %1s %2dMP%s";
+    public static final int GEAR_SUB_STANDARD = 0;
+    public static final int GEAR_SUB_MEKBOOSTERS = 2;
 
     /**
      * Creates and lays out a new movement phase display for the specified
@@ -399,27 +401,31 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void turnLeft() {
-        int dir = cmd.getFinalFacing();
-        dir = (dir + 5) % 6;
-        Coords curPos = cmd.getFinalCoords();
-        Coords target = curPos.translated(dir);
-        // We need to set this to get the rotate behavior
-        shiftheld = true;
-        currentMove(target);
-        shiftheld = false;
-        updateMove();
+        if (buttons.get(MoveCommand.MOVE_TURN).isEnabled()) {
+            int dir = cmd.getFinalFacing();
+            dir = (dir + 5) % 6;
+            Coords curPos = cmd.getFinalCoords();
+            Coords target = curPos.translated(dir);
+            // We need to set this to get the rotate behavior
+            shiftheld = true;
+            currentMove(target);
+            shiftheld = false;
+            updateMove();
+        }
     }
 
     private void turnRight() {
-        int dir = cmd.getFinalFacing();
-        dir = (dir + 7) % 6;
-        Coords curPos = cmd.getFinalCoords();
-        Coords target = curPos.translated(dir);
-        // We need to set this to get the rotate behavior
-        shiftheld = true;
-        currentMove(target);
-        shiftheld = false;
-        updateMove();
+        if (buttons.get(MoveCommand.MOVE_TURN).isEnabled()) {
+            int dir = cmd.getFinalFacing();
+            dir = (dir + 7) % 6;
+            Coords curPos = cmd.getFinalCoords();
+            Coords target = curPos.translated(dir);
+            // We need to set this to get the rotate behavior
+            shiftheld = true;
+            currentMove(target);
+            shiftheld = false;
+            updateMove();
+        }
     }
 
     private void undoIllegalStep() {
@@ -454,36 +460,15 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void performToggleMovemode() {
-        final Entity ce = ce();
-        boolean isAero = ce.isAero();
-        // first check if jumping is available at all
-        if (!isAero && !ce.isImmobileForJump() && (ce.getJumpMP() > 0)
-                && !(ce.isStuck() && !ce.canUnstickByJumping())) {
-            if (gear != MovementDisplay.GEAR_JUMP) {
-                if (!((cmd.getLastStep() != null)
-                        && cmd.getLastStep().isFirstStep()
-                        && (cmd.getLastStep().getType() == MoveStepType.LAY_MINE))) {
-                    clear();
-                }
-                if (!cmd.isJumping()) {
-                    addStepToMovePath(MoveStepType.START_JUMP);
-                }
-                gear = MovementDisplay.GEAR_JUMP;
-                Color jumpColor = GUIP.getMoveJumpColor();
-                clientgui.getBoardView().setHighlightColor(jumpColor);
-            } else {
-                Color walkColor = GUIP.getMoveDefaultColor();
-                clientgui.getBoardView().setHighlightColor(walkColor);
-                gear = MovementDisplay.GEAR_LAND;
-                clear();
+        if (gear != MovementDisplay.GEAR_JUMP) {
+            if (buttons.get(MoveCommand.MOVE_JUMP).isEnabled()) {
+                buttons.get(MoveCommand.MOVE_JUMP).doClick();
             }
         } else {
-            Color walkColor = GUIP.getMoveDefaultColor();
-            clientgui.getBoardView().setHighlightColor(walkColor);
-            gear = MovementDisplay.GEAR_LAND;
-            clear();
+            if (buttons.get(MoveCommand.MOVE_WALK).isEnabled()) {
+                buttons.get(MoveCommand.MOVE_WALK).doClick();
+            }
         }
-        computeMovementEnvelope(ce);
     }
 
     private void performToggleConversionMode() {
@@ -725,6 +710,25 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     /**
+     * @return True when this is a Mek with Mechanical Jump Boosters and the GUI can use its MMJB MP in the place of
+     * standard jump MP, i.e. it has no jump jets. This is currently true for all canon units that have MMJB
+     * as they never have standard JJ as well (which is allowed). See TO:AUE p.105
+     */
+    private boolean useMekMechanicalJumpAsJump() {
+        return ce() instanceof Mek mek && mek.getJumpMP() == 0 && (mek.getMechanicalJumpBoosterMP() > 0)
+              && (mek.getJumpMP() == 0);
+    }
+
+    /**
+     * @return True when the active unit has jump MP available, either standard jump jet MP or, in the case of Meks,
+     * MP of Mechanical Jump Boosters.
+     */
+    private boolean hasJumpMP() {
+        return (ce() != null) &&
+              ((ce().getJumpMP() > 0) || ((ce() instanceof Mek mek) && (mek.getMechanicalJumpBoosterMP() > 0)));
+    }
+
+    /**
      * Sets the buttons to their proper states
      */
     private void updateButtons() {
@@ -746,9 +750,10 @@ public class MovementDisplay extends ActionPhaseDisplay {
         setWalkEnabled(!ce.isImmobile() && ((ce.getWalkMP() > 0) || (ce.getRunMP() > 0))
                 && !ce.isStuck());
         setJumpEnabled(!isAero && !ce.isImmobileForJump() && !ce.isProne()
-        // Conventional infantry also uses jump MP for VTOL and UMU MP
-                && ((ce.getJumpMP() > 0) && (!ce.isConventionalInfantry() || ce.getMovementMode().isJumpInfantry()))
-                && !(ce.isStuck() && !ce.canUnstickByJumping()));
+              // Conventional infantry also uses jump MP for VTOL and UMU MP
+              && (hasJumpMP() && (!ce.isConventionalInfantry()
+              || ce.getMovementMode().isJumpInfantry()))
+              && !(ce.isStuck() && !ce.canUnstickByJumping()));
         setSwimEnabled(!isAero && !ce.isImmobile() && (ce.getActiveUMUCount() > 0)
                 && ce.isUnderwater());
         setBackUpEnabled(!isAero && isEnabled(MoveCommand.MOVE_WALK));
@@ -1282,6 +1287,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
         // set to "walk," or the equivalent
         gear = MovementDisplay.GEAR_LAND;
+        jumpSubGear = GEAR_SUB_STANDARD;
         Color walkColor = GUIP.getMoveDefaultColor();
         clientgui.getBoardView().setHighlightColor(walkColor);
 
@@ -1351,7 +1357,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         } else if (cmd.length() == 0) {
             clear();
             if ((gear == MovementDisplay.GEAR_JUMP) && !cmd.isJumping()) {
-                addStepToMovePath(MoveStepType.START_JUMP);
+                initializeJumpMovePath();
             } else if (entity.isConvertingNow()) {
                 addStepToMovePath(MoveStepType.CONVERT_MODE);
             }
@@ -1373,6 +1379,13 @@ public class MovementDisplay extends ActionPhaseDisplay {
             }
         }
         updateButtons();
+    }
+
+    private void initializeJumpMovePath() {
+        addStepToMovePath(MoveStepType.START_JUMP);
+        if (jumpSubGear == GEAR_SUB_MEKBOOSTERS) {
+            addStepToMovePath(MoveStepType.JUMP_MEK_MECHANICAL_BOOSTER);
+        }
     }
 
     /**
@@ -1734,9 +1747,10 @@ public class MovementDisplay extends ActionPhaseDisplay {
      */
     private void currentMove(Coords dest) {
         if (shiftheld || (gear == GEAR_TURN)) {
-            cmd.rotatePathfinder(cmd.getFinalCoords().direction(dest), false, ManeuverType.MAN_NONE);
-        } else if ((gear == GEAR_JUMP)
-                && (ce().getJumpType() == Mek.JUMP_BOOSTER)) {
+            if (buttons.get(MoveCommand.MOVE_TURN).isEnabled()) {
+                cmd.rotatePathfinder(cmd.getFinalCoords().direction(dest), false, ManeuverType.MAN_NONE);
+            }
+        } else if ((gear == GEAR_JUMP) && (jumpSubGear == GEAR_SUB_MEKBOOSTERS)) {
             // Jumps with mechanical jump boosters are special
             Coords src;
             if (cmd.getLastStep() != null) {
@@ -1752,33 +1766,33 @@ public class MovementDisplay extends ActionPhaseDisplay {
             switch (dir) {
                 case 0:
                     cmd.findSimplePathTo(dest, MoveStepType.FORWARDS,
-                            src.direction(dest), ce().getFacing());
+                          src.direction(dest), ce().getFacing());
                     break;
                 case 1:
                     cmd.findSimplePathTo(dest, MoveStepType.LATERAL_RIGHT,
-                            src.direction(dest), ce().getFacing());
+                          src.direction(dest), ce().getFacing());
                     break;
                 case 2:
                     // TODO: backwards lateral shifts are switched:
                     // LATERAL_LEFT_BACKWARDS moves back+right and vice-versa
                     cmd.findSimplePathTo(dest,
-                            MoveStepType.LATERAL_LEFT_BACKWARDS,
-                            src.direction(dest), ce().getFacing());
+                          MoveStepType.LATERAL_LEFT_BACKWARDS,
+                          src.direction(dest), ce().getFacing());
                     break;
                 case 3:
                     cmd.findSimplePathTo(dest, MoveStepType.BACKWARDS,
-                            src.direction(dest), ce().getFacing());
+                          src.direction(dest), ce().getFacing());
                     break;
                 case 4:
                     // TODO: backwards lateral shifts are switched:
                     // LATERAL_LEFT_BACKWARDS moves back+right and vice-versa
                     cmd.findSimplePathTo(dest,
-                            MoveStepType.LATERAL_RIGHT_BACKWARDS,
-                            src.direction(dest), ce().getFacing());
+                          MoveStepType.LATERAL_RIGHT_BACKWARDS,
+                          src.direction(dest), ce().getFacing());
                     break;
                 case 5:
                     cmd.findSimplePathTo(dest, MoveStepType.LATERAL_LEFT,
-                            src.direction(dest), ce().getFacing());
+                          src.direction(dest), ce().getFacing());
                     break;
             }
         } else if (gear == GEAR_STRAFE) {
@@ -1790,7 +1804,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             // an existing strafing pattern.
             if (start > 0 && !cmd.getStep(start - 1).isStrafingStep()) {
                 while (start < cmd.length()
-                        && cmd.getStep(start).getType() != MoveStepType.FORWARDS) {
+                      && cmd.getStep(start).getType() != MoveStepType.FORWARDS) {
                     start++;
                 }
             }
@@ -1807,7 +1821,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             cmd.findPathTo(dest, MoveStepType.CHARGE);
             // The path planner shouldn't actually add the charge step
             if (cmd.getFinalCoords().equals(dest)
-                    && (cmd.getLastStep().getType() != MoveStepType.CHARGE)) {
+                  && (cmd.getLastStep().getType() != MoveStepType.CHARGE)) {
                 cmd.removeLastStep();
                 addStepToMovePath(MoveStepType.CHARGE);
             }
@@ -1815,7 +1829,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             cmd.findPathTo(dest, MoveStepType.DFA);
             // The path planner shouldn't actually add the DFA step
             if (cmd.getFinalCoords().equals(dest)
-                    && (cmd.getLastStep().getType() != MoveStepType.DFA)) {
+                  && (cmd.getLastStep().getType() != MoveStepType.DFA)) {
                 cmd.removeLastStep();
                 addStepToMovePath(MoveStepType.DFA);
             }
@@ -1825,17 +1839,17 @@ public class MovementDisplay extends ActionPhaseDisplay {
             cmd.findPathTo(dest, MoveStepType.FORWARDS);
         } else if (gear == GEAR_IMMEL) {
             addStepsToMovePath(true, true, ManeuverType.MAN_IMMELMAN,
-                    MoveStepType.UP,
-                    MoveStepType.UP,
-                    MoveStepType.DEC,
-                    MoveStepType.DEC);
+                  MoveStepType.UP,
+                  MoveStepType.UP,
+                  MoveStepType.DEC,
+                  MoveStepType.DEC);
             cmd.rotatePathfinder(cmd.getFinalCoords().direction(dest), true, ManeuverType.MAN_IMMELMAN);
             gear = GEAR_LAND;
         } else if (gear == GEAR_SPLIT_S) {
             addStepsToMovePath(true, true, ManeuverType.MAN_SPLIT_S,
-                    MoveStepType.DOWN,
-                    MoveStepType.DOWN,
-                    MoveStepType.ACC);
+                  MoveStepType.DOWN,
+                  MoveStepType.DOWN,
+                  MoveStepType.ACC);
             cmd.rotatePathfinder(cmd.getFinalCoords().direction(dest), true, ManeuverType.MAN_SPLIT_S);
             gear = GEAR_LAND;
         }
@@ -4573,8 +4587,13 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
     private int maxMP(Entity en, int mvMode) {
         int maxMP;
-        if (mvMode == GEAR_JUMP || mvMode == GEAR_DFA) {
+        if (mvMode == GEAR_DFA) {
             maxMP = en.getJumpMP();
+        } else if (mvMode == GEAR_JUMP) {
+            maxMP = en.getJumpMP();
+            if ((en instanceof Mek mek) && (jumpSubGear == GEAR_SUB_MEKBOOSTERS)) {
+                maxMP = mek.getMechanicalJumpBoosterMP();
+            }
         } else if (mvMode == GEAR_BACKUP) {
             maxMP = en.getWalkMP();
         } else if ((ce() instanceof Mek) && !(ce() instanceof QuadVee)
@@ -4637,10 +4656,12 @@ public class MovementDisplay extends ActionPhaseDisplay {
         Map<Coords, MovePath> mvEnvData = new HashMap<>();
         MovePath mp = new MovePath(clientgui.getClient().getGame(), en);
 
-        MoveStepType stepType = (mvMode == GEAR_BACKUP) ? MoveStepType.BACKWARDS
-                : MoveStepType.FORWARDS;
+        MoveStepType stepType = (mvMode == GEAR_BACKUP) ? MoveStepType.BACKWARDS : MoveStepType.FORWARDS;
         if (mvMode == GEAR_JUMP || mvMode == GEAR_DFA) {
             mp.addStep(MoveStepType.START_JUMP);
+            if (jumpSubGear == GEAR_SUB_MEKBOOSTERS) {
+                mp.addStep(MoveStepType.JUMP_MEK_MECHANICAL_BOOSTER);
+            }
         }
 
         int maxMP = maxMP(en, mvMode);
@@ -4717,6 +4738,9 @@ public class MovementDisplay extends ActionPhaseDisplay {
         MovePath mp = new MovePath(clientgui.getClient().getGame(), ce());
         if (gear == GEAR_JUMP) {
             mp.addStep(MoveStepType.START_JUMP);
+            if (jumpSubGear == GEAR_SUB_MEKBOOSTERS) {
+                mp.addStep(MoveStepType.JUMP_MEK_MECHANICAL_BOOSTER);
+            }
         }
         LongestPathFinder lpf = LongestPathFinder.newInstanceOfLongestPath(maxMP, stepType, ce().getGame());
         final int timeLimit = PreferenceManager.getClientPreferences().getMaxPathfinderTime();
@@ -4817,10 +4841,24 @@ public class MovementDisplay extends ActionPhaseDisplay {
                             && (cmd.getLastStep().getType() == MoveStepType.LAY_MINE))) {
                 clear();
             }
-            if (!cmd.isJumping()) {
-                addStepToMovePath(MoveStepType.START_JUMP);
-            }
             gear = MovementDisplay.GEAR_JUMP;
+            jumpSubGear = GEAR_SUB_STANDARD;
+            if (mustChooseJumpType(ce)) {
+                Object jumpChoice = JOptionPane.showInputDialog(
+                      JOptionPane.getFrameForComponent(this), "Choose jump type:",
+                      "Choose Jump Type", JOptionPane.QUESTION_MESSAGE, null,
+                      new String[] {"Mechanical Jump Boosters", "Jump Jets"}, "Jump Jets");
+                if (jumpChoice instanceof String string && "Mechanical Jump Boosters".equals(string)) {
+                    jumpSubGear = GEAR_SUB_MEKBOOSTERS;
+                }
+            } else {
+                if ((ce instanceof Mek mek) && (mek.getMechanicalJumpBoosterMP() > 0) && (ce.getJumpMP() == 0)) {
+                    jumpSubGear = GEAR_SUB_MEKBOOSTERS;
+                }
+            }
+            if (!cmd.isJumping()) {
+                initializeJumpMovePath();
+            }
             Color jumpColor = GUIP.getMoveJumpColor();
             clientgui.getBoardView().setHighlightColor(jumpColor);
             computeMovementEnvelope(ce);
@@ -4957,7 +4995,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             gear = MovementDisplay.GEAR_DFA;
             computeMovementEnvelope(ce);
             if (!cmd.isJumping()) {
-                addStepToMovePath(MoveStepType.START_JUMP);
+                initializeJumpMovePath();
             }
         } else if (actionCmd.equals(MoveCommand.MOVE_RAM.getCmd())) {
             if (gear != MovementDisplay.GEAR_LAND) {
@@ -5219,7 +5257,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 if (cmd.getLastStep() == null
                         && ce instanceof BattleArmor
                         && ce.getMovementMode().equals(EntityMovementMode.INF_JUMP)) {
-                    addStepToMovePath(MoveStepType.START_JUMP);
+                    initializeJumpMovePath();
                     gear = GEAR_JUMP;
                     Color jumpColor = GUIP.getMoveJumpColor();
                     clientgui.getBoardView().setHighlightColor(jumpColor);
@@ -5532,6 +5570,14 @@ public class MovementDisplay extends ActionPhaseDisplay {
             updateLoadButtons();
             butDone.setEnabled(true);
         }
+    }
+
+    /**
+     * @param ce The entity to test
+     * @return True when the given unit is a Mek with both jump jets and mechanical jump boosters.
+     */
+    private boolean mustChooseJumpType(Entity ce) {
+        return (ce instanceof Mek mek) && (ce.getJumpMP() > 0) && (mek.getMechanicalJumpBoosterMP() > 0);
     }
 
     /**
@@ -6094,7 +6140,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         }
 
         setTurnEnabled(!ce.isImmobile() && !ce.isStuck() && ((ce.getWalkMP() > 0) || (ce.getJumpMP() > 0))
-                && !(cmd.isJumping() && (ce instanceof Mek) && (ce.getJumpType() == Mek.JUMP_BOOSTER)));
+              && !(cmd.isJumping() && (ce instanceof Mek) && (jumpSubGear == GEAR_SUB_MEKBOOSTERS)));
     }
 
     /** Shortcut to clientgui.getClient().getGame(). */

--- a/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/BoardView.java
@@ -755,7 +755,9 @@ public final class BoardView extends AbstractBoardView implements BoardListener,
                 break;
 
             case GUIPreferences.UNIT_LABEL_STYLE:
-                clientgui.systemMessage("Label style changed to " + GUIP.getUnitLabelStyle().description);
+                if (clientgui != null) {
+                    clientgui.systemMessage("Label style changed to " + GUIP.getUnitLabelStyle().description);
+                }
             case GUIPreferences.UNIT_LABEL_BORDER:
             case GUIPreferences.TEAM_COLORING:
             case GUIPreferences.SHOW_DAMAGE_DECAL:

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -2008,6 +2008,15 @@ public final class UnitToolTip {
                 sMove += "/" + jumpMP;
             }
 
+            if (entity instanceof Mek mek) {
+                int mekMechanicalJumpMP = mek.getMechanicalJumpBoosterMP();
+                if (jumpMP == 0) {
+                    sMove += "/%d".formatted(mekMechanicalJumpMP);
+                } else {
+                    sMove += " (%d)".formatted(mekMechanicalJumpMP);
+                }
+            }
+            
             int walkMPModified = entity.getWalkMP();
             int runMPModified = entity.getRunMP();
             int jumpMPModified = entity.getJumpMP();

--- a/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
+++ b/megamek/src/megamek/client/ui/swing/tooltip/UnitToolTip.java
@@ -2010,13 +2010,15 @@ public final class UnitToolTip {
 
             if (entity instanceof Mek mek) {
                 int mekMechanicalJumpMP = mek.getMechanicalJumpBoosterMP();
-                if (jumpMP == 0) {
-                    sMove += "/%d".formatted(mekMechanicalJumpMP);
-                } else {
-                    sMove += " (%d)".formatted(mekMechanicalJumpMP);
+                if (mekMechanicalJumpMP > 0) {
+                    if (jumpMP == 0) {
+                        sMove += "/%d".formatted(mekMechanicalJumpMP);
+                    } else {
+                        sMove += " (%d)".formatted(mekMechanicalJumpMP);
+                    }
                 }
             }
-            
+
             int walkMPModified = entity.getWalkMP();
             int runMPModified = entity.getRunMP();
             int jumpMPModified = entity.getJumpMP();

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -3878,7 +3878,7 @@ public class Compute {
                                         && (abin_type.getMunitionType().contains(AmmoType.Munitions.M_NEMESIS))
                                         && !(target instanceof Infantry)) {
                                     if (!target.isINarcedWith(INarcPod.NEMESIS)) {
-                                        ex_damage = (double) (target.getWalkMP() + target.getJumpMP()) / 2;
+                                        ex_damage = (double) (target.getWalkMP() + target.getAnyTypeMaxJumpMP()) / 2;
                                     } else {
                                         ex_damage = 0.5;
                                     }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -3220,8 +3220,22 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     /**
-     * Returns this entity's current jumping MP, not affected by terrain,
-     * factored for gravity.
+     * @return In most cases, the same as getJumpMP(). For Meks that have either normal jump MP or mechanical booster
+     * jump MP or both, the bigger value is returned.
+     *
+     * @see #getJumpMP()
+     * @see #getMechanicalJumpBoosterMP()
+     */
+    public int getAnyTypeMaxJumpMP() {
+        return Math.max(getJumpMP(), getMechanicalJumpBoosterMP());
+    }
+
+    /**
+     * Returns this entity's current jump jet jumping MP, not affected by terrain, factored for gravity. Note that for
+     * Meks, this does not include jumping MP due to mechanical jump boosters. When the difference between the two
+     * doesn't matter (Princess or scenario estimations or the like), use getAnyTypeMaxJumpMP() instead.
+     *
+     * @see #getAnyTypeMaxJumpMP()
      */
     public int getJumpMP() {
         return getJumpMP(MPCalculationSetting.STANDARD);
@@ -9471,7 +9485,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
 
         str += " MP: " + getWalkMP();
         if (getOriginalJumpMP() > 0) {
-            str += " Jump: " + getJumpMP();
+            str += " Jump: " + getAnyTypeMaxJumpMP();
         }
         str += " Owner: " + getOwner().getName() + " Armor: " + getTotalArmor()
                 + "/" + getTotalOArmor() + " Internal Structure: "

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -325,6 +325,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     protected int[] armorType;
     protected int[] armorTechLevel;
     protected boolean isJumpingNow = false;
+    private boolean isJumpingWithMechanicalBoosters = false;
     protected boolean convertingNow = false;
     private int conversionMode = 0;
     protected EntityMovementMode previousMovementMode;
@@ -3252,6 +3253,22 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
      */
     public int getJumpMPWithTerrain() {
         return getJumpMP(MPCalculationSetting.DEDUCT_SUBMERGED_JJ);
+    }
+
+    /**
+     * @return The jump MP for a Mek's mechanical jump boosters, modified for typical gameplay purposes by damage,
+     * other equipment (shields) and other effects. Returns 0 for non-Meks.
+     */
+    public int getMechanicalJumpBoosterMP() {
+        return getMechanicalJumpBoosterMP(MPCalculationSetting.STANDARD);
+    }
+
+    /**
+     * @return The jump MP for a Mek's mechanical jump boosters, modified as given through the MPCalculationSetting.
+     * Returns 0 for non-Meks.
+     */
+    public int getMechanicalJumpBoosterMP(MPCalculationSetting mpCalculationSetting) {
+        return 0;
     }
 
     /**
@@ -6510,6 +6527,7 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         mpUsedLastRound = mpUsed;
         mpUsed = 0;
         isJumpingNow = false;
+        isJumpingWithMechanicalBoosters = false;
         convertingNow = false;
         damageThisRound = 0;
         if (assaultDropInProgress == 2) {
@@ -7733,7 +7751,8 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
         int maxSafeMP;
         switch (moveType) {
             case MOVE_JUMP:
-                maxSafeMP = getJumpMP(MPCalculationSetting.NO_GRAVITY);
+                maxSafeMP = step.isUsingMekJumpBooster() ? getMechanicalJumpBoosterMP(MPCalculationSetting.NO_GRAVITY)
+                      : getJumpMP(MPCalculationSetting.NO_GRAVITY);
                 break;
             case MOVE_SPRINT:
             case MOVE_VTOL_SPRINT:
@@ -15929,10 +15948,17 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     public boolean canonUnitWithInvalidBuild() {
-        if (this.isCanon() && mulId > -1)
-        {
-            return !this.getInvalidSourceBuildReasons().isEmpty();
+        if (isCanon() && mulId > -1) {
+            return !getInvalidSourceBuildReasons().isEmpty();
         }
         return false;
+    }
+
+    public boolean isJumpingWithMechanicalBoosters() {
+        return isJumpingWithMechanicalBoosters;
+    }
+
+    public void setJumpingWithMechanicalBoosters(boolean jumpingWithMechanicalBoosters) {
+        isJumpingWithMechanicalBoosters = jumpingWithMechanicalBoosters;
     }
 }

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -1901,12 +1901,15 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     public boolean isPermanentlyImmobilized(boolean checkCrew) {
         if ((checkCrew || defaultCrewType().equals(CrewType.NONE)) && ((getCrew() == null) || getCrew().isDead())) {
             return true;
+        } else if ((this instanceof Mek mek) && (mek.getOriginalMechanicalJumpBoosterMP() > 0) &&
+              (getMechanicalJumpBoosterMP(MPCalculationSetting.PERM_IMMOBILIZED) > 0)) {
+            return false;
         } else if (((getOriginalWalkMP() > 0) || (getOriginalRunMP() > 0) || (getOriginalJumpMP() > 0))
-                // Need to make sure here that we're ignoring heat because
-                // that's not actually "permanent":
-                && ((getWalkMP(MPCalculationSetting.PERM_IMMOBILIZED) == 0)
-                        && (getRunMP(MPCalculationSetting.PERM_IMMOBILIZED) == 0)
-                        && (getJumpMP(MPCalculationSetting.PERM_IMMOBILIZED) == 0))) {
+              // Need to make sure here that we're ignoring heat because
+              // that's not actually "permanent":
+              && ((getWalkMP(MPCalculationSetting.PERM_IMMOBILIZED) == 0)
+              && (getRunMP(MPCalculationSetting.PERM_IMMOBILIZED) == 0)
+              && (getJumpMP(MPCalculationSetting.PERM_IMMOBILIZED) == 0))) {
             return true;
         } else {
             return false;
@@ -3202,7 +3205,6 @@ public abstract class Entity extends TurnOrdered implements Transporter, Targeta
     }
 
     public int getOriginalJumpMP(boolean ignoreModularArmor) {
-
         if (!ignoreModularArmor && hasModularArmor()) {
             return Math.max(0, jumpMP - 1);
         }

--- a/megamek/src/megamek/common/MekSummaryCache.java
+++ b/megamek/src/megamek/common/MekSummaryCache.java
@@ -461,7 +461,7 @@ public class MekSummaryCache {
         ms.setCanon(e.isCanon());
         ms.setWalkMp(e.getWalkMP());
         ms.setRunMp(e.getRunMP(MPCalculationSetting.NO_GRAVITY));
-        ms.setJumpMp(e.getJumpMP());
+        ms.setJumpMp(e.getAnyTypeMaxJumpMP());
         ms.setMoveMode(e.getMovementMode());
         ms.setClan(e.isClan());
         if (e.isSupportVehicle()) {

--- a/megamek/src/megamek/common/MekView.java
+++ b/megamek/src/megamek/common/MekView.java
@@ -354,10 +354,12 @@ public class MekView {
             }
             if (entity instanceof Mek mek) {
                 int mekMechanicalJumpMP = mek.getMechanicalJumpBoosterMP();
-                if (entity.getJumpMP() == 0) {
-                    moveString.append("/").append(mekMechanicalJumpMP);
-                } else {
-                    moveString.append(" (%d)".formatted(mekMechanicalJumpMP));
+                if (mekMechanicalJumpMP > 0) {
+                    if (entity.getJumpMP() == 0) {
+                        moveString.append("/").append(mekMechanicalJumpMP);
+                    } else {
+                        moveString.append(" (%d)".formatted(mekMechanicalJumpMP));
+                    }
                 }
             }
             if (entity.getAllUMUCount() > 0) {

--- a/megamek/src/megamek/common/MekView.java
+++ b/megamek/src/megamek/common/MekView.java
@@ -344,15 +344,21 @@ public class MekView {
         if (!isGunEmplacement) {
             sBasic.add(new SingleLine());
             StringBuilder moveString = new StringBuilder();
-            moveString.append(entity.getWalkMP()).append("/")
-                    .append(entity.getRunMPasString());
+            moveString.append(entity.getWalkMP()).append("/").append(entity.getRunMPasString());
             if (entity.getJumpMP() > 0) {
-                moveString.append("/")
-                        .append(entity.getJumpMP());
+                moveString.append("/").append(entity.getJumpMP());
+                if (entity.damagedJumpJets() > 0) {
+                    moveString.append("<font color='red'> (").append(entity.damagedJumpJets())
+                          .append(" damaged jump jets)</font>");
+                }
             }
-            if (entity.damagedJumpJets() > 0) {
-                moveString.append("<font color='red'> (").append(entity.damagedJumpJets())
-                        .append(" damaged jump jets)</font>");
+            if (entity instanceof Mek mek) {
+                int mekMechanicalJumpMP = mek.getMechanicalJumpBoosterMP();
+                if (entity.getJumpMP() == 0) {
+                    moveString.append("/").append(mekMechanicalJumpMP);
+                } else {
+                    moveString.append(" (%d)".formatted(mekMechanicalJumpMP));
+                }
             }
             if (entity.getAllUMUCount() > 0) {
                 // Add in Jump MP if it wasn't already printed

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -450,7 +450,9 @@ public class MiscType extends EquipmentType {
 
     private String sizeSuffix(double size, boolean shortName) {
         if (hasFlag(F_VARIABLE_SIZE)) {
-            if (hasFlag(MiscType.F_DRONE_CARRIER_CONTROL)
+            if (is(EquipmentTypeLookup.MECHANICAL_JUMP_BOOSTER)) {
+                return " (%d MP)".formatted((int) size);
+            } else if (hasFlag(MiscType.F_DRONE_CARRIER_CONTROL)
                     || hasFlag(MiscType.F_ATAC) || hasFlag(MiscType.F_DTAC)) {
                 return String.format(" (%d %s)", (int) size,
                         size > 1 ? Messages.getString("MiscType.drones") : Messages.getString("MiscType.drone"));
@@ -753,10 +755,9 @@ public class MiscType extends EquipmentType {
                 return 2.0 * .250;
             }
         } else if (hasFlag(F_JUMP_BOOSTER)) {
-            // This is the 'Mek mechanical jump booster. The BA jump booster has the same
-            // flag but
+            // This is the 'Mek mechanical jump booster. The BA jump booster has the same flag but
             // has a fixed weight so doesn't get to this point.
-            return defaultRounding.round((entity.getWeight() * entity.getOriginalJumpMP()) * 0.05, entity);
+            return defaultRounding.round((entity.getWeight() * size) * 0.05, entity);
         } else if ((hasFlag(F_HAND_WEAPON) && hasSubType(S_CLAW)) || hasFlag(F_TALON)) {
             return RoundWeight.nextTon(entity.getWeight() / 15.0);
         } else if (hasFlag(F_ACTUATOR_ENHANCEMENT_SYSTEM)) {
@@ -2137,7 +2138,7 @@ public class MiscType extends EquipmentType {
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticals = CRITICALS_VARIABLE;
         misc.bv = 0;
-        misc.flags = misc.flags.or(F_JUMP_BOOSTER).or(F_MEK_EQUIPMENT);
+        misc.flags = misc.flags.or(F_JUMP_BOOSTER).or(F_MEK_EQUIPMENT).or(F_VARIABLE_SIZE);
         misc.spreadable = true;
         misc.rulesRefs = "292, TO";
         // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS

--- a/megamek/src/megamek/common/MovePath.java
+++ b/megamek/src/megamek/common/MovePath.java
@@ -64,6 +64,7 @@ public class MovePath implements Cloneable, Serializable {
         GET_UP(false, "Up"),
         GO_PRONE(false, "Prone"),
         START_JUMP(false, "StrJump"),
+        JUMP_MEK_MECHANICAL_BOOSTER(false, "MekMJB"),
         CHARGE(false, "Ch"),
         DFA(false, "DFA"),
         FLEE(false, "Flee"),
@@ -578,7 +579,7 @@ public class MovePath implements Cloneable, Serializable {
         } else {
             // if we're jumping without a mechanical jump booster (?)
             // or we're acting like a spheroid DropShip in the atmosphere
-            if ((isJumping() && (getEntity().getJumpType() != Mek.JUMP_BOOSTER)) ||
+            if ((isJumping() && !contains(MoveStepType.JUMP_MEK_MECHANICAL_BOOSTER)) ||
                     (Compute.useSpheroidAtmosphere(game, getEntity()) && (step.getType() != MoveStepType.HOVER))) {
                 int distance = start.distance(land);
 
@@ -1782,19 +1783,13 @@ public class MovePath implements Cloneable, Serializable {
     }
 
     /**
-     * Returns true if a jump using mechanical jump boosters would cause falling
-     * damage. Mechanical jump boosters are only designed to handle the stress
-     * of falls from a height equal to their jumpMP; if a jump has a fall that
-     * is further than the jumpMP of the unit, fall damage applies.
-     *
-     * @return
+     * @return true if a jump using mechanical jump boosters would cause falling damage. Mechanical jump boosters are
+     * only designed to handle the stress of falls from a height equal to their jumpMP; if a jump has a fall that is
+     * further than the jumpMP of the unit, fall damage applies.
      */
     public boolean shouldMechanicalJumpCauseFallDamage() {
-        if (isJumping() && (getEntity().getJumpType() == Mek.JUMP_BOOSTER) &&
-                (getJumpMaxElevationChange() > getEntity().getJumpMP())) {
-            return true;
-        }
-        return false;
+        return isJumping() && contains(MoveStepType.JUMP_MEK_MECHANICAL_BOOSTER) &&
+              (getJumpMaxElevationChange() > getEntity().getMechanicalJumpBoosterMP());
     }
 
     /**
@@ -1991,7 +1986,8 @@ public class MovePath implements Cloneable, Serializable {
         int mp = 0;
         for (MoveStep step : steps) {
             if (jumping && (step.getType() != MoveStepType.TURN_LEFT) &&
-                    (step.getType() != MoveStepType.TURN_RIGHT)) {
+                  (step.getType() != MoveStepType.TURN_RIGHT) &&
+                  (step.getType() != MoveStepType.JUMP_MEK_MECHANICAL_BOOSTER)) {
                 mp += step.getMp();
             } else if (!jumping) {
                 mp += step.getMp();
@@ -2158,27 +2154,24 @@ public class MovePath implements Cloneable, Serializable {
     }
 
     /**
-     *
-     * @return maximum movement based on the current movement type
-     *   include sprint if available
+     * @return The maximum MP based on the current movement type of this path, including sprint if available
      */
     public int getMaxMP() {
-        int maxMP;
-
-        if (contains(MoveStepType.START_JUMP) || contains(MoveStepType.DFA)) {
-            maxMP = getEntity().getJumpMP();
+        if (contains(MoveStepType.DFA)) {
+            return getEntity().getJumpMP();
+        } else if (contains(MoveStepType.JUMP_MEK_MECHANICAL_BOOSTER)) {
+            return (getEntity() instanceof Mek mek) ? mek.getMechanicalJumpBoosterMP() : 0;
+        } else if (contains(MoveStepType.START_JUMP)) {
+            return getEntity().getJumpMP();
         } else if (contains(MoveStepType.BACKWARDS)) {
-            maxMP = getEntity().getWalkMP();
+            return getEntity().getWalkMP();
         } else {
-            if ((getLastStep() != null) &&
-                getLastStep().canUseSprint(game)) {
-                maxMP = getEntity().getSprintMP();
+            if ((getLastStep() != null) && getLastStep().canUseSprint(game)) {
+                return getEntity().getSprintMP();
             } else {
-                maxMP = getEntity().getRunMP();
+                return getEntity().getRunMP();
             }
         }
-
-        return maxMP;
     }
 
     @Override

--- a/megamek/src/megamek/common/actions/DfaAttackAction.java
+++ b/megamek/src/megamek/common/actions/DfaAttackAction.java
@@ -89,7 +89,7 @@ public class DfaAttackAction extends DisplacementAttackAction {
             return new ToHitData(TargetRoll.IMPOSSIBLE, "Infantry can't D.F.A.");
         }
 
-        if (ae.getJumpType() == Mek.JUMP_BOOSTER) {
+        if (md.contains(MoveStepType.JUMP_MEK_MECHANICAL_BOOSTER)) {
             return new ToHitData(TargetRoll.IMPOSSIBLE,
                     "Can't D.F.A. using mechanical jump boosters.");
         }

--- a/megamek/src/megamek/common/alphaStrike/conversion/ASMovementConverter.java
+++ b/megamek/src/megamek/common/alphaStrike/conversion/ASMovementConverter.java
@@ -74,6 +74,10 @@ final class ASMovementConverter {
         report.addLine("Base Walking MP", "", Integer.toString(entity.getOriginalWalkMP()));
 
         int jumpMove = entity.getJumpMP(MPCalculationSetting.AS_CONVERSION) * 2;
+        if (entity instanceof Mek mek) {
+            int mechanicalBoosterMP = mek.getMechanicalJumpBoosterMP(MPCalculationSetting.AS_CONVERSION) * 2;
+            jumpMove = Math.max(mechanicalBoosterMP, jumpMove);
+        }
 
         if (hasSupercharger(entity) && hasMekMASC(entity)) {
             walkMP *= 1.5;

--- a/megamek/src/megamek/common/alphaStrike/conversion/ASMovementConverter.java
+++ b/megamek/src/megamek/common/alphaStrike/conversion/ASMovementConverter.java
@@ -74,10 +74,8 @@ final class ASMovementConverter {
         report.addLine("Base Walking MP", "", Integer.toString(entity.getOriginalWalkMP()));
 
         int jumpMove = entity.getJumpMP(MPCalculationSetting.AS_CONVERSION) * 2;
-        if (entity instanceof Mek mek) {
-            int mechanicalBoosterMP = mek.getMechanicalJumpBoosterMP(MPCalculationSetting.AS_CONVERSION) * 2;
-            jumpMove = Math.max(mechanicalBoosterMP, jumpMove);
-        }
+        int mechanicalBoosterMP = entity.getMechanicalJumpBoosterMP(MPCalculationSetting.AS_CONVERSION) * 2;
+        jumpMove = Math.max(mechanicalBoosterMP, jumpMove);
 
         if (hasSupercharger(entity) && hasMekMASC(entity)) {
             walkMP *= 1.5;
@@ -114,15 +112,15 @@ final class ASMovementConverter {
         String movementCode = getMovementCode(conversionData);
         element.setPrimaryMovementMode(movementCode);
 
-        if ((jumpMove == baseMove) && (jumpMove > 0) && movementCode.equals("")) {
+        if ((jumpMove == baseMove) && (jumpMove > 0) && movementCode.isEmpty()) {
             result.put("j", baseMove);
-            report.addLine("Equal to Jump Move", entity.getJumpMP() + " x 2", baseMove + "\"j");
+            report.addLine("Equal to Jump Move", entity.getAnyTypeMaxJumpMP() + " x 2", baseMove + "\"j");
         } else {
             result.put(movementCode, baseMove);
             report.addLine("Standard Movement", baseMove + "\"" + movementCode);
             if (jumpMove > 0) {
                 result.put("j", jumpMove);
-                report.addLine("Jump Movement", entity.getJumpMP() + " x 2", jumpMove + "\"j");
+                report.addLine("Jump Movement", entity.getAnyTypeMaxJumpMP() + " x 2", jumpMove + "\"j");
             }
         }
 

--- a/megamek/src/megamek/common/battlevalue/BVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/BVCalculator.java
@@ -335,7 +335,8 @@ public abstract class BVCalculator {
      * {@link #setRunMP()}.
      */
     protected void setJumpMP() {
-        jumpMP = entity.getJumpMP(MPCalculationSetting.BV_CALCULATION);
+        jumpMP = Math.max(entity.getJumpMP(MPCalculationSetting.BV_CALCULATION),
+              entity.getMechanicalJumpBoosterMP(MPCalculationSetting.BV_CALCULATION));
     }
 
     /**

--- a/megamek/src/megamek/common/battlevalue/MekBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/MekBVCalculator.java
@@ -236,12 +236,6 @@ public class MekBVCalculator extends HeatTrackingBVCalculator {
     }
 
     @Override
-    protected void setJumpMP() {
-        jumpMP = Math.max(entity.getJumpMP(MPCalculationSetting.BV_CALCULATION),
-              ((Mek) entity).getMechanicalJumpBoosterMP(MPCalculationSetting.BV_CALCULATION));
-    }
-
-    @Override
     protected double tmmFactor(int tmmRunning, int tmmJumping, int tmmUmu) {
         int targetMovementModifier = Math.max(tmmRunning, Math.max(tmmJumping, tmmUmu));
         // Try to find a Mek Stealth or similar system.

--- a/megamek/src/megamek/common/battlevalue/MekBVCalculator.java
+++ b/megamek/src/megamek/common/battlevalue/MekBVCalculator.java
@@ -236,6 +236,12 @@ public class MekBVCalculator extends HeatTrackingBVCalculator {
     }
 
     @Override
+    protected void setJumpMP() {
+        jumpMP = Math.max(entity.getJumpMP(MPCalculationSetting.BV_CALCULATION),
+              ((Mek) entity).getMechanicalJumpBoosterMP(MPCalculationSetting.BV_CALCULATION));
+    }
+
+    @Override
     protected double tmmFactor(int tmmRunning, int tmmJumping, int tmmUmu) {
         int targetMovementModifier = Math.max(tmmRunning, Math.max(tmmJumping, tmmUmu));
         // Try to find a Mek Stealth or similar system.

--- a/megamek/src/megamek/common/cost/MekCostCalculator.java
+++ b/megamek/src/megamek/common/cost/MekCostCalculator.java
@@ -80,22 +80,20 @@ public class MekCostCalculator {
             costs[i++] = 300000 * (int) Math.ceil((mek.getOriginalWalkMP() * mek.getWeight()) / 100f);
         }
         double jumpBaseCost = 200;
-        // You cannot have JJ's and UMU's on the same unit.
+        double jumpCost;
+        // Cannot have JJs and UMUs on the same unit.
         if (mek.hasUMU()) {
-            costs[i++] = Math.pow(mek.getAllUMUCount(), 2.0) * mek.getWeight() * jumpBaseCost;
-            // We could have Jump boosters
-            if (mek.getJumpType() == Mek.JUMP_BOOSTER) {
-                jumpBaseCost = 150;
-                costs[i++] = Math.pow(mek.getOriginalJumpMP(), 2.0) * mek.getWeight() * jumpBaseCost;
-            }
+            jumpCost = Math.pow(mek.getAllUMUCount(), 2.0) * mek.getWeight() * jumpBaseCost;
         } else {
-            if (mek.getJumpType() == Mek.JUMP_BOOSTER) {
-                jumpBaseCost = 150;
-            } else if (mek.getJumpType() == Mek.JUMP_IMPROVED) {
+            if (mek.getJumpType() == Mek.JUMP_IMPROVED) {
                 jumpBaseCost = 500;
             }
-            costs[i++] = Math.pow(mek.getOriginalJumpMP(), 2.0) * mek.getWeight() * jumpBaseCost;
+            jumpCost = Math.pow(mek.getOriginalJumpMP(), 2.0) * mek.getWeight() * jumpBaseCost;
         }
+        if (mek.getOriginalMechanicalJumpBoosterMP() > 0) {
+            jumpCost += Math.pow(mek.getOriginalMechanicalJumpBoosterMP(), 2.0) * mek.getWeight() * 150;
+        }
+        costs[i++] = jumpCost;
         // num of sinks we don't pay for
         int freeSinks = mek.hasDoubleHeatSinks() ? 0 : 10;
         int sinkCost = mek.hasDoubleHeatSinks() ? 6000 : 2000;

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -849,6 +849,21 @@ public class MtfFile implements IMekLoader {
                                 isTurreted);
                         m.setOmniPodMounted(isOmniPod);
                         hSharedEquip.put(etype, m);
+                        if (etype.is(EquipmentTypeLookup.MECHANICAL_JUMP_BOOSTER)) {
+                            if (size == 0) {
+                                // legacy MTF loading: MJB gave their MP as the jump MP
+                                size = mek.getOriginalJumpMP(true);
+                                // Legacy MTF loading: If the unit has no JJ/UMU, the jump MP are mech. jump boosters and must be reset
+//                                long jjCount = mek.getMisc().stream()
+//                                      .filter(m -> m.getType().hasFlag(MiscType.F_JUMP_JET) || m.getType().hasFlag(MiscType.F_UMU))
+//                                      .count();
+//                                if (jjCount == 0) {
+                                mek.setOriginalJumpMP(0);
+//                                }
+                            }
+
+                            m.setSize(size);
+                        }
                     } else if (etype instanceof MiscType && etype.hasFlag(MiscType.F_TARGCOMP)) {
                         // Targeting computers are special, they need to be loaded like spreadable
                         // equipment, but they aren't spreadable

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -853,13 +853,7 @@ public class MtfFile implements IMekLoader {
                             if (size == 0) {
                                 // legacy MTF loading: MJB gave their MP as the jump MP
                                 size = mek.getOriginalJumpMP(true);
-                                // Legacy MTF loading: If the unit has no JJ/UMU, the jump MP are mech. jump boosters and must be reset
-//                                long jjCount = mek.getMisc().stream()
-//                                      .filter(m -> m.getType().hasFlag(MiscType.F_JUMP_JET) || m.getType().hasFlag(MiscType.F_UMU))
-//                                      .count();
-//                                if (jjCount == 0) {
                                 mek.setOriginalJumpMP(0);
-//                                }
                             }
 
                             m.setSize(size);

--- a/megamek/src/megamek/common/pathfinder/CachedEntityState.java
+++ b/megamek/src/megamek/common/pathfinder/CachedEntityState.java
@@ -108,7 +108,7 @@ public class CachedEntityState {
 
     public int getJumpMP() {
         if (jumpMP == null) {
-            jumpMP = backingEntity.getJumpMP();
+            jumpMP = backingEntity.getAnyTypeMaxJumpMP();
         }
 
         return jumpMP;

--- a/megamek/src/megamek/common/templates/MekTROView.java
+++ b/megamek/src/megamek/common/templates/MekTROView.java
@@ -68,6 +68,7 @@ public class MekTROView extends TROView {
         setModelData("walkMP", mek.getWalkMP());
         setModelData("runMP", mek.getRunMPasString());
         setModelData("jumpMP", mek.getJumpMP());
+        setModelData("jumpBoosterMP", mek.getMechanicalJumpBoosterMP());
         setModelData("hsType", mek.getHeatSinkTypeName());
         setModelData("hsCount",
                 mek.hasDoubleHeatSinks() ? mek.heatSinks() + " [" + (mek.heatSinks() * 2) + "]" : mek.heatSinks());
@@ -143,6 +144,7 @@ public class MekTROView extends TROView {
                 formatSystemFluff(EntityFluff.System.CHASSIS, mek.getFluff(), this::formatChassisDesc));
         setModelData("jjDesc", formatSystemFluff(EntityFluff.System.JUMPJET, mek.getFluff(), this::formatJJDesc));
         setModelData("jumpCapacity", mek.getJumpMP() * 30);
+        setModelData("jumpBoosterCapacity", mek.getMechanicalJumpBoosterMP() * 30);
     }
 
     private static final int[][] MEK_ARMOR_LOCS = { { Mek.LOC_HEAD }, { Mek.LOC_CT }, { Mek.LOC_RT, Mek.LOC_LT },
@@ -184,20 +186,13 @@ public class MekTROView extends TROView {
     }
 
     private String formatJJDesc() {
-        switch (mek.getJumpType()) {
-            case Mek.JUMP_STANDARD:
-                return Messages.getString("TROView.jjStandard");
-            case Mek.JUMP_IMPROVED:
-                return Messages.getString("TROView.jjImproved");
-            case Mek.JUMP_PROTOTYPE:
-                return Messages.getString("TROView.jjPrototype");
-            case Mek.JUMP_PROTOTYPE_IMPROVED:
-                return Messages.getString("TROView.jjImpPrototype");
-            case Mek.JUMP_BOOSTER:
-                return Messages.getString("TROView.jjBooster");
-            default:
-                return Messages.getString("TROView.jjNone");
-        }
+        return switch (mek.getJumpType()) {
+            case Mek.JUMP_STANDARD -> Messages.getString("TROView.jjStandard");
+            case Mek.JUMP_IMPROVED -> Messages.getString("TROView.jjImproved");
+            case Mek.JUMP_PROTOTYPE -> Messages.getString("TROView.jjPrototype");
+            case Mek.JUMP_PROTOTYPE_IMPROVED -> Messages.getString("TROView.jjImpPrototype");
+            default -> Messages.getString("TROView.jjNone");
+        };
     }
 
     @Override

--- a/megamek/src/megamek/common/verifier/TestMek.java
+++ b/megamek/src/megamek/common/verifier/TestMek.java
@@ -869,11 +869,9 @@ public class TestMek extends TestEntity {
         for (Mounted<?> m : getEntity().getMisc()) {
             final MiscType misc = (MiscType) m.getType();
 
-            if (misc.hasFlag(MiscType.F_UMU) && (mek.getJumpType() != Mek.JUMP_NONE)
-                    && (mek.getJumpType() != Mek.JUMP_BOOSTER)) {
+            if (misc.hasFlag(MiscType.F_UMU) && (mek.getJumpType() != Mek.JUMP_NONE)) {
                 illegal = true;
-                buff.append("UMUs cannot be mounted with jump jets "
-                        + "(jump boosters are legal)\n");
+                buff.append("UMUs cannot be mounted with jump jets\n");
             }
 
             if (misc.hasFlag(MiscType.F_MASC)
@@ -1118,8 +1116,7 @@ public class TestMek extends TestEntity {
             }
             if ((mek.getJumpType() != Mek.JUMP_STANDARD)
                     && (mek.getJumpType() != Mek.JUMP_NONE)
-                    && (mek.getJumpType() != Mek.JUMP_PROTOTYPE)
-                    && (mek.getJumpType() != Mek.JUMP_BOOSTER)) {
+                    && (mek.getJumpType() != Mek.JUMP_PROTOTYPE)) {
                 buff.append("industrial meks can only mount standard jump jets or mechanical jump boosters\n");
                 illegal = true;
             }

--- a/megamek/src/megamek/common/verifier/TestMek.java
+++ b/megamek/src/megamek/common/verifier/TestMek.java
@@ -50,8 +50,7 @@ public class TestMek extends TestEntity {
         JJ_IMPROVED(EquipmentTypeLookup.IMPROVED_JUMP_JET, false, Mek.JUMP_IMPROVED),
         JJ_PROTOTYPE(EquipmentTypeLookup.PROTOTYPE_JUMP_JET, true, Mek.JUMP_PROTOTYPE),
         JJ_PROTOTYPE_IMPROVED(EquipmentTypeLookup.PROTOTYPE_IMPROVED_JJ, false, Mek.JUMP_PROTOTYPE_IMPROVED),
-        JJ_UMU(EquipmentTypeLookup.MEK_UMU, false, Mek.JUMP_NONE),
-        JJ_BOOSTER(EquipmentTypeLookup.MECHANICAL_JUMP_BOOSTER, true, Mek.JUMP_BOOSTER);
+        JJ_UMU(EquipmentTypeLookup.MEK_UMU, false, Mek.JUMP_NONE);
 
         private String internalName;
         private boolean industrial;
@@ -133,9 +132,7 @@ public class TestMek extends TestEntity {
         if (mek.isSuperHeavy()) {
             return 0;
         }
-        if (mek.getJumpType() == Mek.JUMP_BOOSTER) {
-            return null;
-        } else if (!mek.hasEngine()
+        if (!mek.hasEngine()
                 || (!mek.getEngine().isFusion() && (mek.getEngine().getEngineType() != Engine.FISSION))) {
             return 0;
         } else if ((mek.getJumpType() == Mek.JUMP_IMPROVED)

--- a/megamek/src/megamek/common/verifier/TestMek.java
+++ b/megamek/src/megamek/common/verifier/TestMek.java
@@ -681,15 +681,13 @@ public class TestMek extends TestEntity {
         // Mechanical Jump Boosts can be greater then Running as long as
         // the unit can handle the weight.
         if ((mek.getJumpMP(MPCalculationSetting.NO_GRAVITY) > mek.getOriginalRunMP())
-                && !mek.hasJumpBoosters()
                 && !mek.hasWorkingMisc(MiscType.F_PARTIAL_WING)) {
             buff.append("Jump MP exceeds run MP\n");
             return false;
         }
         if ((mek.getJumpMP(MPCalculationSetting.NO_GRAVITY) > mek.getOriginalWalkMP())
                 && (((mek.getJumpType() != Mek.JUMP_IMPROVED) && (mek.getJumpType() != Mek.JUMP_PROTOTYPE_IMPROVED))
-                        && !mek.hasWorkingMisc(MiscType.F_PARTIAL_WING) && !mek
-                                .hasJumpBoosters())) {
+                        && !mek.hasWorkingMisc(MiscType.F_PARTIAL_WING))) {
             buff.append("Jump MP exceeds walk MP without IJJs\n");
             return false;
         }

--- a/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import megamek.MMConstants;
 import megamek.client.ui.Messages;
 import megamek.common.*;
+import megamek.common.MovePath.MoveStepType;
 import megamek.common.actions.AirMekRamAttackAction;
 import megamek.common.actions.AttackAction;
 import megamek.common.actions.ChargeAttackAction;
@@ -169,6 +170,9 @@ class MovePathHandler extends AbstractTWRuleHandler {
         if (md.contains(MovePath.MoveStepType.CAREFUL_STAND)) {
             entity.setCarefulStand(true);
         }
+
+        entity.setJumpingWithMechanicalBoosters(md.contains(MoveStepType.JUMP_MEK_MECHANICAL_BOOSTER));
+
         if (md.contains(MovePath.MoveStepType.BACKWARDS)) {
             entity.setMovedBackwards(true);
             if (md.getMpUsed() > entity.getWalkMP()) {
@@ -2263,7 +2267,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
 
             // set last step parameters
             curPos = step.getPosition();
-            if (!((entity.getJumpType() == Mek.JUMP_BOOSTER) && step.isJumping())) {
+            if (!(step.isUsingMekJumpBooster() && step.isJumping())) {
                 curFacing = step.getFacing();
             }
             // check if a building PSR will be needed later, before setting the
@@ -3201,8 +3205,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
             if (((step.getType() == MovePath.MoveStepType.BACKWARDS)
                     || (step.getType() == MovePath.MoveStepType.LATERAL_LEFT_BACKWARDS)
                     || (step.getType() == MovePath.MoveStepType.LATERAL_RIGHT_BACKWARDS))
-                    && !(md.isJumping()
-                            && (entity.getJumpType() == Mek.JUMP_BOOSTER))
+                    && !(md.isJumping() && step.isUsingMekJumpBooster())
                     && (lastHex.getLevel() + lastElevation != curHex.getLevel() + step.getElevation())
                     && !(entity instanceof VTOL)
                     && !(curClimbMode

--- a/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
@@ -684,7 +684,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
                 gameManager.getMainPhaseReport().addAll(gameManager.doEntityFallsInto(entity,
                         entity.getElevation(), md.getJumpPathHighestPoint(),
                         curPos, entity.getBasePilotingRoll(overallMoveType),
-                        false, entity.getJumpMP()));
+                        false, entity.getMechanicalJumpBoosterMP()));
             }
 
             // jumped into water?
@@ -1969,8 +1969,10 @@ class MovePathHandler extends AbstractTWRuleHandler {
 
             if (cachedGravityLimit < 0) {
                 cachedGravityLimit = EntityMovementType.MOVE_JUMP == moveType
-                        ? entity.getJumpMP(MPCalculationSetting.NO_GRAVITY)
-                        : entity.getRunningGravityLimit();
+                      ? (step.isUsingMekJumpBooster()
+                      ? entity.getMechanicalJumpBoosterMP(MPCalculationSetting.NO_GRAVITY)
+                      : entity.getJumpMP(MPCalculationSetting.NO_GRAVITY))
+                      : entity.getRunningGravityLimit();
             }
             // check for charge
             if (step.getType() == MovePath.MoveStepType.CHARGE) {

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -17161,7 +17161,10 @@ public class TWGameManager extends AbstractGameManager {
                     if (game.getPlanetaryConditions().getGravity() < 1) {
                         int j = entity.mpUsed;
                         int damage = 0;
-                        while (j > entity.getJumpMP(MPCalculationSetting.NO_GRAVITY)) {
+                        int noGravityJumpMP = entity.isJumpingWithMechanicalBoosters()
+                              ? entity.getMechanicalJumpBoosterMP(MPCalculationSetting.NO_GRAVITY)
+                              : entity.getJumpMP(MPCalculationSetting.NO_GRAVITY);
+                        while (j > noGravityJumpMP) {
                             j--;
                             damage++;
                         }

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -8191,7 +8191,7 @@ public class TWGameManager extends AbstractGameManager {
                     || (entity.moved == EntityMovementType.MOVE_VTOL_RUN)
                     || (entity.moved == EntityMovementType.MOVE_SKID)) {
                 entity.heatBuildup += entity.getRunHeat();
-            } else if (entity.moved == EntityMovementType.MOVE_JUMP) {
+            } else if (entity.moved == EntityMovementType.MOVE_JUMP && !entity.isJumpingWithMechanicalBoosters()) {
                 entity.heatBuildup += entity.getJumpHeat(entity.delta_distance);
             } else if (entity.moved == EntityMovementType.MOVE_SPRINT
                     || entity.moved == EntityMovementType.MOVE_VTOL_SPRINT) {

--- a/megamek/testresources/data/scenarios/test_setups/Commando COM-MMJB.mtf
+++ b/megamek/testresources/data/scenarios/test_setups/Commando COM-MMJB.mtf
@@ -1,0 +1,164 @@
+generator:MegaMek Suite 0.50.04-SNAPSHOT on 2025-03-22
+chassis:Commando
+model:COM-MMJB
+
+Config:Biped
+techbase:Inner Sphere
+era:3062
+source:TRO: 3039
+rules level:2
+role:Striker
+
+quirk:exp_actuator
+quirk:low_profile
+
+mass:30
+engine:180 Fusion Engine(IS)
+structure:IS Standard
+myomer:Standard
+
+heat sinks:10 Single
+walk mp:6
+jump mp:5
+
+armor:Standard(Inner Sphere)
+LA armor:3
+RA armor:3
+LT armor:7
+RT armor:7
+CT armor:6
+HD armor:9
+LL armor:5
+RL armor:5
+RTL armor:1
+RTR armor:1
+RTC armor:1
+
+Weapons:2
+Medium Laser, Left Arm
+SRM 6, Center Torso
+
+Left Arm:
+Shoulder
+Upper Arm Actuator
+Lower Arm Actuator
+Hand Actuator
+Medium Laser
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Arm:
+Shoulder
+Upper Arm Actuator
+Lower Arm Actuator
+Hand Actuator
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Torso:
+Heat Sink
+IS Ammo SRM-6
+Jump Jet
+Jump Jet
+Jump Jet
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Torso:
+Heat Sink
+Heat Sink
+Jump Jet
+Jump Jet
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Center Torso:
+Fusion Engine
+Fusion Engine
+Fusion Engine
+Gyro
+Gyro
+Gyro
+Gyro
+Fusion Engine
+Fusion Engine
+Fusion Engine
+SRM 6
+SRM 6
+
+Head:
+Life Support
+Sensors
+Cockpit
+-Empty-
+Sensors
+Life Support
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Left Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+MechanicalJumpBooster:SIZE:3.0
+MechanicalJumpBooster:SIZE:3.0
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+Right Leg:
+Hip
+Upper Leg Actuator
+Lower Leg Actuator
+Foot Actuator
+MechanicalJumpBooster:SIZE:3.0
+MechanicalJumpBooster:SIZE:3.0
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+-Empty-
+
+overview:Created for the Lyran Commonwealth Armed Forces and one of the first 'Mechs ever designed for reconnaissance, the Commando was much lighter and faster than its precursors, though it still utilized primitive BattleMech technology.
+capabilities:With only four tons of armor to protect itself, the Commando is not meant to participate in a stand-up fight against heavier enemies, but it excels at hit-and-run tactics and as a scout hunter.
+deployment:The standard COM-2D Commando carries two different SRM launchers, a Coventry 4-tube and a Shannon Six Shooter, each with one ton of ammo. The secondary weapon is a Defiance B3M Medium Laser. This weapons load can cause a lot of damage for a light 'Mech and makes the Commando an effective striker, especially when used in groups. An often-used tactic for those is to rush upon a single target, concentrate their fire and retreat before the enemy can offer effective resistance. The COM-2D's communication gear, Crystal Flower RG-2, as well as the Star Shark targeting system were produced by TharHes on Tharkad.
+history:In 2463 Coventry Metal Works (then known as Coventry Defense Conglomerate) introduced their second BattleMech, the COM-1A Commando. The Commando was able to destroy much heavier Kuritan Gladiators during the first large-scale battle between BattleMechs in 2475 on Nox. The installed Large Laser caused several problems and other 'Mechs were soon introduced (like the Wasp in 2464 and the Stinger in 2479) that were better equipped for scouting and even mounted jump jets. The Commando's profile was radically changed with the introduction of the sophisticated COM-2D variant in 2486, which exchanged the laser weaponry with short range missiles and turned the machine into a striker. The Commando became popular among LCAF forces and, nearly 600 years later, is still mainly in use by Lyrans. The Commonwealth went to great pains to keep the 'Mech solely in Lyran hands, especially during the years of the Star League. It took an alliance with the Federated Suns and the creation of the Federated Commonwealth to break the stranglehold. The Commando was chosen as the standard light BattleMech for the Armed Forces of the Federated Commonwealth next to the Valkyrie, and after the upgrade to the COM-5S model in 3050, Vandenberg Mechanized Industries was allowed to produce the old COM-2D for the Taurian Defense Force. Furthermore, the Marian Hegemony deploys the Rocket Launcher-packed COM-4H, and the Word of Blake produced its own variant (the COM-7B) during its occupation of Coventry from 3068 to 3074.
+manufacturer:Coventry Defense Conglomerate,Coventry Metal Works,Vandenberg Mechanized Industries,Rim Motors
+primaryfactory:Coventry,Coventry,Illiushin,Otisberg
+systemmanufacturer:CHASSIS:Coventry Metal Works
+systemmanufacturer:ENGINE:GM 150
+systemmanufacturer:ARMOR:Lexington Limited
+systemmanufacturer:COMMUNICATIONS:TharHes Crystal Flower RG-2
+systemmanufacturer:TARGETING:TharHes Star Shark
+

--- a/megamek/testresources/data/scenarios/test_setups/MMJB.mms
+++ b/megamek/testresources/data/scenarios/test_setups/MMJB.mms
@@ -1,0 +1,28 @@
+MMSVersion: 2
+name: Test Setup for MMJB
+planet: None
+description: Units with MMJB and standard JJ
+map: Map Pack Savannahs/16x17 River Delta-Drainage Basin 1 (Savannah).board
+
+options:
+  off:
+    - check_victory
+  on:
+    - friendly_fire
+
+factions:
+- name: Test Player
+
+  units:
+  - fullname: Thunder Fox TFT-C3
+    # only MMJB
+    at: [ 9, 12 ]
+
+  - fullname: Thunder Fox TFT-L8
+    # standard JJ
+    at: [ 9, 8 ]
+
+  - fullname: Commando COM-MMJB
+    # both JJ and MMJB
+    # the mtf file must be moved so that it's part of the cache for this to work
+    at: [ 10, 11 ]

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -110,6 +110,7 @@ class PrincessTest {
         Entity mockMek = mock(BipedMek.class);
         when(mockMek.getRunMP(MPCalculationSetting.STANDARD)).thenReturn(9);
         when(mockMek.getJumpMP(MPCalculationSetting.STANDARD)).thenReturn(6);
+        when(mockMek.getAnyTypeMaxJumpMP()).thenReturn(0);
         when(mockMek.isProne()).thenReturn(false);
         when(mockMek.isCommander()).thenReturn(false);
         when(mockMek.isMilitary()).thenReturn(true);
@@ -164,7 +165,7 @@ class PrincessTest {
         // Test a BA unit.
         Entity mockBA = mock(BattleArmor.class);
         when(mockBA.getRunMP()).thenReturn(1);
-        when(mockBA.getJumpMP()).thenReturn(3);
+        when(mockBA.getAnyTypeMaxJumpMP()).thenReturn(3);
         when(mockBA.isProne()).thenReturn(false);
         when(mockBA.isCommander()).thenReturn(false);
         when(mockBA.isMilitary()).thenReturn(true);
@@ -178,6 +179,7 @@ class PrincessTest {
         // Test an Inf unit.
         Entity mockInf = mock(Infantry.class);
         when(mockInf.getRunMP(MPCalculationSetting.STANDARD)).thenReturn(1);
+        when(mockInf.getAnyTypeMaxJumpMP()).thenReturn(0);
         when(mockInf.getJumpMP(MPCalculationSetting.STANDARD)).thenReturn(0);
         when(mockInf.isProne()).thenReturn(false);
         when(mockInf.isCommander()).thenReturn(false);
@@ -192,6 +194,7 @@ class PrincessTest {
         // Test a Tank.
         Entity mockTank = mock(Tank.class);
         when(mockTank.getRunMP(MPCalculationSetting.STANDARD)).thenReturn(6);
+        when(mockInf.getAnyTypeMaxJumpMP()).thenReturn(0);
         when(mockTank.getJumpMP(MPCalculationSetting.STANDARD)).thenReturn(0);
         when(mockTank.isProne()).thenReturn(false);
         when(mockTank.isCommander()).thenReturn(false);


### PR DESCRIPTION
This is the MM part of allowing both jump jets and Mek mechanical jump boosters.
- When a unit has only MMJB, movement behaves as before
- When a unit has both JJ and MMJB and the player selects jumping, they'll have to choose between the systems
- In the code, the various versions of getJumpMP() now only address jump jets. For MMJB, separate methods are used. If only a general jump value of any sort is needed, e.g. for scenario generation, a new method getAnyTypeMaxJumpMP() can be used. The two have the same result on anything unit but Meks when MMJB are involved.

Requires Megamek/megameklab#1780 and Megamek/mekhq#6347