### PR TITLE
Restrict user dir loading to the correct subfolders

### DIFF
--- a/megamek/docs/UserDirHelp.html
+++ b/megamek/docs/UserDirHelp.html
@@ -6,9 +6,9 @@
 
 <P>How to place files within the user data directory:</P>
 <UL>
-    <LI><B>Fonts</B> can be placed anywhere in the user data directory (i.e., in the directory itself or in any subfolder)
+    <LI><B>Fonts</B> must be placed in &lt;user data directory&gt;/data/fonts/. In this subfolder, further subfolders can be used (optional).
 
-    <LI><B>Units</B> (.mtf and .blk files) can be placed anywhere in the user data directory
+    <LI><B>Units</B> (.mtf and .blk files) must be placed in &lt;user data directory&gt;/data/mekfiles/. In this subfolder, further subfolders can be used (optional).
 
     <LI><B>Camo</B> images must be placed in &lt;user data directory&gt;/data/images/camo/. In this subfolder, further subfolders can be used (optional).
 
@@ -16,11 +16,15 @@
 
     <LI><B>Unit fluff</B> images must be placed in &lt;user data directory&gt;/data/images/fluff/&lt;unit type&gt;/. To find the exact subfolders to use, go to your megamek folder and open /data/images/fluff/.
 
-    <LI><B>Skin</B> definition files (.xml) can be placed anywhere in the user data directory
+    <LI><B>Skin</B> definition files (.xml) must be placed in &lt;user data directory&gt;/mmconf/skins/. In this subfolder, further subfolders can be used (optional).
 
-    <LI><B>Rank Systems</B> may be defined in &lt;user data directory&gt;/data/universe/ranks.xml
+    <LI><B>MM Scenario</B> files (.mms) must be placed in &lt;user data directory&gt;/data/scenarios/. In this subfolder, further subfolders can be used (optional).
 
-    <LI><B>Award</B> definition files (.xml) can be placed in &lt;user data directory&gt;/data/universe/awards
+    <LI><B>Rank Systems</B> may be defined in &lt;user data directory&gt;/data/universe/ranks.xml.
+
+    <LI><B>Award</B> definition files (.xml) can be placed in &lt;user data directory&gt;/data/universe/awards/.
+
+    <LI><B>Force Icon</B> images can be placed in &lt;user data directory&gt;/data/images/force/.
 </UL>
 
 <P>
@@ -33,13 +37,9 @@
 <P>This is an example of a suitable directory structure with a few example files:
 <BR><BR>
 D:/myBTStuff<BR>
-&nbsp;&nbsp;&nbsp;&nbsp;Oxanium.ttf<BR>
-&nbsp;&nbsp;&nbsp;&nbsp;Exo.ttf<BR>
-&nbsp;&nbsp;&nbsp;&nbsp;campaign_units/<BR>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Atlas AS8-XT.mtf<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;data/<BR>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Jura.ttf<BR>
-        MyMMSkin.xml<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mekfiles/<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Atlas AS8-XT.mtf<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;images/<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;camo/<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;myForceCamo.png<BR>
@@ -53,11 +53,17 @@ D:/myBTStuff<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Atlas.png<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;DropShip/<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Colossus.png<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fonts/
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Oxanium.ttf<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Exo.ttf<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;universe/<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ranks.xml<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;awards/<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;MyAwards.xml<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;AuriganAwards.xml<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;mmconf/<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;skins/<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;myskin.xml<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;.mml_tmp/<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Here be dragons!<BR>
 </P>

--- a/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CommonSettingsDialog.java
@@ -2111,10 +2111,10 @@ public class CommonSettingsDialog extends AbstractButtonDialog implements ItemLi
             skinFiles.removeAllItems();
             ArrayList<String> xmlFiles = new ArrayList<>(filteredFiles(Configuration.skinsDir(), ".xml"));
 
