### PR TITLE
Catch for file not found on mek load

### DIFF
--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -495,12 +495,3 @@ tasks.register('testAi', JavaExec) {
 
     jvmArgs = mmJvmOptions
 }
-
-sentry {
-    debug = true
-    includeSourceContext = true
-    includeDependenciesReport = true
-    autoInstallation {
-        enabled = true
-    }
-}


### PR DESCRIPTION
Will stop sending FileNotFound exceptions to Sentry that might include PII on MekFileLoad error.

Removed Sentry Source upload for now as wasn't working as thought and isn't playing nice with enhanced security.