### PR TITLE
Update Mackie MSK-6S introduction date

### DIFF
--- a/megamek/data/mekfiles/meks/3075/Mackie MSK-6S.mtf
+++ b/megamek/data/mekfiles/meks/3075/Mackie MSK-6S.mtf
@@ -3,7 +3,7 @@ model:MSK-6S
 mul id:1973
 Config:Biped
 techbase:Inner Sphere
-era:2439
+era:2443
 source:TRO: 3075
 rules level:4
 role:Juggernaut


### PR DESCRIPTION
MUL lists intro date as 2443

http://masterunitlist.info/Unit/Details/1973/mackie-msk-6s

<img width="771" alt="Screenshot 2025-03-06 at 8 23 30 AM" src="https://github.com/user-attachments/assets/c7ff23e3-6af1-46bc-9be0-c7f8cdb6b2dc" />