-            String userDirName = PreferenceManager.getClientPreferences().getUserDir();
-            File userDir = new File(userDirName);
-            if (!userDirName.isBlank() && userDir.isDirectory()) {
-                xmlFiles.addAll(filteredFilesWithSubDirs(userDir, ".xml"));
+            String userDir = PreferenceManager.getClientPreferences().getUserDir();
+            if (!userDir.isBlank()) {
+                File subDir = new File(userDir, Configuration.skinsDir().toString());
+                xmlFiles.addAll(filteredFilesWithSubDirs(subDir, ".xml"));
             }
 
             File internalUserDataDir = new File(Configuration.userdataDir(), Configuration.skinsDir().toString());

--- a/megamek/src/megamek/client/ui/swing/skinEditor/SkinSpecEditor.java
+++ b/megamek/src/megamek/client/ui/swing/skinEditor/SkinSpecEditor.java
@@ -209,10 +209,10 @@ public class SkinSpecEditor extends JPanel implements ListSelectionListener, Act
         currSkinCombo.removeAllItems();
         List<String> xmlFiles = new ArrayList<>(CommonSettingsDialog.filteredFiles(Configuration.skinsDir(), ".xml"));
 
-        String userDirName = PreferenceManager.getClientPreferences().getUserDir();
-        File userDir = new File(userDirName);
-        if (!userDirName.isBlank() && userDir.isDirectory()) {
-            xmlFiles.addAll(CommonSettingsDialog.filteredFilesWithSubDirs(userDir, ".xml"));
+        String userDir = PreferenceManager.getClientPreferences().getUserDir();
+        if (!userDir.isBlank()) {
+            File subDir = new File(userDir, Configuration.skinsDir().toString());
+            xmlFiles.addAll(CommonSettingsDialog.filteredFilesWithSubDirs(subDir, ".xml"));
         }
 
         xmlFiles.removeIf(file -> !SkinXMLHandler.validSkinSpecFile(file));
@@ -372,7 +372,7 @@ public class SkinSpecEditor extends JPanel implements ListSelectionListener, Act
 
     private String saveDialog() {
         String userDirName = PreferenceManager.getClientPreferences().getUserDir();
-        File userDir = new File(userDirName);
+        File userDir = new File(userDirName, Configuration.skinsDir().toString());
         String path;
         if (!userDirName.isBlank() && userDir.isDirectory()) {
             path = userDir.getPath();

--- a/megamek/src/megamek/client/ui/swing/tileset/MMStaticDirectoryManager.java
+++ b/megamek/src/megamek/client/ui/swing/tileset/MMStaticDirectoryManager.java
@@ -81,7 +81,7 @@ public class MMStaticDirectoryManager {
                         new ImageFileFactory());
 
                 String userDir = PreferenceManager.getClientPreferences().getUserDir();
-                File portraitUserDir = new File(userDir + "/" + Configuration.portraitImagesDir());
+                File portraitUserDir = new File(userDir, Configuration.portraitImagesDir().toString());
                 if (!userDir.isBlank() && portraitUserDir.isDirectory()) {
                     DirectoryItems userDirPortraits = new DirectoryItems(portraitUserDir, new ImageFileFactory());
                     portraitDirectory.merge(userDirPortraits);
@@ -123,7 +123,7 @@ public class MMStaticDirectoryManager {
                         new ScaledImageFileFactory());
 
                 String userDir = PreferenceManager.getClientPreferences().getUserDir();
-                File camoUserDir = new File(userDir + "/" + Configuration.camoDir());
+                File camoUserDir = new File(userDir, Configuration.camoDir().toString());
                 if (!userDir.isBlank() && camoUserDir.isDirectory()) {
                     DirectoryItems userDirCamo = new DirectoryItems(camoUserDir, new ScaledImageFileFactory());
                     camouflageDirectory.merge(userDirCamo);

--- a/megamek/src/megamek/client/ui/swing/util/FontHandler.java
+++ b/megamek/src/megamek/client/ui/swing/util/FontHandler.java
@@ -20,6 +20,7 @@ package megamek.client.ui.swing.util;
 
 import megamek.MMConstants;
 import megamek.client.ui.swing.CommonSettingsDialog;
+import megamek.common.Configuration;
 import megamek.common.preference.PreferenceManager;
 import megamek.logging.MMLogger;
 
@@ -116,8 +117,9 @@ public final class FontHandler {
 
         String userDir = PreferenceManager.getClientPreferences().getUserDir();
         if (!userDir.isBlank()) {
-            logger.info("Loading fonts from {}", userDir);
-            parseFontsInDirectory(userDir);
+            File subDir = new File(userDir, Configuration.fontsDir().toString());
+            logger.info("Loading fonts from {}", subDir);
+            parseFontsInDirectory(subDir);
         }
 
         logger.info("Loading fonts from Java's GraphicsEnvironment");

--- a/megamek/src/megamek/common/MekSummaryCache.java
+++ b/megamek/src/megamek/common/MekSummaryCache.java
@@ -265,7 +265,7 @@ public class MekSummaryCache {
 
             // load units from the external user data dir
             String userDir = PreferenceManager.getClientPreferences().getUserDir();
-            File userDataUnits2 = new File(userDir, "");
+            File userDataUnits2 = new File(userDir, Configuration.unitsDir().toString());
             if (!userDir.isBlank() && userDataUnits2.isDirectory()) {
                 bNeedsUpdate |= loadMeksFromDirectory(vMeks, sKnownFiles, lLastCheck, userDataUnits2, false);
             }

--- a/megamek/src/megamek/common/preference/ClientPreferences.java
+++ b/megamek/src/megamek/common/preference/ClientPreferences.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.PrintWriter;
 import java.util.Locale;
+import java.util.Objects;
 
 public class ClientPreferences extends PreferenceStoreProxy {
     private static final MMLogger logger = MMLogger.create(ClientPreferences.class);
@@ -464,6 +465,7 @@ public class ClientPreferences extends PreferenceStoreProxy {
     }
 
     public void setUserDir(String userDir) {
+        userDir = Objects.requireNonNullElse(userDir, "");
         // remove directory separators at the end
         while (!userDir.isBlank() && (userDir.endsWith("/") || userDir.endsWith("\\"))) {
             userDir = userDir.substring(0, userDir.length() - 1);


### PR DESCRIPTION
This was requested by Hammer a while ago: loading content from the userdir now requires it to be placed in the same folder structure that is used internally even for those files where it wouldnt technically be necessary like .mtf or .ttf. Units must now be somewhere in userdir/data/mekfiles etc. 