### PR TITLE
MM-side fix for MHQ 6373: Prevent impossible Counter-Battery Fire shots from being taken

### DIFF
--- a/megamek/src/megamek/client/ui/swing/OffBoardTargetOverlay.java
+++ b/megamek/src/megamek/client/ui/swing/OffBoardTargetOverlay.java
@@ -349,7 +349,14 @@ public class OffBoardTargetOverlay implements IDisplayable {
                 targetingPhaseDisplay.ce().getEquipmentNum(clientgui.getBoardView().getSelectedArtilleryWeapon()),
                 clientgui.getClient().getGame());
 
-            targetingPhaseDisplay.updateDisplayForPendingAttack(clientgui.getBoardView().getSelectedArtilleryWeapon(), waa);
+            // Only add if chance of success.
+            // TODO: properly display any toHit "IMPOSSIBLE" reasons
+            if (!waa.toHit(getCurrentGame(), true).cannotSucceed()) {
+                targetingPhaseDisplay.updateDisplayForPendingAttack(
+                      clientgui.getBoardView().getSelectedArtilleryWeapon(),
+                      waa
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
Per MegaMek/mekhq#6373, MegaMek will allow impossible Counter-Battery Fire shots to be initiated by players, causing them to lose that ammo to no purpose.

The specific cause in this case was that Player and OpFor off-board artillery both deployed into the same map board in the same direction, meaning that they essentially occupied the same hexes and were at 0 range from each other.  This is, of course, impossible.  Or in the case of the toHit data that the game uses to determine if an attack can even be evaluated, "IMPOSSIBLE".

Currently we don't check for any to-hit restrictions before creating the CBF WeaponAttackAction and adding it to the queue.  This appears to be for the sake of speed; making users click the CBF arrow, then click the "Fire" button, would slow down this phase so we just auto-fire the WAA when the arrow is clicked.

In the future, we would probably like to display the reason that a given CBF shot is impossible, but this will require a fair bit of refactoring.

Testing:
- Tested that the new code prevents wasteful impossible CBF shots from being registered.
- Ran all 3 projects' unit tests.

NOTE: this PR can be merged independently of any MHQ work for this issue.