### PR TITLE
Fixed Missing Prone Modifier in Weapon Attack Calculation

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -13,7 +13,13 @@
  */
 package megamek.common.actions;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Vector;
 
 import megamek.MMConstants;
 import megamek.client.Client;
@@ -67,13 +73,11 @@ public class WeaponAttackAction extends AbstractAttackAction {
     private boolean swarmingMissiles;
     protected int launchVelocity = DEFAULT_VELOCITY;
     /**
-     * Keeps track of the ID of the current primary target for a swarm missile
-     * attack.
+     * Keeps track of the ID of the current primary target for a swarm missile attack.
      */
     private int oldTargetId = UNASSIGNED;
     /**
-     * Keeps track of the Targetable type for the current primary target for a
-     * swarm missile attack.
+     * Keeps track of the Targetable type for the current primary target for a swarm missile attack.
      */
     private int oldTargetType;
 
@@ -83,8 +87,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
     private int originalTargetId = Entity.NONE;
 
     /**
-     * Keeps track of the type of the original target for a swarm missile
-     * attack.
+     * Keeps track of the type of the original target for a swarm missile attack.
      */
     private int originalTargetType;
 
@@ -98,29 +101,25 @@ public class WeaponAttackAction extends AbstractAttackAction {
     private transient List<WeaponMounted> vCounterEquipment;
 
     /**
-     * Boolean flag that determines whether or not this attack is part of a
-     * strafing run.
+     * Boolean flag that determines whether or not this attack is part of a strafing run.
      */
     private boolean isStrafing = false;
 
     /**
-     * Boolean flag that determines if this shot was the first one by a
-     * particular weapon in a strafing run. Used to ensure that heat is only
-     * added once.
+     * Boolean flag that determines if this shot was the first one by a particular weapon in a strafing run. Used to
+     * ensure that heat is only added once.
      */
     protected boolean isStrafingFirstShot = false;
 
     /**
-     * Boolean flag that determines if this shot was fired as part of a
-     * pointblank shot from a hidden unit. In this case, to-hit numbers should
-     * not be modified for terrain or movement. See TW pg 260
+     * Boolean flag that determines if this shot was fired as part of a pointblank shot from a hidden unit. In this
+     * case, to-hit numbers should not be modified for terrain or movement. See TW pg 260
      */
     protected boolean isPointblankShot = false;
 
     /**
-     * Boolean flag that determines if this shot was fired using homing ammunition.
-     * Can be checked to allow casting of attack handlers to the proper homing
-     * handler.
+     * Boolean flag that determines if this shot was fired using homing ammunition. Can be checked to allow casting of
+     * attack handlers to the proper homing handler.
      */
     protected boolean isHomingShot = false;
 
@@ -208,8 +207,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
     }
 
     /**
-     * Sets the entity id of the ammo carrier for this shot, if different than the
-     * firing entity
+     * Sets the entity id of the ammo carrier for this shot, if different than the firing entity
      *
      * @param entityId
      */
@@ -278,82 +276,155 @@ public class WeaponAttackAction extends AbstractAttackAction {
     }
 
     public ToHitData toHit(Game game) {
-        return toHit(game, getEntityId(), game.getTarget(getTargetType(), getTargetId()),
-                getWeaponId(), getAimedLocation(), getAimingMode(), nemesisConfused, swarmingMissiles,
-                game.getTarget(getOldTargetType(), getOldTargetId()),
-                game.getTarget(getOriginalTargetType(), getOriginalTargetId()), isStrafing(), isPointblankShot(),
-                UNASSIGNED, UNASSIGNED);
+        return toHit(game,
+              getEntityId(),
+              game.getTarget(getTargetType(), getTargetId()),
+              getWeaponId(),
+              getAimedLocation(),
+              getAimingMode(),
+              nemesisConfused,
+              swarmingMissiles,
+              game.getTarget(getOldTargetType(), getOldTargetId()),
+              game.getTarget(getOriginalTargetType(), getOriginalTargetId()),
+              isStrafing(),
+              isPointblankShot(),
+              UNASSIGNED,
+              UNASSIGNED);
     }
 
     /**
-     *
      * @param game
-     * @param evenIfAlreadyFired false: an already fired weapon will return a
-     *                           ToHitData with value IMPOSSIBLE
-     *                           true: an already fired weapon will return a
-     *                           ToHitData with the value of its chance to hit
+     * @param evenIfAlreadyFired false: an already fired weapon will return a ToHitData with value IMPOSSIBLE true: an
+     *                           already fired weapon will return a ToHitData with the value of its chance to hit
      */
     public ToHitData toHit(Game game, boolean evenIfAlreadyFired) {
-        return toHit(game, getEntityId(), game.getTarget(getTargetType(), getTargetId()),
-                getWeaponId(), getAimedLocation(), getAimingMode(), nemesisConfused, swarmingMissiles,
-                game.getTarget(getOldTargetType(), getOldTargetId()),
-                game.getTarget(getOriginalTargetType(), getOriginalTargetId()), isStrafing(), isPointblankShot(),
-                evenIfAlreadyFired, ammoId, ammoCarrier);
+        return toHit(game,
+              getEntityId(),
+              game.getTarget(getTargetType(), getTargetId()),
+              getWeaponId(),
+              getAimedLocation(),
+              getAimingMode(),
+              nemesisConfused,
+              swarmingMissiles,
+              game.getTarget(getOldTargetType(), getOldTargetId()),
+              game.getTarget(getOriginalTargetType(), getOriginalTargetId()),
+              isStrafing(),
+              isPointblankShot(),
+              evenIfAlreadyFired,
+              ammoId,
+              ammoCarrier);
     }
 
     public ToHitData toHit(Game game, List<ECMInfo> allECMInfo) {
-        return toHitCalc(game, getEntityId(), game.getTarget(getTargetType(), getTargetId()),
-                getWeaponId(), getAimedLocation(), getAimingMode(), nemesisConfused, swarmingMissiles,
-                game.getTarget(getOldTargetType(), getOldTargetId()),
-                game.getTarget(getOriginalTargetType(), getOriginalTargetId()), isStrafing(), isPointblankShot(),
-                allECMInfo, false, ammoId, ammoCarrier);
+        return toHitCalc(game,
+              getEntityId(),
+              game.getTarget(getTargetType(), getTargetId()),
+              getWeaponId(),
+              getAimedLocation(),
+              getAimingMode(),
+              nemesisConfused,
+              swarmingMissiles,
+              game.getTarget(getOldTargetType(), getOldTargetId()),
+              game.getTarget(getOriginalTargetType(), getOriginalTargetId()),
+              isStrafing(),
+              isPointblankShot(),
+              allECMInfo,
+              false,
+              ammoId,
+              ammoCarrier);
     }
 
     public static ToHitData toHit(Game game, int attackerId, Targetable target, int weaponId, boolean isStrafing) {
         // Use -1 as ammoId because this method should always use the currently linked
         // ammo for display calcs
-        return toHit(game, attackerId, target, weaponId, Entity.LOC_NONE, AimingMode.NONE,
-                false, false, null, null, isStrafing,
-                false, UNASSIGNED, UNASSIGNED);
+        return toHit(game,
+              attackerId,
+              target,
+              weaponId,
+              Entity.LOC_NONE,
+              AimingMode.NONE,
+              false,
+              false,
+              null,
+              null,
+              isStrafing,
+              false,
+              UNASSIGNED,
+              UNASSIGNED);
     }
 
-    public static ToHitData toHit(Game game, int attackerId, Targetable target, int weaponId,
-            int aimingAt, AimingMode aimingMode, boolean isStrafing) {
+    public static ToHitData toHit(Game game, int attackerId, Targetable target, int weaponId, int aimingAt,
+                                  AimingMode aimingMode, boolean isStrafing) {
         // Use -1 as ammoId because this method should always use the currently linked
         // ammo for display calcs
-        return toHit(game, attackerId, target, weaponId, aimingAt, aimingMode, false,
-                false, null, null, isStrafing, false, UNASSIGNED, UNASSIGNED);
+        return toHit(game,
+              attackerId,
+              target,
+              weaponId,
+              aimingAt,
+              aimingMode,
+              false,
+              false,
+              null,
+              null,
+              isStrafing,
+              false,
+              UNASSIGNED,
+              UNASSIGNED);
     }
 
-    public static ToHitData toHit(Game game, int attackerId, Targetable target, int weaponId,
-            int aimingAt, AimingMode aimingMode, boolean isNemesisConfused,
-            boolean exchangeSwarmTarget, Targetable oldTarget,
-            Targetable originalTarget, boolean isStrafing, boolean isPointblankShot,
-            int ammoId, int ammoCarrier) {
-        return toHitCalc(game, attackerId, target, weaponId, aimingAt, aimingMode, isNemesisConfused,
-                exchangeSwarmTarget, oldTarget, originalTarget, isStrafing, isPointblankShot, null,
-                false, ammoId, ammoCarrier);
+    public static ToHitData toHit(Game game, int attackerId, Targetable target, int weaponId, int aimingAt,
+                                  AimingMode aimingMode, boolean isNemesisConfused, boolean exchangeSwarmTarget,
+                                  Targetable oldTarget, Targetable originalTarget, boolean isStrafing,
+                                  boolean isPointblankShot, int ammoId, int ammoCarrier) {
+        return toHitCalc(game,
+              attackerId,
+              target,
+              weaponId,
+              aimingAt,
+              aimingMode,
+              isNemesisConfused,
+              exchangeSwarmTarget,
+              oldTarget,
+              originalTarget,
+              isStrafing,
+              isPointblankShot,
+              null,
+              false,
+              ammoId,
+              ammoCarrier);
     }
 
-    public static ToHitData toHit(Game game, int attackerId, Targetable target, int weaponId,
-            int aimingAt, AimingMode aimingMode, boolean isNemesisConfused,
-            boolean exchangeSwarmTarget, Targetable oldTarget,
-            Targetable originalTarget, boolean isStrafing, boolean isPointblankShot,
-            boolean evenIfAlreadyFired, int ammoId, int ammoCarrier) {
-        return toHitCalc(game, attackerId, target, weaponId, aimingAt, aimingMode, isNemesisConfused,
-                exchangeSwarmTarget, oldTarget, originalTarget, isStrafing, isPointblankShot, null,
-                evenIfAlreadyFired, ammoId, ammoCarrier);
+    public static ToHitData toHit(Game game, int attackerId, Targetable target, int weaponId, int aimingAt,
+                                  AimingMode aimingMode, boolean isNemesisConfused, boolean exchangeSwarmTarget,
+                                  Targetable oldTarget, Targetable originalTarget, boolean isStrafing,
+                                  boolean isPointblankShot, boolean evenIfAlreadyFired, int ammoId, int ammoCarrier) {
+        return toHitCalc(game,
+              attackerId,
+              target,
+              weaponId,
+              aimingAt,
+              aimingMode,
+              isNemesisConfused,
+              exchangeSwarmTarget,
+              oldTarget,
+              originalTarget,
+              isStrafing,
+              isPointblankShot,
+              null,
+              evenIfAlreadyFired,
+              ammoId,
+              ammoCarrier);
     }
 
     /**
      * To-hit number for attacker firing a weapon at the target.
      */
-    private static ToHitData toHitCalc(Game game, int attackerId, Targetable target, int weaponId,
-            int aimingAt, AimingMode aimingMode, boolean isNemesisConfused,
-            boolean exchangeSwarmTarget, Targetable oldTarget,
-            Targetable originalTarget, boolean isStrafing,
-            boolean isPointblankShot, List<ECMInfo> allECMInfo, boolean evenIfAlreadyFired,
-            int ammoId, int ammoCarrier) {
+    private static ToHitData toHitCalc(Game game, int attackerId, Targetable target, int weaponId, int aimingAt,
+                                       AimingMode aimingMode, boolean isNemesisConfused, boolean exchangeSwarmTarget,
+                                       Targetable oldTarget, Targetable originalTarget, boolean isStrafing,
+                                       boolean isPointblankShot, List<ECMInfo> allECMInfo, boolean evenIfAlreadyFired,
+                                       int ammoId, int ammoCarrier) {
         final Entity ae = game.getEntity(attackerId);
         final WeaponMounted weapon = (WeaponMounted) ae.getEquipment(weaponId);
         final AmmoMounted linkedAmmo;
@@ -414,54 +485,58 @@ public class WeaponAttackAction extends AbstractAttackAction {
             bMekTankStealthActive = ae.isStealthActive();
         }
 
-        boolean isFlakAttack = !game.getBoard().inSpace() && (te != null)
-                && Compute.isFlakAttack(ae, te)
-                && (wtype instanceof CLBALBX
-                        || ((atype != null)
-                                && ((((atype.getAmmoType() == AmmoType.T_AC_LBX)
-                                        || (atype.getAmmoType() == AmmoType.T_AC_LBX_THB)
-                                        || (atype.getAmmoType() == AmmoType.T_SBGAUSS))
-                                        && (munition.contains(AmmoType.Munitions.M_CLUSTER)))
-                                        || munition.contains(AmmoType.Munitions.M_FLAK)
-                                        || (atype.getAmmoType() == AmmoType.T_HAG)
-                                        || atype.countsAsFlak())));
+        boolean isFlakAttack = !game.getBoard().inSpace() &&
+                                     (te != null) &&
+                                     Compute.isFlakAttack(ae, te) &&
+                                     (wtype instanceof CLBALBX ||
+                                            ((atype != null) &&
+                                                   ((((atype.getAmmoType() == AmmoType.T_AC_LBX) ||
+                                                            (atype.getAmmoType() == AmmoType.T_AC_LBX_THB) ||
+                                                            (atype.getAmmoType() == AmmoType.T_SBGAUSS)) &&
+                                                           (munition.contains(AmmoType.Munitions.M_CLUSTER))) ||
+                                                          munition.contains(AmmoType.Munitions.M_FLAK) ||
+                                                          (atype.getAmmoType() == AmmoType.T_HAG) ||
+                                                          atype.countsAsFlak())));
 
         boolean isIndirect = weapon.hasModes() && (weapon.curMode().isIndirect());
 
         // BMM p. 31, semi-guided indirect missile attacks vs tagged targets ignore
         // terrain modifiers
         boolean semiGuidedIndirectVsTaggedTarget = isIndirect &&
-                (atype != null) && atype.getMunitionType().contains(AmmoType.Munitions.M_SEMIGUIDED) &&
-                Compute.isTargetTagged(target, game);
+                                                         (atype != null) &&
+                                                         atype.getMunitionType()
+                                                               .contains(AmmoType.Munitions.M_SEMIGUIDED) &&
+                                                         Compute.isTargetTagged(target, game);
 
-        boolean isInferno = ((atype != null)
-                && ((atype.getAmmoType() == AmmoType.T_SRM)
-                        || (atype.getAmmoType() == AmmoType.T_SRM_IMP)
-                        || (atype.getAmmoType() == AmmoType.T_MML))
-                && (atype.getMunitionType().contains(AmmoType.Munitions.M_INFERNO))
-                || (isWeaponInfantry && (wtype.hasFlag(WeaponType.F_INFERNO))));
+        boolean isInferno = ((atype != null) &&
+                                   ((atype.getAmmoType() == AmmoType.T_SRM) ||
+                                          (atype.getAmmoType() == AmmoType.T_SRM_IMP) ||
+                                          (atype.getAmmoType() == AmmoType.T_MML)) &&
+                                   (atype.getMunitionType().contains(AmmoType.Munitions.M_INFERNO)) ||
+                                   (isWeaponInfantry && (wtype.hasFlag(WeaponType.F_INFERNO))));
 
         boolean isArtilleryDirect = (wtype.hasFlag(WeaponType.F_ARTILLERY) ||
-                (wtype instanceof CapitalMissileWeapon
-                        && Compute.isGroundToGround(ae, target)))
-                && game.getPhase().isFiring();
+                                           (wtype instanceof CapitalMissileWeapon &&
+                                                  Compute.isGroundToGround(ae, target))) && game.getPhase().isFiring();
 
         boolean isArtilleryIndirect = (wtype.hasFlag(WeaponType.F_ARTILLERY) ||
-                (wtype instanceof CapitalMissileWeapon
-                        && Compute.isGroundToGround(ae, target)))
-                && (game.getPhase().isTargeting() || game.getPhase().isOffboard());
+                                             (wtype instanceof CapitalMissileWeapon &&
+                                                    Compute.isGroundToGround(ae, target))) &&
+                                            (game.getPhase().isTargeting() || game.getPhase().isOffboard());
 
-        boolean isBearingsOnlyMissile = (weapon.isInBearingsOnlyMode())
-                && (game.getPhase().isTargeting() || game.getPhase().isFiring());
+        boolean isBearingsOnlyMissile = (weapon.isInBearingsOnlyMode()) &&
+                                              (game.getPhase().isTargeting() || game.getPhase().isFiring());
 
-        boolean isCruiseMissile = (weapon.getType().hasFlag(WeaponType.F_CRUISE_MISSILE)
-                || (wtype instanceof CapitalMissileWeapon
-                        && Compute.isGroundToGround(ae, target)));
+        boolean isCruiseMissile = (weapon.getType().hasFlag(WeaponType.F_CRUISE_MISSILE) ||
+                                         (wtype instanceof CapitalMissileWeapon &&
+                                                Compute.isGroundToGround(ae, target)));
 
         // hack, otherwise when actually resolves shot labeled impossible.
-        boolean isArtilleryFLAK = isArtilleryDirect && (te != null)
-                && Compute.isFlakAttack(ae, te)
-                && (atype != null) && (usesAmmo && (atype.countsAsFlak()));
+        boolean isArtilleryFLAK = isArtilleryDirect &&
+                                        (te != null) &&
+                                        Compute.isFlakAttack(ae, te) &&
+                                        (atype != null) &&
+                                        (usesAmmo && (atype.countsAsFlak()));
 
         boolean isHaywireINarced = ae.isINarcedWith(INarcPod.HAYWIRE);
 
@@ -471,8 +546,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
         boolean isECMAffected = ComputeECM.isAffectedByECM(ae, ae.getPosition(), target.getPosition(), allECMInfo);
 
         // for attacks where only ECM on the target hex makes a difference
-        boolean isTargetECMAffected = ComputeECM.isAffectedByECM(ae, target.getPosition(), target.getPosition(),
-                allECMInfo);
+        boolean isTargetECMAffected = ComputeECM.isAffectedByECM(ae,
+              target.getPosition(),
+              target.getPosition(),
+              allECMInfo);
 
         boolean isTAG = wtype.hasFlag(WeaponType.F_TAG);
 
@@ -480,31 +557,42 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // direct/indirect (BMRr p77 on board arrow IV)
         boolean isHoming = ammo != null && ammo.isHomingAmmoInHomingMode();
 
-        boolean bHeatSeeking = (atype != null)
-                && ((atype.getAmmoType() == AmmoType.T_SRM)
-                        || (atype.getAmmoType() == AmmoType.T_SRM_IMP)
-                        || (atype.getAmmoType() == AmmoType.T_MML)
-                        || (atype.getAmmoType() == AmmoType.T_LRM)
-                        || (atype.getAmmoType() == AmmoType.T_LRM_IMP))
-                && (munition.contains(AmmoType.Munitions.M_HEAT_SEEKING));
+        boolean bHeatSeeking = (atype != null) &&
+                                     ((atype.getAmmoType() == AmmoType.T_SRM) ||
+                                            (atype.getAmmoType() == AmmoType.T_SRM_IMP) ||
+                                            (atype.getAmmoType() == AmmoType.T_MML) ||
+                                            (atype.getAmmoType() == AmmoType.T_LRM) ||
+                                            (atype.getAmmoType() == AmmoType.T_LRM_IMP)) &&
+                                     (munition.contains(AmmoType.Munitions.M_HEAT_SEEKING));
 
-        boolean bFTL = (atype != null)
-                && ((atype.getAmmoType() == AmmoType.T_MML)
-                        || (atype.getAmmoType() == AmmoType.T_LRM)
-                        || (atype.getAmmoType() == AmmoType.T_LRM_IMP))
-                && (munition.contains(AmmoType.Munitions.M_FOLLOW_THE_LEADER)
-                        && !ComputeECM.isAffectedByECM(ae, ae.getPosition(), target.getPosition()));
+        boolean bFTL = (atype != null) &&
+                             ((atype.getAmmoType() == AmmoType.T_MML) ||
+                                    (atype.getAmmoType() == AmmoType.T_LRM) ||
+                                    (atype.getAmmoType() == AmmoType.T_LRM_IMP)) &&
+                             (munition.contains(AmmoType.Munitions.M_FOLLOW_THE_LEADER) &&
+                                    !ComputeECM.isAffectedByECM(ae, ae.getPosition(), target.getPosition()));
 
         Mounted<?> mLinker = weapon.getLinkedBy();
 
-        boolean bApollo = ((mLinker != null) && (mLinker.getType() instanceof MiscType) && !mLinker.isDestroyed()
-                && !mLinker.isMissing() && !mLinker.isBreached() && mLinker.getType().hasFlag(MiscType.F_APOLLO))
-                && (atype != null) && (atype.getAmmoType() == AmmoType.T_MRM);
+        boolean bApollo = ((mLinker != null) &&
+                                 (mLinker.getType() instanceof MiscType) &&
+                                 !mLinker.isDestroyed() &&
+                                 !mLinker.isMissing() &&
+                                 !mLinker.isBreached() &&
+                                 mLinker.getType().hasFlag(MiscType.F_APOLLO)) &&
+                                (atype != null) &&
+                                (atype.getAmmoType() == AmmoType.T_MRM);
 
-        boolean bArtemisV = ((mLinker != null) && (mLinker.getType() instanceof MiscType) && !mLinker.isDestroyed()
-                && !mLinker.isMissing() && !mLinker.isBreached() && mLinker.getType().hasFlag(MiscType.F_ARTEMIS_V)
-                && !isECMAffected && !bMekTankStealthActive && (atype != null)
-                && (munition.contains(AmmoType.Munitions.M_ARTEMIS_V_CAPABLE)));
+        boolean bArtemisV = ((mLinker != null) &&
+                                   (mLinker.getType() instanceof MiscType) &&
+                                   !mLinker.isDestroyed() &&
+                                   !mLinker.isMissing() &&
+                                   !mLinker.isBreached() &&
+                                   mLinker.getType().hasFlag(MiscType.F_ARTEMIS_V) &&
+                                   !isECMAffected &&
+                                   !bMekTankStealthActive &&
+                                   (atype != null) &&
+                                   (munition.contains(AmmoType.Munitions.M_ARTEMIS_V_CAPABLE)));
 
         if (ae.usesWeaponBays()) {
             for (WeaponMounted bayW : weapon.getBayWeapons()) {
@@ -528,17 +616,26 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 }
 
                 mLinker = bayW.getLinkedBy();
-                bApollo = ((mLinker != null) && (mLinker.getType() instanceof MiscType) && !mLinker.isDestroyed()
-                        && !mLinker.isMissing() && !mLinker.isBreached()
-                        && mLinker.getType().hasFlag(MiscType.F_APOLLO))
-                        && (bAmmo != null) && (bAmmo.getAmmoType() == AmmoType.T_MRM);
+                bApollo = ((mLinker != null) &&
+                                 (mLinker.getType() instanceof MiscType) &&
+                                 !mLinker.isDestroyed() &&
+                                 !mLinker.isMissing() &&
+                                 !mLinker.isBreached() &&
+                                 mLinker.getType().hasFlag(MiscType.F_APOLLO)) &&
+                                (bAmmo != null) &&
+                                (bAmmo.getAmmoType() == AmmoType.T_MRM);
 
-                bArtemisV = ((mLinker != null) && (mLinker.getType() instanceof MiscType) && !mLinker.isDestroyed()
-                        && !mLinker.isMissing() && !mLinker.isBreached()
-                        && mLinker.getType().hasFlag(MiscType.F_ARTEMIS_V)
-                        && !isECMAffected && !bMekTankStealthActive && (atype != null)
-                        && (bAmmo != null)
-                        && (bAmmo.getMunitionType().contains(AmmoType.Munitions.M_ARTEMIS_V_CAPABLE)));
+                bArtemisV = ((mLinker != null) &&
+                                   (mLinker.getType() instanceof MiscType) &&
+                                   !mLinker.isDestroyed() &&
+                                   !mLinker.isMissing() &&
+                                   !mLinker.isBreached() &&
+                                   mLinker.getType().hasFlag(MiscType.F_ARTEMIS_V) &&
+                                   !isECMAffected &&
+                                   !bMekTankStealthActive &&
+                                   (atype != null) &&
+                                   (bAmmo != null) &&
+                                   (bAmmo.getMunitionType().contains(AmmoType.Munitions.M_ARTEMIS_V_CAPABLE)));
             }
         }
 
@@ -559,18 +656,21 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // TODO: assuming that torpedoes are underwater attacks even if fired
         // from surface vessel, awaiting rules clarification
         // http://www.classicbattletech.com/forums/index.php/topic,48744.0.html
-        boolean underWater = (ae.getLocationStatus(weapon.getLocation()) == ILocationExposureStatus.WET)
-                || (wtype instanceof SRTWeapon) || (wtype instanceof LRTWeapon);
+        boolean underWater = (ae.getLocationStatus(weapon.getLocation()) == ILocationExposureStatus.WET) ||
+                                   (wtype instanceof SRTWeapon) ||
+                                   (wtype instanceof LRTWeapon);
 
         if (te != null) {
-            if (!isTargetECMAffected && te.isINarcedBy(ae.getOwner().getTeam()) && (atype != null)
-                    && ((atype.getAmmoType() == AmmoType.T_LRM)
-                            || (atype.getAmmoType() == AmmoType.T_LRM_IMP)
-                            || (atype.getAmmoType() == AmmoType.T_MML)
-                            || (atype.getAmmoType() == AmmoType.T_SRM)
-                            || (atype.getAmmoType() == AmmoType.T_SRM_IMP)
-                            || (atype.getAmmoType() == AmmoType.T_NLRM))
-                    && (munition.contains(AmmoType.Munitions.M_NARC_CAPABLE))) {
+            if (!isTargetECMAffected &&
+                      te.isINarcedBy(ae.getOwner().getTeam()) &&
+                      (atype != null) &&
+                      ((atype.getAmmoType() == AmmoType.T_LRM) ||
+                             (atype.getAmmoType() == AmmoType.T_LRM_IMP) ||
+                             (atype.getAmmoType() == AmmoType.T_MML) ||
+                             (atype.getAmmoType() == AmmoType.T_SRM) ||
+                             (atype.getAmmoType() == AmmoType.T_SRM_IMP) ||
+                             (atype.getAmmoType() == AmmoType.T_NLRM)) &&
+                      (munition.contains(AmmoType.Munitions.M_NARC_CAPABLE))) {
                 isINarcGuided = true;
             }
         }
@@ -582,21 +682,26 @@ public class WeaponAttackAction extends AbstractAttackAction {
         Entity spotter = null;
         boolean narcSpotter = false;
         if (isIndirect && !ae.hasAbility(OptionsConstants.GUNNERY_OBLIQUE_ATTACKER)) {
-            if ((target instanceof Entity) && !isTargetECMAffected && (te != null) && (atype != null) && usesAmmo
-                    && (munition.contains(AmmoType.Munitions.M_NARC_CAPABLE)
-                            && (te.isNarcedBy(ae.getOwner().getTeam()) || te.isINarcedBy(ae.getOwner().getTeam())))) {
+            if ((target instanceof Entity) &&
+                      !isTargetECMAffected &&
+                      (te != null) &&
+                      (atype != null) &&
+                      usesAmmo &&
+                      (munition.contains(AmmoType.Munitions.M_NARC_CAPABLE) &&
+                             (te.isNarcedBy(ae.getOwner().getTeam()) || te.isINarcedBy(ae.getOwner().getTeam())))) {
                 spotter = te;
                 narcSpotter = true;
             } else {
                 spotter = Compute.findSpotter(game, ae, target);
             }
-            if ((spotter == null) && (atype != null)
-                    && ((atype.getAmmoType() == AmmoType.T_LRM)
-                            || (atype.getAmmoType() == AmmoType.T_LRM_IMP)
-                            || (atype.getAmmoType() == AmmoType.T_MML)
-                            || (atype.getAmmoType() == AmmoType.T_NLRM)
-                            || (atype.getAmmoType() == AmmoType.T_MEK_MORTAR))
-                    && (munition.contains(AmmoType.Munitions.M_SEMIGUIDED))) {
+            if ((spotter == null) &&
+                      (atype != null) &&
+                      ((atype.getAmmoType() == AmmoType.T_LRM) ||
+                             (atype.getAmmoType() == AmmoType.T_LRM_IMP) ||
+                             (atype.getAmmoType() == AmmoType.T_MML) ||
+                             (atype.getAmmoType() == AmmoType.T_NLRM) ||
+                             (atype.getAmmoType() == AmmoType.T_MEK_MORTAR)) &&
+                      (munition.contains(AmmoType.Munitions.M_SEMIGUIDED))) {
                 for (TagInfo ti : game.getTagInfo()) {
                     if (target.getId() == ti.target.getId()) {
                         spotter = game.getEntity(ti.attackerId);
@@ -613,12 +718,12 @@ public class WeaponAttackAction extends AbstractAttackAction {
         int eistatus = 0;
 
         boolean mpMelevationHack = false;
-        if (usesAmmo
-                && ((wtype.getAmmoType() == AmmoType.T_LRM) || (wtype.getAmmoType() == AmmoType.T_LRM_IMP))
-                && (atype != null)
-                && (munition.contains(AmmoType.Munitions.M_MULTI_PURPOSE))
-                && (ae.getElevation() == -1)
-                && (ae.getLocationStatus(weapon.getLocation()) == ILocationExposureStatus.WET)) {
+        if (usesAmmo &&
+                  ((wtype.getAmmoType() == AmmoType.T_LRM) || (wtype.getAmmoType() == AmmoType.T_LRM_IMP)) &&
+                  (atype != null) &&
+                  (munition.contains(AmmoType.Munitions.M_MULTI_PURPOSE)) &&
+                  (ae.getElevation() == -1) &&
+                  (ae.getLocationStatus(weapon.getLocation()) == ILocationExposureStatus.WET)) {
             mpMelevationHack = true;
             // surface to fire
             ae.setElevation(0);
@@ -627,8 +732,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // check LOS (indirect LOS is from the spotter)
         LosEffects los;
         ToHitData losMods;
-        if (isIndirect && ae.hasAbility(OptionsConstants.GUNNERY_OBLIQUE_ATTACKER)
-                && !underWater) {
+        if (isIndirect && ae.hasAbility(OptionsConstants.GUNNERY_OBLIQUE_ATTACKER) && !underWater) {
             los = new LosEffects();
             losMods = new ToHitData();
         } else if (!isIndirect || (spotter == null)) {
@@ -638,11 +742,13 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 // Swarm should draw LoS between targets, not attacker, since
                 // we don't want LoS to be blocked
                 if (swarmPrimaryTarget.getTargetType() == Targetable.TYPE_ENTITY) {
-                    los = LosEffects.calculateLOS(game, game.getEntity(swarmPrimaryTarget.getId()),
-                            swarmSecondaryTarget);
+                    los = LosEffects.calculateLOS(game,
+                          game.getEntity(swarmPrimaryTarget.getId()),
+                          swarmSecondaryTarget);
                 } else {
-                    los = LosEffects.calculateLOS(game, game.getEntity(swarmSecondaryTarget.getId()),
-                            swarmPrimaryTarget);
+                    los = LosEffects.calculateLOS(game,
+                          game.getEntity(swarmSecondaryTarget.getId()),
+                          swarmPrimaryTarget);
                 }
             }
 
@@ -704,20 +810,53 @@ public class WeaponAttackAction extends AbstractAttackAction {
         ToHitData toHit = new ToHitData();
 
         // Check to see if this attack is impossible and return the reason code
-        String reasonImpossible = WeaponAttackAction.toHitIsImpossible(game, ae, attackerId, target, ttype, los,
-                losMods,
-                toHit, distance, spotter, wtype, weapon, weaponId, atype, ammo, munition,
-                isArtilleryDirect, isArtilleryFLAK, isArtilleryIndirect, isAttackerInfantry, isBearingsOnlyMissile,
-                isCruiseMissile, exchangeSwarmTarget, isHoming, isInferno, isIndirect, isStrafing, isTAG,
-                targetInBuilding, usesAmmo, underWater, evenIfAlreadyFired);
+        String reasonImpossible = WeaponAttackAction.toHitIsImpossible(game,
+              ae,
+              attackerId,
+              target,
+              ttype,
+              los,
+              losMods,
+              toHit,
+              distance,
+              spotter,
+              wtype,
+              weapon,
+              weaponId,
+              atype,
+              ammo,
+              munition,
+              isArtilleryDirect,
+              isArtilleryFLAK,
+              isArtilleryIndirect,
+              isAttackerInfantry,
+              isBearingsOnlyMissile,
+              isCruiseMissile,
+              exchangeSwarmTarget,
+              isHoming,
+              isInferno,
+              isIndirect,
+              isStrafing,
+              isTAG,
+              targetInBuilding,
+              usesAmmo,
+              underWater,
+              evenIfAlreadyFired);
         if (reasonImpossible != null) {
             return new ToHitData(TargetRoll.IMPOSSIBLE, reasonImpossible);
         }
 
         // Check to see if this attack is automatically successful and return the reason
         // code
-        String reasonAutoHit = WeaponAttackAction.toHitIsAutomatic(game, ae, target, ttype, los, distance,
-                wtype, weapon, isBearingsOnlyMissile);
+        String reasonAutoHit = WeaponAttackAction.toHitIsAutomatic(game,
+              ae,
+              target,
+              ttype,
+              los,
+              distance,
+              wtype,
+              weapon,
+              isBearingsOnlyMissile);
         if (reasonAutoHit != null) {
             return new ToHitData(TargetRoll.AUTOMATIC_SUCCESS, reasonAutoHit);
         }
@@ -754,16 +893,28 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 toHit = new ToHitData(ae.getCrew().getGunneryB(), Messages.getString("WeaponAttackAction.GunBSkill"));
             }
         }
-        if (wtype.hasFlag(WeaponType.F_ARTILLERY)
-                && game.getOptions().booleanOption(OptionsConstants.RPG_ARTILLERY_SKILL)) {
+        if (wtype.hasFlag(WeaponType.F_ARTILLERY) &&
+                  game.getOptions().booleanOption(OptionsConstants.RPG_ARTILLERY_SKILL)) {
             toHit = new ToHitData(ae.getCrew().getArtillery(), Messages.getString("WeaponAttackAction.ArtySkill"));
         }
 
         // Is this an Artillery attack?
         if (isArtilleryDirect || isArtilleryIndirect) {
-            toHit = handleArtilleryAttacks(game, ae, target, ttype, losMods, toHit, wtype, weapon, atype,
-                    isArtilleryDirect,
-                    isArtilleryFLAK, isArtilleryIndirect, isHoming, usesAmmo, srt);
+            toHit = handleArtilleryAttacks(game,
+                  ae,
+                  target,
+                  ttype,
+                  losMods,
+                  toHit,
+                  wtype,
+                  weapon,
+                  atype,
+                  isArtilleryDirect,
+                  isArtilleryFLAK,
+                  isArtilleryIndirect,
+                  isHoming,
+                  usesAmmo,
+                  srt);
         }
         if (srt.isSpecialResolution()) {
             return toHit;
@@ -796,15 +947,42 @@ public class WeaponAttackAction extends AbstractAttackAction {
         if (ae != null) {
             // Conventional fighter, Aerospace and fighter LAM attackers
             if (ae.isAero()) {
-                toHit = compileAeroAttackerToHitMods(game, ae, target, ttype, toHit, aimingAt, aimingMode, eistatus,
-                        wtype, weapon, atype, munition, isArtilleryIndirect, isFlakAttack, isNemesisConfused,
-                        isStrafing,
-                        usesAmmo);
+                toHit = compileAeroAttackerToHitMods(game,
+                      ae,
+                      target,
+                      ttype,
+                      toHit,
+                      aimingAt,
+                      aimingMode,
+                      eistatus,
+                      wtype,
+                      weapon,
+                      atype,
+                      munition,
+                      isArtilleryIndirect,
+                      isFlakAttack,
+                      isNemesisConfused,
+                      isStrafing,
+                      usesAmmo);
                 // Everyone else
             } else {
-                toHit = compileAttackerToHitMods(game, ae, target, los, toHit, aimingAt, aimingMode, wtype,
-                        weapon, weaponId, atype, munition, isFlakAttack, isHaywireINarced, isNemesisConfused,
-                        isWeaponFieldGuns, usesAmmo);
+                toHit = compileAttackerToHitMods(game,
+                      ae,
+                      target,
+                      los,
+                      toHit,
+                      aimingAt,
+                      aimingMode,
+                      wtype,
+                      weapon,
+                      weaponId,
+                      atype,
+                      munition,
+                      isFlakAttack,
+                      isHaywireINarced,
+                      isNemesisConfused,
+                      isWeaponFieldGuns,
+                      usesAmmo);
             }
         }
 
@@ -826,41 +1004,114 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // Collect the modifiers for the target's condition/actions
-        toHit = compileTargetToHitMods(game, ae, target, ttype, los, toHit, aimingAt, aimingMode, distance,
-                wtype, weapon, atype, munition, isArtilleryDirect, isArtilleryIndirect, isAttackerInfantry,
-                exchangeSwarmTarget, isIndirect, isPointblankShot, usesAmmo);
+        toHit = compileTargetToHitMods(game,
+              ae,
+              target,
+              ttype,
+              los,
+              toHit,
+              aimingAt,
+              aimingMode,
+              distance,
+              wtype,
+              weapon,
+              atype,
+              munition,
+              isArtilleryDirect,
+              isArtilleryIndirect,
+              isAttackerInfantry,
+              exchangeSwarmTarget,
+              isIndirect,
+              isPointblankShot,
+              usesAmmo);
 
         // Collect the modifiers for terrain and line-of-sight. This includes any
         // related to-hit table changes
-        toHit = compileTerrainAndLosToHitMods(game, ae, target, ttype, aElev, tElev, targEl, distance, los, toHit,
-                losMods, eistatus, wtype, weapon, weaponId, atype, ammo, munition, isAttackerInfantry,
-                inSameBuilding, isIndirect, isPointblankShot, underWater);
+        toHit = compileTerrainAndLosToHitMods(game,
+              ae,
+              target,
+              ttype,
+              aElev,
+              tElev,
+              targEl,
+              distance,
+              los,
+              toHit,
+              losMods,
+              eistatus,
+              wtype,
+              weapon,
+              weaponId,
+              atype,
+              ammo,
+              munition,
+              isAttackerInfantry,
+              inSameBuilding,
+              isIndirect,
+              isPointblankShot,
+              underWater);
 
         // If this is a swarm LRM secondary attack, remove old target movement and
         // terrain mods, then
         // add those for new target.
         if (exchangeSwarmTarget) {
-            toHit = handleSwarmSecondaryAttacks(game, ae, target, swarmPrimaryTarget, swarmSecondaryTarget, toHit,
-                eistatus, aimingAt, aimingMode, weapon, atype, munition, isECMAffected,
-                    inSameBuilding, underWater);
+            toHit = handleSwarmSecondaryAttacks(game,
+                  ae,
+                  target,
+                  swarmPrimaryTarget,
+                  swarmSecondaryTarget,
+                  toHit,
+                  eistatus,
+                  aimingAt,
+                  aimingMode,
+                  weapon,
+                  atype,
+                  munition,
+                  isECMAffected,
+                  inSameBuilding,
+                  underWater);
         }
 
         // Collect the modifiers specific to the weapon the attacker is using
-        toHit = compileWeaponToHitMods(game, ae, spotter, target, ttype, toHit, wtype, weapon, atype, ammo, munition,
-                isFlakAttack, isIndirect, narcSpotter);
+        toHit = compileWeaponToHitMods(game,
+              ae,
+              spotter,
+              target,
+              ttype,
+              toHit,
+              wtype,
+              weapon,
+              atype,
+              ammo,
+              munition,
+              isFlakAttack,
+              isIndirect,
+              narcSpotter);
 
         // Collect the modifiers specific to the ammo the attacker is using
-        toHit = compileAmmoToHitMods(game, ae, target, ttype, toHit, wtype, weapon, atype, munition, bApollo,
-                bArtemisV, bFTL, bHeatSeeking, isECMAffected, isINarcGuided);
+        toHit = compileAmmoToHitMods(game,
+              ae,
+              target,
+              ttype,
+              toHit,
+              wtype,
+              weapon,
+              atype,
+              munition,
+              bApollo,
+              bArtemisV,
+              bFTL,
+              bHeatSeeking,
+              isECMAffected,
+              isINarcGuided);
 
         // okay!
         return toHit;
     }
 
     /**
-     * To-hit number for attacker firing a generic weapon at the target. Does
-     * not factor in any special weapon or ammo considerations, including range
-     * modifiers. Also does not include gunnery skill.
+     * To-hit number for attacker firing a generic weapon at the target. Does not factor in any special weapon or ammo
+     * considerations, including range modifiers. Also does not include gunnery skill.
      *
      * @param game The current {@link Game}
      */
@@ -925,38 +1176,100 @@ public class WeaponAttackAction extends AbstractAttackAction {
         if (ae != null) {
             // Conventional fighter, Aerospace and fighter LAM attackers
             if (ae.isAero()) {
-                toHit = compileAeroAttackerToHitMods(game, ae, target, ttype, toHit, Entity.LOC_NONE,
-                        AimingMode.NONE, eistatus, null, null, null, EnumSet.of(AmmoType.Munitions.M_STANDARD),
-                        false, false, false, false, false);
+                toHit = compileAeroAttackerToHitMods(game,
+                      ae,
+                      target,
+                      ttype,
+                      toHit,
+                      Entity.LOC_NONE,
+                      AimingMode.NONE,
+                      eistatus,
+                      null,
+                      null,
+                      null,
+                      EnumSet.of(AmmoType.Munitions.M_STANDARD),
+                      false,
+                      false,
+                      false,
+                      false,
+                      false);
                 // Everyone else
             } else {
-                toHit = compileAttackerToHitMods(game, ae, target, los, toHit, Entity.LOC_NONE,
-                        AimingMode.NONE, null, null, weaponId, null, EnumSet.of(AmmoType.Munitions.M_STANDARD),
-                        false, false, false, false, false);
+                toHit = compileAttackerToHitMods(game,
+                      ae,
+                      target,
+                      los,
+                      toHit,
+                      Entity.LOC_NONE,
+                      AimingMode.NONE,
+                      null,
+                      null,
+                      weaponId,
+                      null,
+                      EnumSet.of(AmmoType.Munitions.M_STANDARD),
+                      false,
+                      false,
+                      false,
+                      false,
+                      false);
             }
         }
 
         // Collect the modifiers for the target's condition/actions
-        toHit = compileTargetToHitMods(game, ae, target, ttype, los, toHit, Entity.LOC_NONE,
-                AimingMode.NONE, distance, null, null, null, EnumSet.of(AmmoType.Munitions.M_STANDARD),
-                false, false, isAttackerInfantry, false,
-                false, false, false);
+        toHit = compileTargetToHitMods(game,
+              ae,
+              target,
+              ttype,
+              los,
+              toHit,
+              Entity.LOC_NONE,
+              AimingMode.NONE,
+              distance,
+              null,
+              null,
+              null,
+              EnumSet.of(AmmoType.Munitions.M_STANDARD),
+              false,
+              false,
+              isAttackerInfantry,
+              false,
+              false,
+              false,
+              false);
 
         // Collect the modifiers for terrain and line-of-sight. This includes any
         // related to-hit table changes
-        toHit = compileTerrainAndLosToHitMods(game, ae, target, ttype, aElev, tElev, targEl, distance, los, toHit,
-                losMods, eistatus, null, null, weaponId, null, null,
-                EnumSet.of(AmmoType.Munitions.M_STANDARD), isAttackerInfantry,
-                inSameBuilding, false, false, false);
+        toHit = compileTerrainAndLosToHitMods(game,
+              ae,
+              target,
+              ttype,
+              aElev,
+              tElev,
+              targEl,
+              distance,
+              los,
+              toHit,
+              losMods,
+              eistatus,
+              null,
+              null,
+              weaponId,
+              null,
+              null,
+              EnumSet.of(AmmoType.Munitions.M_STANDARD),
+              isAttackerInfantry,
+              inSameBuilding,
+              false,
+              false,
+              false);
 
         // okay!
         return toHit;
     }
 
     /**
-     * Method that tests each attack to see if it's impossible.
-     * If so, a reason string will be returned. A null return means we can continue
-     * processing the attack
+     * Method that tests each attack to see if it's impossible. If so, a reason string will be returned. A null return
+     * means we can continue processing the attack
      *
      * @param game                  The current {@link Game}
      * @param ae                    The Entity making this attack
@@ -964,60 +1277,43 @@ public class WeaponAttackAction extends AbstractAttackAction {
      * @param target                The Targetable object being attacked
      * @param ttype                 The targetable object type
      * @param los                   The calculated LOS between attacker and target
-     * @param losMods               ToHitData calculated from the spotter for
-     *                              indirect fire scenarios
-     * @param toHit                 The running total ToHitData for this
-     *                              WeaponAttackAction
-     *
+     * @param losMods               ToHitData calculated from the spotter for indirect fire scenarios
+     * @param toHit                 The running total ToHitData for this WeaponAttackAction
      * @param distance              The distance in hexes from attacker to target
-     * @param spotter               The spotting entity for indirect fire, if
-     *                              present
-     *
+     * @param spotter               The spotting entity for indirect fire, if present
      * @param wtype                 The WeaponType of the weapon being used
      * @param weapon                The Mounted weapon being used
      * @param atype                 The AmmoType being used for this attack
      * @param ammo                  The Mounted ammo being used
-     * @param munition              Long indicating the munition type flag being
-     *                              used, if applicable
-     *
-     * @param isArtilleryDirect     flag that indicates whether this is a
-     *                              direct-fire artillery attack
-     * @param isArtilleryFLAK       flag that indicates whether or not this is an
-     *                              artillery flak attack against an entity
-     * @param isArtilleryIndirect   flag that indicates whether this is an
-     *                              indirect-fire artillery attack
-     * @param isAttackerInfantry    flag that indicates whether the attacker is an
-     *                              infantry/BA unit
-     * @param isBearingsOnlyMissile flag that indicates whether this is a
-     *                              bearings-only capital missile attack
-     * @param isCruiseMissile       flag that indicates whether this is a cruise
-     *                              missile artillery attack
-     * @param exchangeSwarmTarget   flag that indicates whether this is the
-     *                              secondary target of Swarm LRMs
-     * @param isHoming              flag that indicates whether this is a homing
-     *                              artillery attack
-     * @param isIndirect            flag that indicates whether this is an indirect
-     *                              attack (LRM, mortar...)
-     * @param isInferno             flag that indicates whether this is an inferno
-     *                              munition attack
-     * @param isStrafing            flag that indicates whether this is an aero
-     *                              strafing attack
+     * @param munition              Long indicating the munition type flag being used, if applicable
+     * @param isArtilleryDirect     flag that indicates whether this is a direct-fire artillery attack
+     * @param isArtilleryFLAK       flag that indicates whether or not this is an artillery flak attack against an
+     *                              entity
+     * @param isArtilleryIndirect   flag that indicates whether this is an indirect-fire artillery attack
+     * @param isAttackerInfantry    flag that indicates whether the attacker is an infantry/BA unit
+     * @param isBearingsOnlyMissile flag that indicates whether this is a bearings-only capital missile attack
+     * @param isCruiseMissile       flag that indicates whether this is a cruise missile artillery attack
+     * @param exchangeSwarmTarget   flag that indicates whether this is the secondary target of Swarm LRMs
+     * @param isHoming              flag that indicates whether this is a homing artillery attack
+     * @param isIndirect            flag that indicates whether this is an indirect attack (LRM, mortar...)
+     * @param isInferno             flag that indicates whether this is an inferno munition attack
+     * @param isStrafing            flag that indicates whether this is an aero strafing attack
      * @param isTAG                 flag that indicates whether this is a TAG attack
-     * @param targetInBuilding      flag that indicates whether or not the target
-     *                              occupies a building hex
-     * @param usesAmmo              flag that indicates whether or not the
-     *                              WeaponType being used is ammo-fed
-     * @param underWater            flag that indicates whether or not the weapon
-     *                              being used is underwater
+     * @param targetInBuilding      flag that indicates whether or not the target occupies a building hex
+     * @param usesAmmo              flag that indicates whether or not the WeaponType being used is ammo-fed
+     * @param underWater            flag that indicates whether or not the weapon being used is underwater
      */
     private static String toHitIsImpossible(Game game, Entity ae, int attackerId, Targetable target, int ttype,
-            LosEffects los, ToHitData losMods, ToHitData toHit, int distance, Entity spotter,
-            WeaponType wtype, WeaponMounted weapon, int weaponId, AmmoType atype, AmmoMounted ammo,
-            EnumSet<AmmoType.Munitions> munition,
-            boolean isArtilleryDirect, boolean isArtilleryFLAK, boolean isArtilleryIndirect, boolean isAttackerInfantry,
-            boolean isBearingsOnlyMissile, boolean isCruiseMissile, boolean exchangeSwarmTarget, boolean isHoming,
-            boolean isInferno, boolean isIndirect, boolean isStrafing, boolean isTAG, boolean targetInBuilding,
-            boolean usesAmmo, boolean underWater, boolean evenIfAlreadyFired) {
+                                            LosEffects los, ToHitData losMods, ToHitData toHit, int distance,
+                                            Entity spotter, WeaponType wtype, WeaponMounted weapon, int weaponId,
+                                            AmmoType atype, AmmoMounted ammo, EnumSet<AmmoType.Munitions> munition,
+                                            boolean isArtilleryDirect, boolean isArtilleryFLAK,
+                                            boolean isArtilleryIndirect, boolean isAttackerInfantry,
+                                            boolean isBearingsOnlyMissile, boolean isCruiseMissile,
+                                            boolean exchangeSwarmTarget, boolean isHoming, boolean isInferno,
+                                            boolean isIndirect, boolean isStrafing, boolean isTAG,
+                                            boolean targetInBuilding, boolean usesAmmo, boolean underWater,
+                                            boolean evenIfAlreadyFired) {
 
         // Block the shot if the attacker is null
         if (ae == null) {
@@ -1052,7 +1348,8 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // are we bracing a location that's not where the weapon is located?
         if (ae.isBracing() && weapon != null && (ae.braceLocation() != weapon.getLocation())) {
             return String.format(Messages.getString("WeaponAttackAction.BracingOtherLocation"),
-                    ae.getLocationName(ae.braceLocation()), ae.getLocationName(weapon.getLocation()));
+                  ae.getLocationName(ae.braceLocation()),
+                  ae.getLocationName(weapon.getLocation()));
         }
 
         // Ammo-specific Reasons
@@ -1065,59 +1362,63 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 }
             }
             // make sure weapon can deliver flares
-            if ((target.getTargetType() == Targetable.TYPE_FLARE_DELIVER) && !(usesAmmo
-                    && ((atype.getAmmoType() == AmmoType.T_LRM)
-                            || (atype.getAmmoType() == AmmoType.T_MML)
-                            || (atype.getAmmoType() == AmmoType.T_LRM_IMP)
-                            || (atype.getAmmoType() == AmmoType.T_MEK_MORTAR))
-                    && (munition.contains(AmmoType.Munitions.M_FLARE)))) {
+            if ((target.getTargetType() == Targetable.TYPE_FLARE_DELIVER) &&
+                      !(usesAmmo &&
+                              ((atype.getAmmoType() == AmmoType.T_LRM) ||
+                                     (atype.getAmmoType() == AmmoType.T_MML) ||
+                                     (atype.getAmmoType() == AmmoType.T_LRM_IMP) ||
+                                     (atype.getAmmoType() == AmmoType.T_MEK_MORTAR)) &&
+                              (munition.contains(AmmoType.Munitions.M_FLARE)))) {
                 return Messages.getString("WeaponAttackAction.NoFlares");
             }
 
             // These ammo types can only target hexes for flare delivery
-            if (((atype.getAmmoType() == AmmoType.T_LRM)
-                    || (atype.getAmmoType() == AmmoType.T_LRM_IMP)
-                    || (atype.getAmmoType() == AmmoType.T_MML))
-                    && (atype.getMunitionType().contains(AmmoType.Munitions.M_FLARE))
-                    && (target.getTargetType() != Targetable.TYPE_FLARE_DELIVER)) {
+            if (((atype.getAmmoType() == AmmoType.T_LRM) ||
+                       (atype.getAmmoType() == AmmoType.T_LRM_IMP) ||
+                       (atype.getAmmoType() == AmmoType.T_MML)) &&
+                      (atype.getMunitionType().contains(AmmoType.Munitions.M_FLARE)) &&
+                      (target.getTargetType() != Targetable.TYPE_FLARE_DELIVER)) {
                 return Messages.getString("WeaponAttackAction.OnlyFlare");
             }
 
             // Aeros must have enough ammo for the maximum rate of fire because
             // they cannot lower it
-            if (ae.isAero() && usesAmmo && ammo != null && weapon != null
-                    && (ae.getTotalAmmoOfType(ammo.getType()) < weapon.getCurrentShots())) {
+            if (ae.isAero() &&
+                      usesAmmo &&
+                      ammo != null &&
+                      weapon != null &&
+                      (ae.getTotalAmmoOfType(ammo.getType()) < weapon.getCurrentShots())) {
                 return Messages.getString("WeaponAttackAction.InsufficientAmmo");
             }
 
             // Some Mek mortar ammo types can only be aimed at a hex
-            if (wtype != null && wtype.hasFlag(WeaponType.F_MEK_MORTAR)
-                    && ((atype.getMunitionType().contains(AmmoType.Munitions.M_AIRBURST))
-                            || (atype.getMunitionType().contains(AmmoType.Munitions.M_FLARE))
-                            || (atype.getMunitionType().contains(AmmoType.Munitions.M_SMOKE_WARHEAD)))) {
+            if (wtype != null &&
+                      wtype.hasFlag(WeaponType.F_MEK_MORTAR) &&
+                      ((atype.getMunitionType().contains(AmmoType.Munitions.M_AIRBURST)) ||
+                             (atype.getMunitionType().contains(AmmoType.Munitions.M_FLARE)) ||
+                             (atype.getMunitionType().contains(AmmoType.Munitions.M_SMOKE_WARHEAD)))) {
                 if (!(target instanceof HexTarget)) {
                     return String.format(Messages.getString("WeaponAttackAction.AmmoAtHexOnly"),
-                            atype.getSubMunitionName());
+                          atype.getSubMunitionName());
                 }
             }
 
             // make sure weapon can deliver minefield
-            if ((target.getTargetType() == Targetable.TYPE_MINEFIELD_DELIVER)
-                    && !AmmoType.canDeliverMinefield(atype)) {
+            if ((target.getTargetType() == Targetable.TYPE_MINEFIELD_DELIVER) && !AmmoType.canDeliverMinefield(atype)) {
                 return Messages.getString("WeaponAttackAction.NoMinefields");
             }
 
             // These ammo types can only target hexes for minefield delivery
-            if (((atype.getAmmoType() == AmmoType.T_LRM)
-                    || (atype.getAmmoType() == AmmoType.T_LRM_IMP)
-                    || (atype.getAmmoType() == AmmoType.T_MML)
-                    || (atype.getAmmoType() == AmmoType.T_MEK_MORTAR))
-                    && ((atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER))
-                            || (atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_ACTIVE))
-                            || (atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_INFERNO))
-                            || (atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_VIBRABOMB))
-                            || (atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_AUGMENTED)))
-                    && (target.getTargetType() != Targetable.TYPE_MINEFIELD_DELIVER)) {
+            if (((atype.getAmmoType() == AmmoType.T_LRM) ||
+                       (atype.getAmmoType() == AmmoType.T_LRM_IMP) ||
+                       (atype.getAmmoType() == AmmoType.T_MML) ||
+                       (atype.getAmmoType() == AmmoType.T_MEK_MORTAR)) &&
+                      ((atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER)) ||
+                             (atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_ACTIVE)) ||
+                             (atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_INFERNO)) ||
+                             (atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_VIBRABOMB)) ||
+                             (atype.getMunitionType().contains(AmmoType.Munitions.M_THUNDER_AUGMENTED))) &&
+                      (target.getTargetType() != Targetable.TYPE_MINEFIELD_DELIVER)) {
                 return Messages.getString("WeaponAttackAction.OnlyMinefields");
             }
         }
@@ -1145,9 +1446,12 @@ public class WeaponAttackAction extends AbstractAttackAction {
             if (weapon != null) {
                 int loc = weapon.getLocation();
                 // Can't fire arm and leg-mounted weapons while grappling
-                if (((ae instanceof Mek) && (ae.getGrappleSide() == Entity.GRAPPLE_BOTH)
-                        && ((loc != Mek.LOC_CT) && (loc != Mek.LOC_LT) && (loc != Mek.LOC_RT) && (loc != Mek.LOC_HEAD)))
-                        || weapon.isRearMounted()) {
+                if (((ae instanceof Mek) &&
+                           (ae.getGrappleSide() == Entity.GRAPPLE_BOTH) &&
+                           ((loc != Mek.LOC_CT) &&
+                                  (loc != Mek.LOC_LT) &&
+                                  (loc != Mek.LOC_RT) &&
+                                  (loc != Mek.LOC_HEAD))) || weapon.isRearMounted()) {
                     return Messages.getString("WeaponAttackAction.CantFireWhileGrappled");
                 }
                 // If caught by a chain whip, can't use weapons in the affected arm
@@ -1203,9 +1507,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
         // Vehicles with a single crewman can't shoot and unjam a RAC in the same turn
         // (like meks...)
-        if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_TANK_CREWS)
-                && (ae instanceof Tank) && ae.isUnjammingRAC()
-                && (ae.getCrew().getSize() == 1)) {
+        if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_TANK_CREWS) &&
+                  (ae instanceof Tank) &&
+                  ae.isUnjammingRAC() &&
+                  (ae.getCrew().getSize() == 1)) {
             return Messages.getString("WeaponAttackAction.VeeSingleCrew");
         }
 
@@ -1245,8 +1550,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
             }
             // Industrialmeks and other unit types have destroyed sensors with 2 or more
             // hits
-        } else if ((sensorHits > 1)
-                || ((ae instanceof Mek) && (((Mek) ae).isIndustrial() && (sensorHits == 1)))) {
+        } else if ((sensorHits > 1) || ((ae instanceof Mek) && (((Mek) ae).isIndustrial() && (sensorHits == 1)))) {
             return Messages.getString("WeaponAttackAction.SensorsDestroyed");
         }
 
@@ -1255,8 +1559,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // a friendly unit can never be the target of a direct attack.
         // but we do allow vehicle flamers to cool. Also swarm missile secondary targets
         // and strafing are exempt.
-        if (!game.getOptions().booleanOption(OptionsConstants.BASE_FRIENDLY_FIRE) && !isStrafing
-                && !exchangeSwarmTarget) {
+        if (!game.getOptions().booleanOption(OptionsConstants.BASE_FRIENDLY_FIRE) &&
+                  !isStrafing &&
+                  !exchangeSwarmTarget) {
             if (te != null && !te.getOwner().isEnemyOf(ae.getOwner())) {
                 if (!(usesAmmo && atype != null && (atype.getMunitionType().contains(AmmoType.Munitions.M_COOLANT)))) {
                     return Messages.getString("WeaponAttackAction.NoFriendlyTarget");
@@ -1280,39 +1585,43 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // Can't target infantry with Inferno rounds (BMRr, pg. 141).
         // Also, enforce options for keeping vehicles and protos safe
         // if those options are checked.
-        if (isInferno && (((te instanceof Tank)
-                && game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_VEHICLES_SAFE_FROM_INFERNOS))
-                || ((te instanceof ProtoMek)
-                        && game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_PROTOS_SAFE_FROM_INFERNOS)))) {
+        if (isInferno &&
+                  (((te instanceof Tank) &&
+                          game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_VEHICLES_SAFE_FROM_INFERNOS)) ||
+                         ((te instanceof ProtoMek) &&
+                                game.getOptions()
+                                      .booleanOption(OptionsConstants.ADVCOMBAT_PROTOS_SAFE_FROM_INFERNOS)))) {
             return Messages.getString("WeaponAttackAction.CantShootWithInferno");
         }
 
         // Only weapons allowed to clear minefields can target a hex for minefield
         // clearance
         if ((target.getTargetType() == Targetable.TYPE_MINEFIELD_CLEAR) &&
-                ((atype == null) || !AmmoType.canClearMinefield(atype))) {
+                  ((atype == null) || !AmmoType.canClearMinefield(atype))) {
             return Messages.getString("WeaponAttackAction.CantClearMines");
         }
 
         // Mine Clearance munitions can only target hexes for minefield clearance
-        if (!(target instanceof HexTarget) && (atype != null)
-                && (atype.getMunitionType().contains(AmmoType.Munitions.M_MINE_CLEARANCE))) {
+        if (!(target instanceof HexTarget) &&
+                  (atype != null) &&
+                  (atype.getMunitionType().contains(AmmoType.Munitions.M_MINE_CLEARANCE))) {
             return Messages.getString("WeaponAttackAction.MineClearHexOnly");
         }
 
         // Only screen launchers may target a hex for screen launch
         if (Targetable.TYPE_HEX_SCREEN == target.getTargetType()) {
             if (wtype != null &&
-                    (!((wtype.getAmmoType() == AmmoType.T_SCREEN_LAUNCHER)
-                            || (wtype instanceof ScreenLauncherBayWeapon)))) {
+                      (!((wtype.getAmmoType() == AmmoType.T_SCREEN_LAUNCHER) ||
+                               (wtype instanceof ScreenLauncherBayWeapon)))) {
                 return Messages.getString("WeaponAttackAction.ScreenLauncherOnly");
             }
         }
 
         // Screen Launchers can only target hexes
-        if ((Targetable.TYPE_HEX_SCREEN != target.getTargetType())
-                && (wtype != null && ((wtype.getAmmoType() == AmmoType.T_SCREEN_LAUNCHER)
-                        || (wtype instanceof ScreenLauncherBayWeapon)))) {
+        if ((Targetable.TYPE_HEX_SCREEN != target.getTargetType()) &&
+                  (wtype != null &&
+                         ((wtype.getAmmoType() == AmmoType.T_SCREEN_LAUNCHER) ||
+                                (wtype instanceof ScreenLauncherBayWeapon)))) {
             return Messages.getString("WeaponAttackAction.ScreenHexOnly");
         }
 
@@ -1346,8 +1655,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // Must target infantry in buildings from the inside.
-        if (targetInBuilding && (te instanceof Infantry)
-                && (null == los.getThruBldg())) {
+        if (targetInBuilding && (te instanceof Infantry) && (null == los.getThruBldg())) {
             return Messages.getString("WeaponAttackAction.CantShootThruBuilding");
         }
 
@@ -1358,9 +1666,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
 
         // If using SO advanced sensors, the firing unit or one on its NC3 network must
         // have a valid firing solution
-        if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ADVANCED_SENSORS)
-                && game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND)
-                && ae.isSpaceborne()) {
+        if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ADVANCED_SENSORS) &&
+                  game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND) &&
+                  ae.isSpaceborne()) {
             boolean networkFiringSolution = false;
             // Check to see if the attacker has a firing solution. Naval C3 networks share
             // targeting data
@@ -1375,8 +1683,8 @@ public class WeaponAttackAction extends AbstractAttackAction {
             if (!networkFiringSolution) {
                 // If we don't check for target type here, we can't fire screens and missiles at
                 // hexes...
-                if (target.getTargetType() == Targetable.TYPE_ENTITY
-                        && (te != null && !ae.hasFiringSolutionFor(te.getId()))) {
+                if (target.getTargetType() == Targetable.TYPE_ENTITY &&
+                          (te != null && !ae.hasFiringSolutionFor(te.getId()))) {
                     return Messages.getString("WeaponAttackAction.NoFiringSolution");
                 }
             }
@@ -1385,15 +1693,18 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // http://www.classicbattletech.com/forums/index.php/topic,47618.0.html
         // anything outside of visual range requires a "sensor lock" in order to
         // direct fire. Note that this is for ground combat with tacops sensors rules
-        if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND)
-                && !ae.isSpaceborne()
-                && !Compute.inVisualRange(game, ae, target)
-                && !(Compute.inSensorRange(game, ae, target, null)
-                        // Can shoot at something in sensor range if it has
-                        // been spotted by another unit
-                        && (te != null) && te.hasSeenEntity(ae.getOwner()))
-                && !isArtilleryIndirect && !isIndirect && !isBearingsOnlyMissile
-                && !isStrafing && !target.isHexBeingBombed()) {
+        if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND) &&
+                  !ae.isSpaceborne() &&
+                  !Compute.inVisualRange(game, ae, target) &&
+                  !(Compute.inSensorRange(game, ae, target, null)
+                          // Can shoot at something in sensor range if it has
+                          // been spotted by another unit
+                          && (te != null) && te.hasSeenEntity(ae.getOwner())) &&
+                  !isArtilleryIndirect &&
+                  !isIndirect &&
+                  !isBearingsOnlyMissile &&
+                  !isStrafing &&
+                  !target.isHexBeingBombed()) {
             boolean networkSee = false;
             if (ae.hasC3() || ae.hasC3i() || ae.hasActiveNovaCEWS()) {
                 // c3 units can fire if any other unit in their network is in
@@ -1401,7 +1712,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 for (Entity en : game.getEntitiesVector()) {
                     // We got here because ae can't see the target, so we need a C3 buddy that _can_
                     // or there's no shot.
-                    if (!en.isEnemyOf(ae) && en.onSameC3NetworkAs(ae) && Compute.canSee(game, en, target, false, null, null)) {
+                    if (!en.isEnemyOf(ae) &&
+                              en.onSameC3NetworkAs(ae) &&
+                              Compute.canSee(game, en, target, false, null, null)) {
                         networkSee = true;
                         break;
                     }
@@ -1417,17 +1730,17 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // Torpedos must remain in the water over their whole path to the target
-        if ((atype != null)
-                && ((atype.getAmmoType() == AmmoType.T_LRM_TORPEDO)
-                        || (atype.getAmmoType() == AmmoType.T_SRM_TORPEDO)
-                        || (((atype.getAmmoType() == AmmoType.T_SRM)
-                                || (atype.getAmmoType() == AmmoType.T_SRM_IMP)
-                                || (atype.getAmmoType() == AmmoType.T_MRM)
-                                || (atype.getAmmoType() == AmmoType.T_LRM)
-                                || (atype.getAmmoType() == AmmoType.T_LRM_IMP)
-                                || (atype.getAmmoType() == AmmoType.T_MML))
-                                && (atype.getMunitionType().contains(AmmoType.Munitions.M_TORPEDO))))
-                && (los.getMinimumWaterDepth() < 1)) {
+        if ((atype != null) &&
+                  ((atype.getAmmoType() == AmmoType.T_LRM_TORPEDO) ||
+                         (atype.getAmmoType() == AmmoType.T_SRM_TORPEDO) ||
+                         (((atype.getAmmoType() == AmmoType.T_SRM) ||
+                                 (atype.getAmmoType() == AmmoType.T_SRM_IMP) ||
+                                 (atype.getAmmoType() == AmmoType.T_MRM) ||
+                                 (atype.getAmmoType() == AmmoType.T_LRM) ||
+                                 (atype.getAmmoType() == AmmoType.T_LRM_IMP) ||
+                                 (atype.getAmmoType() == AmmoType.T_MML)) &&
+                                (atype.getMunitionType().contains(AmmoType.Munitions.M_TORPEDO)))) &&
+                  (los.getMinimumWaterDepth() < 1)) {
             return Messages.getString("WeaponAttackAction.TorpOutOfWater");
         }
 
@@ -1472,38 +1785,45 @@ public class WeaponAttackAction extends AbstractAttackAction {
 
         // Hull down meks cannot fire any leg weapons
         if (ae.isHullDown() && weapon != null) {
-            if (((ae instanceof BipedMek)
-                    && ((weapon.getLocation() == Mek.LOC_LLEG) || (weapon.getLocation() == Mek.LOC_RLEG)))
-                    || ((ae instanceof QuadMek) && ((weapon.getLocation() == Mek.LOC_LLEG)
-                            || (weapon.getLocation() == Mek.LOC_RLEG) || (weapon.getLocation() == Mek.LOC_LARM)
-                            || (weapon.getLocation() == Mek.LOC_RARM)))) {
+            if (((ae instanceof BipedMek) &&
+                       ((weapon.getLocation() == Mek.LOC_LLEG) || (weapon.getLocation() == Mek.LOC_RLEG))) ||
+                      ((ae instanceof QuadMek) &&
+                             ((weapon.getLocation() == Mek.LOC_LLEG) ||
+                                    (weapon.getLocation() == Mek.LOC_RLEG) ||
+                                    (weapon.getLocation() == Mek.LOC_LARM) ||
+                                    (weapon.getLocation() == Mek.LOC_RARM)))) {
                 return Messages.getString("WeaponAttackAction.NoLegHullDown");
             }
         }
 
         // hull down vees can't fire front weapons unless indirect
-        if ((ae instanceof Tank) && ae.isHullDown() && (weapon != null) &&
-                (weapon.getLocation() == Tank.LOC_FRONT) && !isIndirect) {
+        if ((ae instanceof Tank) &&
+                  ae.isHullDown() &&
+                  (weapon != null) &&
+                  (weapon.getLocation() == Tank.LOC_FRONT) &&
+                  !isIndirect) {
             return Messages.getString("WeaponAttackAction.FrontBlockedByTerrain");
         }
 
         // LAMs in fighter mode are restricted to only the ammo types that Aeros can use
-        if ((ae instanceof LandAirMek) && (ae.getConversionMode() == LandAirMek.CONV_MODE_FIGHTER)
-                && usesAmmo && ammo != null
-                && !((AmmoType) ammo.getType()).canAeroUse(
-                        game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AERO_ARTILLERY_MUNITIONS))) {
+        if ((ae instanceof LandAirMek) &&
+                  (ae.getConversionMode() == LandAirMek.CONV_MODE_FIGHTER) &&
+                  usesAmmo &&
+                  ammo != null &&
+                  !((AmmoType) ammo.getType()).canAeroUse(game.getOptions()
+                                                                .booleanOption(OptionsConstants.ADVAERORULES_AERO_ARTILLERY_MUNITIONS))) {
             return Messages.getString("WeaponAttackAction.InvalidAmmoForFighter");
         }
 
         // LAMs carrying certain types of bombs that require a weapon have attacks that
         // cannot
         // be used in mek mode.
-        if ((ae instanceof LandAirMek)
-                && wtype != null
-                && (ae.getConversionMode() == LandAirMek.CONV_MODE_MEK)
-                && wtype.hasFlag(WeaponType.F_BOMB_WEAPON)
-                && wtype.getAmmoType() != AmmoType.T_RL_BOMB
-                && !wtype.hasFlag(WeaponType.F_TAG)) {
+        if ((ae instanceof LandAirMek) &&
+                  wtype != null &&
+                  (ae.getConversionMode() == LandAirMek.CONV_MODE_MEK) &&
+                  wtype.hasFlag(WeaponType.F_BOMB_WEAPON) &&
+                  wtype.getAmmoType() != AmmoType.T_RL_BOMB &&
+                  !wtype.hasFlag(WeaponType.F_TAG)) {
             return Messages.getString("WeaponAttackAction.NoBombInMekMode");
         }
 
@@ -1543,7 +1863,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 usedRearArc[i] = false;
             }
 
-            for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements();) {
+            for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements(); ) {
                 Object o = i.nextElement();
                 if (!(o instanceof WeaponAttackAction)) {
                     continue;
@@ -1617,7 +1937,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
         } else if (ae instanceof Dropship) {
             int totalheat = 0;
 
-            for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements();) {
+            for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements(); ) {
                 Object o = i.nextElement();
                 if (!(o instanceof WeaponAttackAction)) {
                     continue;
@@ -1635,8 +1955,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // Protomeks can't fire energy weapons while charging EDP armor
-        if ((ae instanceof ProtoMek) && ((ProtoMek) ae).isEDPCharging()
-                && wtype != null && wtype.hasFlag(WeaponType.F_ENERGY)) {
+        if ((ae instanceof ProtoMek) &&
+                  ((ProtoMek) ae).isEDPCharging() &&
+                  wtype != null &&
+                  wtype.hasFlag(WeaponType.F_ENERGY)) {
             return Messages.getString("WeaponAttackAction.ChargingEDP");
         }
 
@@ -1645,8 +1967,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // TW errata 2.1
 
         if ((Compute.useSpheroidAtmosphere(game, ae) ||
-                (ae.isAero() && ((IAero) ae).isSpheroid() && (ae.getAltitude() == 0) && game.getBoard().onGround()))
-                && (weapon != null)) {
+                   (ae.isAero() &&
+                          ((IAero) ae).isSpheroid() &&
+                          (ae.getAltitude() == 0) &&
+                          game.getBoard().onGround())) && (weapon != null)) {
             int range = Compute.effectiveDistance(game, ae, target, false);
             // Only aft-mounted weapons can be fired at range 0 (targets directly
             // underneath)
@@ -1657,19 +1981,23 @@ public class WeaponAttackAction extends AbstractAttackAction {
             int altDif = target.getAltitude() - ae.getAltitude();
 
             // Nose-mounted weapons can only be fired at targets at least 1 altitude higher
-            if ((weapon.getLocation() == Aero.LOC_NOSE) && (altDif < 1)
-                    && wtype != null
-                    // Unless the weapon is used as artillery
-                    && (!(wtype instanceof ArtilleryWeapon || wtype.hasFlag(WeaponType.F_ARTILLERY)
-                            || (ae.getAltitude() == 0 && wtype instanceof CapitalMissileWeapon)
-                            || isIndirect))) {
+            if ((weapon.getLocation() == Aero.LOC_NOSE) &&
+                      (altDif < 1) &&
+                      wtype != null
+                      // Unless the weapon is used as artillery
+                      &&
+                      (!(wtype instanceof ArtilleryWeapon ||
+                               wtype.hasFlag(WeaponType.F_ARTILLERY) ||
+                               (ae.getAltitude() == 0 && wtype instanceof CapitalMissileWeapon) ||
+                               isIndirect))) {
                 return Messages.getString("WeaponAttackAction.TooLowForNose");
             }
             // Front-side-mounted weapons can only be fired at targets at the same altitude
             // or higher
-            if ((!weapon.isRearMounted() && (weapon.getLocation() != Aero.LOC_AFT)) && (altDif < 0)
-                    && wtype != null
-                    && !((wtype instanceof ArtilleryWeapon) || wtype.hasFlag(WeaponType.F_ARTILLERY))) {
+            if ((!weapon.isRearMounted() && (weapon.getLocation() != Aero.LOC_AFT)) &&
+                      (altDif < 0) &&
+                      wtype != null &&
+                      !((wtype instanceof ArtilleryWeapon) || wtype.hasFlag(WeaponType.F_ARTILLERY))) {
                 return Messages.getString("WeaponAttackAction.TooLowForFrontSide");
             }
             // Aft-mounted weapons can only be fired at targets at least 1 altitude lower
@@ -1692,9 +2020,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 // that overhanging dropships are implemented
                 if (!ae.isAirborne() && !target.isAirborne()) {
                     boolean targetInAttackerHex = ae.getOccupiedCoords().contains(target.getPosition()) ||
-                            ae.getPosition().equals(target.getPosition());
-                    boolean targetBelowAttacker = game.getBoard().getHex(ae.getPosition()).getLevel() > game.getBoard()
-                            .getHex(target.getPosition()).getLevel() + target.getElevation();
+                                                        ae.getPosition().equals(target.getPosition());
+                    boolean targetBelowAttacker = game.getBoard().getHex(ae.getPosition()).getLevel() >
+                                                        game.getBoard().getHex(target.getPosition()).getLevel() +
+                                                              target.getElevation();
 
                     if (!targetInAttackerHex || !targetBelowAttacker) {
                         return Messages.getString("WeaponAttackAction.GroundedSpheroidDropshipAftWeaponRestriction");
@@ -1728,8 +2057,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
 
             // "Cool" mode for vehicle flamer requires coolant ammo
             boolean vf_cool = false;
-            if (atype != null && ammo != null
-                    && (((AmmoType) ammo.getType()).getMunitionType().contains(AmmoType.Munitions.M_COOLANT))) {
+            if (atype != null &&
+                      ammo != null &&
+                      (((AmmoType) ammo.getType()).getMunitionType().contains(AmmoType.Munitions.M_COOLANT))) {
                 vf_cool = true;
             }
 
@@ -1746,8 +2076,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
                     return Messages.getString("WeaponAttackAction.AlreadyUsedMaxInternalBombs");
                 }
                 // Can't strike from above altitude 5. Dive bombing uses a different test below
-                if ((ae.getAltitude() > 5)
-                        && !wtype.hasFlag(WeaponType.F_DIVE_BOMB) && !wtype.hasFlag(WeaponType.F_ALT_BOMB)) {
+                if ((ae.getAltitude() > 5) &&
+                          !wtype.hasFlag(WeaponType.F_DIVE_BOMB) &&
+                          !wtype.hasFlag(WeaponType.F_ALT_BOMB)) {
                     return Messages.getString("WeaponAttackAction.AttackerTooHigh");
                 }
                 // Can't strafe from above altitude 3
@@ -1779,14 +2110,17 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 }
 
                 // Only direct-fire energy weapons can strafe
-                boolean isDirectFireEnergy = (wtype.hasFlag(WeaponType.F_DIRECT_FIRE)
-                        && (wtype.hasFlag(WeaponType.F_LASER) || wtype.hasFlag(WeaponType.F_PPC)
-                                || wtype.hasFlag(WeaponType.F_PLASMA) || wtype.hasFlag(WeaponType.F_PLASMA_MFUK)))
-                        || wtype.hasFlag(WeaponType.F_FLAMER);
+                boolean isDirectFireEnergy = (wtype.hasFlag(WeaponType.F_DIRECT_FIRE) &&
+                                                    (wtype.hasFlag(WeaponType.F_LASER) ||
+                                                           wtype.hasFlag(WeaponType.F_PPC) ||
+                                                           wtype.hasFlag(WeaponType.F_PLASMA) ||
+                                                           wtype.hasFlag(WeaponType.F_PLASMA_MFUK))) ||
+                                                   wtype.hasFlag(WeaponType.F_FLAMER);
                 // Note: flamers are direct fire energy, but don't have the flag,
                 // so they won't work with targeting computers
-                boolean isEnergyBay = (wtype instanceof LaserBayWeapon) || (wtype instanceof PPCBayWeapon)
-                        || (wtype instanceof PulseLaserBayWeapon);
+                boolean isEnergyBay = (wtype instanceof LaserBayWeapon) ||
+                                            (wtype instanceof PPCBayWeapon) ||
+                                            (wtype instanceof PulseLaserBayWeapon);
                 if (isStrafing && !isDirectFireEnergy && !isEnergyBay) {
                     return Messages.getString("WeaponAttackAction.StrafeDirectEnergyOnly");
                 }
@@ -1805,9 +2139,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
                         }
                         // LAMs can't use leg or rear-mounted weapons
                     } else if (ae instanceof LandAirMek) {
-                        if ((weapon.getLocation() == Mek.LOC_LLEG)
-                                || (weapon.getLocation() == Mek.LOC_RLEG)
-                                || weapon.isRearMounted()) {
+                        if ((weapon.getLocation() == Mek.LOC_LLEG) ||
+                                  (weapon.getLocation() == Mek.LOC_RLEG) ||
+                                  weapon.isRearMounted()) {
                             return Messages.getString("WeaponAttackAction.InvalidAeroDSAtgArc");
                         }
                     } else {
@@ -1850,30 +2184,32 @@ public class WeaponAttackAction extends AbstractAttackAction {
 
                 // can only make a strike attack against a single target
                 if (!isStrafing) {
-                    for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements();) {
+                    for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements(); ) {
                         EntityAction ea = i.nextElement();
                         if (!(ea instanceof WeaponAttackAction)) {
                             continue;
                         }
 
                         WeaponAttackAction prevAttk = (WeaponAttackAction) ea;
-                        if ((prevAttk.getEntityId() == ae.getId()) && (prevAttk.getTargetId() != target.getId())
-                                && !wtype.hasFlag(WeaponType.F_ALT_BOMB)) {
+                        if ((prevAttk.getEntityId() == ae.getId()) &&
+                                  (prevAttk.getTargetId() != target.getId()) &&
+                                  !wtype.hasFlag(WeaponType.F_ALT_BOMB)) {
                             return Messages.getString("WeaponAttackAction.CantSplitFire");
                         }
                     }
                 }
                 // VTOL Strafing
             } else if ((ae instanceof VTOL) && isStrafing) {
-                if (!(wtype.hasFlag(WeaponType.F_DIRECT_FIRE)
-                        && (wtype.hasFlag(WeaponType.F_LASER) || wtype.hasFlag(WeaponType.F_PPC)
-                                || wtype.hasFlag(WeaponType.F_PLASMA) || wtype.hasFlag(WeaponType.F_PLASMA_MFUK)))
-                        || wtype.hasFlag(WeaponType.F_FLAMER)) {
+                if (!(wtype.hasFlag(WeaponType.F_DIRECT_FIRE) &&
+                            (wtype.hasFlag(WeaponType.F_LASER) ||
+                                   wtype.hasFlag(WeaponType.F_PPC) ||
+                                   wtype.hasFlag(WeaponType.F_PLASMA) ||
+                                   wtype.hasFlag(WeaponType.F_PLASMA_MFUK))) || wtype.hasFlag(WeaponType.F_FLAMER)) {
                     return Messages.getString("WeaponAttackAction.StrafeDirectEnergyOnly");
                 }
-                if (weapon.getLocation() != VTOL.LOC_FRONT
-                        && weapon.getLocation() != VTOL.LOC_TURRET
-                        && weapon.getLocation() != VTOL.LOC_TURRET_2) {
+                if (weapon.getLocation() != VTOL.LOC_FRONT &&
+                          weapon.getLocation() != VTOL.LOC_TURRET &&
+                          weapon.getLocation() != VTOL.LOC_TURRET_2) {
                     return Messages.getString("WeaponAttackAction.InvalidStrafingArc");
                 }
             }
@@ -1891,9 +2227,11 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 // check artillery is targeted appropriately for its ammo
                 // Artillery only targets hexes unless making a direct fire flak shot or using
                 // homing ammo.
-                if ((ttype != Targetable.TYPE_HEX_ARTILLERY) && (ttype != Targetable.TYPE_MINEFIELD_CLEAR)
-                        && !(isArtilleryFLAK || (atype != null && atype.countsAsFlak())) && !isHoming
-                        && !target.isOffBoard()) {
+                if ((ttype != Targetable.TYPE_HEX_ARTILLERY) &&
+                          (ttype != Targetable.TYPE_MINEFIELD_CLEAR) &&
+                          !(isArtilleryFLAK || (atype != null && atype.countsAsFlak())) &&
+                          !isHoming &&
+                          !target.isOffBoard()) {
                     return Messages.getString("WeaponAttackAction.ArtyAttacksOnly");
                 }
                 // Airborne units can't make direct-fire artillery attacks
@@ -1917,13 +2255,14 @@ public class WeaponAttackAction extends AbstractAttackAction {
                                 }
                             }
                         } else if ((wtype.getAmmoType() != AmmoType.T_ARROW_IV) &&
-                                (wtype.getAmmoType() != AmmoType.T_ARROW_IV_BOMB)) {
+                                         (wtype.getAmmoType() != AmmoType.T_ARROW_IV_BOMB)) {
                             // For Fighters, LAMs, Small Craft and VTOLs
                             return Messages.getString("WeaponAttackAction.OnlyArrowArty");
                         }
                     }
-                } else if ((wtype.getAmmoType() == AmmoType.T_ARROW_IV)
-                        && atype != null && atype.getMunitionType().contains(AmmoType.Munitions.M_ADA)) {
+                } else if ((wtype.getAmmoType() == AmmoType.T_ARROW_IV) &&
+                                 atype != null &&
+                                 atype.getMunitionType().contains(AmmoType.Munitions.M_ADA)) {
                     // Air-Defense Arrow IV can only target airborne enemy units between 1 and 51 hexes away
                     // (same ground map/Low Altitude hex, 1 LAH, or 2 Low Altitude hexes away) and below altitude 8.
                     if (!(target.isAirborne() || target.isAirborneVTOLorWIGE())) {
@@ -1939,8 +2278,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
             } else if (weapon.isInBearingsOnlyMode()) {
                 // We don't really need to do anything here. This just prevents these weapons
                 // from passing the next test erroneously.
-            } else if (wtype instanceof CapitalMissileWeapon
-                    && Compute.isGroundToGround(ae, target)) {
+            } else if (wtype instanceof CapitalMissileWeapon && Compute.isGroundToGround(ae, target)) {
                 // Grounded units firing capital missiles at ground targets must do so as artillery
                 if (ttype != Targetable.TYPE_HEX_ARTILLERY) {
                     return Messages.getString("WeaponAttackAction.ArtyAttacksOnly");
@@ -2021,15 +2359,13 @@ public class WeaponAttackAction extends AbstractAttackAction {
 
             // Ballistic and Missile weapons are subject to wind conditions
             PlanetaryConditions conditions = game.getPlanetaryConditions();
-            if (conditions.getWind().isTornadoF1ToF3() && wtype.hasFlag(WeaponType.F_MISSILE)
-                    && !game.getBoard().inSpace()) {
+            if (conditions.getWind().isTornadoF1ToF3() &&
+                      wtype.hasFlag(WeaponType.F_MISSILE) &&
+                      !game.getBoard().inSpace()) {
                 return Messages.getString("WeaponAttackAction.NoMissileTornado");
             }
-            boolean missleOrBallistic = wtype.hasFlag(WeaponType.F_MISSILE)
-                    || wtype.hasFlag(WeaponType.F_BALLISTIC);
-            if (conditions.getWind().isTornadoF4()
-                    && !game.getBoard().inSpace()
-                    && missleOrBallistic) {
+            boolean missleOrBallistic = wtype.hasFlag(WeaponType.F_MISSILE) || wtype.hasFlag(WeaponType.F_BALLISTIC);
+            if (conditions.getWind().isTornadoF4() && !game.getBoard().inSpace() && missleOrBallistic) {
                 return Messages.getString("WeaponAttackAction.F4Tornado");
             }
 
@@ -2039,7 +2375,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
             if ((ae instanceof BattleArmor) && wtype.hasFlag(WeaponType.F_INFANTRY)) {
                 final int weapId = ae.getEquipmentNum(weapon);
                 // See if this unit has made a previous AP attack
-                for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements();) {
+                for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements(); ) {
                     Object o = i.nextElement();
                     if (!(o instanceof WeaponAttackAction)) {
                         continue;
@@ -2059,7 +2395,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
             // BA compact narc: we have one weapon for each trooper, but you
             // can fire only at one target at a time
             if (wtype.getName().equals("Compact Narc")) {
-                for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements();) {
+                for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements(); ) {
                     EntityAction ea = i.nextElement();
                     if (!(ea instanceof WeaponAttackAction)) {
                         continue;
@@ -2084,11 +2420,11 @@ public class WeaponAttackAction extends AbstractAttackAction {
             }
 
             // BA NARCs and Tasers can only fire at one target in a round
-            if ((ae instanceof BattleArmor)
-                    && (wtype.hasFlag(WeaponType.F_TASER) || wtype.getAmmoType() == AmmoType.T_NARC)) {
+            if ((ae instanceof BattleArmor) &&
+                      (wtype.hasFlag(WeaponType.F_TASER) || wtype.getAmmoType() == AmmoType.T_NARC)) {
                 // Go through all of the current actions to see if a NARC or Taser
                 // has been fired
-                for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements();) {
+                for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements(); ) {
                     Object o = i.nextElement();
                     if (!(o instanceof WeaponAttackAction)) {
                         continue;
@@ -2098,8 +2434,8 @@ public class WeaponAttackAction extends AbstractAttackAction {
                     if (prevAttack.getEntityId() == ae.getId() && prevAttack.getTargetId() != target.getId()) {
                         Mounted<?> prevWeapon = ae.getEquipment(prevAttack.getWeaponId());
                         WeaponType prevWtype = (WeaponType) prevWeapon.getType();
-                        if (prevWeapon.getType().hasFlag(WeaponType.F_TASER)
-                                && weapon.getType().hasFlag(WeaponType.F_TASER)) {
+                        if (prevWeapon.getType().hasFlag(WeaponType.F_TASER) &&
+                                  weapon.getType().hasFlag(WeaponType.F_TASER)) {
                             return Messages.getString("WeaponAttackAction.BATaserSameTarget");
                         }
                         if (prevWtype.getAmmoType() == AmmoType.T_NARC && wtype.getAmmoType() == AmmoType.T_NARC) {
@@ -2124,8 +2460,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
             }
 
             // ASEW Missiles cannot be launched in an atmosphere
-            if ((wtype.getAmmoType() == AmmoType.T_ASEW_MISSILE)
-                    && !ae.isSpaceborne()) {
+            if ((wtype.getAmmoType() == AmmoType.T_ASEW_MISSILE) && !ae.isSpaceborne()) {
                 return Messages.getString("WeaponAttackAction.ASEWAtmo");
             }
 
@@ -2135,7 +2470,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 // adjacent to a prior one
                 boolean adjacentAltBomb = false;
                 boolean firstAltBomb = true;
-                for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements();) {
+                for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements(); ) {
                     Object o = i.nextElement();
                     if (!(o instanceof WeaponAttackAction)) {
                         continue;
@@ -2144,18 +2479,18 @@ public class WeaponAttackAction extends AbstractAttackAction {
                     if (prevAttack.getEntityId() == attackerId) {
                         // You also can't mix and match the 3 different types of bombing: Space, Dive
                         // and Altitude
-                        if ((weaponId != prevAttack.getWeaponId())
-                                && ae.getEquipment(prevAttack.getWeaponId()).getType()
+                        if ((weaponId != prevAttack.getWeaponId()) &&
+                                  ae.getEquipment(prevAttack.getWeaponId())
+                                        .getType()
                                         .hasFlag(WeaponType.F_SPACE_BOMB)) {
                             return Messages.getString("WeaponAttackAction.BusySpaceBombing");
                         }
-                        if ((weaponId != prevAttack.getWeaponId())
-                                && ae.getEquipment(prevAttack.getWeaponId()).getType()
-                                        .hasFlag(WeaponType.F_DIVE_BOMB)) {
+                        if ((weaponId != prevAttack.getWeaponId()) &&
+                                  ae.getEquipment(prevAttack.getWeaponId()).getType().hasFlag(WeaponType.F_DIVE_BOMB)) {
                             return Messages.getString("WeaponAttackAction.BusyDiveBombing");
                         }
-                        if ((weaponId != prevAttack.getWeaponId())
-                                && ae.getEquipment(prevAttack.getWeaponId()).getType().hasFlag(WeaponType.F_ALT_BOMB)) {
+                        if ((weaponId != prevAttack.getWeaponId()) &&
+                                  ae.getEquipment(prevAttack.getWeaponId()).getType().hasFlag(WeaponType.F_ALT_BOMB)) {
                             if (!wtype.hasFlag(WeaponType.F_ALT_BOMB)) {
                                 return Messages.getString("WeaponAttackAction.BusyAltBombing");
                             }
@@ -2215,8 +2550,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
             }
 
             // Can't attack bomb hex targets with weapons other than alt/dive bombs
-            if ((target.getTargetType() == Targetable.TYPE_HEX_AERO_BOMB) && !wtype.hasFlag(WeaponType.F_DIVE_BOMB)
-                    && !wtype.hasFlag(WeaponType.F_ALT_BOMB)) {
+            if ((target.getTargetType() == Targetable.TYPE_HEX_AERO_BOMB) &&
+                      !wtype.hasFlag(WeaponType.F_DIVE_BOMB) &&
+                      !wtype.hasFlag(WeaponType.F_ALT_BOMB)) {
                 return Messages.getString("WeaponAttackAction.InvalidForBombing");
             }
 
@@ -2234,8 +2570,8 @@ public class WeaponAttackAction extends AbstractAttackAction {
             }
 
             // Can't attack a Micro Bomb hex target with other weapons
-            if ((target.getTargetType() == Targetable.TYPE_HEX_BOMB)
-                    && !(usesAmmo && atype != null && (atype.getAmmoType() == AmmoType.T_BA_MICRO_BOMB))) {
+            if ((target.getTargetType() == Targetable.TYPE_HEX_BOMB) &&
+                      !(usesAmmo && atype != null && (atype.getAmmoType() == AmmoType.T_BA_MICRO_BOMB))) {
                 return Messages.getString("WeaponAttackAction.InvalidForBombing");
             }
 
@@ -2263,8 +2599,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
                         return Messages.getString("WeaponAttackAction.OnlyLegBPod");
                     }
                 } else if (ae instanceof QuadMek) {
-                    if (!((weapon.getLocation() == Mek.LOC_LLEG) || (weapon.getLocation() == Mek.LOC_RLEG)
-                            || (weapon.getLocation() == Mek.LOC_LARM) || (weapon.getLocation() == Mek.LOC_RARM))) {
+                    if (!((weapon.getLocation() == Mek.LOC_LLEG) ||
+                                (weapon.getLocation() == Mek.LOC_RLEG) ||
+                                (weapon.getLocation() == Mek.LOC_LARM) ||
+                                (weapon.getLocation() == Mek.LOC_RARM))) {
                         return Messages.getString("WeaponAttackAction.OnlyLegBPod");
                     }
                 }
@@ -2280,10 +2618,12 @@ public class WeaponAttackAction extends AbstractAttackAction {
 
             // Capital Mass Drivers can only fire at targets directly in front of the
             // attacker
-            if ((target.getTargetType() == Targetable.TYPE_ENTITY) && wtype.hasFlag(WeaponType.F_MASS_DRIVER)
-                    && (ae instanceof SpaceStation)) {
-                if (!ae.getPosition().translated(ae.getFacing(), Compute.effectiveDistance(game, ae, target))
-                        .equals(target.getPosition())) {
+            if ((target.getTargetType() == Targetable.TYPE_ENTITY) &&
+                      wtype.hasFlag(WeaponType.F_MASS_DRIVER) &&
+                      (ae instanceof SpaceStation)) {
+                if (!ae.getPosition()
+                           .translated(ae.getFacing(), Compute.effectiveDistance(game, ae, target))
+                           .equals(target.getPosition())) {
                     return Messages.getString("WeaponAttackAction.MassDriverFrontOnly");
                 }
             }
@@ -2310,9 +2650,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
             if (wtype.isSubCapital() || wtype.isCapital()) {
                 // Can't fire any but capital/subcapital missiles surface to surface
                 // (but VTOL dive bombing is allowed)
-                if (Compute.isGroundToGround(ae, target)
-                        && !((ae.getMovementMode() == EntityMovementMode.VTOL) && (wtype instanceof DiveBombAttack))
-                        && !(wtype instanceof CapitalMissileWeapon)) {
+                if (Compute.isGroundToGround(ae, target) &&
+                          !((ae.getMovementMode() == EntityMovementMode.VTOL) && (wtype instanceof DiveBombAttack)) &&
+                          !(wtype instanceof CapitalMissileWeapon)) {
                     return Messages.getString("WeaponAttackAction.NoS2SCapWeapons");
                 }
             }
@@ -2320,20 +2660,23 @@ public class WeaponAttackAction extends AbstractAttackAction {
             // Causing Fires
 
             // Some weapons can't cause fires, but Infernos always can.
-            if ((vf_cool || (wtype.hasFlag(WeaponType.F_NO_FIRES) && !isInferno))
-                    && (Targetable.TYPE_HEX_IGNITE == target.getTargetType())) {
+            if ((vf_cool || (wtype.hasFlag(WeaponType.F_NO_FIRES) && !isInferno)) &&
+                      (Targetable.TYPE_HEX_IGNITE == target.getTargetType())) {
                 return Messages.getString("WeaponAttackAction.WeaponCantIgnite");
             }
 
             // only woods and buildings can be set intentionally on fire
-            if ((target.getTargetType() == Targetable.TYPE_HEX_IGNITE)
-                    && game.getOptions().booleanOption(OptionsConstants.ADVANCED_NO_IGNITE_CLEAR)
-                    && !(game.getBoard().getHex(((HexTarget) target).getPosition()).containsTerrain(Terrains.WOODS)
-                            || game.getBoard().getHex(((HexTarget) target).getPosition())
-                                    .containsTerrain(Terrains.JUNGLE)
-                            || game.getBoard().getHex(((HexTarget) target).getPosition())
-                                    .containsTerrain(Terrains.FUEL_TANK)
-                            || game.getBoard().getHex(((HexTarget) target).getPosition())
+            if ((target.getTargetType() == Targetable.TYPE_HEX_IGNITE) &&
+                      game.getOptions().booleanOption(OptionsConstants.ADVANCED_NO_IGNITE_CLEAR) &&
+                      !(game.getBoard().getHex(((HexTarget) target).getPosition()).containsTerrain(Terrains.WOODS) ||
+                              game.getBoard()
+                                    .getHex(((HexTarget) target).getPosition())
+                                    .containsTerrain(Terrains.JUNGLE) ||
+                              game.getBoard()
+                                    .getHex(((HexTarget) target).getPosition())
+                                    .containsTerrain(Terrains.FUEL_TANK) ||
+                              game.getBoard()
+                                    .getHex(((HexTarget) target).getPosition())
                                     .containsTerrain(Terrains.BUILDING))) {
                 return Messages.getString("WeaponAttackAction.CantIntentionallyBurn");
             }
@@ -2343,13 +2686,14 @@ public class WeaponAttackAction extends AbstractAttackAction {
             if (isAttackerInfantry && !(ae instanceof BattleArmor)) {
                 // 0 MP infantry units: move or shoot, except for anti-mek attacks,
                 // those are handled above
-                if ((ae.getMovementMode() == EntityMovementMode.INF_LEG) && (ae.getWalkMP() == 0)
-                        && (ae.moved != EntityMovementType.MOVE_NONE)) {
+                if ((ae.getMovementMode() == EntityMovementMode.INF_LEG) &&
+                          (ae.getWalkMP() == 0) &&
+                          (ae.moved != EntityMovementType.MOVE_NONE)) {
                     return Messages.getString("WeaponAttackAction.0MPInf");
                 }
                 // Can't shoot if platoon used fast movement
-                if (game.getOptions().booleanOption(OptionsConstants.ADVGRNDMOV_TACOPS_FAST_INFANTRY_MOVE)
-                        && (ae.moved == EntityMovementType.MOVE_RUN)) {
+                if (game.getOptions().booleanOption(OptionsConstants.ADVGRNDMOV_TACOPS_FAST_INFANTRY_MOVE) &&
+                          (ae.moved == EntityMovementType.MOVE_RUN)) {
                     return Messages.getString("WeaponAttackAction.CantShootAndFastMove");
                 }
                 // check for trying to fire field gun after moving
@@ -2357,7 +2701,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
                     return Messages.getString("WeaponAttackAction.CantMoveAndFieldGun");
                 }
                 // check for mixing infantry and field gun attacks
-                for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements();) {
+                for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements(); ) {
                     EntityAction ea = i.nextElement();
                     if (!(ea instanceof WeaponAttackAction)) {
                         continue;
@@ -2365,10 +2709,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
                     final WeaponAttackAction prevAttack = (WeaponAttackAction) ea;
                     if (prevAttack.getEntityId() == attackerId) {
                         Mounted<?> prevWeapon = ae.getEquipment(prevAttack.getWeaponId());
-                        if ((prevWeapon.getType().hasFlag(WeaponType.F_INFANTRY)
-                                && (weapon.getLocation() == Infantry.LOC_FIELD_GUNS))
-                                || (weapon.getType().hasFlag(WeaponType.F_INFANTRY)
-                                        && (prevWeapon.getLocation() == Infantry.LOC_FIELD_GUNS))) {
+                        if ((prevWeapon.getType().hasFlag(WeaponType.F_INFANTRY) &&
+                                   (weapon.getLocation() == Infantry.LOC_FIELD_GUNS)) ||
+                                  (weapon.getType().hasFlag(WeaponType.F_INFANTRY) &&
+                                         (prevWeapon.getLocation() == Infantry.LOC_FIELD_GUNS))) {
                             return Messages.getString("WeaponAttackAction.FieldGunOrSAOnly");
                         }
                     }
@@ -2390,15 +2734,16 @@ public class WeaponAttackAction extends AbstractAttackAction {
                     return Messages.getString("WeaponAttackAction.TargetNotBurning");
                 }
             } else if (wtype.hasFlag(WeaponType.F_EXTINGUISHER)) {
-                if (!(((target instanceof Tank) && ((Tank) target).isOnFire())
-                        || ((target instanceof Entity) && (((Entity) target).infernos.getTurnsLeftToBurn() > 0)))) {
+                if (!(((target instanceof Tank) && ((Tank) target).isOnFire()) ||
+                            ((target instanceof Entity) && (((Entity) target).infernos.getTurnsLeftToBurn() > 0)))) {
                     return Messages.getString("WeaponAttackAction.TargetNotBurning");
                 }
             }
 
             // Gauss weapons using the TacOps powered down rule can't fire
-            if ((wtype instanceof GaussWeapon)
-                    && weapon.hasModes() && weapon.curMode().equals(Weapon.MODE_GAUSS_POWERED_DOWN)) {
+            if ((wtype instanceof GaussWeapon) &&
+                      weapon.hasModes() &&
+                      weapon.curMode().equals(Weapon.MODE_GAUSS_POWERED_DOWN)) {
                 return Messages.getString("WeaponAttackAction.WeaponNotReady");
             }
 
@@ -2406,7 +2751,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
 
             // air2air and air2ground cannot be combined by any aerospace units
             if (Compute.isAirToAir(ae, target) || Compute.isAirToGround(ae, target)) {
-                for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements();) {
+                for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements(); ) {
                     EntityAction ea = i.nextElement();
                     if (!(ea instanceof WeaponAttackAction)) {
                         continue;
@@ -2433,16 +2778,18 @@ public class WeaponAttackAction extends AbstractAttackAction {
             // specialized AA infantry weapons,
             // or direct-fire artillery flak attacks
             boolean isWeaponFieldGuns = isAttackerInfantry && (weapon.getLocation() == Infantry.LOC_FIELD_GUNS);
-            if ((ae instanceof Infantry) && Compute.isGroundToAir(ae, target) && !wtype.hasFlag(WeaponType.F_INF_AA)
-                    && !isArtilleryFLAK
-                    && !isWeaponFieldGuns) {
+            if ((ae instanceof Infantry) &&
+                      Compute.isGroundToAir(ae, target) &&
+                      !wtype.hasFlag(WeaponType.F_INF_AA) &&
+                      !isArtilleryFLAK &&
+                      !isWeaponFieldGuns) {
                 return Messages.getString("WeaponAttackAction.NoInfantryGta");
             }
 
             // only one ground-to-air attack allowed per turn
             // grounded spheroid dropships dont have this limitation
             if (!ae.isAirborne() && !((ae instanceof Dropship) && ((Aero) ae).isSpheroid())) {
-                for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements();) {
+                for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements(); ) {
                     EntityAction ea = i.nextElement();
                     if (!(ea instanceof WeaponAttackAction)) {
                         continue;
@@ -2457,8 +2804,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
                             return Messages.getString("WeaponAttackAction.AlreadyGtgAttack");
                         }
                         // Or split ground-to-air fire across multiple targets
-                        if (prevAttack.isGroundToAir(game) && Compute.isGroundToAir(ae, target) && (null != te)
-                                && (prevAttack.getTargetId() != te.getId())) {
+                        if (prevAttack.isGroundToAir(game) &&
+                                  Compute.isGroundToAir(ae, target) &&
+                                  (null != te) &&
+                                  (prevAttack.getTargetId() != te.getId())) {
                             return Messages.getString("WeaponAttackAction.OneTargetForGta");
                         }
                     }
@@ -2478,8 +2827,11 @@ public class WeaponAttackAction extends AbstractAttackAction {
             }
 
             // Can't fire an MML indirectly when loaded with SRM munitions
-            if (isIndirect && usesAmmo
-                    && atype != null && (atype.getAmmoType() == AmmoType.T_MML) && !atype.hasFlag(AmmoType.F_MML_LRM)) {
+            if (isIndirect &&
+                      usesAmmo &&
+                      atype != null &&
+                      (atype.getAmmoType() == AmmoType.T_MML) &&
+                      !atype.hasFlag(AmmoType.F_MML_LRM)) {
                 return Messages.getString("WeaponAttackAction.NoIndirectSRM");
             }
 
@@ -2487,9 +2839,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
             // a spotter
             // unless the attack has the Oblique Attacker SPA
             if (isIndirect) {
-                if ((spotter == null) && !(wtype instanceof ArtilleryCannonWeapon)
-                        && !ae.hasAbility(OptionsConstants.GUNNERY_OBLIQUE_ATTACKER)
-                        && !wtype.hasFlag(WeaponType.F_MORTARTYPE_INDIRECT)) {
+                if ((spotter == null) &&
+                          !(wtype instanceof ArtilleryCannonWeapon) &&
+                          !ae.hasAbility(OptionsConstants.GUNNERY_OBLIQUE_ATTACKER) &&
+                          !wtype.hasFlag(WeaponType.F_MORTARTYPE_INDIRECT)) {
                     return Messages.getString("WeaponAttackAction.NoSpotter");
                 }
             }
@@ -2571,8 +2924,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
             }
 
             // Protomek can fire MGA only into front arc, TW page 137
-            if (!Compute.isInArc(ae.getPosition(), ae.getFacing(), target, Compute.ARC_FORWARD)
-                    && wtype.hasFlag(WeaponType.F_MGA) && (ae instanceof ProtoMek)) {
+            if (!Compute.isInArc(ae.getPosition(), ae.getFacing(), target, Compute.ARC_FORWARD) &&
+                      wtype.hasFlag(WeaponType.F_MGA) &&
+                      (ae instanceof ProtoMek)) {
                 return Messages.getString("WeaponAttackAction.ProtoMGAOnlyFront");
             }
 
@@ -2589,9 +2943,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
             }
 
             // PPCs linked to capacitors can't fire while charging
-            if (weapon.getType().hasFlag(WeaponType.F_PPC) && (weapon.getLinkedBy() != null)
-                    && weapon.getLinkedBy().getType().hasFlag(MiscType.F_PPC_CAPACITOR)
-                    && weapon.getLinkedBy().pendingMode().equals(Weapon.MODE_PPC_CHARGE)) {
+            if (weapon.getType().hasFlag(WeaponType.F_PPC) &&
+                      (weapon.getLinkedBy() != null) &&
+                      weapon.getLinkedBy().getType().hasFlag(MiscType.F_PPC_CAPACITOR) &&
+                      weapon.getLinkedBy().pendingMode().equals(Weapon.MODE_PPC_CHARGE)) {
                 return Messages.getString("WeaponAttackAction.PPCCharging");
             }
 
@@ -2609,8 +2964,8 @@ public class WeaponAttackAction extends AbstractAttackAction {
                         continue;
                     }
                     final WeaponType otherWtype = (WeaponType) otherWeapon.getType();
-                    hasSoloAttack |= (otherWtype.hasFlag(WeaponType.F_SOLO_ATTACK)
-                            && otherWAA.getWeaponId() != weaponId);
+                    hasSoloAttack |= (otherWtype.hasFlag(WeaponType.F_SOLO_ATTACK) &&
+                                            otherWAA.getWeaponId() != weaponId);
                     if (hasSoloAttack) {
                         soloWeaponName = otherWeapon.getName();
                         break;
@@ -2638,18 +2993,19 @@ public class WeaponAttackAction extends AbstractAttackAction {
             }
 
             // Protomeks cannot fire arm weapons and main gun in the same turn
-            if ((ae instanceof ProtoMek)
-                    && ((weapon.getLocation() == ProtoMek.LOC_MAINGUN)
-                            || (weapon.getLocation() == ProtoMek.LOC_RARM)
-                            || (weapon.getLocation() == ProtoMek.LOC_LARM))) {
+            if ((ae instanceof ProtoMek) &&
+                      ((weapon.getLocation() == ProtoMek.LOC_MAINGUN) ||
+                             (weapon.getLocation() == ProtoMek.LOC_RARM) ||
+                             (weapon.getLocation() == ProtoMek.LOC_LARM))) {
                 final boolean firingMainGun = weapon.getLocation() == ProtoMek.LOC_MAINGUN;
                 for (EntityAction ea : game.getActionsVector()) {
                     if ((ea.getEntityId() == attackerId) && (ea instanceof WeaponAttackAction)) {
                         WeaponAttackAction otherWAA = (WeaponAttackAction) ea;
                         final Mounted<?> otherWeapon = ae.getEquipment(otherWAA.getWeaponId());
-                        if ((firingMainGun && ((otherWeapon.getLocation() == ProtoMek.LOC_RARM)
-                                || (otherWeapon.getLocation() == ProtoMek.LOC_LARM)))
-                                || !firingMainGun && (otherWeapon.getLocation() == ProtoMek.LOC_MAINGUN)) {
+                        if ((firingMainGun &&
+                                   ((otherWeapon.getLocation() == ProtoMek.LOC_RARM) ||
+                                          (otherWeapon.getLocation() == ProtoMek.LOC_LARM))) ||
+                                  !firingMainGun && (otherWeapon.getLocation() == ProtoMek.LOC_MAINGUN)) {
                             return Messages.getString("WeaponAttackAction.CantFireArmsAndMainGun");
                         }
                     }
@@ -2683,28 +3039,34 @@ public class WeaponAttackAction extends AbstractAttackAction {
             // Weapon Bays
 
             // Large Craft weapon bays cannot bracket small craft at short range
-            if (weapon.hasModes()
-                    && (weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_80)
-                            || weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_60)
-                            || weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_40))
-                    && target.isAero() && te != null && !te.isLargeCraft()
-                    && (RangeType.rangeBracket(ae.getPosition().distance(target.getPosition()),
+            if (weapon.hasModes() &&
+                      (weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_80) ||
+                             weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_60) ||
+                             weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_40)) &&
+                      target.isAero() &&
+                      te != null &&
+                      !te.isLargeCraft() &&
+                      (RangeType.rangeBracket(ae.getPosition().distance(target.getPosition()),
                             wtype.getRanges(weapon, ammo),
-                            true, false) == RangeType.RANGE_SHORT)) {
+                            true,
+                            false) == RangeType.RANGE_SHORT)) {
                 return Messages.getString("WeaponAttackAction.TooCloseForSCBracket");
             }
 
             // you must have enough weapons in your bay to be able to use bracketing
-            if (weapon.hasModes() && weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_80)
-                    && (weapon.getBayWeapons().size() < 2)) {
+            if (weapon.hasModes() &&
+                      weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_80) &&
+                      (weapon.getBayWeapons().size() < 2)) {
                 return Messages.getString("WeaponAttackAction.BayTooSmallForBracket");
             }
-            if (weapon.hasModes() && weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_60)
-                    && (weapon.getBayWeapons().size() < 3)) {
+            if (weapon.hasModes() &&
+                      weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_60) &&
+                      (weapon.getBayWeapons().size() < 3)) {
                 return Messages.getString("WeaponAttackAction.BayTooSmallForBracket");
             }
-            if (weapon.hasModes() && weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_40)
-                    && (weapon.getBayWeapons().size() < 4)) {
+            if (weapon.hasModes() &&
+                      weapon.curMode().equals(Weapon.MODE_CAPITAL_BRACKET_40) &&
+                      (weapon.getBayWeapons().size() < 4)) {
                 return Messages.getString("WeaponAttackAction.BayTooSmallForBracket");
             }
 
@@ -2717,10 +3079,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
             }
 
             // Weapon in arc?
-            if (!Compute.isInArc(game, attackerId, weaponId, target)
-                    && (!Compute.isAirToGround(ae, target) || isArtilleryIndirect)
-                    && !ae.isMakingVTOLGroundAttack()
-                    && !ae.isOffBoard()) {
+            if (!Compute.isInArc(game, attackerId, weaponId, target) &&
+                      (!Compute.isAirToGround(ae, target) || isArtilleryIndirect) &&
+                      !ae.isMakingVTOLGroundAttack() &&
+                      !ae.isOffBoard()) {
                 return Messages.getString("WeaponAttackAction.OutOfArc");
             }
 
@@ -2737,52 +3099,52 @@ public class WeaponAttackAction extends AbstractAttackAction {
     }
 
     /**
-     * Method that tests each attack to see if it would automatically hit.
-     * If so, a reason string will be returned. A null return means we can continue
-     * processing the attack
+     * Method that tests each attack to see if it would automatically hit. If so, a reason string will be returned. A
+     * null return means we can continue processing the attack
      *
      * @param game                  The current {@link Game}
      * @param ae                    The Entity making this attack
      * @param target                The Targetable object being attacked
      * @param ttype                 The targetable object type
      * @param los                   The calculated LOS between attacker and target
-     *
      * @param distance              The distance in hexes from attacker to target
-     *
      * @param wtype                 The WeaponType of the weapon being used
      * @param weapon                The Mounted weapon being used
-     *
-     * @param isBearingsOnlyMissile flag that indicates whether this is a
-     *                              bearings-only capital missile attack
+     * @param isBearingsOnlyMissile flag that indicates whether this is a bearings-only capital missile attack
      */
     private static String toHitIsAutomatic(Game game, Entity ae, Targetable target, int ttype, LosEffects los,
-            int distance, WeaponType wtype, Mounted<?> weapon, boolean isBearingsOnlyMissile) {
+                                           int distance, WeaponType wtype, Mounted<?> weapon,
+                                           boolean isBearingsOnlyMissile) {
 
         // Buildings
 
         // Attacks against adjacent buildings automatically hit.
-        if ((distance == 1) && ((ttype == Targetable.TYPE_BUILDING)
-                || (ttype == Targetable.TYPE_BLDG_IGNITE)
-                || (ttype == Targetable.TYPE_FUEL_TANK)
-                || (ttype == Targetable.TYPE_FUEL_TANK_IGNITE)
-                || (target instanceof GunEmplacement))) {
+        if ((distance == 1) &&
+                  ((ttype == Targetable.TYPE_BUILDING) ||
+                         (ttype == Targetable.TYPE_BLDG_IGNITE) ||
+                         (ttype == Targetable.TYPE_FUEL_TANK) ||
+                         (ttype == Targetable.TYPE_FUEL_TANK_IGNITE) ||
+                         (target instanceof GunEmplacement))) {
             return Messages.getString("WeaponAttackAction.AdjBuilding");
         }
 
         // Attacks against buildings from inside automatically hit.
-        if ((null != los.getThruBldg()) && ((ttype == Targetable.TYPE_BUILDING)
-                || (ttype == Targetable.TYPE_BLDG_IGNITE)
-                || (ttype == Targetable.TYPE_FUEL_TANK)
-                || (ttype == Targetable.TYPE_FUEL_TANK_IGNITE)
-                || (target instanceof GunEmplacement))) {
+        if ((null != los.getThruBldg()) &&
+                  ((ttype == Targetable.TYPE_BUILDING) ||
+                         (ttype == Targetable.TYPE_BLDG_IGNITE) ||
+                         (ttype == Targetable.TYPE_FUEL_TANK) ||
+                         (ttype == Targetable.TYPE_FUEL_TANK_IGNITE) ||
+                         (target instanceof GunEmplacement))) {
             return Messages.getString("WeaponAttackAction.InsideBuilding");
         }
 
         // Special Weapon Rules
 
         // B-Pod firing at infantry in the same hex autohit
-        if (wtype != null && wtype.hasFlag(WeaponType.F_B_POD) && (target instanceof Infantry)
-                && target.getPosition().equals(ae.getPosition())) {
+        if (wtype != null &&
+                  wtype.hasFlag(WeaponType.F_B_POD) &&
+                  (target instanceof Infantry) &&
+                  target.getPosition().equals(ae.getPosition())) {
             return Messages.getString("WeaponAttackAction.BPodAtInf");
         }
 
@@ -2794,8 +3156,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // Screen launchers target hexes and hit automatically (if in range)
-        if (wtype != null && ((wtype.getAmmoType() == AmmoType.T_SCREEN_LAUNCHER)
-                || (wtype instanceof ScreenLauncherBayWeapon)) && distance <= wtype.getExtremeRange()) {
+        if (wtype != null &&
+                  ((wtype.getAmmoType() == AmmoType.T_SCREEN_LAUNCHER) || (wtype instanceof ScreenLauncherBayWeapon)) &&
+                  distance <= wtype.getExtremeRange()) {
             return Messages.getString("WeaponAttackAction.ScreenAutoHit");
         }
 
@@ -2816,12 +3179,12 @@ public class WeaponAttackAction extends AbstractAttackAction {
     }
 
     /**
-     * Some attacks are the only actions that a particular entity can make
-     * during its turn Also, only this unit can make that particular attack.
+     * Some attacks are the only actions that a particular entity can make during its turn Also, only this unit can make
+     * that particular attack.
      */
     private static boolean isOnlyAttack(Game game, Entity attacker, String attackType, Entity target) {
         // meks can only be the target of one leg or swarm attack
-        for (Enumeration<EntityAction> actions = game.getActions(); actions.hasMoreElements();) {
+        for (Enumeration<EntityAction> actions = game.getActions(); actions.hasMoreElements(); ) {
             EntityAction ea = actions.nextElement();
             if (ea instanceof WeaponAttackAction) {
                 WeaponAttackAction waa = (WeaponAttackAction) ea;
@@ -2858,8 +3221,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
     }
 
     /**
-     * @param nemesisConfused
-     *                        The nemesisConfused to set.
+     * @param nemesisConfused The nemesisConfused to set.
      */
     public void setNemesisConfused(boolean nemesisConfused) {
         this.nemesisConfused = nemesisConfused;
@@ -2926,13 +3288,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
     }
 
     /**
-     *
-     * @param bpls These are the "bomb payload" for internal and external bomb
-     *             stores.
-     *             It's a HashMap of two arrays, each indexed by the constants
-     *             declared in BombType.
-     *             Each element indicates how many types of that bomb should be
-     *             fired.
+     * @param bpls These are the "bomb payload" for internal and external bomb stores. It's a HashMap of two arrays,
+     *             each indexed by the constants declared in BombType. Each element indicates how many types of that
+     *             bomb should be fired.
      */
     public void setBombPayloads(HashMap<String, int[]> bpls) {
         bombPayloads = (HashMap<String, int[]>) bpls.clone();
@@ -2984,8 +3342,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
     }
 
     /**
-     * Convenience method that compiles the ToHit modifiers applicable to the
-     * weather or other special environmental
+     * Convenience method that compiles the ToHit modifiers applicable to the weather or other special environmental
      * effects. These affect everyone on the board.
      *
      * @param game                The current {@link Game}
@@ -2993,13 +3350,12 @@ public class WeaponAttackAction extends AbstractAttackAction {
      * @param target              The Targetable object being attacked
      * @param wtype               The WeaponType of the weapon being used
      * @param atype               The AmmoType being used for this attack
-     * @param toHit               The running total ToHitData for this
-     *                            WeaponAttackAction
-     * @param isArtilleryIndirect flag that indicates whether this is an
-     *                            indirect-fire artillery attack
+     * @param toHit               The running total ToHitData for this WeaponAttackAction
+     * @param isArtilleryIndirect flag that indicates whether this is an indirect-fire artillery attack
      */
     private static ToHitData compileEnvironmentalToHitMods(Game game, Entity ae, Targetable target, WeaponType wtype,
-            AmmoType atype, ToHitData toHit, boolean isArtilleryIndirect) {
+                                                           AmmoType atype, ToHitData toHit,
+                                                           boolean isArtilleryIndirect) {
         PlanetaryConditions conditions = game.getPlanetaryConditions();
 
         if (toHit == null) {
@@ -3041,8 +3397,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
             } else if (conditions.getWind().isTornadoF1ToF3()) {
                 if (wtype != null && wtype.hasFlag(WeaponType.F_ENERGY)) {
                     weatherToHitMods.addModifier(2, conditions.getWind().toString());
-                } else if (wtype != null && wtype.hasFlag(WeaponType.F_BALLISTIC)
-                        && wtype.hasFlag(WeaponType.F_DIRECT_FIRE)) {
+                } else if (wtype != null &&
+                                 wtype.hasFlag(WeaponType.F_BALLISTIC) &&
+                                 wtype.hasFlag(WeaponType.F_DIRECT_FIRE)) {
                     weatherToHitMods.addModifier(3, conditions.getWind().toString());
                 }
             } else if (conditions.getWind().isTornadoF4()) {
@@ -3051,18 +3408,18 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // fog mods (not in space)
-        if (wtype != null
-                && wtype.hasFlag(WeaponType.F_ENERGY)
-                && !game.getBoard().inSpace()
-                && conditions.getFog().isFogHeavy()) {
+        if (wtype != null &&
+                  wtype.hasFlag(WeaponType.F_ENERGY) &&
+                  !game.getBoard().inSpace() &&
+                  conditions.getFog().isFogHeavy()) {
             weatherToHitMods.addModifier(1, Messages.getString("WeaponAttackAction.HeavyFog"));
         }
 
         // blowing sand mods
-        if (wtype != null
-                && wtype.hasFlag(WeaponType.F_ENERGY)
-                && !game.getBoard().inSpace()
-                && conditions.isBlowingSandActive()) {
+        if (wtype != null &&
+                  wtype.hasFlag(WeaponType.F_ENERGY) &&
+                  !game.getBoard().inSpace() &&
+                  conditions.isBlowingSandActive()) {
             weatherToHitMods.addModifier(1, Messages.getString("WeaponAttackAction.BlowingSand"));
         }
 
@@ -3076,27 +3433,25 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // gravity mods (not in space)
         if (!game.getBoard().inSpace()) {
             int mod = (int) Math.floor(Math.abs((conditions.getGravity() - 1.0f) / 0.2f));
-            if ((mod != 0) && wtype != null &&
-                    ((wtype.hasFlag(WeaponType.F_BALLISTIC) && wtype.hasFlag(WeaponType.F_DIRECT_FIRE))
-                            || wtype.hasFlag(WeaponType.F_MISSILE))) {
+            if ((mod != 0) &&
+                      wtype != null &&
+                      ((wtype.hasFlag(WeaponType.F_BALLISTIC) && wtype.hasFlag(WeaponType.F_DIRECT_FIRE)) ||
+                             wtype.hasFlag(WeaponType.F_MISSILE))) {
                 toHit.addModifier(mod, Messages.getString("WeaponAttackAction.Gravity"));
             }
         }
 
         // Electro-Magnetic Interference
-        if (conditions.getEMI().isEMI()
-                && !ae.isConventionalInfantry()) {
+        if (conditions.getEMI().isEMI() && !ae.isConventionalInfantry()) {
             toHit.addModifier(2, Messages.getString("WeaponAttackAction.EMI"));
         }
         return toHit;
     }
 
     /**
-     * Convenience method that compiles the ToHit modifiers applicable to the weapon
-     * being fired
-     * Got a heavy large laser that gets a +1 TH penalty? You'll find that here.
-     * Bonuses related to the attacker's condition? Ammunition being used? Those are
-     * in other methods.
+     * Convenience method that compiles the ToHit modifiers applicable to the weapon being fired Got a heavy large laser
+     * that gets a +1 TH penalty? You'll find that here. Bonuses related to the attacker's condition? Ammunition being
+     * used? Those are in other methods.
      *
      * @param game         The current {@link Game}
      * @param ae           The attacking entity
@@ -3104,24 +3459,19 @@ public class WeaponAttackAction extends AbstractAttackAction {
      * @param target       The Targetable object being attacked
      * @param ttype        The Targetable object type
      * @param toHit        The running total ToHitData for this WeaponAttackAction
-     *
      * @param wtype        The WeaponType of the weapon being used
      * @param weapon       The Mounted weapon being used for this attack
      * @param atype        The AmmoType being used for this attack
-     * @param munition     Long indicating the munition type flag being used, if
-     *                     applicable
-     *
-     * @param isFlakAttack flag that indicates whether the attacker is using Flak
-     *                     against an airborne target
-     * @param isIndirect   flag that indicates whether this is an indirect attack
-     *                     (LRM, mortar...)
-     * @param narcSpotter  flag that indicates whether this spotting entity is using
-     *                     NARC equipment
+     * @param munition     Long indicating the munition type flag being used, if applicable
+     * @param isFlakAttack flag that indicates whether the attacker is using Flak against an airborne target
+     * @param isIndirect   flag that indicates whether this is an indirect attack (LRM, mortar...)
+     * @param narcSpotter  flag that indicates whether this spotting entity is using NARC equipment
      */
-    private static ToHitData compileWeaponToHitMods(Game game, Entity ae, Entity spotter, Targetable target,
-            int ttype, ToHitData toHit, WeaponType wtype, Mounted<?> weapon, AmmoType atype, Mounted<?> ammo,
-            EnumSet<AmmoType.Munitions> munition,
-            boolean isFlakAttack, boolean isIndirect, boolean narcSpotter) {
+    private static ToHitData compileWeaponToHitMods(Game game, Entity ae, Entity spotter, Targetable target, int ttype,
+                                                    ToHitData toHit, WeaponType wtype, Mounted<?> weapon,
+                                                    AmmoType atype, Mounted<?> ammo,
+                                                    EnumSet<AmmoType.Munitions> munition, boolean isFlakAttack,
+                                                    boolean isIndirect, boolean narcSpotter) {
         if (ae == null || wtype == null || weapon == null) {
             // Can't calculate weapon mods without a valid weapon and an attacker to fire it
             return toHit;
@@ -3139,14 +3489,17 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // +4 for trying to fire ASEW or antiship missile at a target of < 500 tons
-        if ((wtype.hasFlag(WeaponType.F_ANTI_SHIP) || wtype.getAmmoType() == AmmoType.T_ASEW_MISSILE)
-                && (te != null) && (te.getWeight() < 500)) {
+        if ((wtype.hasFlag(WeaponType.F_ANTI_SHIP) || wtype.getAmmoType() == AmmoType.T_ASEW_MISSILE) &&
+                  (te != null) &&
+                  (te.getWeight() < 500)) {
             toHit.addModifier(4, Messages.getString("WeaponAttackAction.TeTooSmallForASM"));
         }
 
         // AAA mode makes targeting large craft more difficult
-        if (weapon.hasModes() && weapon.curMode().equals(Weapon.MODE_CAP_LASER_AAA) && te != null
-                && te.isLargeCraft()) {
+        if (weapon.hasModes() &&
+                  weapon.curMode().equals(Weapon.MODE_CAP_LASER_AAA) &&
+                  te != null &&
+                  te.isLargeCraft()) {
             toHit.addModifier(+1, Messages.getString("WeaponAttackAction.AAALaserAtShip"));
         }
 
@@ -3183,8 +3536,11 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // Capital weapon (except missiles) penalties at small targets
-        if (wtype.isCapital() && (wtype.getAtClass() != WeaponType.CLASS_CAPITAL_MISSILE)
-                && (wtype.getAtClass() != WeaponType.CLASS_AR10) && te != null && !te.isLargeCraft()) {
+        if (wtype.isCapital() &&
+                  (wtype.getAtClass() != WeaponType.CLASS_CAPITAL_MISSILE) &&
+                  (wtype.getAtClass() != WeaponType.CLASS_AR10) &&
+                  te != null &&
+                  !te.isLargeCraft()) {
             // Capital Lasers have an AAA mode for shooting at small targets
             int aaaMod = 0;
             if (weapon.hasModes() && weapon.curMode().equals(Weapon.MODE_CAP_LASER_AAA)) {
@@ -3239,12 +3595,13 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // own
         if (isIndirect) {
             // semiguided ammo negates this modifier, if TAG succeeded
-            if ((atype != null) && ((atype.getAmmoType() == AmmoType.T_LRM)
-                    || (atype.getAmmoType() == AmmoType.T_LRM_IMP)
-                    || (atype.getAmmoType() == AmmoType.T_MML)
-                    || (atype.getAmmoType() == AmmoType.T_NLRM)
-                    || (atype.getAmmoType() == AmmoType.T_MEK_MORTAR))
-                    && (munition.contains(AmmoType.Munitions.M_SEMIGUIDED))) {
+            if ((atype != null) &&
+                      ((atype.getAmmoType() == AmmoType.T_LRM) ||
+                             (atype.getAmmoType() == AmmoType.T_LRM_IMP) ||
+                             (atype.getAmmoType() == AmmoType.T_MML) ||
+                             (atype.getAmmoType() == AmmoType.T_NLRM) ||
+                             (atype.getAmmoType() == AmmoType.T_MEK_MORTAR)) &&
+                      (munition.contains(AmmoType.Munitions.M_SEMIGUIDED))) {
 
                 if (Compute.isTargetTagged(target, game)) {
                     toHit.addModifier(-1, Messages.getString("WeaponAttackAction.SemiGuidedIndirect"));
@@ -3253,8 +3610,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 // Unless the target has been tagged, or the spotter has an active command
                 // console
                 toHit.append(Compute.getSpotterMovementModifier(game, spotter.getId()));
-                if (spotter.isAttackingThisTurn() && !spotter.getCrew().hasActiveCommandConsole() &&
-                        !Compute.isTargetTagged(target, game)) {
+                if (spotter.isAttackingThisTurn() &&
+                          !spotter.getCrew().hasActiveCommandConsole() &&
+                          !Compute.isTargetTagged(target, game)) {
                     toHit.addModifier(1, Messages.getString("WeaponAttackAction.SpotterAttacking"));
                 }
             }
@@ -3276,8 +3634,8 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // +1 to hit if the Kinder Rapid-Fire ACs optional rule is turned on, but only
         // Jams on a 2.
         // See TacOps Autocannons for the rest of the rules
-        if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_KIND_RAPID_AC)
-                && weapon.curMode().equals(Weapon.MODE_AC_RAPID)) {
+        if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_KIND_RAPID_AC) &&
+                  weapon.curMode().equals(Weapon.MODE_AC_RAPID)) {
             toHit.addModifier(1, Messages.getString("WeaponAttackAction.AcRapid"));
         }
 
@@ -3288,41 +3646,31 @@ public class WeaponAttackAction extends AbstractAttackAction {
     }
 
     /**
-     * Convenience method that compiles the ToHit modifiers applicable to the
-     * ammunition being used
-     * Using precision AC rounds that get a -1 TH bonus? You'll find that here.
-     * Bonuses related to the attacker's condition? Using a weapon with a TH
-     * penalty? Those are in other methods.
+     * Convenience method that compiles the ToHit modifiers applicable to the ammunition being used Using precision AC
+     * rounds that get a -1 TH bonus? You'll find that here. Bonuses related to the attacker's condition? Using a weapon
+     * with a TH penalty? Those are in other methods.
      *
      * @param game          The current {@link Game}
      * @param ae            The Entity making this attack
      * @param target        The Targetable object being attacked
      * @param ttype         The targetable object type
      * @param toHit         The running total ToHitData for this WeaponAttackAction
-     *
      * @param wtype         The WeaponType of the weapon being used
      * @param weapon        The Mounted weapon being used
      * @param atype         The AmmoType being used for this attack
-     * @param munition      Long indicating the munition type flag being used, if
-     *                      applicable
-     *
-     * @param bApollo       flag that indicates whether the attacker is using an
-     *                      Apollo FCS for MRMs
-     * @param bArtemisV     flag that indicates whether the attacker is using an
-     *                      Artemis V FCS
-     * @param bFTL          flag that indicates whether the attacker is using FTL
-     *                      missiles
-     * @param bHeatSeeking  flag that indicates whether the attacker is using Heat
-     *                      Seeking missiles
-     * @param isECMAffected flag that indicates whether the target is inside an ECM
-     *                      bubble
-     * @param isINarcGuided flag that indicates whether the target is broadcasting
-     *                      an iNarc beacon
+     * @param munition      Long indicating the munition type flag being used, if applicable
+     * @param bApollo       flag that indicates whether the attacker is using an Apollo FCS for MRMs
+     * @param bArtemisV     flag that indicates whether the attacker is using an Artemis V FCS
+     * @param bFTL          flag that indicates whether the attacker is using FTL missiles
+     * @param bHeatSeeking  flag that indicates whether the attacker is using Heat Seeking missiles
+     * @param isECMAffected flag that indicates whether the target is inside an ECM bubble
+     * @param isINarcGuided flag that indicates whether the target is broadcasting an iNarc beacon
      */
     private static ToHitData compileAmmoToHitMods(Game game, Entity ae, Targetable target, int ttype, ToHitData toHit,
-            WeaponType wtype, Mounted<?> weapon, AmmoType atype, EnumSet<AmmoType.Munitions> munition, boolean bApollo,
-            boolean bArtemisV,
-            boolean bFTL, boolean bHeatSeeking, boolean isECMAffected, boolean isINarcGuided) {
+                                                  WeaponType wtype, Mounted<?> weapon, AmmoType atype,
+                                                  EnumSet<AmmoType.Munitions> munition, boolean bApollo,
+                                                  boolean bArtemisV, boolean bFTL, boolean bHeatSeeking,
+                                                  boolean isECMAffected, boolean isINarcGuided) {
         if (ae == null || atype == null) {
             // Can't calculate ammo mods without valid ammo and an attacker to fire it
             return toHit;
@@ -3342,19 +3690,19 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // Autocannon Munitions
 
         // Armor Piercing ammo is a flat +1
-        if (((atype.getAmmoType() == AmmoType.T_AC)
-                || (atype.getAmmoType() == AmmoType.T_LAC)
-                || (atype.getAmmoType() == AmmoType.T_AC_IMP)
-                || (atype.getAmmoType() == AmmoType.T_PAC))
-                && (munition.contains(AmmoType.Munitions.M_ARMOR_PIERCING))) {
+        if (((atype.getAmmoType() == AmmoType.T_AC) ||
+                   (atype.getAmmoType() == AmmoType.T_LAC) ||
+                   (atype.getAmmoType() == AmmoType.T_AC_IMP) ||
+                   (atype.getAmmoType() == AmmoType.T_PAC)) &&
+                  (munition.contains(AmmoType.Munitions.M_ARMOR_PIERCING))) {
             toHit.addModifier(1, Messages.getString("WeaponAttackAction.ApAmmo"));
         }
 
         // Bombs
 
         // Air-to-air Arrow and Light Air-to-air missiles
-        if (((atype.getAmmoType() == AmmoType.T_AAA_MISSILE) || (atype.getAmmoType() == AmmoType.T_LAA_MISSILE))
-                && Compute.isAirToGround(ae, target)) {
+        if (((atype.getAmmoType() == AmmoType.T_AAA_MISSILE) || (atype.getAmmoType() == AmmoType.T_LAA_MISSILE)) &&
+                  Compute.isAirToGround(ae, target)) {
             // +4 penalty if trying to use one against a ground target that is not flying
             // (Errata: https://bg.battletech.com/forums/index.php?topic=87401.msg2060972#msg2060972 )
             if (!target.isAirborneVTOLorWIGE()) {
@@ -3369,7 +3717,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // Flat modifiers defined in AmmoType
         if (atype.getToHitModifier() != 0) {
             toHit.addModifier(atype.getToHitModifier(),
-                    atype.getSubMunitionName() + Messages.getString("WeaponAttackAction.AmmoMod"));
+                  atype.getSubMunitionName() + Messages.getString("WeaponAttackAction.AmmoMod"));
         }
 
         // Missile Munitions
@@ -3387,8 +3735,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
 
         // Follow-the-leader LRMs
         if (bFTL) {
-            toHit.addModifier(2, atype.getSubMunitionName()
-                    + Messages.getString("WeaponAttackAction.AmmoMod"));
+            toHit.addModifier(2, atype.getSubMunitionName() + Messages.getString("WeaponAttackAction.AmmoMod"));
         }
 
         // Heat Seeking Missiles
@@ -3406,18 +3753,16 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 }
                 if ((te.isAirborne()) && (toHit.getSideTable() == ToHitData.SIDE_REAR)) {
                     // -2 bonus if shooting an Aero through the rear arc
-                    toHit.addModifier(-2, atype.getSubMunitionName()
-                            + Messages.getString("WeaponAttackAction.AmmoMod"));
+                    toHit.addModifier(-2,
+                          atype.getSubMunitionName() + Messages.getString("WeaponAttackAction.AmmoMod"));
                 } else if (te.heat == 0) {
                     // +1 penalty if shooting at a non-heat-tracking unit or a heat-tracking unit at
                     // 0 heat
-                    toHit.addModifier(1, atype.getSubMunitionName()
-                            + Messages.getString("WeaponAttackAction.AmmoMod"));
+                    toHit.addModifier(1, atype.getSubMunitionName() + Messages.getString("WeaponAttackAction.AmmoMod"));
                 } else {
                     // -1 bonus for each -1MP the target would get due to heat
                     toHit.addModifier(-te.getHeatMPReduction(),
-                            atype.getSubMunitionName()
-                                    + Messages.getString("WeaponAttackAction.AmmoMod"));
+                          atype.getSubMunitionName() + Messages.getString("WeaponAttackAction.AmmoMod"));
                 }
             }
 
@@ -3433,13 +3778,14 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // Listen-Kill ammo from War of 3039 sourcebook?
-        if (!isECMAffected
-                && ((atype.getAmmoType() == AmmoType.T_LRM)
-                        || (atype.getAmmoType() == AmmoType.T_LRM_IMP)
-                        || (atype.getAmmoType() == AmmoType.T_MML)
-                        || (atype.getAmmoType() == AmmoType.T_SRM)
-                        || (atype.getAmmoType() == AmmoType.T_SRM_IMP))
-                && (munition.contains(AmmoType.Munitions.M_LISTEN_KILL)) && !((te != null) && te.isClan())) {
+        if (!isECMAffected &&
+                  ((atype.getAmmoType() == AmmoType.T_LRM) ||
+                         (atype.getAmmoType() == AmmoType.T_LRM_IMP) ||
+                         (atype.getAmmoType() == AmmoType.T_MML) ||
+                         (atype.getAmmoType() == AmmoType.T_SRM) ||
+                         (atype.getAmmoType() == AmmoType.T_SRM_IMP)) &&
+                  (munition.contains(AmmoType.Munitions.M_LISTEN_KILL)) &&
+                  !((te != null) && te.isClan())) {
             toHit.addModifier(-1, Messages.getString("WeaponAttackAction.ListenKill"));
         }
 
@@ -3447,51 +3793,34 @@ public class WeaponAttackAction extends AbstractAttackAction {
     }
 
     /**
-     * Convenience method that compiles the ToHit modifiers applicable to the
-     * attacker's condition
-     * Attacker has damaged sensors? You'll find that here.
-     * Defender's a superheavy mek? Using a weapon with a TH penalty? Those are in
-     * other methods.
+     * Convenience method that compiles the ToHit modifiers applicable to the attacker's condition Attacker has damaged
+     * sensors? You'll find that here. Defender's a superheavy mek? Using a weapon with a TH penalty? Those are in other
+     * methods.
      *
      * @param game              The current {@link Game}
      * @param ae                The Entity making this attack
      * @param target            The Targetable object being attacked
      * @param los               The calculated LOS between attacker and target
-     * @param toHit             The running total ToHitData for this
-     *                          WeaponAttackAction
-     * @param aimingAt          An int value representing the location being aimed
-     *                          at
-     * @param aimingMode        An int value that determines the reason aiming is
-     *                          allowed
-     *
+     * @param toHit             The running total ToHitData for this WeaponAttackAction
+     * @param aimingAt          An int value representing the location being aimed at
+     * @param aimingMode        An int value that determines the reason aiming is allowed
      * @param wtype             The WeaponType of the weapon being used
      * @param weapon            The Mounted weapon being used
-     * @param weaponId          The id number of the weapon being used - used by
-     *                          some external calculations
+     * @param weaponId          The id number of the weapon being used - used by some external calculations
      * @param atype             The AmmoType being used for this attack
-     * @param munition          Long indicating the munition type flag being used,
-     *                          if applicable
-     *
-     * @param isFlakAttack      flag that indicates whether the attacker is using
-     *                          Flak against an airborne target
-     * @param isHaywireINarced  flag that indicates whether the attacker is affected
-     *                          by an iNarc Haywire pod
-     * @param isNemesisConfused flag that indicates whether the attack is affected
-     *                          by an iNarc Nemesis pod
-     * @param isWeaponFieldGuns flag that indicates whether the attack is being made
-     *                          with infantry field guns
-     * @param usesAmmo          flag that indicates if the WeaponType being used is
-     *                          ammo-fed
+     * @param munition          Long indicating the munition type flag being used, if applicable
+     * @param isFlakAttack      flag that indicates whether the attacker is using Flak against an airborne target
+     * @param isHaywireINarced  flag that indicates whether the attacker is affected by an iNarc Haywire pod
+     * @param isNemesisConfused flag that indicates whether the attack is affected by an iNarc Nemesis pod
+     * @param isWeaponFieldGuns flag that indicates whether the attack is being made with infantry field guns
+     * @param usesAmmo          flag that indicates if the WeaponType being used is ammo-fed
      */
-    private static ToHitData compileAttackerToHitMods(Game game, Entity ae, Targetable target,
-            LosEffects los, ToHitData toHit,
-            int aimingAt,
-            AimingMode aimingMode, WeaponType wtype,
-            Mounted<?> weapon, int weaponId, AmmoType atype,
-            EnumSet<AmmoType.Munitions> munition, boolean isFlakAttack,
-            boolean isHaywireINarced,
-            boolean isNemesisConfused,
-            boolean isWeaponFieldGuns, boolean usesAmmo) {
+    private static ToHitData compileAttackerToHitMods(Game game, Entity ae, Targetable target, LosEffects los,
+                                                      ToHitData toHit, int aimingAt, AimingMode aimingMode,
+                                                      WeaponType wtype, Mounted<?> weapon, int weaponId, AmmoType atype,
+                                                      EnumSet<AmmoType.Munitions> munition, boolean isFlakAttack,
+                                                      boolean isHaywireINarced, boolean isNemesisConfused,
+                                                      boolean isWeaponFieldGuns, boolean usesAmmo) {
         if (toHit == null) {
             // Without valid toHit data, the rest of this will fail
             toHit = new ToHitData();
@@ -3515,12 +3844,11 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // add penalty for called shots and change hit table, if necessary
-        if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_CALLED_SHOTS)
-                && weapon != null) {
+        if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_CALLED_SHOTS) && weapon != null) {
             int call = weapon.getCalledShot().getCall();
             if ((call > CalledShot.CALLED_NONE) && !aimingMode.isNone()) {
                 return new ToHitData(TargetRoll.IMPOSSIBLE,
-                        Messages.getString("WeaponAttackAction.CantAimAndCallShots"));
+                      Messages.getString("WeaponAttackAction.CantAimAndCallShots"));
             }
 
             switch (call) {
@@ -3533,7 +3861,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 case CalledShot.CALLED_LOW:
                     if (los.getTargetCover() == LosEffects.COVER_HORIZONTAL) {
                         return new ToHitData(TargetRoll.IMPOSSIBLE,
-                                Messages.getString("WeaponAttackAction.CalledLowPartCover"));
+                              Messages.getString("WeaponAttackAction.CalledLowPartCover"));
                     }
                     toHit.addModifier(+3, Messages.getString("WeaponAttackAction.CalledLow"));
                     toHit.setHitTable(ToHitData.HIT_BELOW);
@@ -3581,8 +3909,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // if we're spotting for indirect fire, add +1
-        if (ae.isSpotting() && !ae.getCrew().hasActiveCommandConsole()
-                && game.getTagInfo().stream().noneMatch(inf -> inf.attackerId == ae.getId())) {
+        if (ae.isSpotting() &&
+                  !ae.getCrew().hasActiveCommandConsole() &&
+                  game.getTagInfo().stream().noneMatch(inf -> inf.attackerId == ae.getId())) {
             toHit.addModifier(+1, Messages.getString("WeaponAttackAction.AeSpotting"));
         }
 
@@ -3639,18 +3968,19 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // primitive industrial cockpit with advanced firing control: +1 to hit
-        if ((ae instanceof Mek) && (((Mek) ae).getCockpitType() == Mek.COCKPIT_PRIMITIVE)
-                && ((Mek) ae).isIndustrial()) {
+        if ((ae instanceof Mek) &&
+                  (((Mek) ae).getCockpitType() == Mek.COCKPIT_PRIMITIVE) &&
+                  ((Mek) ae).isIndustrial()) {
             toHit.addModifier(1, Messages.getString("WeaponAttackAction.PrimIndustrialAfc"));
         }
 
         // Support vehicle basic/advanced fire control systems
         if ((ae instanceof SupportTank) || (ae instanceof SupportVTOL)) {
-            if (!ae.hasWorkingMisc(MiscType.F_BASIC_FIRECONTROL)
-                    && !ae.hasWorkingMisc(MiscType.F_ADVANCED_FIRECONTROL)) {
+            if (!ae.hasWorkingMisc(MiscType.F_BASIC_FIRECONTROL) &&
+                      !ae.hasWorkingMisc(MiscType.F_ADVANCED_FIRECONTROL)) {
                 toHit.addModifier(2, Messages.getString("WeaponAttackAction.SupVeeNoFc"));
-            } else if (ae.hasWorkingMisc(MiscType.F_BASIC_FIRECONTROL)
-                    && !(ae.hasWorkingMisc(MiscType.F_ADVANCED_FIRECONTROL))) {
+            } else if (ae.hasWorkingMisc(MiscType.F_BASIC_FIRECONTROL) &&
+                             !(ae.hasWorkingMisc(MiscType.F_ADVANCED_FIRECONTROL))) {
                 toHit.addModifier(1, Messages.getString("WeaponAttackAction.SupVeeBfc"));
             }
         }
@@ -3681,16 +4011,20 @@ public class WeaponAttackAction extends AbstractAttackAction {
             }
         } else {
             // LB-X cluster, HAG flak, flak ammo ineligible for TC bonus
-            boolean usesLBXCluster = usesAmmo && (atype != null)
-                    && (atype.getAmmoType() == AmmoType.T_AC_LBX || atype.getAmmoType() == AmmoType.T_AC_LBX_THB)
-                    && munition.contains(AmmoType.Munitions.M_CLUSTER);
+            boolean usesLBXCluster = usesAmmo &&
+                                           (atype != null) &&
+                                           (atype.getAmmoType() == AmmoType.T_AC_LBX ||
+                                                  atype.getAmmoType() == AmmoType.T_AC_LBX_THB) &&
+                                           munition.contains(AmmoType.Munitions.M_CLUSTER);
             boolean usesHAGFlak = usesAmmo && (atype != null) && atype.getAmmoType() == AmmoType.T_HAG && isFlakAttack;
             boolean isSBGauss = usesAmmo && (atype != null) && atype.getAmmoType() == AmmoType.T_SBGAUSS;
             boolean isFlakAmmo = usesAmmo && (atype != null) && (munition.contains(AmmoType.Munitions.M_FLAK));
-            if (ae.hasTargComp() && wtype != null && wtype.hasFlag(WeaponType.F_DIRECT_FIRE)
-                    && !wtype.hasFlag(WeaponType.F_CWS)
-                    && !wtype.hasFlag(WeaponType.F_TASER)
-                    && (!usesAmmo || !(usesLBXCluster || usesHAGFlak || isSBGauss || isFlakAmmo))) {
+            if (ae.hasTargComp() &&
+                      wtype != null &&
+                      wtype.hasFlag(WeaponType.F_DIRECT_FIRE) &&
+                      !wtype.hasFlag(WeaponType.F_CWS) &&
+                      !wtype.hasFlag(WeaponType.F_TASER) &&
+                      (!usesAmmo || !(usesLBXCluster || usesHAGFlak || isSBGauss || isFlakAmmo))) {
                 toHit.addModifier(-1, Messages.getString("WeaponAttackAction.TComp"));
             }
         }
@@ -3716,7 +4050,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
             }
             if (weapon != null && tank.isStabiliserHit(weapon.getLocation())) {
                 toHit.addModifier(Compute.getAttackerMovementModifier(game, tank.getId()).getValue(),
-                        "stabiliser damage");
+                      "stabiliser damage");
             }
         }
 
@@ -3724,53 +4058,35 @@ public class WeaponAttackAction extends AbstractAttackAction {
     }
 
     /**
-     * Convenience method that compiles the ToHit modifiers applicable to the
-     * attacker's condition,
-     * if the attacker is an aero
-     * Attacker has damaged sensors? You'll find that here.
-     * Defender's a superheavy mek? Using a weapon with a TH penalty? Those are in
-     * other methods.
+     * Convenience method that compiles the ToHit modifiers applicable to the attacker's condition, if the attacker is
+     * an aero Attacker has damaged sensors? You'll find that here. Defender's a superheavy mek? Using a weapon with a
+     * TH penalty? Those are in other methods.
      *
      * @param game                The current {@link Game}
      * @param ae                  The Entity making this attack
      * @param target              The Targetable object being attacked
      * @param ttype               The targetable object type
-     * @param toHit               The running total ToHitData for this
-     *                            WeaponAttackAction
-     *
-     * @param aimingAt            An int value representing the location being aimed
-     *                            at
-     * @param aimingMode          An int value that determines the reason aiming is
-     *                            allowed
-     * @param eistatus            An int value representing the ei cockpit/pilot
-     *                            upgrade status
-     *
+     * @param toHit               The running total ToHitData for this WeaponAttackAction
+     * @param aimingAt            An int value representing the location being aimed at
+     * @param aimingMode          An int value that determines the reason aiming is allowed
+     * @param eistatus            An int value representing the ei cockpit/pilot upgrade status
      * @param wtype               The WeaponType of the weapon being used
      * @param weapon              The Mounted weapon being used
      * @param atype               The AmmoType being used for this attack
-     * @param munition            Long indicating the munition type flag being used,
-     *                            if applicable
-     *
-     * @param isArtilleryIndirect flag that indicates whether this is an
-     *                            indirect-fire artillery attack
-     * @param isFlakAttack        flag that indicates whether the attacker is using
-     *                            Flak against an airborne target
-     * @param isNemesisConfused   flag that indicates whether the attack is affected
-     *                            by an iNarc Nemesis pod
-     * @param isStrafing          flag that indicates whether this is an aero
-     *                            strafing attack
-     * @param usesAmmo            flag that indicates if the WeaponType being used
-     *                            is ammo-fed
+     * @param munition            Long indicating the munition type flag being used, if applicable
+     * @param isArtilleryIndirect flag that indicates whether this is an indirect-fire artillery attack
+     * @param isFlakAttack        flag that indicates whether the attacker is using Flak against an airborne target
+     * @param isNemesisConfused   flag that indicates whether the attack is affected by an iNarc Nemesis pod
+     * @param isStrafing          flag that indicates whether this is an aero strafing attack
+     * @param usesAmmo            flag that indicates if the WeaponType being used is ammo-fed
      */
-    private static ToHitData compileAeroAttackerToHitMods(Game game, Entity ae, Targetable target,
-            int ttype, ToHitData toHit, int aimingAt,
-            AimingMode aimingMode, int eistatus,
-            WeaponType wtype, WeaponMounted weapon,
-            AmmoType atype, EnumSet<AmmoType.Munitions> munition,
-            boolean isArtilleryIndirect,
-            boolean isFlakAttack,
-            boolean isNemesisConfused,
-            boolean isStrafing, boolean usesAmmo) {
+    private static ToHitData compileAeroAttackerToHitMods(Game game, Entity ae, Targetable target, int ttype,
+                                                          ToHitData toHit, int aimingAt, AimingMode aimingMode,
+                                                          int eistatus, WeaponType wtype, WeaponMounted weapon,
+                                                          AmmoType atype, EnumSet<AmmoType.Munitions> munition,
+                                                          boolean isArtilleryIndirect, boolean isFlakAttack,
+                                                          boolean isNemesisConfused, boolean isStrafing,
+                                                          boolean usesAmmo) {
         if (toHit == null) {
             // Without valid toHit data, the rest of this will fail
             toHit = new ToHitData();
@@ -3813,16 +4129,20 @@ public class WeaponAttackAction extends AbstractAttackAction {
             }
         } else {
             // LB-X cluster, HAG flak, flak ammo ineligible for TC bonus
-            boolean usesLBXCluster = usesAmmo && (atype != null)
-                    && (atype.getAmmoType() == AmmoType.T_AC_LBX || atype.getAmmoType() == AmmoType.T_AC_LBX_THB)
-                    && munition.contains(AmmoType.Munitions.M_CLUSTER);
+            boolean usesLBXCluster = usesAmmo &&
+                                           (atype != null) &&
+                                           (atype.getAmmoType() == AmmoType.T_AC_LBX ||
+                                                  atype.getAmmoType() == AmmoType.T_AC_LBX_THB) &&
+                                           munition.contains(AmmoType.Munitions.M_CLUSTER);
             boolean usesHAGFlak = usesAmmo && (atype != null) && atype.getAmmoType() == AmmoType.T_HAG && isFlakAttack;
             boolean isSBGauss = usesAmmo && (atype != null) && atype.getAmmoType() == AmmoType.T_SBGAUSS;
             boolean isFlakAmmo = usesAmmo && (atype != null) && (munition.contains(AmmoType.Munitions.M_FLAK));
-            if (ae.hasTargComp() && wtype != null && wtype.hasFlag(WeaponType.F_DIRECT_FIRE)
-                    && !wtype.hasFlag(WeaponType.F_CWS)
-                    && !wtype.hasFlag(WeaponType.F_TASER)
-                    && (!usesAmmo || !(usesLBXCluster || usesHAGFlak || isSBGauss || isFlakAmmo))) {
+            if (ae.hasTargComp() &&
+                      wtype != null &&
+                      wtype.hasFlag(WeaponType.F_DIRECT_FIRE) &&
+                      !wtype.hasFlag(WeaponType.F_CWS) &&
+                      !wtype.hasFlag(WeaponType.F_TASER) &&
+                      (!usesAmmo || !(usesLBXCluster || usesHAGFlak || isSBGauss || isFlakAmmo))) {
                 toHit.addModifier(-1, Messages.getString("WeaponAttackAction.TComp"));
             }
         }
@@ -3836,17 +4156,15 @@ public class WeaponAttackAction extends AbstractAttackAction {
             // (isn't recoil fun?)
             // So it's here instead of with other weapon mods that apply across the board
             if ((wtype != null) &&
-                    ((wtype.ammoType == AmmoType.T_GAUSS_HEAVY) ||
-                            (wtype.ammoType == AmmoType.T_IGAUSS_HEAVY))
-                    &&
-                    !(ae instanceof Dropship)
-                    && !(ae instanceof Jumpship)) {
+                      ((wtype.ammoType == AmmoType.T_GAUSS_HEAVY) || (wtype.ammoType == AmmoType.T_IGAUSS_HEAVY)) &&
+                      !(ae instanceof Dropship) &&
+                      !(ae instanceof Jumpship)) {
                 toHit.addModifier(+1, Messages.getString("WeaponAttackAction.FighterHeavyGauss"));
             }
 
             // Space ECM
-            if (game.getBoard().inSpace()
-                    && game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ECM)) {
+            if (game.getBoard().inSpace() &&
+                      game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ECM)) {
                 int ecm = ComputeECM.getLargeCraftECM(ae, ae.getPosition(), target.getPosition());
                 if (!ae.isLargeCraft()) {
                     ecm += ComputeECM.getSmallCraftECM(ae, ae.getPosition(), target.getPosition());
@@ -3901,8 +4219,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
             }
 
             // air-to-ground strikes
-            if (Compute.isAirToGround(ae, target)
-                    || (ae.isMakingVTOLGroundAttack())) {
+            if (Compute.isAirToGround(ae, target) || (ae.isMakingVTOLGroundAttack())) {
                 // When altitude bombing, add the altitude as a modifier
                 if (wtype != null && wtype.hasFlag(WeaponType.F_ALT_BOMB)) {
                     toHit.addModifier(ae.getAltitude(), Messages.getString("WeaponAttackAction.BombAltitude"));
@@ -3940,7 +4257,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
             // units making air to ground attacks are easier to hit by air-to-air
             // attacks
             if (Compute.isAirToAir(ae, target)) {
-                for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements();) {
+                for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements(); ) {
                     EntityAction ea = i.nextElement();
                     if (!(ea instanceof WeaponAttackAction)) {
                         continue;
@@ -3999,16 +4316,17 @@ public class WeaponAttackAction extends AbstractAttackAction {
 
             // targeting mods for evasive action by large craft
             // Per TW, this does not apply when firing Capital Missiles
-            if (aero.isEvading() && wtype != null &&
-                    (!(wtype.getAtClass() == WeaponType.CLASS_CAPITAL_MISSILE
-                            || wtype.getAtClass() == WeaponType.CLASS_AR10
-                            || wtype.getAtClass() == WeaponType.CLASS_TELE_MISSILE))) {
+            if (aero.isEvading() &&
+                      wtype != null &&
+                      (!(wtype.getAtClass() == WeaponType.CLASS_CAPITAL_MISSILE ||
+                               wtype.getAtClass() == WeaponType.CLASS_AR10 ||
+                               wtype.getAtClass() == WeaponType.CLASS_TELE_MISSILE))) {
                 toHit.addModifier(+2, Messages.getString("WeaponAttackAction.AeEvading"));
             }
 
             // stratops page 113: ECHO maneuvers for large craft
             if (((aero instanceof Warship) || (aero instanceof Dropship)) &&
-                    (aero.getFacing() != aero.getSecondaryFacing())) {
+                      (aero.getFacing() != aero.getSecondaryFacing())) {
                 // if we're computing this for an "attack preview", then we add 2 MP to
                 // the mp used, as we haven't used the MP yet. If we're actually processing
                 // the attack, then the entity will be marked as 'done' and we have already
@@ -4025,7 +4343,8 @@ public class WeaponAttackAction extends AbstractAttackAction {
 
                 // any heavy lasers
                 if (wtype.getAtClass() == WeaponType.CLASS_LASER &&
-                        weapon.getBayWeapons().stream()
+                          weapon.getBayWeapons()
+                                .stream()
                                 .map(WeaponMounted::getType)
                                 .map(WeaponType::getInternalName)
                                 .anyMatch(i -> i.startsWith("CLHeavyLaser"))) {
@@ -4087,18 +4406,15 @@ public class WeaponAttackAction extends AbstractAttackAction {
     }
 
     /**
-     * Convenience method that compiles the ToHit modifiers applicable to the
-     * attacker's crew/pilot
-     * Pilot wounded? Has an SPA? You'll find that here.
-     * Defender's a superheavy mek? Using a weapon with a TH penalty? Those are in
-     * other methods.
+     * Convenience method that compiles the ToHit modifiers applicable to the attacker's crew/pilot Pilot wounded? Has
+     * an SPA? You'll find that here. Defender's a superheavy mek? Using a weapon with a TH penalty? Those are in other
+     * methods.
      *
      * @param game   The current {@link Game}
      * @param ae     The Entity making this attack
      * @param te     The target Entity
      * @param toHit  The running total ToHitData for this WeaponAttackAction
      * @param weapon The weapon being used (it's type should be WeaponType!)
-     *
      */
     private static ToHitData compileCrewToHitMods(Game game, Entity ae, Entity te, ToHitData toHit, Mounted<?> weapon) {
 
@@ -4132,8 +4448,8 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // Fatigue
-        if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_FATIGUE)
-                && ae.getCrew().isGunneryFatigued()) {
+        if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_FATIGUE) &&
+                  ae.getCrew().isGunneryFatigued()) {
             toHit.addModifier(1, Messages.getString("WeaponAttackAction.Fatigue"));
         }
 
@@ -4162,19 +4478,17 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // Manei Domini Upgrades
 
         // VDNI
-        if (ae.hasAbility(OptionsConstants.MD_VDNI)
-                || ae.hasAbility(OptionsConstants.MD_BVDNI)) {
+        if (ae.hasAbility(OptionsConstants.MD_VDNI) || ae.hasAbility(OptionsConstants.MD_BVDNI)) {
             toHit.addModifier(-1, Messages.getString("WeaponAttackAction.Vdni"));
         }
 
-        WeaponType wtype = ((weapon != null) && (weapon.getType() instanceof WeaponType))
-                ? (WeaponType) weapon.getType()
-                : null;
+        WeaponType wtype = ((weapon != null) && (weapon.getType() instanceof WeaponType)) ?
+                                 (WeaponType) weapon.getType() :
+                                 null;
 
         if (ae.isConventionalInfantry()) {
             // check for cyber eye laser sighting on ranged attacks
-            if (ae.hasAbility(OptionsConstants.MD_CYBER_IMP_LASER)
-                    && !(wtype instanceof InfantryAttack)) {
+            if (ae.hasAbility(OptionsConstants.MD_CYBER_IMP_LASER) && !(wtype instanceof InfantryAttack)) {
                 toHit.addModifier(-1, Messages.getString("WeaponAttackAction.MdEye"));
             }
         }
@@ -4183,58 +4497,41 @@ public class WeaponAttackAction extends AbstractAttackAction {
     }
 
     /**
-     * Convenience method that compiles the ToHit modifiers applicable to the
-     * defender's condition and actions
-     * -4 for shooting at an immobile target? You'll find that here.
-     * Attacker strafing? Using a weapon with a TH penalty? Those are in other
-     * methods.
-     * For simplicity's sake, Quirks and SPAs now get applied here for general cases
-     * (elsewhere for Artillery or ADA)
+     * Convenience method that compiles the ToHit modifiers applicable to the defender's condition and actions -4 for
+     * shooting at an immobile target? You'll find that here. Attacker strafing? Using a weapon with a TH penalty? Those
+     * are in other methods. For simplicity's sake, Quirks and SPAs now get applied here for general cases (elsewhere
+     * for Artillery or ADA)
      *
      * @param game                The current {@link Game}
      * @param ae                  The Entity making this attack
      * @param target              The Targetable object being attacked
      * @param ttype               The targetable object type
      * @param los                 The calculated LOS between attacker and target
-     * @param toHit               The running total ToHitData for this
-     *                            WeaponAttackAction
-     * @param aimingAt            An int value representing the location being aimed
-     *                            at - used by immobile target calculations
-     * @param aimingMode          An int value that determines the reason aiming is
-     *                            allowed - used by immobile target calculations
+     * @param toHit               The running total ToHitData for this WeaponAttackAction
+     * @param aimingAt            An int value representing the location being aimed at - used by immobile target
+     *                            calculations
+     * @param aimingMode          An int value that determines the reason aiming is allowed - used by immobile target
+     *                            calculations
      * @param distance            The distance in hexes from attacker to target
-     *
      * @param wtype               The WeaponType of the weapon being used
      * @param weapon              The Mounted weapon being used
      * @param atype               The AmmoType being used for this attack
-     * @param munition            Long indicating the munition type flag being used,
-     *                            if applicable
-     *
-     * @param isArtilleryDirect   flag that indicates whether this is a direct-fire
-     *                            artillery attack
-     * @param isArtilleryIndirect flag that indicates whether this is an
-     *                            indirect-fire artillery attack
-     * @param isAttackerInfantry  flag that indicates whether the attacker is an
-     *                            infantry/BA unit
-     * @param exchangeSwarmTarget flag that indicates whether this is the secondary
-     *                            target of Swarm LRMs
-     * @param isIndirect          flag that indicates whether this is an indirect
-     *                            attack (LRM, mortar...)
-     * @param isPointBlankShot    flag that indicates whether or not this is a PBS
-     *                            by a hidden unit
-     * @param usesAmmo            flag that indicates whether or not the WeaponType
-     *                            being used is ammo-fed
+     * @param munition            Long indicating the munition type flag being used, if applicable
+     * @param isArtilleryDirect   flag that indicates whether this is a direct-fire artillery attack
+     * @param isArtilleryIndirect flag that indicates whether this is an indirect-fire artillery attack
+     * @param isAttackerInfantry  flag that indicates whether the attacker is an infantry/BA unit
+     * @param exchangeSwarmTarget flag that indicates whether this is the secondary target of Swarm LRMs
+     * @param isIndirect          flag that indicates whether this is an indirect attack (LRM, mortar...)
+     * @param isPointBlankShot    flag that indicates whether or not this is a PBS by a hidden unit
+     * @param usesAmmo            flag that indicates whether or not the WeaponType being used is ammo-fed
      */
-    private static ToHitData compileTargetToHitMods(Game game, Entity ae, Targetable target,
-            int ttype, LosEffects los, ToHitData toHit,
-            int aimingAt,
-            AimingMode aimingMode, int distance,
-            WeaponType wtype, WeaponMounted weapon, AmmoType atype,
-            EnumSet<AmmoType.Munitions> munition, boolean isArtilleryDirect,
-            boolean isArtilleryIndirect,
-            boolean isAttackerInfantry,
-            boolean exchangeSwarmTarget, boolean isIndirect,
-            boolean isPointBlankShot, boolean usesAmmo) {
+    private static ToHitData compileTargetToHitMods(Game game, Entity ae, Targetable target, int ttype, LosEffects los,
+                                                    ToHitData toHit, int aimingAt, AimingMode aimingMode, int distance,
+                                                    WeaponType wtype, WeaponMounted weapon, AmmoType atype,
+                                                    EnumSet<AmmoType.Munitions> munition, boolean isArtilleryDirect,
+                                                    boolean isArtilleryIndirect, boolean isAttackerInfantry,
+                                                    boolean exchangeSwarmTarget, boolean isIndirect,
+                                                    boolean isPointBlankShot, boolean usesAmmo) {
         if (ae == null || target == null) {
             // Can't handle these attacks without a valid attacker and target
             return toHit;
@@ -4280,6 +4577,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 proneMod = new ToHitData(1, Messages.getString("WeaponAttackAction.ProneRange"));
             }
         }
+        if (proneMod != null) {
+            toHit.append(proneMod);
+        }
 
         // Special effects affecting the target
 
@@ -4307,8 +4607,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // Special Equipment and Quirks that the target possesses
 
         // ECM suite generating Ghost Targets
-        if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_GHOST_TARGET) && !isIndirect
-                && !isArtilleryIndirect && !isArtilleryDirect) {
+        if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_GHOST_TARGET) &&
+                  !isIndirect &&
+                  !isArtilleryIndirect &&
+                  !isArtilleryDirect) {
             int ghostTargetMod = Compute.getGhostTargetNumber(ae, ae.getPosition(), target.getPosition());
             if ((ghostTargetMod > -1) && !ae.isConventionalInfantry()) {
                 int bapMod = 0;
@@ -4316,16 +4618,20 @@ public class WeaponAttackAction extends AbstractAttackAction {
                     bapMod = 1;
                 }
                 int tcMod = 0;
-                if (ae.hasTargComp() && wtype != null
-                        && wtype.hasFlag(WeaponType.F_DIRECT_FIRE) && !wtype.hasFlag(WeaponType.F_CWS)
-                        && !wtype.hasFlag(WeaponType.F_TASER) && (atype != null)
-                        && (!usesAmmo || !(((atype.getAmmoType() == AmmoType.T_AC_LBX)
-                                || (atype.getAmmoType() == AmmoType.T_AC_LBX_THB))
-                                && (munition.contains(AmmoType.Munitions.M_CLUSTER))))) {
+                if (ae.hasTargComp() &&
+                          wtype != null &&
+                          wtype.hasFlag(WeaponType.F_DIRECT_FIRE) &&
+                          !wtype.hasFlag(WeaponType.F_CWS) &&
+                          !wtype.hasFlag(WeaponType.F_TASER) &&
+                          (atype != null) &&
+                          (!usesAmmo ||
+                                 !(((atype.getAmmoType() == AmmoType.T_AC_LBX) ||
+                                          (atype.getAmmoType() == AmmoType.T_AC_LBX_THB)) &&
+                                         (munition.contains(AmmoType.Munitions.M_CLUSTER))))) {
                     tcMod = 2;
                 }
-                int ghostTargetMoF = (ae.getCrew().getSensorOps() + ghostTargetMod)
-                        - (ae.getGhostTargetOverride() + bapMod + tcMod);
+                int ghostTargetMoF = (ae.getCrew().getSensorOps() + ghostTargetMod) -
+                                           (ae.getGhostTargetOverride() + bapMod + tcMod);
                 if (ghostTargetMoF > 1) {
                     // according to this rules clarification the +4 max is on
                     // the PSR not on the to-hit roll
@@ -4348,24 +4654,26 @@ public class WeaponAttackAction extends AbstractAttackAction {
             toHit.append(thTemp);
 
             // semiguided ammo negates this modifier, if TAG succeeded
-            if ((atype != null) && ((atype.getAmmoType() == AmmoType.T_LRM)
-                    || (atype.getAmmoType() == AmmoType.T_LRM_IMP)
-                    || (atype.getAmmoType() == AmmoType.T_MML)
-                    || (atype.getAmmoType() == AmmoType.T_NLRM)
-                    || (atype.getAmmoType() == AmmoType.T_MEK_MORTAR))
-                    && (munition.contains(AmmoType.Munitions.M_SEMIGUIDED)) && (te.getTaggedBy() != UNASSIGNED)) {
+            if ((atype != null) &&
+                      ((atype.getAmmoType() == AmmoType.T_LRM) ||
+                             (atype.getAmmoType() == AmmoType.T_LRM_IMP) ||
+                             (atype.getAmmoType() == AmmoType.T_MML) ||
+                             (atype.getAmmoType() == AmmoType.T_NLRM) ||
+                             (atype.getAmmoType() == AmmoType.T_MEK_MORTAR)) &&
+                      (munition.contains(AmmoType.Munitions.M_SEMIGUIDED)) &&
+                      (te.getTaggedBy() != UNASSIGNED)) {
                 int nAdjust = thTemp.getValue();
                 if (nAdjust > 0) {
                     toHit.append(new ToHitData(-nAdjust, Messages.getString("WeaponAttackAction.SemiGuidedTag")));
                 }
             }
             // precision ammo reduces this modifier
-            else if ((atype != null)
-                    && ((atype.getAmmoType() == AmmoType.T_AC)
-                            || (atype.getAmmoType() == AmmoType.T_LAC)
-                            || (atype.getAmmoType() == AmmoType.T_AC_IMP)
-                            || (atype.getAmmoType() == AmmoType.T_PAC))
-                    && (munition.contains(AmmoType.Munitions.M_PRECISION))) {
+            else if ((atype != null) &&
+                           ((atype.getAmmoType() == AmmoType.T_AC) ||
+                                  (atype.getAmmoType() == AmmoType.T_LAC) ||
+                                  (atype.getAmmoType() == AmmoType.T_AC_IMP) ||
+                                  (atype.getAmmoType() == AmmoType.T_PAC)) &&
+                           (munition.contains(AmmoType.Munitions.M_PRECISION))) {
                 int nAdjust = Math.min(2, thTemp.getValue());
                 if (nAdjust > 0) {
                     toHit.append(new ToHitData(-nAdjust, Messages.getString("WeaponAttackAction.Precision")));
@@ -4384,9 +4692,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
 
         // Ground-to-air attacks against a target flying at any other altitude (if
         // StratOps Velocity mods are on)
-        if (Compute.isGroundToAir(ae, target)
-                && game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_AA_FIRE) && (null != te)
-                && (te.isAero())) {
+        if (Compute.isGroundToAir(ae, target) &&
+                  game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_AA_FIRE) &&
+                  (null != te) &&
+                  (te.isAero())) {
             int vMod = ((IAero) te).getCurrentVelocity();
             if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_AA_MOVE_MOD)) {
                 vMod = Math.min(vMod / 2, 4);
@@ -4395,8 +4704,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // target immobile
-        boolean mekMortarMunitionsIgnoreImmobile = wtype != null && wtype.hasFlag(WeaponType.F_MEK_MORTAR)
-                && (atype != null) && (munition.contains(AmmoType.Munitions.M_AIRBURST));
+        boolean mekMortarMunitionsIgnoreImmobile = wtype != null &&
+                                                         wtype.hasFlag(WeaponType.F_MEK_MORTAR) &&
+                                                         (atype != null) &&
+                                                         (munition.contains(AmmoType.Munitions.M_AIRBURST));
         if (wtype != null && !(wtype instanceof ArtilleryCannonWeapon) && !mekMortarMunitionsIgnoreImmobile) {
             ToHitData immobileMod;
             // grounded dropships are treated as immobile as well for purpose of
@@ -4404,7 +4715,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
             if ((null != te) && !te.isAirborne() && !te.isSpaceborne() && (te instanceof Dropship)) {
                 immobileMod = new ToHitData(-4, Messages.getString("WeaponAttackAction.ImmobileDs"));
             } else {
-                if(Compute.allowAimedShotWith(weapon, aimingMode)) {
+                if (Compute.allowAimedShotWith(weapon, aimingMode)) {
                     immobileMod = Compute.getImmobileMod(target, aimingAt, aimingMode);
                 } else {
                     immobileMod = Compute.getImmobileMod(target, aimingAt, AimingMode.NONE);
@@ -4424,14 +4735,18 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // large support tanks get a -1 per TW
-        if ((te != null) && (te.getWeightClass() == EntityWeightClass.WEIGHT_LARGE_SUPPORT) && !te.isAirborne()
-                && !te.isSpaceborne()) {
+        if ((te != null) &&
+                  (te.getWeightClass() == EntityWeightClass.WEIGHT_LARGE_SUPPORT) &&
+                  !te.isAirborne() &&
+                  !te.isSpaceborne()) {
             toHit.addModifier(-1, Messages.getString("WeaponAttackAction.TeLargeSupportUnit"));
         }
 
         // "grounded small craft" get a -1 per TW
-        if ((te instanceof SmallCraft) && (te.getUnitType() == UnitType.SMALL_CRAFT) && !te.isAirborne()
-                && !te.isSpaceborne()) {
+        if ((te instanceof SmallCraft) &&
+                  (te.getUnitType() == UnitType.SMALL_CRAFT) &&
+                  !te.isAirborne() &&
+                  !te.isSpaceborne()) {
             toHit.addModifier(-1, Messages.getString("WeaponAttackAction.TeGroundedSmallCraft"));
         }
 
@@ -4452,9 +4767,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // pl-masc makes foot infantry harder to hit - IntOps p.84
-        if ((te instanceof Infantry) && te.hasAbility(OptionsConstants.MD_PL_MASC)
-                && te.getMovementMode().isLegInfantry()
-                && te.isConventionalInfantry()) {
+        if ((te instanceof Infantry) &&
+                  te.hasAbility(OptionsConstants.MD_PL_MASC) &&
+                  te.getMovementMode().isLegInfantry() &&
+                  te.isConventionalInfantry()) {
             toHit.addModifier(1, Messages.getString("WeaponAttackAction.PlMasc"));
         }
 
@@ -4487,18 +4803,21 @@ public class WeaponAttackAction extends AbstractAttackAction {
             }
 
             // Target hidden in the sensor shadow of a larger spacecraft
-            if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_SENSOR_SHADOW)
-                    && game.getBoard().inSpace()) {
+            if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_SENSOR_SHADOW) &&
+                      game.getBoard().inSpace()) {
                 for (Entity en : Compute.getAdjacentEntitiesAlongAttack(ae.getPosition(), target.getPosition(), game)) {
-                    if (!en.isEnemyOf(te) && en.isLargeCraft()
-                            && ((en.getWeight() - te.getWeight()) >= -STRATOPS_SENSOR_SHADOW_WEIGHT_DIFF)) {
+                    if (!en.isEnemyOf(te) &&
+                              en.isLargeCraft() &&
+                              ((en.getWeight() - te.getWeight()) >= -STRATOPS_SENSOR_SHADOW_WEIGHT_DIFF)) {
                         toHit.addModifier(+1, Messages.getString("WeaponAttackAction.SensorShadow"));
                         break;
                     }
                 }
                 for (Entity en : game.getEntitiesVector(target.getPosition())) {
-                    if (!en.isEnemyOf(te) && en.isLargeCraft() && !en.equals((Entity) a)
-                            && ((en.getWeight() - te.getWeight()) >= -STRATOPS_SENSOR_SHADOW_WEIGHT_DIFF)) {
+                    if (!en.isEnemyOf(te) &&
+                              en.isLargeCraft() &&
+                              !en.equals((Entity) a) &&
+                              ((en.getWeight() - te.getWeight()) >= -STRATOPS_SENSOR_SHADOW_WEIGHT_DIFF)) {
                         toHit.addModifier(+1, Messages.getString("WeaponAttackAction.SensorShadow"));
                         break;
                     }
@@ -4517,11 +4836,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
     }
 
     /**
-     * Convenience method that compiles the ToHit modifiers applicable to the
-     * terrain and line of sight (LOS)
-     * Woods along the LOS? Target Underwater? Partial cover? You'll find that here.
-     * Also, if the to-hit table is changed due to cover/angle/elevation, look here.
-     * -4 for shooting at an immobile target? Using a weapon with a TH penalty?
+     * Convenience method that compiles the ToHit modifiers applicable to the terrain and line of sight (LOS) Woods
+     * along the LOS? Target Underwater? Partial cover? You'll find that here. Also, if the to-hit table is changed due
+     * to cover/angle/elevation, look here. -4 for shooting at an immobile target? Using a weapon with a TH penalty?
      * Those are in other methods.
      *
      * @param game             The current {@link Game}
@@ -4530,39 +4847,31 @@ public class WeaponAttackAction extends AbstractAttackAction {
      * @param ttype            The targetable object type
      * @param aElev            An int value representing the attacker's elevation
      * @param tElev            An int value representing the target's elevation
-     * @param targEl           An int value representing the target's relative
-     *                         elevation
+     * @param targEl           An int value representing the target's relative elevation
      * @param distance         The distance in hexes from attacker to target
      * @param los              The calculated LOS between attacker and target
-     * @param toHit            The running total ToHitData for this
-     *                         WeaponAttackAction
+     * @param toHit            The running total ToHitData for this WeaponAttackAction
      * @param losMods          A cached set of LOS-related modifiers
-     * @param eistatus         An int value representing the ei cockpit/pilot
-     *                         upgrade status
-     *
+     * @param eistatus         An int value representing the ei cockpit/pilot upgrade status
      * @param wtype            The WeaponType of the weapon being used
      * @param weapon           The Mounted weapon being used
-     * @param weaponId         The id number of the weapon being used - used by some
-     *                         external calculations
+     * @param weaponId         The id number of the weapon being used - used by some external calculations
      * @param atype            The AmmoType being used for this attack
-     * @param munition         Long indicating the munition type flag being used, if
-     *                         applicable
-     *
-     * @param inSameBuilding   flag that indicates whether this attack originates
-     *                         from within the same building
-     * @param isIndirect       flag that indicates whether this is an indirect
-     *                         attack (LRM, mortar...)
-     * @param isPointBlankShot flag that indicates whether or not this is a PBS by a
-     *                         hidden unit
-     * @param underWater       flag that indicates whether the weapon being used is
-     *                         underwater
+     * @param munition         Long indicating the munition type flag being used, if applicable
+     * @param inSameBuilding   flag that indicates whether this attack originates from within the same building
+     * @param isIndirect       flag that indicates whether this is an indirect attack (LRM, mortar...)
+     * @param isPointBlankShot flag that indicates whether or not this is a PBS by a hidden unit
+     * @param underWater       flag that indicates whether the weapon being used is underwater
      */
     private static ToHitData compileTerrainAndLosToHitMods(Game game, Entity ae, Targetable target, int ttype,
-            int aElev, int tElev,
-            int targEl, int distance, LosEffects los, ToHitData toHit, ToHitData losMods, int eistatus,
-            WeaponType wtype, WeaponMounted weapon, int weaponId, AmmoType atype, AmmoMounted ammo,
-            EnumSet<AmmoType.Munitions> munition, boolean isAttackerInfantry,
-            boolean inSameBuilding, boolean isIndirect, boolean isPointBlankShot, boolean underWater) {
+                                                           int aElev, int tElev, int targEl, int distance,
+                                                           LosEffects los, ToHitData toHit, ToHitData losMods,
+                                                           int eistatus, WeaponType wtype, WeaponMounted weapon,
+                                                           int weaponId, AmmoType atype, AmmoMounted ammo,
+                                                           EnumSet<AmmoType.Munitions> munition,
+                                                           boolean isAttackerInfantry, boolean inSameBuilding,
+                                                           boolean isIndirect, boolean isPointBlankShot,
+                                                           boolean underWater) {
         if (ae == null || target == null) {
             // Can't handle these attacks without a valid attacker and target
             return toHit;
@@ -4590,12 +4899,12 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // Don't apply this to bomb attacks either, which are going to be at 0 range of
         // necessity
         // Also don't apply to ADA Missiles (range computed separately)
-        if (((los.getThruBldg() == null) || !los.getTargetPosition().equals(ae.getPosition()))
-                && (wtype != null
-                        && (!(wtype.hasFlag(WeaponType.F_ALT_BOMB)
-                                || wtype.hasFlag(WeaponType.F_DIVE_BOMB)
-                                || (atype != null && atype.getMunitionType().contains(AmmoType.Munitions.M_ADA))))
-                        && weaponId > WeaponType.WEAPON_NA)) {
+        if (((los.getThruBldg() == null) || !los.getTargetPosition().equals(ae.getPosition())) &&
+                  (wtype != null &&
+                         (!(wtype.hasFlag(WeaponType.F_ALT_BOMB) ||
+                                  wtype.hasFlag(WeaponType.F_DIVE_BOMB) ||
+                                  (atype != null && atype.getMunitionType().contains(AmmoType.Munitions.M_ADA)))) &&
+                         weaponId > WeaponType.WEAPON_NA)) {
             toHit.append(Compute.getRangeMods(game, ae, weapon, ammo, target));
         }
 
@@ -4610,24 +4919,29 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // BMM p. 31, semi-guided indirect missile attacks vs tagged targets ignore
         // terrain modifiers
         boolean semiGuidedIndirectVsTaggedTarget = isIndirect &&
-                (atype != null) && atype.getMunitionType().contains(AmmoType.Munitions.M_SEMIGUIDED) &&
-                Compute.isTargetTagged(target, game);
+                                                         (atype != null) &&
+                                                         atype.getMunitionType()
+                                                               .contains(AmmoType.Munitions.M_SEMIGUIDED) &&
+                                                         Compute.isTargetTagged(target, game);
 
         // TW p.111
-        boolean indirectMortarWithoutSpotter = (wtype != null) && wtype.hasFlag(WeaponType.F_MORTARTYPE_INDIRECT)
-                && isIndirect && (Compute.findSpotter(game, ae, target) == null);
+        boolean indirectMortarWithoutSpotter = (wtype != null) &&
+                                                     wtype.hasFlag(WeaponType.F_MORTARTYPE_INDIRECT) &&
+                                                     isIndirect &&
+                                                     (Compute.findSpotter(game, ae, target) == null);
 
         // Base terrain calculations, not applicable when delivering minefields or bombs
         // also not applicable in pointblank shots from hidden units
-        if ((ttype != Targetable.TYPE_MINEFIELD_DELIVER) && !isPointBlankShot && !semiGuidedIndirectVsTaggedTarget
-                && !indirectMortarWithoutSpotter) {
+        if ((ttype != Targetable.TYPE_MINEFIELD_DELIVER) &&
+                  !isPointBlankShot &&
+                  !semiGuidedIndirectVsTaggedTarget &&
+                  !indirectMortarWithoutSpotter) {
             toHit.append(Compute.getTargetTerrainModifier(game, target, eistatus, inSameBuilding, underWater));
         }
 
         // Fortified/Dug-In Infantry
         if ((target instanceof Infantry) && wtype != null && !wtype.hasFlag(WeaponType.F_FLAMER)) {
-            if (targetHexContainsFortified
-                    || (((Infantry) target).getDugIn() == Infantry.DUG_IN_COMPLETE)) {
+            if (targetHexContainsFortified || (((Infantry) target).getDugIn() == Infantry.DUG_IN_COMPLETE)) {
                 toHit.addModifier(2, Messages.getString("WeaponAttackAction.DugInInf"));
             }
         }
@@ -4637,16 +4951,19 @@ public class WeaponAttackAction extends AbstractAttackAction {
         if (te != null && (te instanceof Mek) && ((Mek) te).isSuperHeavy()) {
             partialWaterLevel = 2;
         }
-        if ((te != null) && targetHexContainsWater
-        // target in partial water
-                && (targHex.terrainLevel(Terrains.WATER) == partialWaterLevel) && (targEl == 0) && (te.height() > 0)) {
+        if ((te != null) &&
+                  targetHexContainsWater
+                  // target in partial water
+                  &&
+                  (targHex.terrainLevel(Terrains.WATER) == partialWaterLevel) &&
+                  (targEl == 0) &&
+                  (te.height() > 0)) {
             los.setTargetCover(los.getTargetCover() | LosEffects.COVER_HORIZONTAL);
         }
 
         // Change hit table for partial cover, accommodate for partial underwater (legs)
         if (los.getTargetCover() != LosEffects.COVER_NONE) {
-            if (underWater && (targetHexContainsWater && (targEl == 0)
-                    && (te != null && te.height() > 0))) {
+            if (underWater && (targetHexContainsWater && (targEl == 0) && (te != null && te.height() > 0))) {
                 // weapon underwater, target in partial water
                 toHit.setHitTable(ToHitData.HIT_PARTIAL_COVER);
                 toHit.setCover(LosEffects.COVER_UPPER);
@@ -4675,15 +4992,16 @@ public class WeaponAttackAction extends AbstractAttackAction {
 
         // Hull Down - Some cover states are dependent on LOS
         if ((te != null) && te.isHullDown()) {
-            if ((te instanceof Mek) && !(te instanceof QuadVee && te.getConversionMode() == QuadVee.CONV_MODE_VEHICLE)
-                && (los.getTargetCover() > LosEffects.COVER_NONE)) {
+            if ((te instanceof Mek) &&
+                      !(te instanceof QuadVee && te.getConversionMode() == QuadVee.CONV_MODE_VEHICLE) &&
+                      (los.getTargetCover() > LosEffects.COVER_NONE)) {
                 toHit.addModifier(2, Messages.getString("WeaponAttackAction.HullDown"));
             }
             // tanks going Hull Down is different rules then 'Meks, the
             // direction the attack comes from matters
-            else if ((te instanceof Tank
-                || (te instanceof QuadVee && te.getConversionMode() == QuadVee.CONV_MODE_VEHICLE))
-                && targetHexContainsFortified) {
+            else if ((te instanceof Tank ||
+                            (te instanceof QuadVee && te.getConversionMode() == QuadVee.CONV_MODE_VEHICLE)) &&
+                           targetHexContainsFortified) {
                 // TODO make this a LoS mod so that attacks will come in from
                 // directions that grant Hull Down Mods
                 int moveInDirection;
@@ -4694,9 +5012,9 @@ public class WeaponAttackAction extends AbstractAttackAction {
                     moveInDirection = ToHitData.SIDE_REAR;
                 }
 
-                if ((te.sideTable(ae.getPosition()) == moveInDirection)
-                    || (te.sideTable(ae.getPosition()) == ToHitData.SIDE_LEFT)
-                    || (te.sideTable(ae.getPosition()) == ToHitData.SIDE_RIGHT)) {
+                if ((te.sideTable(ae.getPosition()) == moveInDirection) ||
+                          (te.sideTable(ae.getPosition()) == ToHitData.SIDE_LEFT) ||
+                          (te.sideTable(ae.getPosition()) == ToHitData.SIDE_RIGHT)) {
                     toHit.addModifier(2, Messages.getString("WeaponAttackAction.HullDown"));
                 }
             }
@@ -4709,10 +5027,13 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // we have BAP in range or C3 member has BAP in range
         // we reduce the BTH by 1
         if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_BAP)) {
-            boolean targetWoodsAffectModifier = (te != null) && !te.isOffBoard() && (te.getPosition() != null)
-                && (game.getBoard().getHex(te.getPosition()) != null)
-                && game.getBoard().getHex(te.getPosition()).hasVegetation()
-                && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_WOODS_COVER);
+            boolean targetWoodsAffectModifier = (te != null) &&
+                                                      !te.isOffBoard() &&
+                                                      (te.getPosition() != null) &&
+                                                      (game.getBoard().getHex(te.getPosition()) != null) &&
+                                                      game.getBoard().getHex(te.getPosition()).hasVegetation() &&
+                                                      !game.getOptions()
+                                                             .booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_WOODS_COVER);
             if (los.canSee() && (targetWoodsAffectModifier || los.thruWoods())) {
                 boolean bapInRange = Compute.bapInRange(game, ae, te);
                 boolean c3BAP = false;
@@ -4746,11 +5067,13 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 toHit.setHitTable(ToHitData.HIT_ABOVE);
             } else if ((target.getAltitude() - ae.getAltitude()) > 2) {
                 toHit.setHitTable(ToHitData.HIT_BELOW);
-            } else if (((ae.getAltitude() - target.getAltitude()) > 0)
-                    && te != null && (te.isAero() && ((IAero) te).isSpheroid())) {
+            } else if (((ae.getAltitude() - target.getAltitude()) > 0) &&
+                             te != null &&
+                             (te.isAero() && ((IAero) te).isSpheroid())) {
                 toHit.setHitTable(ToHitData.HIT_ABOVE);
-            } else if (((ae.getAltitude() - target.getAltitude()) < 0)
-                    && te != null && (te.isAero() && ((IAero) te).isSpheroid())) {
+            } else if (((ae.getAltitude() - target.getAltitude()) < 0) &&
+                             te != null &&
+                             (te.isAero() && ((IAero) te).isSpheroid())) {
                 toHit.setHitTable(ToHitData.HIT_BELOW);
             }
         }
@@ -4796,8 +5119,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
     }
 
     /**
-     * Quick routine to determine if the target should be treated as being in a
-     * short building.
+     * Quick routine to determine if the target should be treated as being in a short building.
      */
     public static boolean targetInShortCoverBuilding(Targetable target) {
         if (target.getTargetType() != Targetable.TYPE_ENTITY) {
@@ -4817,13 +5139,13 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // and its height above the hex ceiling (i.e building roof) is 1
         // the height determination takes being prone into account
         return targetHex.containsTerrain(Terrains.BUILDING) &&
-                (targetEntity.getHeight() > 0) &&
-                (targetEntity.relHeight() == 1);
+                     (targetEntity.getHeight() > 0) &&
+                     (targetEntity.relHeight() == 1);
     }
 
     /**
-     * If you're using a weapon that does something totally special and doesn't
-     * apply mods like everything else, look here
+     * If you're using a weapon that does something totally special and doesn't apply mods like everything else, look
+     * here
      *
      * @param game   The current {@link Game}
      * @param ae     The Entity making this attack
@@ -4831,14 +5153,13 @@ public class WeaponAttackAction extends AbstractAttackAction {
      * @param ttype  The targetable object type
      * @param los    The calculated LOS between attacker and target
      * @param toHit  The running total ToHitData for this WeaponAttackAction
-     *
      * @param wtype  The WeaponType of the weapon being used
      * @param atype  The AmmoType being used for this attack
-     * @param srt    Class that stores whether or not this WAA should return a
-     *               special resolution
+     * @param srt    Class that stores whether or not this WAA should return a special resolution
      */
     private static ToHitData handleSpecialWeaponAttacks(Game game, Entity ae, Targetable target, int ttype,
-            LosEffects los, ToHitData toHit, WeaponType wtype, AmmoType atype, SpecialResolutionTracker srt) {
+                                                        LosEffects los, ToHitData toHit, WeaponType wtype,
+                                                        AmmoType atype, SpecialResolutionTracker srt) {
         if (ae == null) {
             // *Should* be impossible at this point in the process
             return toHit;
@@ -4871,12 +5192,12 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // Note that coolant trucks make a regular attack.
         if (wtype.hasFlag(WeaponType.F_EXTINGUISHER)) {
             toHit = new ToHitData(8, Messages.getString("WeaponAttackAction.FireExt"));
-            if (((target instanceof Entity) && ((Entity) target).infernos.isStillBurning())
-                    || ((target instanceof Tank) && ((Tank) target).isInfernoFire())) {
+            if (((target instanceof Entity) && ((Entity) target).infernos.isStillBurning()) ||
+                      ((target instanceof Tank) && ((Tank) target).isInfernoFire())) {
                 toHit.addModifier(2, Messages.getString("WeaponAttackAction.PutOutInferno"));
             }
-            if ((target.getTargetType() == Targetable.TYPE_HEX_EXTINGUISH)
-                    && game.getBoard().isInfernoBurning(target.getPosition())) {
+            if ((target.getTargetType() == Targetable.TYPE_HEX_EXTINGUISH) &&
+                      game.getBoard().isInfernoBurning(target.getPosition())) {
                 toHit.addModifier(2, Messages.getString("WeaponAttackAction.PutOutInferno"));
             }
             srt.setSpecialResolution(true);
@@ -4898,21 +5219,19 @@ public class WeaponAttackAction extends AbstractAttackAction {
     }
 
     /**
-     * Convenience method that compiles the ToHit modifiers applicable to
-     * infantry/BA swarm attacks
+     * Convenience method that compiles the ToHit modifiers applicable to infantry/BA swarm attacks
      *
      * @param game   The current {@link Game}
      * @param ae     The Entity making this attack
      * @param target The Targetable object being attacked
      * @param ttype  The targetable object type
      * @param toHit  The running total ToHitData for this WeaponAttackAction
-     *
      * @param wtype  The WeaponType of the weapon being used
-     * @param srt    Class that stores whether or not this WAA should return a
-     *               special resolution
+     * @param srt    Class that stores whether or not this WAA should return a special resolution
      */
-    private static ToHitData handleInfantrySwarmAttacks(Game game, Entity ae, Targetable target,
-            int ttype, ToHitData toHit, WeaponType wtype, SpecialResolutionTracker srt) {
+    private static ToHitData handleInfantrySwarmAttacks(Game game, Entity ae, Targetable target, int ttype,
+                                                        ToHitData toHit, WeaponType wtype,
+                                                        SpecialResolutionTracker srt) {
         if (ae == null) {
             // *Should* be impossible at this point in the process
             return toHit;
@@ -5007,12 +5326,15 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 }
                 srt.setSpecialResolution(true);
                 return new ToHitData(TargetRoll.AUTOMATIC_SUCCESS,
-                        Messages.getString("WeaponAttackAction.SwarmingAutoHit"), ToHitData.HIT_SWARM,
-                        side);
+                      Messages.getString("WeaponAttackAction.SwarmingAutoHit"),
+                      ToHitData.HIT_SWARM,
+                      side);
             }
             srt.setSpecialResolution(true);
-            return new ToHitData(TargetRoll.AUTOMATIC_SUCCESS, Messages.getString("WeaponAttackAction.SwarmingAutoHit"),
-                    ToHitData.HIT_SWARM_CONVENTIONAL, side);
+            return new ToHitData(TargetRoll.AUTOMATIC_SUCCESS,
+                  Messages.getString("WeaponAttackAction.SwarmingAutoHit"),
+                  ToHitData.HIT_SWARM_CONVENTIONAL,
+                  side);
         }
         // If we get here, no swarm attack applies
         return toHit;
@@ -5026,34 +5348,24 @@ public class WeaponAttackAction extends AbstractAttackAction {
      * @param target               The Targetable object being attacked
      * @param swarmPrimaryTarget   The original Targetable object being attacked
      * @param swarmSecondaryTarget The current Targetable object being attacked
-     * @param toHit                The running total ToHitData for this
-     *                             WeaponAttackAction
-     * @param eistatus             An int value representing the ei cockpit/pilot
-     *                             upgrade status - used for terrain calculation
-     * @param aimingAt             An int value representing the location being
-     *                             aimed at - used for immobile target
-     * @param aimingMode           An int value that determines the reason aiming is
-     *                             allowed - used for immobile target
+     * @param toHit                The running total ToHitData for this WeaponAttackAction
+     * @param eistatus             An int value representing the ei cockpit/pilot upgrade status - used for terrain
+     *                             calculation
+     * @param aimingAt             An int value representing the location being aimed at - used for immobile target
+     * @param aimingMode           An int value that determines the reason aiming is allowed - used for immobile target
      * @param weapon               The Mounted weapon being used
      * @param atype                The AmmoType being used for this attack
-     * @param munition             Long indicating the munition type flag being
-     *                             used, if applicable
-     * @param isECMAffected        flag that indicates whether the target is inside
-     *                             an ECM bubble
-     * @param inSameBuilding       flag that indicates whether this attack
-     *                             originates from within the same building
-     * @param underWater           flag that indicates whether the weapon being used
-     *                             is underwater
+     * @param munition             Long indicating the munition type flag being used, if applicable
+     * @param isECMAffected        flag that indicates whether the target is inside an ECM bubble
+     * @param inSameBuilding       flag that indicates whether this attack originates from within the same building
+     * @param underWater           flag that indicates whether the weapon being used is underwater
      */
     private static ToHitData handleSwarmSecondaryAttacks(Game game, Entity ae, Targetable target,
-            Targetable swarmPrimaryTarget,
-            Targetable swarmSecondaryTarget,
-            ToHitData toHit,
-            int eistatus, int aimingAt,
-            AimingMode aimingMode, Mounted<?> weapon,
-            AmmoType atype, EnumSet<AmmoType.Munitions> munition,
-            boolean isECMAffected,
-            boolean inSameBuilding, boolean underWater) {
+                                                         Targetable swarmPrimaryTarget, Targetable swarmSecondaryTarget,
+                                                         ToHitData toHit, int eistatus, int aimingAt,
+                                                         AimingMode aimingMode, Mounted<?> weapon, AmmoType atype,
+                                                         EnumSet<AmmoType.Munitions> munition, boolean isECMAffected,
+                                                         boolean inSameBuilding, boolean underWater) {
         if (ae == null || swarmPrimaryTarget == null || swarmSecondaryTarget == null) {
             // This method won't work without these 3 things
             return toHit;
@@ -5069,8 +5381,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
 
         toHit.append(Compute.getImmobileMod(swarmSecondaryTarget, aimingAt, aimingMode));
         toHit.append(Compute.getTargetTerrainModifier(game,
-                game.getTarget(swarmSecondaryTarget.getTargetType(), swarmSecondaryTarget.getId()), eistatus,
-                inSameBuilding, underWater));
+              game.getTarget(swarmSecondaryTarget.getTargetType(), swarmSecondaryTarget.getId()),
+              eistatus,
+              inSameBuilding,
+              underWater));
         toHit.setCover(LosEffects.COVER_NONE);
 
         Hex targHex = game.getBoard().getHex(swarmSecondaryTarget.getPosition());
@@ -5119,9 +5433,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
             if (target != null && (target instanceof Mek) && ((Mek) target).isSuperHeavy()) {
                 partialWaterLevel = 2;
             }
-            if (targHex.containsTerrain(Terrains.WATER)
-                    && (targHex.terrainLevel(Terrains.WATER) == partialWaterLevel) && (targEl == 0)
-                    && (oldEnt.height() > 0)) {
+            if (targHex.containsTerrain(Terrains.WATER) &&
+                      (targHex.terrainLevel(Terrains.WATER) == partialWaterLevel) &&
+                      (targEl == 0) &&
+                      (oldEnt.height() > 0)) {
                 toHit.setCover(toHit.getCover() | LosEffects.COVER_HORIZONTAL);
             }
             // Prone
@@ -5137,9 +5452,11 @@ public class WeaponAttackAction extends AbstractAttackAction {
             }
             // I-Swarm bonus
             toHit.append(proneMod);
-            if (!isECMAffected && (atype != null) && !oldEnt.isEnemyOf(ae)
-                    && !(oldEnt.getBadCriticals(CriticalSlot.TYPE_SYSTEM, Mek.SYSTEM_SENSORS, Mek.LOC_HEAD) > 0)
-                    && (munition.contains(AmmoType.Munitions.M_SWARM_I))) {
+            if (!isECMAffected &&
+                      (atype != null) &&
+                      !oldEnt.isEnemyOf(ae) &&
+                      !(oldEnt.getBadCriticals(CriticalSlot.TYPE_SYSTEM, Mek.SYSTEM_SENSORS, Mek.LOC_HEAD) > 0) &&
+                      (munition.contains(AmmoType.Munitions.M_SWARM_I))) {
                 toHit.addModifier(+2, Messages.getString("WeaponAttackAction.SwarmIFriendly"));
             }
         }
@@ -5147,34 +5464,27 @@ public class WeaponAttackAction extends AbstractAttackAction {
     }
 
     /**
-     * Convenience method that compiles the ToHit modifiers applicable to direct
-     * artillery attacks
+     * Convenience method that compiles the ToHit modifiers applicable to direct artillery attacks
      *
      * @param game            The current {@link Game}
      * @param ae              The Entity making this attack
      * @param target          The Targetable object being attacked
      * @param ttype           The targetable object type
-     * @param toHit           The running total ToHitData for this
-     *                        WeaponAttackAction
-     *
+     * @param toHit           The running total ToHitData for this WeaponAttackAction
      * @param wtype           The WeaponType of the weapon being used
      * @param weapon          The Mounted weapon being used
      * @param atype           The AmmoType being used for this attack
-     *
-     * @param isArtilleryFLAK flag that indicates whether this is a flak artillery
-     *                        attack
-     * @param usesAmmo        flag that indicates if the WeaponType being used is
-     *                        ammo-fed
-     * @param srt             Class that stores whether or not this WAA should
-     *                        return a special resolution
+     * @param isArtilleryFLAK flag that indicates whether this is a flak artillery attack
+     * @param usesAmmo        flag that indicates if the WeaponType being used is ammo-fed
+     * @param srt             Class that stores whether or not this WAA should return a special resolution
      */
-    private static ToHitData artilleryDirectToHit(Game game, Entity ae, Targetable target, int ttype,
-            ToHitData losMods, ToHitData toHit, WeaponType wtype, WeaponMounted weapon, AmmoType atype,
-            boolean isArtilleryFLAK, boolean usesAmmo, SpecialResolutionTracker srt) {
+    private static ToHitData artilleryDirectToHit(Game game, Entity ae, Targetable target, int ttype, ToHitData losMods,
+                                                  ToHitData toHit, WeaponType wtype, WeaponMounted weapon,
+                                                  AmmoType atype, boolean isArtilleryFLAK, boolean usesAmmo,
+                                                  SpecialResolutionTracker srt) {
 
         if (null == atype) {
-            return new ToHitData(TargetRoll.AUTOMATIC_FAIL,
-                    "No ammo type!");
+            return new ToHitData(TargetRoll.AUTOMATIC_FAIL, "No ammo type!");
         }
         Entity te = null;
         if (ttype == Targetable.TYPE_ENTITY) {
@@ -5192,7 +5502,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
             // Special range calc
             int distance = Compute.effectiveDistance(game, ae, target);
             toHit.addModifier(Compute.getADARangeModifier(distance),
-                    Messages.getString("WeaponAttackAction.ADARangeBracket"));
+                  Messages.getString("WeaponAttackAction.ADARangeBracket"));
 
             // Return without SRT set so that regular to-hit mods get applied.
             return toHit;
@@ -5252,29 +5562,24 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // ammo to-hit modifier
         if (usesAmmo && (atype.getToHitModifier() != 0)) {
             toHit.addModifier(atype.getToHitModifier(),
-                    atype.getSubMunitionName()
-                            + Messages.getString("WeaponAttackAction.AmmoMod"));
+                  atype.getSubMunitionName() + Messages.getString("WeaponAttackAction.AmmoMod"));
         }
         srt.setSpecialResolution(true);
         return toHit;
     }
 
     /**
-     * Convenience method that compiles the ToHit modifiers applicable to indirect
-     * artillery attacks
+     * Convenience method that compiles the ToHit modifiers applicable to indirect artillery attacks
      *
      * @param ae     The Entity making this attack
      * @param target The Targetable object being attacked
      * @param toHit  The running total ToHitData for this WeaponAttackAction
-     *
      * @param wtype  The WeaponType of the weapon being used
      * @param weapon The Mounted weapon being used
-     *
-     * @param srt    Class that stores whether or not this WAA should return a
-     *               special resolution
+     * @param srt    Class that stores whether or not this WAA should return a special resolution
      */
-    private static ToHitData artilleryIndirectToHit(Entity ae, Targetable target,
-            ToHitData toHit, WeaponType wtype, Mounted<?> weapon, SpecialResolutionTracker srt) {
+    private static ToHitData artilleryIndirectToHit(Entity ae, Targetable target, ToHitData toHit, WeaponType wtype,
+                                                    Mounted<?> weapon, SpecialResolutionTracker srt) {
 
         // See MegaMek/megamek#5168
         int mod = (ae.getPosition().distance(target.getPosition()) <= 17) ? 4 : 7;
@@ -5288,8 +5593,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
         boolean spotterIsForwardObserver = ae.aTracker.getSpotterHasForwardObs();
         if (adjust == TargetRoll.AUTOMATIC_SUCCESS) {
-            return new ToHitData(TargetRoll.AUTOMATIC_SUCCESS,
-                    "Artillery firing at target that's been hit before.");
+            return new ToHitData(TargetRoll.AUTOMATIC_SUCCESS, "Artillery firing at target that's been hit before.");
         } else if (adjust != 0) {
             toHit.addModifier(adjust, Messages.getString("WeaponAttackAction.AdjustedFire"));
             if (spotterIsForwardObserver) {
@@ -5299,8 +5603,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
         // Capital missiles used for surface-to-surface artillery attacks
         // See SO p110
         // Start with a flat +2 modifier
-        if (wtype instanceof CapitalMissileWeapon
-                && Compute.isGroundToGround(ae, target)) {
+        if (wtype instanceof CapitalMissileWeapon && Compute.isGroundToGround(ae, target)) {
             toHit.addModifier(2, Messages.getString("WeaponAttackAction.SubCapArtillery"));
             // +3 additional modifier if fired underwater
             if (ae.isUnderwater()) {
@@ -5325,37 +5628,28 @@ public class WeaponAttackAction extends AbstractAttackAction {
     }
 
     /**
-     * Convenience method that compiles the ToHit modifiers applicable to artillery
-     * attacks
+     * Convenience method that compiles the ToHit modifiers applicable to artillery attacks
      *
      * @param game                The current {@link Game}
      * @param ae                  The Entity making this attack
      * @param target              The Targetable object being attacked
      * @param ttype               The targetable object type
-     * @param toHit               The running total ToHitData for this
-     *                            WeaponAttackAction
-     *
+     * @param toHit               The running total ToHitData for this WeaponAttackAction
      * @param wtype               The WeaponType of the weapon being used
      * @param weapon              The Mounted weapon being used
      * @param atype               The AmmoType being used for this attack
-     *
-     * @param isArtilleryDirect   flag that indicates whether this is a direct-fire
-     *                            artillery attack
-     * @param isArtilleryFLAK     flag that indicates whether this is a flak
-     *                            artillery attack
-     * @param isArtilleryIndirect flag that indicates whether this is an
-     *                            indirect-fire artillery attack
-     * @param isHoming            flag that indicates whether this is a homing
-     *                            missile/copperhead shot
-     * @param usesAmmo            flag that indicates if the WeaponType being used
-     *                            is ammo-fed
-     * @param srt                 Class that stores whether or not this WAA should
-     *                            return a special resolution
+     * @param isArtilleryDirect   flag that indicates whether this is a direct-fire artillery attack
+     * @param isArtilleryFLAK     flag that indicates whether this is a flak artillery attack
+     * @param isArtilleryIndirect flag that indicates whether this is an indirect-fire artillery attack
+     * @param isHoming            flag that indicates whether this is a homing missile/copperhead shot
+     * @param usesAmmo            flag that indicates if the WeaponType being used is ammo-fed
+     * @param srt                 Class that stores whether or not this WAA should return a special resolution
      */
     private static ToHitData handleArtilleryAttacks(Game game, Entity ae, Targetable target, int ttype,
-            ToHitData losMods, ToHitData toHit, WeaponType wtype, WeaponMounted weapon, AmmoType atype,
-            boolean isArtilleryDirect, boolean isArtilleryFLAK, boolean isArtilleryIndirect, boolean isHoming,
-            boolean usesAmmo, SpecialResolutionTracker srt) {
+                                                    ToHitData losMods, ToHitData toHit, WeaponType wtype,
+                                                    WeaponMounted weapon, AmmoType atype, boolean isArtilleryDirect,
+                                                    boolean isArtilleryFLAK, boolean isArtilleryIndirect,
+                                                    boolean isHoming, boolean usesAmmo, SpecialResolutionTracker srt) {
         Entity te = null;
         if (ttype == Targetable.TYPE_ENTITY) {
             te = (Entity) target;
@@ -5369,8 +5663,8 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // Don't bother adding up modifiers if the target hex has been hit before
-        if (game.getEntity(ae.getId()).getOwner().getArtyAutoHitHexes().contains(target.getPosition())
-                && !isArtilleryFLAK) {
+        if (game.getEntity(ae.getId()).getOwner().getArtyAutoHitHexes().contains(target.getPosition()) &&
+                  !isArtilleryFLAK) {
             srt.setSpecialResolution(true);
             return new ToHitData(TargetRoll.AUTOMATIC_SUCCESS, Messages.getString("WeaponAttackAction.ArtyDesTarget"));
         }
@@ -5384,8 +5678,18 @@ public class WeaponAttackAction extends AbstractAttackAction {
 
         // Handle direct artillery attacks.
         if (isArtilleryDirect) {
-            return artilleryDirectToHit(game, ae, target, ttype, losMods, toHit, wtype,
-                    weapon, atype, isArtilleryFLAK, usesAmmo, srt);
+            return artilleryDirectToHit(game,
+                  ae,
+                  target,
+                  ttype,
+                  losMods,
+                  toHit,
+                  wtype,
+                  weapon,
+                  atype,
+                  isArtilleryFLAK,
+                  usesAmmo,
+                  srt);
         } else if (isArtilleryIndirect) {
             // And now for indirect artillery fire; process quirks and SPAs here or they'll
             // be missed
@@ -5428,8 +5732,8 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 toHit.addModifier(+1, Messages.getString("WeaponAttackAction.InAccWeapon"));
             }
             // Stable Weapon - Reduces running/flanking penalty by 1
-            if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_POS_STABLE_WEAPON)
-                    && (ae.moved == EntityMovementType.MOVE_RUN)) {
+            if (weapon.hasQuirk(OptionsConstants.QUIRK_WEAP_POS_STABLE_WEAPON) &&
+                      (ae.moved == EntityMovementType.MOVE_RUN)) {
                 toHit.addModifier(-1, Messages.getString("WeaponAttackAction.StableWeapon"));
             }
             // +1 for a Misrepaired Weapon - See StratOps Partial Repairs
@@ -5445,7 +5749,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
     }
 
     public static ToHitData processAttackerSPAs(ToHitData toHit, Entity ae, Targetable target, WeaponMounted weapon,
-            Game game) {
+                                                Game game) {
         PlanetaryConditions conditions = game.getPlanetaryConditions();
 
         // blood stalker SPA
@@ -5463,24 +5767,22 @@ public class WeaponAttackAction extends AbstractAttackAction {
 
         if (wtype != null) {
             // Unofficial weapon class specialist - Does not have an unspecialized penalty
-            if (ae.hasAbility(OptionsConstants.UNOFF_GUNNERY_LASER)
-                    && wtype.hasFlag(WeaponType.F_ENERGY)) {
+            if (ae.hasAbility(OptionsConstants.UNOFF_GUNNERY_LASER) && wtype.hasFlag(WeaponType.F_ENERGY)) {
                 toHit.addModifier(-1, Messages.getString("WeaponAttackAction.GunLSkill"));
             }
 
-            if (ae.hasAbility(OptionsConstants.UNOFF_GUNNERY_BALLISTIC)
-                    && wtype.hasFlag(WeaponType.F_BALLISTIC)) {
+            if (ae.hasAbility(OptionsConstants.UNOFF_GUNNERY_BALLISTIC) && wtype.hasFlag(WeaponType.F_BALLISTIC)) {
                 toHit.addModifier(-1, Messages.getString("WeaponAttackAction.GunBSkill"));
             }
 
-            if (ae.hasAbility(OptionsConstants.UNOFF_GUNNERY_MISSILE)
-                    && wtype.hasFlag(WeaponType.F_MISSILE)) {
+            if (ae.hasAbility(OptionsConstants.UNOFF_GUNNERY_MISSILE) && wtype.hasFlag(WeaponType.F_MISSILE)) {
                 toHit.addModifier(-1, Messages.getString("WeaponAttackAction.GunMSkill"));
             }
 
             // Is the pilot a weapon specialist?
-            if (wtype instanceof BayWeapon
-                    && weapon.getBayWeapons().stream()
+            if (wtype instanceof BayWeapon &&
+                      weapon.getBayWeapons()
+                            .stream()
                             .allMatch(w -> ae.hasAbility(OptionsConstants.GUNNERY_WEAPON_SPECIALIST, w.getName()))) {
                 // All weapons in a bay must match the specialization
                 toHit.addModifier(-2, Messages.getString("WeaponAttackAction.WeaponSpec"));
@@ -5519,30 +5821,35 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 Entity te = (Entity) target;
 
                 // Fog Specialist
-                if (ae.getCrew().getOptions().stringOption(OptionsConstants.MISC_ENV_SPECIALIST).equals(Crew.ENVSPC_FOG)
-                        && wtype.hasFlag(WeaponType.F_ENERGY)
-                        && !game.getBoard().inSpace()
-                        && conditions.getFog().isFogHeavy()) {
+                if (ae.getCrew()
+                          .getOptions()
+                          .stringOption(OptionsConstants.MISC_ENV_SPECIALIST)
+                          .equals(Crew.ENVSPC_FOG) &&
+                          wtype.hasFlag(WeaponType.F_ENERGY) &&
+                          !game.getBoard().inSpace() &&
+                          conditions.getFog().isFogHeavy()) {
                     toHit.addModifier(-1, Messages.getString("WeaponAttackAction.FogSpec"));
                 }
 
                 // Light Specialist
-                if (ae.getCrew().getOptions().stringOption(OptionsConstants.MISC_ENV_SPECIALIST)
-                        .equals(Crew.ENVSPC_LIGHT)) {
-                    if (!te.isIlluminated()
-                            && conditions.getLight().isDuskOrFullMoonOrGlareOrMoonlessOrSolarFlareOrPitchBack()) {
+                if (ae.getCrew()
+                          .getOptions()
+                          .stringOption(OptionsConstants.MISC_ENV_SPECIALIST)
+                          .equals(Crew.ENVSPC_LIGHT)) {
+                    if (!te.isIlluminated() &&
+                              conditions.getLight().isDuskOrFullMoonOrGlareOrMoonlessOrSolarFlareOrPitchBack()) {
                         toHit.addModifier(-1, Messages.getString("WeaponAttackAction.LightSpec"));
-                    } else if (te.isIlluminated()
-                            && conditions.getLight().isPitchBack()) {
+                    } else if (te.isIlluminated() && conditions.getLight().isPitchBack()) {
                         toHit.addModifier(-1, Messages.getString("WeaponAttackAction.LightSpec"));
                     }
                 }
 
                 // Rain Specialist
-                if (ae.getCrew().getOptions().stringOption(OptionsConstants.MISC_ENV_SPECIALIST)
-                        .equals(Crew.ENVSPC_RAIN)) {
-                    if (conditions.getWeather().isLightRain()
-                            && ae.isConventionalInfantry()) {
+                if (ae.getCrew()
+                          .getOptions()
+                          .stringOption(OptionsConstants.MISC_ENV_SPECIALIST)
+                          .equals(Crew.ENVSPC_RAIN)) {
+                    if (conditions.getWeather().isLightRain() && ae.isConventionalInfantry()) {
                         toHit.addModifier(-1, Messages.getString("WeaponAttackAction.RainSpec"));
                     }
 
@@ -5552,15 +5859,15 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 }
 
                 // Snow Specialist
-                if (ae.getCrew().getOptions().stringOption(OptionsConstants.MISC_ENV_SPECIALIST)
-                        .equals(Crew.ENVSPC_SNOW)) {
-                    if (conditions.getWeather().isLightSnow()
-                            && ae.isConventionalInfantry()) {
+                if (ae.getCrew()
+                          .getOptions()
+                          .stringOption(OptionsConstants.MISC_ENV_SPECIALIST)
+                          .equals(Crew.ENVSPC_SNOW)) {
+                    if (conditions.getWeather().isLightSnow() && ae.isConventionalInfantry()) {
                         toHit.addModifier(-1, Messages.getString("WeaponAttackAction.SnowSpec"));
                     }
 
-                    if (conditions.getWeather().isIceStorm()
-                            && wtype.hasFlag(WeaponType.F_MISSILE)) {
+                    if (conditions.getWeather().isIceStorm() && wtype.hasFlag(WeaponType.F_MISSILE)) {
                         toHit.addModifier(-1, Messages.getString("WeaponAttackAction.SnowSpec"));
                     }
 
@@ -5570,16 +5877,17 @@ public class WeaponAttackAction extends AbstractAttackAction {
                 }
 
                 // Wind Specialist
-                if (ae.getCrew().getOptions().stringOption(OptionsConstants.MISC_ENV_SPECIALIST)
-                        .equals(Crew.ENVSPC_WIND)) {
-                    if (conditions.getWind().isModerateGale()
-                            && wtype.hasFlag(WeaponType.F_MISSILE)) {
+                if (ae.getCrew()
+                          .getOptions()
+                          .stringOption(OptionsConstants.MISC_ENV_SPECIALIST)
+                          .equals(Crew.ENVSPC_WIND)) {
+                    if (conditions.getWind().isModerateGale() && wtype.hasFlag(WeaponType.F_MISSILE)) {
                         toHit.addModifier(-1, Messages.getString("WeaponAttackAction.SnowSpec"));
                     }
 
-                    if (wtype.hasFlag(WeaponType.F_MISSILE)
-                            && wtype.hasFlag(WeaponType.F_BALLISTIC)
-                            && conditions.getWind().isStrongGaleOrStorm()) {
+                    if (wtype.hasFlag(WeaponType.F_MISSILE) &&
+                              wtype.hasFlag(WeaponType.F_BALLISTIC) &&
+                              conditions.getWind().isStrongGaleOrStorm()) {
                         toHit.addModifier(-1, Messages.getString("WeaponAttackAction.WindSpec"));
                     }
 
@@ -5600,37 +5908,38 @@ public class WeaponAttackAction extends AbstractAttackAction {
         }
 
         // Shaky Stick - Target gets a +1 bonus against Ground-to-Air attacks
-        if (te.hasAbility(OptionsConstants.PILOT_SHAKY_STICK)
-                && (te.isAirborne() || te.isAirborneVTOLorWIGE())
-                && !ae.isAirborne() && !ae.isAirborneVTOLorWIGE()) {
+        if (te.hasAbility(OptionsConstants.PILOT_SHAKY_STICK) &&
+                  (te.isAirborne() || te.isAirborneVTOLorWIGE()) &&
+                  !ae.isAirborne() &&
+                  !ae.isAirborneVTOLorWIGE()) {
             toHit.addModifier(+1, Messages.getString("WeaponAttackAction.ShakyStick"));
         }
         // Terrain Abilities - Offboard units don't have a hex, so if an offboard unit has one of these
         // it will cause a NPE. Let's check to make sure the target entity is on the board:
         if (game.getBoard().contains(te.getPosition())) {
             // Urban Guerrilla - Target gets a +1 bonus in any sort of urban terrain
-            if (te.hasAbility(OptionsConstants.INFANTRY_URBAN_GUERRILLA)
-                && (game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.PAVEMENT)
-                    || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.ROAD)
-                    || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.RUBBLE)
-                    || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.BUILDING)
-                    || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.ROUGH))) {
+            if (te.hasAbility(OptionsConstants.INFANTRY_URBAN_GUERRILLA) &&
+                      (game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.PAVEMENT) ||
+                             game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.ROAD) ||
+                             game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.RUBBLE) ||
+                             game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.BUILDING) ||
+                             game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.ROUGH))) {
                 toHit.addModifier(+1, Messages.getString("WeaponAttackAction.UrbanGuerilla"));
             }
             // Forest Ranger - Target gets a +1 bonus in wooded terrain when moving at
             // walking speed or greater
-            if (te.hasAbility(OptionsConstants.PILOT_TM_FOREST_RANGER)
-                && (game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.WOODS)
-                    || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.JUNGLE))
-                && te.moved == EntityMovementType.MOVE_WALK) {
+            if (te.hasAbility(OptionsConstants.PILOT_TM_FOREST_RANGER) &&
+                      (game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.WOODS) ||
+                             game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.JUNGLE)) &&
+                      te.moved == EntityMovementType.MOVE_WALK) {
                 toHit.addModifier(+1, Messages.getString("WeaponAttackAction.ForestRanger"));
             }
             // Swamp Beast - Target gets a +1 bonus in mud/swamp terrain when
             // running/flanking
-            if (te.hasAbility(OptionsConstants.PILOT_TM_SWAMP_BEAST)
-                && (game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.MUD)
-                    || game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.SWAMP))
-                && te.moved == EntityMovementType.MOVE_RUN) {
+            if (te.hasAbility(OptionsConstants.PILOT_TM_SWAMP_BEAST) &&
+                      (game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.MUD) ||
+                             game.getBoard().getHex(te.getPosition()).containsTerrain(Terrains.SWAMP)) &&
+                      te.moved == EntityMovementType.MOVE_RUN) {
                 toHit.addModifier(+1, Messages.getString("WeaponAttackAction.SwampBeast"));
             }
         }
@@ -5644,8 +5953,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
             logger.warn("Unable to construct WAA displayable string due to null reference");
             return "Attacking Null Target with id " + getTargetId() + " using Weapon with id " + weaponId;
         }
-        return "attacking " + getTarget(client.getGame()).getDisplayName() + " with " +
-                getEntity(client.getGame()).getEquipment(weaponId).getName();
+        return "attacking " +
+                     getTarget(client.getGame()).getDisplayName() +
+                     " with " +
+                     getEntity(client.getGame()).getEquipment(weaponId).getName();
     }
 
     @Override


### PR DESCRIPTION
- Corrected the logic to append the prone modifier (`proneMod`) to the hit calculation when applicable.

Fix #6778

### Dev Notes
This conditional looks like it was accidentally removed during the recent fixes made to swarm missiles. All I did was restore it.

Sleet, I've requested you as a reviewer as it looks like you were the one to remove the conditional, so I want your confirmation that it wasn't an intentional change. :)