### PR TITLE
Data updates - Throw the freebirths a bone, quiaff?  Clan conventional infantry

### DIFF
--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -2889,7 +2889,7 @@
 			</model>
 		</chassis>
 		<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
-			<availability>CLAN:5,PP:4+,IS:5,Periphery:5,TC:1-,Periphery.Deep:4+</availability>
+			<availability>PP:4+,IS:5,Periphery:5,TC:1-,Periphery.Deep:4+</availability>
 			<model name='(Demolition)'>
 				<roles>recon,engineer</roles>
 				<availability>General:2,CLAN:0,CGS:3,PP:2</availability>
@@ -2937,6 +2937,26 @@
                 <availability>TC:5</availability>
 			</model>
 		</chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1</availability>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:2-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:6+</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:7</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+</availability>
+            </model>
+        </chassis>
 		<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 			<availability>CLAN:7,PP:7,IS:7,Periphery:7,TC:3-,Periphery.Deep:6+</availability>
 			<model name='(Flamer)'>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -882,7 +882,8 @@
         <chassis name='Clan Foot Point' unitType='Infantry'>
             <availability>CLAN!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8</availability>
             <model name='(Flamer Basic)'>
-                <availability>CLAN.HW:3-,CLAN.IS:3-</availability>
+                <roles>urban</roles>
+                <availability>CLAN:3-</availability>
             </model>
             <model name='(Laser Basic)'>
                 <availability>CLAN!Keshik:6!Front Line:5!Second Line:4</availability>
@@ -892,7 +893,7 @@
             </model>
             <model name='(MG Basic)'>
                 <roles>anti_infantry</roles>
-                <availability>CLAN.HW:4,CLAN.IS:4</availability>
+                <availability>CLAN:4</availability>
             </model>
             <model name='(Rifle AA Basic)'>
                 <roles>anti_aircraft</roles>
@@ -902,10 +903,34 @@
                 <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2</availability>
             </model>
             <model name='(Rifle Light)'>
-                <availability>CLAN.HW!Solahma:2!Provisional Garrison:7,CLAN.HW!Solahma:2!Provisional Garrison:7</availability>
+                <roles>urban</roles>
+                <availability>CLAN!Solahma:2!Provisional Garrison:7</availability>
             </model>
             <model name='(SRM Basic)'>
                 <availability>CLAN!Keshik:5!Front Line:4!Second Line:2!Solahma:1</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:8!Front Line:7!Second Line:5!Solahma:1,CGB!Keshik:5!Front Line:5!Second Line:5!Solahma:1</availability>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:6+</availability>
+            </model>
+            <model name='(Mauser 960 Basic)'>
+                <availability>CLAN!Keshik:3,CHH!Keshik:5!Front Line:1</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:6</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+</availability>
             </model>
         </chassis>
 		<chassis name='Clint' unitType='Mek'>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -1643,10 +1643,10 @@
 			</model>
 		</chassis>
 		<chassis name='Foot Platoon' unitType='Infantry'>
-			<availability>CLAN:10,PP:10,IS:10,Periphery:10,TC:3-,Periphery.Deep:10</availability>
+			<availability>PP:10,IS:10,Periphery:10,TC:3-,Periphery.Deep:10</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
-                <availability>CLAN:7,PP:7,IS:8,Periphery:8,TC:6-,Periphery.Deep:8</availability>
+                <availability>PP:7,IS:8,Periphery:8,TC:6-,Periphery.Deep:8</availability>
 			</model>
 			<model name='(LRM Heavy)'>
 				<availability>IS:2,MERC:3</availability>
@@ -1663,21 +1663,21 @@
 				<availability>General:3,TC:4</availability>
 			</model>
 			<model name='(Laser)'>
-				<availability>CLAN:7,PP:6,IS:6,Periphery:5,TC:3+,Periphery.Deep:5</availability>
+				<availability>PP:6,IS:6,Periphery:5,TC:3+,Periphery.Deep:5</availability>
 			</model>
 			<model name='(Light Scout)'>
 				<roles>recon</roles>
-				<availability>CLAN:5-,PP:6-,IS:5-,Periphery:7-,TC:7-</availability>
+				<availability>PP:6-,IS:5-,Periphery:7-,TC:7-</availability>
 			</model>
 			<model name='(MG)'>
-				<availability>CLAN:7,PP:7,IS:7,Periphery:7,TC:5,Periphery.Deep:5</availability>
+				<availability>PP:7,IS:7,Periphery:7,TC:5,Periphery.Deep:5</availability>
 			</model>
 			<model name='(Rifle AA)'>
 				<roles>anti_aircraft</roles>
-				<availability>CLAN:4,PP:0,IS:6,Periphery:5+,TC:3+,Periphery.Deep:0</availability>
+				<availability>PP:0,IS:6,Periphery:5+,TC:3+,Periphery.Deep:0</availability>
 			</model>
 			<model name='(Rifle Light)'>
-				<availability>CLAN:4,PP:5,IS:5,Periphery:7-,TC:8,Periphery.Deep:7</availability>
+				<availability>PP:5,IS:5,Periphery:7-,TC:8,Periphery.Deep:7</availability>
 			</model>
 			<model name='(Rifle Mountain)'>
 				<roles>mountaineer</roles>
@@ -1685,13 +1685,13 @@
 			</model>
 			<model name='(Rifle Paratrooper)'>
 				<roles>paratrooper</roles>
-				<availability>CLAN:4,PP:2,IS:3,Periphery:2,TC:0</availability>
+				<availability>PP:2,IS:3,Periphery:2,TC:0</availability>
 			</model>
 			<model name='(Rifle)'>
-				<availability>CLAN:7,PP:8,IS:8,Periphery:8,TC:6,Periphery.Deep:6</availability>
+				<availability>PP:8,IS:8,Periphery:8,TC:6,Periphery.Deep:6</availability>
 			</model>
 			<model name='(SRM)'>
-				<availability>CLAN:5,PP:5,IS:5,Periphery:5,TC:3+,Periphery.Deep:5+</availability>
+				<availability>PP:5,IS:5,Periphery:5,TC:3+,Periphery.Deep:5+</availability>
 			</model>
 		</chassis>
         <chassis name='Foot Platoon (Taurian)' unitType='Infantry'>
@@ -2349,26 +2349,26 @@
 			</model>
 		</chassis>
 		<chassis name='Jump Platoon' unitType='Infantry'>
-			<availability>CLAN:8,PP:7,IS:8,Periphery:7,TC:2-,Periphery.Deep:5+</availability>
+			<availability>PP:7,IS:8,Periphery:7,TC:2-,Periphery.Deep:5+</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
-				<availability>CLAN:6,PP:8,IS:8,Periphery:8,TC:3-,Periphery.Deep:8</availability>
+				<availability>PP:8,IS:8,Periphery:8,TC:3-,Periphery.Deep:8</availability>
 			</model>
 			<model name='(LRM)'>
 				<availability>General:5</availability>
 			</model>
 			<model name='(Laser)'>
-				<availability>CLAN:8,PP:8,IS:6,Periphery:5,TC:5+,Periphery.Deep:6+</availability>
+				<availability>PP:8,IS:6,Periphery:5,TC:5+,Periphery.Deep:6+</availability>
 			</model>
 			<model name='(MG)'>
                 <roles>anti_infantry</roles>
-				<availability>CLAN:7,PP:7,IS:7,Periphery:7,TC:5,Periphery.Deep:4</availability>
+				<availability>PP:7,IS:7,Periphery:7,TC:5,Periphery.Deep:4</availability>
 			</model>
 			<model name='(Rifle)'>
-				<availability>CLAN:5-,PP:8,IS:8,Periphery:8,TC:3,Periphery.Deep:6</availability>
+				<availability>PP:8,IS:8,Periphery:8,TC:3,Periphery.Deep:6</availability>
 			</model>
 			<model name='(SRM)'>
-				<availability>CLAN:5,PP:5,IS:5,Periphery:5,TC:4+,Periphery.Deep:4+</availability>
+				<availability>PP:5,IS:5,Periphery:5,TC:4+,Periphery.Deep:4+</availability>
 			</model>
 		</chassis>
         <chassis name='Jump Platoon (Taurian)' unitType='Infantry'>
@@ -2958,26 +2958,26 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
-			<availability>CLAN:7,PP:7,IS:7,Periphery:7,TC:3-,Periphery.Deep:6+</availability>
+			<availability>PP:7,IS:7,Periphery:7,TC:3-,Periphery.Deep:6+</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
-				<availability>CLAN:6,PP:8,IS:8,Periphery:8,TC:3-,Periphery.Deep:8</availability>
+				<availability>PP:8,IS:8,Periphery:8,TC:3-,Periphery.Deep:8</availability>
 			</model>
 			<model name='(LRM)'>
 				<availability>General:5</availability>
 			</model>
 			<model name='(Laser)'>
-				<availability>CLAN:8,PP:6,IS:6,Periphery:5,TC:5+,Periphery.Deep:5+</availability>
+				<availability>PP:6,IS:6,Periphery:5,TC:5+,Periphery.Deep:5+</availability>
 			</model>
 			<model name='(MG)'>
                 <roles>anti_infantry</roles>
-				<availability>CLAN:7,PP:7,IS:7,Periphery:7,TC:5,Periphery.Deep:7</availability>
+				<availability>PP:7,IS:7,Periphery:7,TC:5,Periphery.Deep:7</availability>
 			</model>
 			<model name='(Rifle)'>
-				<availability>CLAN:4-,PP:8,IS:8,Periphery:8,TC:3,Periphery.Deep:6</availability>
+				<availability>PP:8,IS:8,Periphery:8,TC:3,Periphery.Deep:6</availability>
 			</model>
 			<model name='(SRM)'>
-				<availability>CLAN:5,PP:5,IS:5,Periphery:5,TC:4+,Periphery.Deep:4+</availability>
+				<availability>PP:5,IS:5,Periphery:5,TC:4+,Periphery.Deep:4+</availability>
 			</model>
 		</chassis>
         <chassis name='Mechanized Tracked Platoon (Taurian)' unitType='Infantry'>
@@ -2998,6 +2998,30 @@
             </model>
             <model name='(SRM)'>
                 <availability>TC:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CGB!Keshik:8!Front Line:7!Second Line:4!Solahma:1,CIH!Keshik:3!Front Line:2!Second Line:2!Solahma:2</availability>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:7</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+</availability>
             </model>
         </chassis>
 		<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2807-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>
@@ -876,6 +879,35 @@
 				<availability>General:8</availability>
 			</model>
 		</chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8</availability>
+            <model name='(Flamer Basic)'>
+                <availability>CLAN.HW:3-,CLAN.IS:3-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4</availability>
+            </model>
+            <model name='(Mauser 960 Basic)'>
+                <availability>CHH!Keshik:5!Front Line:1</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW:4,CLAN.IS:4</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <availability>CLAN.HW!Solahma:2!Provisional Garrison:7,CLAN.HW!Solahma:2!Provisional Garrison:7</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:2!Solahma:1</availability>
+            </model>
+        </chassis>
 		<chassis name='Clint' unitType='Mek'>
 			<availability>PP:3,CC:7,MOC:4,CLAN:3-,IS:5,FS:7,MERC:5,CS:3-,OA:4,FWL:5,NIOPS:3-</availability>
 			<model name='CLNT-1-2R'>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -908,11 +908,11 @@
         </chassis>
         <chassis name='Clan Field Gun Point' unitType='Infantry'>
             <availability>CLAN!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CIH!Keshik:4!Front Line:3!Second Line:2!Solahma:1!Provisional Garrison:1</availability>
-            <model name='(Motorized AC2)'>
+            <model name='(Motorized AC2 Basic)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
                 <availability>CLAN!Solahma:2!Provisional Garrison:8</availability>
             </model>
-            <model name='(Motorized AC5)'>
+            <model name='(Motorized AC5 Basic)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
                 <availability>CLAN!Solahma:1!Provisional Garrison:6</availability>
             </model>
@@ -926,7 +926,7 @@
             </model>
             <model name='(Tracked AC20 Basic)'>
                 <roles>field_gun</roles>
-                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CGB:0</availability>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CGB:0,CIH:0</availability>
             </model>
             <model name='(Tracked AC5 Basic)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
@@ -950,7 +950,7 @@
             </model>
             <model name='(Wheeled AC20 Basic)'>
                 <roles>field_gun,urban</roles>
-                <availability>CLAN!Second Line:1,CGB!Front Line:1!Second Line:2,CIH:0</availability>
+                <availability>CLAN!Second Line:1,CGB!Front Line:1!Second Line:2,CGB!Front Line:1!Second Line:2,CIH:0</availability>
             </model>
             <model name='(Wheeled AC5 Basic)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
@@ -960,7 +960,7 @@
                 <roles>anti_aircraft,field_gun,urban</roles>
                 <availability>CLAN!Front Line:3!Second Line:4</availability>
             </model>
-            <model name='(Wheeled UAC Basic)'>
+            <model name='(Wheeled UAC5 Basic)'>
                 <roles>field_gun,fire_support,urban</roles>
                 <availability>CLAN!Front Line:2!Second Line:3</availability>
             </model>
@@ -1903,10 +1903,10 @@
 			</model>
 		</chassis>
 		<chassis name='Foot Stealth Squad' unitType='Infantry'>
-			<availability>General:1+</availability>
+			<availability>IS:1+,PP:1+,Periphery:1+</availability>
 			<model name='(Sniper Paratrooper)'>
 				<roles>recon,specops,paratrooper</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,PP:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Fortress' unitType='Dropship'>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -3025,10 +3025,10 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
-			<availability>CLAN:7,PP:7,IS:7,Periphery:7,TC:2-,Periphery.Deep:8+</availability>
+			<availability>PP:7,IS:7,Periphery:7,TC:2-,Periphery.Deep:8+</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
-				<availability>CLAN:6,PP:8,IS:8,Periphery:8,TC:4-,Periphery.Deep:8</availability>
+				<availability>PP:8,IS:8,Periphery:8,TC:4-,Periphery.Deep:8</availability>
 			</model>
 			<model name='(LRM)'>
                 <roles>urban</roles>
@@ -3036,19 +3036,19 @@
 			</model>
 			<model name='(Laser)'>
                 <roles>urban</roles>
-				<availability>CLAN:8,PP:6,IS:6,Periphery:5,TC:5+,Periphery.Deep:5+</availability>
+				<availability>PP:6,IS:6,Periphery:5,TC:5+,Periphery.Deep:5+</availability>
 			</model>
 			<model name='(MG)'>
                 <roles>anti_infantry,urban</roles>
-				<availability>CLAN:7,PP:7,IS:7,Periphery:7,TC:6,Periphery.Deep:7</availability>
+				<availability>PP:7,IS:7,Periphery:7,TC:6,Periphery.Deep:7</availability>
 			</model>
 			<model name='(Rifle)'>
                 <roles>urban</roles>
-				<availability>CLAN:4-,PP:8,IS:8,Periphery:8,TC:4,Periphery.Deep:6</availability>
+				<availability>PP:8,IS:8,Periphery:8,TC:4,Periphery.Deep:6</availability>
 			</model>
 			<model name='(SRM)'>
                 <roles>urban</roles>
-				<availability>CLAN:5,PP:5,IS:5,Periphery:5,TC:4+,Periphery.Deep:4+</availability>
+				<availability>PP:5,IS:5,Periphery:5,TC:4+,Periphery.Deep:4+</availability>
 			</model>
 		</chassis>
         <chassis name='Mechanized Wheeled Platoon (Taurian)' unitType='Infantry'>
@@ -3072,6 +3072,33 @@
             <model name='(SRM)'>
                 <roles>urban</roles>
                 <availability>TC:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN:6+,CIH!Keshik:4!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN:4</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CLAN!Keshik:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:7</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:5+</availability>
             </model>
         </chassis>
 		<chassis name='Medium Strike Fighter' unitType='Conventional Fighter'>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -879,6 +879,33 @@
 				<availability>General:8</availability>
 			</model>
 		</chassis>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:1!Second Line:4!Solahma:3!Provisional Garrison:2,CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:3!Provisional Garrison:2,CIH!Second Line:4!Solahma:3!Provisional Garrison:2</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Keshik:2!Second Line:4!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:5!Solahma:6!Provisional Garrison:4</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7!Provisional Garrison:5</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Keshik:1!Second Line:5!Solahma:2,CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7!Provisional Garrison:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:7!Solahma:8!Provisional Garrison:8</availability>
+            </model>
+        </chassis>
         <chassis name='Clan Foot Point' unitType='Infantry'>
             <availability>CLAN!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8</availability>
             <model name='(Flamer Basic)'>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -933,6 +933,77 @@
                 <availability>CLAN:5+</availability>
             </model>
         </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1</availability>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:2-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:6+</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:7</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CGB!Keshik:8!Front Line:7!Second Line:4!Solahma:1,CIH!Keshik:3!Front Line:2!Second Line:2!Solahma:2</availability>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:7</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN:6+,CIH!Keshik:4!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN:4</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CLAN!Keshik:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:7</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:5+</availability>
+            </model>
+        </chassis>
 		<chassis name='Clint' unitType='Mek'>
 			<availability>PP:3,CC:7,MOC:4,CLAN:3-,IS:5,FS:7,MERC:5,CS:3-,OA:4,FWL:5,NIOPS:3-</availability>
 			<model name='CLNT-1-2R'>
@@ -2937,26 +3008,6 @@
                 <availability>TC:5</availability>
 			</model>
 		</chassis>
-        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-            <availability>CLAN!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1</availability>
-            <model name='(Flamer Basic)'>
-                <roles>urban</roles>
-                <availability>CLAN:2-</availability>
-            </model>
-            <model name='(Laser Basic)'>
-                <availability>CLAN:6+</availability>
-            </model>
-            <model name='(MG Basic)'>
-                <roles>anti_infantry</roles>
-                <availability>CLAN:4</availability>
-            </model>
-            <model name='(Rifle Basic)'>
-                <availability>CLAN:7</availability>
-            </model>
-            <model name='(SRM Basic)'>
-                <availability>CLAN:5+</availability>
-            </model>
-        </chassis>
 		<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
 			<availability>PP:7,IS:7,Periphery:7,TC:3-,Periphery.Deep:6+</availability>
 			<model name='(Flamer)'>
@@ -2998,30 +3049,6 @@
             </model>
             <model name='(SRM)'>
                 <availability>TC:5+</availability>
-            </model>
-        </chassis>
-        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-            <availability>CLAN!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CGB!Keshik:8!Front Line:7!Second Line:4!Solahma:1,CIH!Keshik:3!Front Line:2!Second Line:2!Solahma:2</availability>
-            <model name='(Flamer Basic)'>
-                <roles>urban</roles>
-                <availability>CLAN:3-</availability>
-            </model>
-            <model name='(Laser Basic)'>
-                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4</availability>
-            </model>
-            <model name='(MG Basic)'>
-                <roles>anti_infantry</roles>
-                <availability>CLAN:4</availability>
-            </model>
-            <model name='(Rifle AA Basic)'>
-                <roles>anti_aircraft</roles>
-                <availability>CLAN!Keshik:1,CHH!Keshik:2!Front Line:1</availability>
-            </model>
-            <model name='(Rifle Basic)'>
-                <availability>CLAN:7</availability>
-            </model>
-            <model name='(SRM Basic)'>
-                <availability>CLAN:5+</availability>
             </model>
         </chassis>
 		<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
@@ -3072,33 +3099,6 @@
             <model name='(SRM)'>
                 <roles>urban</roles>
                 <availability>TC:5+</availability>
-            </model>
-        </chassis>
-        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-            <availability>CLAN:6+,CIH!Keshik:4!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
-            <model name='(Flamer Basic)'>
-                <roles>urban</roles>
-                <availability>CLAN:3-</availability>
-            </model>
-            <model name='(Laser Basic)'>
-                <roles>urban</roles>
-                <availability>CLAN!Keshik:5!Front Line:4!Second Line:3</availability>
-            </model>
-            <model name='(MG Basic)'>
-                <roles>anti_infantry,urban</roles>
-                <availability>CLAN:4</availability>
-            </model>
-            <model name='(Rifle AA Basic)'>
-                <roles>anti_aircraft,urban</roles>
-                <availability>CLAN!Keshik:1</availability>
-            </model>
-            <model name='(Rifle Basic)'>
-                <roles>urban</roles>
-                <availability>CLAN:7</availability>
-            </model>
-            <model name='(SRM Basic)'>
-                <roles>urban</roles>
-                <availability>CLAN:5+</availability>
             </model>
         </chassis>
 		<chassis name='Medium Strike Fighter' unitType='Conventional Fighter'>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -1004,6 +1004,30 @@
                 <availability>CLAN:5+</availability>
             </model>
         </chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4</availability>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:3+</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:3</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN!Solahma:1!Provisional Garrison:8</availability>
+            </model>
+            <model name='(SRM)'>
+                <availability>CLAN:4+</availability>
+            </model>
+        </chassis>
 		<chassis name='Clint' unitType='Mek'>
 			<availability>PP:3,CC:7,MOC:4,CLAN:3-,IS:5,FS:7,MERC:5,CS:3-,OA:4,FWL:5,NIOPS:3-</availability>
 			<model name='CLNT-1-2R'>
@@ -3241,38 +3265,38 @@
 			</model>
 		</chassis>
 		<chassis name='Motorized Platoon' unitType='Infantry'>
-			<availability>CLAN:9,PP:9,IS:9,Periphery:9,TC:3-,Periphery.Deep:9</availability>
+			<availability>PP:9,IS:9,Periphery:9,TC:3-,Periphery.Deep:9</availability>
 			<model name='(Fieldworks)'>
 				<roles>engineer</roles>
-				<availability>CHH:2,CGS:2,PP:0,IS:4,Periphery:2</availability>
+				<availability>PP:0,IS:4,Periphery:2</availability>
 			</model>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
-				<availability>CLAN:6,PP:8,IS:8,Periphery:8,TC:5-,Periphery.Deep:8</availability>
+				<availability>PP:8,IS:8,Periphery:8,TC:5-,Periphery.Deep:8</availability>
 			</model>
 			<model name='(LRM)'>
 				<availability>General:5</availability>
 			</model>
 			<model name='(Laser XCT)'>
 				<roles>xct</roles>
-				<availability>CLAN:4,IS:2</availability>
+				<availability>IS:2</availability>
 			</model>
 			<model name='(Laser)'>
-				<availability>CLAN:7,PP:6,IS:6,Periphery:5,TC:4+,Periphery.Deep:5</availability>
+				<availability>PP:6,IS:6,Periphery:5,TC:4+,Periphery.Deep:5</availability>
 			</model>
 			<model name='(MG)'>
                 <roles>anti_infantry</roles>
-				<availability>CLAN:7,PP:7,IS:7,Periphery:7,TC:5,Periphery.Deep:5</availability>
+				<availability>PP:7,IS:7,Periphery:7,TC:5,Periphery.Deep:5</availability>
 			</model>
 			<model name='(Nonlethal)'>
 				<roles>urban,anti_infantry</roles>
-				<availability>CLAN:0,PP:3,CS:7,General:4</availability>
+				<availability>PP:3,CS:7,General:4</availability>
 			</model>
 			<model name='(Rifle)'>
-				<availability>CLAN:6,PP:8,IS:8,Periphery:8,TC:7,Periphery.Deep:8</availability>
+				<availability>PP:8,IS:8,Periphery:8,TC:7,Periphery.Deep:8</availability>
 			</model>
 			<model name='(SRM)'>
-				<availability>CLAN:5,PP:5,IS:5,Periphery:5,TC:4+,Periphery.Deep:5+</availability>
+				<availability>PP:5,IS:5,Periphery:5,TC:4+,Periphery.Deep:5+</availability>
 			</model>
 		</chassis>
         <chassis name='Motorized Platoon (Taurian)' unitType='Infantry'>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -863,7 +863,7 @@
 		<chassis name='Chippewa' unitType='AeroSpaceFighter'>
 			<availability>MOC:3,PP:6,CC:5,OA:3,LA:8,FWL:6,MERC:5,FS:5,CIR:3,Periphery:2,TC:3,DC:3</availability>
 			<model name='CHP-W5'>
-				<availability>PP:3,:0,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
+				<availability>PP:3,LA:8,IS:8,Periphery.Deep:8,MERC:8,FS:8,Periphery:8</availability>
 			</model>
 			<model name='CHP-W5b'>
 				<availability>PP:4</availability>
@@ -904,6 +904,65 @@
             <model name='(Wheeled Thumper)'>
                 <roles>mixed_artillery</roles>
                 <availability>CLAN!Second Line:7!Solahma:8!Provisional Garrison:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CIH!Keshik:4!Front Line:3!Second Line:2!Solahma:1!Provisional Garrison:1</availability>
+            <model name='(Motorized AC2)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Solahma:2!Provisional Garrison:8</availability>
+            </model>
+            <model name='(Motorized AC5)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Solahma:1!Provisional Garrison:6</availability>
+            </model>
+            <model name='(Tracked AC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:7!Front Line:5!Second Line:2,CGB:7+</availability>
+            </model>
+            <model name='(Tracked AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:2,CGB:0</availability>
+            </model>
+            <model name='(Tracked AC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CGB:0</availability>
+            </model>
+            <model name='(Tracked AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:8!Front Line:6!Second Line:3!Solahma:2</availability>
+            </model>
+            <model name='(Tracked LBX10 Basic)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:5!Front Line:1</availability>
+            </model>
+            <model name='(Tracked UAC5 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled AC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Second Line:6!Solahma:1,CGB!Second Line:8!Solahma:1</availability>
+            </model>
+            <model name='(Wheeled AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:5!Solahma:5</availability>
+            </model>
+            <model name='(Wheeled AC20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Second Line:1,CGB!Front Line:1!Second Line:2,CIH:0</availability>
+            </model>
+            <model name='(Wheeled AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:8!Solahma:6,CGB!Second Line:6!Solahma:6</availability>
+            </model>
+            <model name='(Wheeled LBX10 Basic)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN!Front Line:3!Second Line:4</availability>
+            </model>
+            <model name='(Wheeled UAC Basic)'>
+                <roles>field_gun,fire_support,urban</roles>
+                <availability>CLAN!Front Line:2!Second Line:3</availability>
             </model>
         </chassis>
         <chassis name='Clan Foot Point' unitType='Infantry'>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -922,15 +922,15 @@
             </model>
             <model name='(Tracked AC2 Basic)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
-                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:2,CGB:0</availability>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:2,CGB:3+,CIH!Keshik:4!Front Line:4!Second Line:3!Solahma:2</availability>
             </model>
             <model name='(Tracked AC20 Basic)'>
                 <roles>field_gun</roles>
-                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CGB:0,CIH:0</availability>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CGB:4+,CIH:0</availability>
             </model>
             <model name='(Tracked AC5 Basic)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
-                <availability>CLAN!Keshik:8!Front Line:6!Second Line:3!Solahma:2</availability>
+                <availability>CLAN!Keshik:8!Front Line:6!Second Line:3!Solahma:2,CGB:6+,CIH!Keshik:8!Front Line:6!Second Line:3!Solahma:2</availability>
             </model>
             <model name='(Tracked LBX10 Basic)'>
                 <roles>anti_aircraft,field_gun</roles>
@@ -950,7 +950,7 @@
             </model>
             <model name='(Wheeled AC20 Basic)'>
                 <roles>field_gun,urban</roles>
-                <availability>CLAN!Second Line:1,CGB!Front Line:1!Second Line:2,CGB!Front Line:1!Second Line:2,CIH:0</availability>
+                <availability>CLAN!Second Line:1,CGB!Front Line:1!Second Line:2,CIH:0</availability>
             </model>
             <model name='(Wheeled AC5 Basic)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
@@ -990,7 +990,7 @@
             </model>
             <model name='(Rifle Light)'>
                 <roles>urban</roles>
-                <availability>CLAN!Solahma:2!Provisional Garrison:7</availability>
+                <availability>CLAN!Solahma:4!Provisional Garrison:7</availability>
             </model>
             <model name='(SRM Basic)'>
                 <availability>CLAN!Keshik:5!Front Line:4!Second Line:2!Solahma:1</availability>
@@ -1026,6 +1026,7 @@
                 <availability>CLAN:2-</availability>
             </model>
             <model name='(Laser Basic)'>
+                <roles>recon</roles>
                 <availability>CLAN:6+</availability>
             </model>
             <model name='(MG Basic)'>
@@ -1033,6 +1034,7 @@
                 <availability>CLAN:4</availability>
             </model>
             <model name='(Rifle Basic)'>
+                <roles>recon</roles>
                 <availability>CLAN:7</availability>
             </model>
             <model name='(SRM Basic)'>
@@ -1047,6 +1049,9 @@
             </model>
             <model name='(Laser Basic)'>
                 <availability>CLAN!Keshik:6!Front Line:5!Second Line:4</availability>
+            </model>
+            <model name='(Mauser 960 Basic)'>
+                <availability>CGB:2+,CHH:1+</availability>
             </model>
             <model name='(MG Basic)'>
                 <roles>anti_infantry</roles>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2815-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>
@@ -1072,134 +1075,309 @@
 				<availability>General:8</availability>
 			</model>
 		</chassis>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:1!Second Line:4!Solahma:3!Provisional Garrison:2,CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:3!Provisional Garrison:2,CIH!Second Line:4!Solahma:3!Provisional Garrison:2</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Keshik:2!Second Line:4!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:5!Solahma:6!Provisional Garrison:4</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7!Provisional Garrison:5</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Keshik:1!Second Line:5!Solahma:2,CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7!Provisional Garrison:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:7!Solahma:8!Provisional Garrison:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CIH!Keshik:4!Front Line:3!Second Line:2!Solahma:1!Provisional Garrison:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Solahma:2!Provisional Garrison:8</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Solahma:1!Provisional Garrison:6</availability>
+            </model>
+            <model name='(Tracked AC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:2,CGB:7+,CIH!Keshik:7!Front Line:5!Second Line:2</availability>
+            </model>
+            <model name='(Tracked AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:4!Second Line:3!Solahma:2,CGB:3+,CIH!Keshik:4!Front Line:4!Second Line:3!Solahma:2</availability>
+            </model>
+            <model name='(Tracked AC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CGB:4+,CIH:0</availability>
+            </model>
+            <model name='(Tracked AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:7!Front Line:6!Second Line:3!Solahma:2,CGB:6+,CIH!Keshik:8!Front Line:6!Second Line:3!Solahma:2</availability>
+            </model>
+            <model name='(Tracked CLBX10 Basic)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:2,CIH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2,CIH:0</availability>
+            </model>
+            <model name='(Tracked CLBX5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:2,CGB!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CIH:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:1,CIH!Keshik:2</availability>
+            </model>
+            <model name='(Tracked CUAC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2,CIH:0</availability>
+            </model>
+            <model name='(Tracked CUAC5 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:2,CGB!Keshik:1,CIH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked LBX10 Basic)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:5!Front Line:1</availability>
+            </model>
+            <model name='(Tracked UAC5 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled AC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Second Line:6!Solahma:1,CGB!Second Line:8!Solahma:1</availability>
+            </model>
+            <model name='(Wheeled AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:5!Solahma:5</availability>
+            </model>
+            <model name='(Wheeled AC20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Second Line:1,CGB!Front Line:1!Second Line:2,CIH:0</availability>
+            </model>
+            <model name='(Wheeled AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:8!Solahma:6,CGB!Second Line:6!Solahma:6</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Basic)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:3,CIH!Keshik:1</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:2,CGB!Keshik:1</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2,CIH:1</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:2,CGB!Keshik:1</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:1,CIH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:2,CGB!Keshik:1,CIH!Keshik:1</availability>
+            </model>
+            <model name='(Wheeled LBX10 Basic)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN!Front Line:3!Second Line:4</availability>
+            </model>
+            <model name='(Wheeled UAC5 Basic)'>
+                <roles>field_gun,fire_support,urban</roles>
+                <availability>CLAN!Front Line:2!Second Line:3</availability>
+            </model>
+        </chassis>
 		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CIH:5,CLAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
+			<availability>CLAN!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8</availability>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4</availability>
+            </model>
+            <model name='(Mauser 960 Basic)'>
+                <availability>CHH!Keshik:5!Front Line:1</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN!Solahma:4!Provisional Garrison:7</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:2!Solahma:1</availability>
+            </model>
 		</chassis>
 		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
+			<availability>CLAN!Keshik:8!Front Line:7!Second Line:5!Solahma:1,CGB!Keshik:5!Front Line:5!Second Line:5!Solahma:1</availability>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:6+</availability>
+            </model>
+            <model name='(Mauser 960 Basic)'>
+                <availability>CLAN!Keshik:3,CHH!Keshik:5!Front Line:1</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:6</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+</availability>
+            </model>
 		</chassis>
 		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CIH:7,CLAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
+			<availability>CLAN!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1</availability>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:2-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>recon</roles>
+                <availability>CLAN:6+</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>recon</roles>
+                <availability>CLAN:7</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+</availability>
+            </model>
 		</chassis>
 		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
+			<availability>CLAN!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CGB!Keshik:8!Front Line:7!Second Line:4!Solahma:1,CIH!Keshik:3!Front Line:2!Second Line:2!Solahma:2</availability>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4</availability>
+            </model>
+            <model name='(Mauser 960 Basic)'>
+                <availability>CGB:2+,CHH:1+</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:7</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+</availability>
+            </model>
 		</chassis>
 		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7</availability>
-			<model name='(Flamer)'>
+			<availability>CLAN:6+,CIH!Keshik:4!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN:3-</availability>
+            </model>
+            <model name='(Laser Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN:4</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CLAN!Keshik:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN:7</availability>
+            </model>
+            <model name='(SRM Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-                <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-                <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
+                <availability>CLAN:5+</availability>
+            </model>
 		</chassis>
 		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CIH:6,CLAN:9</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
+			<availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4</availability>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:3+</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:3</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN!Solahma:1!Provisional Garrison:8</availability>
+            </model>
+            <model name='(SRM)'>
+                <availability>CLAN:4+</availability>
+            </model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
 			<availability>PP:3,CC:7,MOC:4,CLAN:3-,IS:5,FS:7,MERC:5,CS:3-,OA:4,FWL:5,NIOPS:3-</availability>
@@ -1929,10 +2107,10 @@
 			</model>
 		</chassis>
 		<chassis name='Foot Platoon' unitType='Infantry'>
-			<availability>CLAN:6-,PP:10,IS:10,Periphery:10,TC:3-,Periphery.Deep:10</availability>
+			<availability>PP:10,IS:10,Periphery:10,TC:3-,Periphery.Deep:10</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
-                <availability>CLAN:7,PP:7,IS:8,Periphery:8,TC:6-,Periphery.Deep:8</availability>
+                <availability>PP:7,IS:8,Periphery:8,TC:6-,Periphery.Deep:8</availability>
 			</model>
 			<model name='(LRM Heavy)'>
 				<availability>IS:2,MERC:3</availability>
@@ -1949,21 +2127,21 @@
 				<availability>General:3,TC:4</availability>
 			</model>
 			<model name='(Laser)'>
-				<availability>CLAN:3+,PP:5+,IS:6,Periphery:5,TC:3+,Periphery.Deep:5</availability>
+				<availability>PP:5+,IS:6,Periphery:5,TC:3+,Periphery.Deep:5</availability>
 			</model>
 			<model name='(Light Scout)'>
 				<roles>recon</roles>
-				<availability>CLAN:4-,PP:6-,IS:5-,Periphery:7-,TC:7-</availability>
+				<availability>PP:6-,IS:5-,Periphery:7-,TC:7-</availability>
 			</model>
 			<model name='(MG)'>
-				<availability>CLAN:5,PP:6,IS:7,Periphery:7,TC:5,Periphery.Deep:5</availability>
+				<availability>PP:6,IS:7,Periphery:7,TC:5,Periphery.Deep:5</availability>
 			</model>
 			<model name='(Rifle AA)'>
 				<roles>anti_aircraft</roles>
 				<availability>IS:6,Periphery:5+,TC:3+,Periphery.Deep:0</availability>
 			</model>
 			<model name='(Rifle Light)'>
-				<availability>CLAN:6,PP:6,IS:5,Periphery:7-,TC:8,Periphery.Deep:7</availability>
+				<availability>PP:6,IS:5,Periphery:7-,TC:8,Periphery.Deep:7</availability>
 			</model>
 			<model name='(Rifle Mountain)'>
 				<roles>mountaineer</roles>
@@ -1971,13 +2149,13 @@
 			</model>
 			<model name='(Rifle Paratrooper)'>
 				<roles>paratrooper</roles>
-				<availability>CLAN:2,IS:3,Periphery:2,TC:0</availability>
+				<availability>IS:3,Periphery:2,TC:0</availability>
 			</model>
 			<model name='(Rifle)'>
-				<availability>CLAN:8,PP:7,IS:8,Periphery:8,TC:6,Periphery.Deep:6</availability>
+				<availability>PP:7,IS:8,Periphery:8,TC:6,Periphery.Deep:6</availability>
 			</model>
 			<model name='(SRM)'>
-				<availability>CLAN:5+,PP:4+,IS:5,Periphery:5,TC:3+,Periphery.Deep:5+</availability>
+				<availability>PP:4+,IS:5,Periphery:5,TC:3+,Periphery.Deep:5+</availability>
 			</model>
 		</chassis>
         <chassis name='Foot Platoon (Taurian)' unitType='Infantry'>
@@ -2008,10 +2186,10 @@
 			</model>
 		</chassis>
 		<chassis name='Foot Stealth Squad' unitType='Infantry'>
-			<availability>General:1+</availability>
+			<availability>IS:1+,PP:1+,Periphery:1+</availability>
 			<model name='(Sniper Paratrooper)'>
 				<roles>recon,specops,paratrooper</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,PP:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Fortress' unitType='Dropship'>
@@ -2654,26 +2832,26 @@
 			</model>
 		</chassis>
 		<chassis name='Jump Platoon' unitType='Infantry'>
-			<availability>CLAN:6-,PP:6+,IS:8,Periphery:7,TC:2-,Periphery.Deep:5+</availability>
+			<availability>PP:6+,IS:8,Periphery:7,TC:2-,Periphery.Deep:5+</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
-				<availability>CLAN:6,PP:8,IS:8,Periphery:8,TC:3-,Periphery.Deep:8</availability>
+				<availability>PP:8,IS:8,Periphery:8,TC:3-,Periphery.Deep:8</availability>
 			</model>
 			<model name='(LRM)'>
 				<availability>General:5</availability>
 			</model>
 			<model name='(Laser)'>
-				<availability>CLAN:6,PP:8,IS:6,Periphery:5,TC:5+,Periphery.Deep:6+</availability>
+				<availability>PP:8,IS:6,Periphery:5,TC:5+,Periphery.Deep:6+</availability>
 			</model>
 			<model name='(MG)'>
                 <roles>anti_infantry</roles>
-				<availability>CLAN:7,PP:7,IS:7,Periphery:7,TC:5,Periphery.Deep:4</availability>
+				<availability>PP:7,IS:7,Periphery:7,TC:5,Periphery.Deep:4</availability>
 			</model>
 			<model name='(Rifle)'>
-				<availability>CLAN:5-,PP:8,IS:8,Periphery:8,TC:3,Periphery.Deep:6</availability>
+				<availability>PP:8,IS:8,Periphery:8,TC:3,Periphery.Deep:6</availability>
 			</model>
 			<model name='(SRM)'>
-				<availability>CLAN:5+,PP:4+,IS:5,Periphery:5,TC:4+,Periphery.Deep:4+</availability>
+				<availability>PP:4+,IS:5,Periphery:5,TC:4+,Periphery.Deep:4+</availability>
 			</model>
 		</chassis>
         <chassis name='Jump Platoon (Taurian)' unitType='Infantry'>
@@ -3197,31 +3375,31 @@
 			</model>
 		</chassis>
 		<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
-			<availability>CLAN:4-,PP:3+,IS:5,Periphery:5,TC:1-,Periphery.Deep:4+</availability>
+			<availability>PP:3+,IS:5,Periphery:5,TC:1-,Periphery.Deep:4+</availability>
 			<model name='(Demolition)'>
 				<roles>recon,engineer</roles>
 				<availability>General:2,CLAN:0,PP:1+</availability>
 			</model>
 			<model name='(Flamer)'>
-				<availability>CLAN:5,PP:8,IS:8,Periphery:8,TC:2-,Periphery.Deep:8</availability>
+				<availability>PP:8,IS:8,Periphery:8,TC:2-,Periphery.Deep:8</availability>
 			</model>
 			<model name='(LRM)'>
 				<availability>General:5</availability>
 			</model>
 			<model name='(Laser)'>
                 <roles>recon</roles>
-				<availability>CLAN:8,PP:6,IS:6,Periphery:5,TC:5+,Periphery.Deep:5+</availability>
+				<availability>PP:6,IS:6,Periphery:5,TC:5+,Periphery.Deep:5+</availability>
 			</model>
 			<model name='(MG)'>
                 <roles>anti_infantry</roles>
-				<availability>CLAN:7,PP:7,IS:7,Periphery:7,TC:4,Periphery.Deep:6</availability>
+				<availability>PP:7,IS:7,Periphery:7,TC:4,Periphery.Deep:6</availability>
 			</model>
 			<model name='(Rifle)'>
                 <roles>recon</roles>
-				<availability>CLAN:4-,PP:6-,IS:8,Periphery:8,TC:3,Periphery.Deep:8</availability>
+				<availability>PP:6-,IS:8,Periphery:8,TC:3,Periphery.Deep:8</availability>
 			</model>
 			<model name='(SRM)'>
-				<availability>CLAN:5+,PP:5+,IS:5,Periphery:5,TC:4+,Periphery.Deep:5+</availability>
+				<availability>PP:5+,IS:5,Periphery:5,TC:4+,Periphery.Deep:5+</availability>
 			</model>
 		</chassis>
         <chassis name='Mechanized Hover Platoon (Taurian)' unitType='Infantry'>
@@ -3246,26 +3424,26 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
-			<availability>CLAN:5-,PP:5,IS:7,Periphery:7,TC:3-,Periphery.Deep:6+</availability>
+			<availability>PP:5,IS:7,Periphery:7,TC:3-,Periphery.Deep:6+</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
-				<availability>CLAN:6,PP:8,IS:8,Periphery:8,TC:3-,Periphery.Deep:8</availability>
+				<availability>PP:8,IS:8,Periphery:8,TC:3-,Periphery.Deep:8</availability>
 			</model>
 			<model name='(LRM)'>
 				<availability>General:5</availability>
 			</model>
 			<model name='(Laser)'>
-				<availability>CLAN:3+,PP:6,IS:6,Periphery:5,TC:5+,Periphery.Deep:5+</availability>
+				<availability>PP:6,IS:6,Periphery:5,TC:5+,Periphery.Deep:5+</availability>
 			</model>
 			<model name='(MG)'>
                 <roles>anti_infantry</roles>
-				<availability>CLAN:7,PP:7,IS:7,Periphery:7,TC:5,Periphery.Deep:7</availability>
+				<availability>PP:7,IS:7,Periphery:7,TC:5,Periphery.Deep:7</availability>
 			</model>
 			<model name='(Rifle)'>
-				<availability>CLAN:4,PP:6-,IS:8,Periphery:8,TC:3,Periphery.Deep:6</availability>
+				<availability>PP:6-,IS:8,Periphery:8,TC:3,Periphery.Deep:6</availability>
 			</model>
 			<model name='(SRM)'>
-				<availability>CLAN:5+,PP:4+,IS:5,Periphery:5,TC:4+,Periphery.Deep:4+</availability>
+				<availability>PP:4+,IS:5,Periphery:5,TC:4+,Periphery.Deep:4+</availability>
 			</model>
 		</chassis>
         <chassis name='Mechanized Tracked Platoon (Taurian)' unitType='Infantry'>
@@ -3289,10 +3467,10 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
-			<availability>CLAN:4-,PP:6,IS:7,Periphery:7,TC:2-,Periphery.Deep:8+</availability>
+			<availability>PP:6,IS:7,Periphery:7,TC:2-,Periphery.Deep:8+</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
-				<availability>CLAN:6,PP:8,IS:8,Periphery:8,TC:4-,Periphery.Deep:8</availability>
+				<availability>PP:8,IS:8,Periphery:8,TC:4-,Periphery.Deep:8</availability>
 			</model>
 			<model name='(LRM)'>
                 <roles>urban</roles>
@@ -3300,19 +3478,19 @@
 			</model>
 			<model name='(Laser)'>
                 <roles>urban</roles>
-				<availability>CLAN:3+,PP:5+,IS:6,Periphery:5,TC:5+,Periphery.Deep:5+</availability>
+				<availability>PP:5+,IS:6,Periphery:5,TC:5+,Periphery.Deep:5+</availability>
 			</model>
 			<model name='(MG)'>
                 <roles>anti_infantry,urban</roles>
-				<availability>CLAN:7,PP:5,IS:7,Periphery:7,TC:6,Periphery.Deep:7</availability>
+				<availability>PP:5,IS:7,Periphery:7,TC:6,Periphery.Deep:7</availability>
 			</model>
 			<model name='(Rifle)'>
                 <roles>urban</roles>
-				<availability>CLAN:4,PP:8,IS:8,Periphery:8,TC:4,Periphery.Deep:6</availability>
+				<availability>PP:8,IS:8,Periphery:8,TC:4,Periphery.Deep:6</availability>
 			</model>
 			<model name='(SRM)'>
                 <roles>urban</roles>
-				<availability>CLAN:5+,PP:4+,IS:5,Periphery:5,TC:4+,Periphery.Deep:4+</availability>
+				<availability>PP:4+,IS:5,Periphery:5,TC:4+,Periphery.Deep:4+</availability>
 			</model>
 		</chassis>
         <chassis name='Mechanized Wheeled Platoon (Taurian)' unitType='Infantry'>
@@ -3462,38 +3640,38 @@
 			</model>
 		</chassis>
 		<chassis name='Motorized Platoon' unitType='Infantry'>
-			<availability>CLAN:5-,PP:9,IS:9,Periphery:9,TC:3-,Periphery.Deep:9</availability>
+			<availability>PP:9,IS:9,Periphery:9,TC:3-,Periphery.Deep:9</availability>
 			<model name='(Fieldworks)'>
 				<roles>engineer</roles>
-				<availability>CHH:5,CGS:2,IS:4,Periphery:2</availability>
+				<availability>IS:4,Periphery:2</availability>
 			</model>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
-				<availability>CLAN:6,PP:8,IS:8,Periphery:8,TC:5-,Periphery.Deep:8</availability>
+				<availability>PP:8,IS:8,Periphery:8,TC:5-,Periphery.Deep:8</availability>
 			</model>
 			<model name='(LRM)'>
 				<availability>General:5</availability>
 			</model>
 			<model name='(Laser XCT)'>
 				<roles>xct</roles>
-				<availability>CLAN:4,IS:2</availability>
+				<availability>IS:2</availability>
 			</model>
 			<model name='(Laser)'>
-				<availability>CLAN:5+,PP:4+,IS:6,Periphery:5,TC:4+,Periphery.Deep:5</availability>
+				<availability>PP:4+,IS:6,Periphery:5,TC:4+,Periphery.Deep:5</availability>
 			</model>
 			<model name='(MG)'>
                 <roles>anti_infantry</roles>
-				<availability>CLAN:7,PP:6,IS:7,Periphery:7,TC:5,Periphery.Deep:5</availability>
+				<availability>PP:6,IS:7,Periphery:7,TC:5,Periphery.Deep:5</availability>
 			</model>
 			<model name='(Nonlethal)'>
 				<roles>urban,anti_infantry</roles>
-				<availability>CLAN:0,PP:2,CS:7,General:4</availability>
+				<availability>PP:2,CS:7,General:4</availability>
 			</model>
 			<model name='(Rifle)'>
-				<availability>CLAN:8,PP:8,IS:8,Periphery:8,TC:7,Periphery.Deep:8</availability>
+				<availability>PP:8,IS:8,Periphery:8,TC:7,Periphery.Deep:8</availability>
 			</model>
 			<model name='(SRM)'>
-				<availability>CLAN:5+,PP:4+,IS:5,Periphery:5,TC:4+,Periphery.Deep:5+</availability>
+				<availability>PP:4+,IS:5,Periphery:5,TC:4+,Periphery.Deep:5+</availability>
 			</model>
 		</chassis>
         <chassis name='Motorized Platoon (Taurian)' unitType='Infantry'>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -1182,7 +1182,7 @@
                 <availability>CLAN!Second Line:8!Solahma:6,CGB!Second Line:6!Solahma:6</availability>
             </model>
             <model name='(Wheeled CLBX10 Basic)'>
-                <roles>anti_aircraft,field_gun</roles>
+                <roles>anti_aircraft,field_gun,urban</roles>
                 <availability>CLAN!Keshik:3,CIH!Keshik:1</availability>
             </model>
             <model name='(Wheeled CLBX2 Basic)'>
@@ -1190,7 +1190,7 @@
                 <availability>CLAN!Keshik:2,CGB!Keshik:1</availability>
             </model>
             <model name='(Wheeled CLBX20 Basic)'>
-                <roles>field_gun</roles>
+                <roles>field_gun,urban</roles>
                 <availability>CLAN!Keshik:1,CGB!Keshik:2</availability>
             </model>
             <model name='(Wheeled CLBX5 Basic)'>
@@ -1198,7 +1198,7 @@
                 <availability>CLAN!Keshik:2,CGB!Keshik:1</availability>
             </model>
             <model name='(Wheeled CUAC10 Basic)'>
-                <roles>field_gun</roles>
+                <roles>field_gun,urban</roles>
                 <availability>CLAN!Keshik:1,CGB!Keshik:2</availability>
             </model>
             <model name='(Wheeled CUAC2 Basic)'>
@@ -1206,7 +1206,7 @@
                 <availability>CLAN!Keshik:1,CIH!Keshik:2</availability>
             </model>
             <model name='(Wheeled CUAC20 Basic)'>
-                <roles>field_gun</roles>
+                <roles>field_gun,urban</roles>
                 <availability>CLAN!Keshik:1,CGB!Keshik:2</availability>
             </model>
             <model name='(Wheeled CUAC5 Basic)'>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2815-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>
@@ -1194,7 +1191,7 @@
             </model>
             <model name='(Wheeled CLBX20 Basic)'>
                 <roles>field_gun</roles>
-                <availability>CLAN!Keshik:1,CGB!Keshik:2,CIH:1</availability>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2</availability>
             </model>
             <model name='(Wheeled CLBX5 Basic)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2823-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -1267,7 +1267,7 @@
                 <availability>CLAN!Second Line:8!Solahma:6,CGB!Second Line:6!Solahma:6</availability>
             </model>
             <model name='(Wheeled CLBX10 Basic)'>
-                <roles>anti_aircraft,field_gun</roles>
+                <roles>anti_aircraft,field_gun,urban</roles>
                 <availability>CLAN!Keshik:3!Front Line:1,CGB!Keshik:4!Front Line:2,CHH!Keshik:4!Front Line:2,CIH!Keshik:1</availability>
             </model>
             <model name='(Wheeled CLBX2 Basic)'>
@@ -1275,7 +1275,7 @@
                 <availability>CLAN!Keshik:4!Front Line:2,CGB!Keshik:1,CHH!Keshik:3!Front Line:1</availability>
             </model>
             <model name='(Wheeled CLBX20 Basic)'>
-                <roles>field_gun</roles>
+                <roles>field_gun,urban</roles>
                 <availability>CLAN!Keshik:1,CGB!Keshik:2,CHH!Keshik:1!Front Line:1</availability>
             </model>
             <model name='(Wheeled CLBX5 Basic)'>
@@ -1283,7 +1283,7 @@
                 <availability>CLAN!Keshik:4!Front Line:2,CGB!Keshik:2</availability>
             </model>
             <model name='(Wheeled CUAC10 Basic)'>
-                <roles>field_gun</roles>
+                <roles>field_gun,urban</roles>
                 <availability>CLAN!Keshik:2!Front Line:1,CGB!Keshik:3!Front Line:1,CIH!Keshik:1</availability>
             </model>
             <model name='(Wheeled CUAC2 Basic)'>
@@ -1291,7 +1291,7 @@
                 <availability>CLAN!Keshik:3!Front Line:2,CGB!Keshik:1,CHH!Keshik:3!Front Line:1,CIH!Keshik:4!Front Line:1</availability>
             </model>
             <model name='(Wheeled CUAC20 Basic)'>
-                <roles>field_gun</roles>
+                <roles>field_gun,urban</roles>
                 <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CHH!Keshik:1!Front Line:1</availability>
             </model>
             <model name='(Wheeled CUAC5 Basic)'>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2823-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>
@@ -1165,135 +1168,294 @@
 				<availability>IS:4</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CIH:5,CLAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CIH:7,CLAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:1!Second Line:4!Solahma:3!Provisional Garrison:2,CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:3!Provisional Garrison:2,CIH!Second Line:4!Solahma:3!Provisional Garrison:2</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Keshik:2!Second Line:4!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:5!Solahma:6!Provisional Garrison:4</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7!Provisional Garrison:5</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Keshik:1!Second Line:5!Solahma:2,CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7!Provisional Garrison:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:7!Solahma:8!Provisional Garrison:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CIH!Keshik:4!Front Line:3!Second Line:2!Solahma:1!Provisional Garrison:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Solahma:2!Provisional Garrison:8</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Solahma:1!Provisional Garrison:6</availability>
+            </model>
+            <model name='(Tracked AC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:2,CGB:7+,CIH!Keshik:7!Front Line:5!Second Line:2</availability>
+            </model>
+            <model name='(Tracked AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:4!Second Line:3!Solahma:2,CGB:3+,CIH!Keshik:4!Front Line:4!Second Line:3!Solahma:2</availability>
+            </model>
+            <model name='(Tracked AC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CGB:4+,CIH:0</availability>
+            </model>
+            <model name='(Tracked AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:7!Front Line:6!Second Line:3!Solahma:2,CGB:6+,CIH!Keshik:8!Front Line:6!Second Line:3!Solahma:2</availability>
+            </model>
+            <model name='(Tracked CLBX10 Basic)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CGB!Keshik:4!Front Line:2,CHH!Keshik:2,CIH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CGB!Keshik:1,CHH!Keshik:1,CIH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CIH:0</availability>
+            </model>
+            <model name='(Tracked CLBX5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CGB!Keshik:2,CHH!Keshik:2,CIH!Keshik:2</availability>
+            </model>
+            <model name='(Tracked CUAC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:2!Front Line:1,CGB!Keshik:3!Front Line:1,CHH!Keshik:1,CIH:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:2,CGB!Keshik:1,CHH!Keshik:1,CIH!Keshik:2</availability>
+            </model>
+            <model name='(Tracked CUAC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CIH:0</availability>
+            </model>
+            <model name='(Tracked CUAC5 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:2!Front Line:1,CGB!Keshik:1,CHH!Keshik:2,CIH!Keshik:1</availability>
+            </model>
+            <model name='(Wheeled AC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Second Line:6!Solahma:1,CGB!Second Line:8!Solahma:1</availability>
+            </model>
+            <model name='(Wheeled AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:5!Solahma:5</availability>
+            </model>
+            <model name='(Wheeled AC20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Second Line:1,CGB!Front Line:1!Second Line:2,CIH:0</availability>
+            </model>
+            <model name='(Wheeled AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:8!Solahma:6,CGB!Second Line:6!Solahma:6</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Basic)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CGB!Keshik:4!Front Line:2,CHH!Keshik:4!Front Line:2,CIH!Keshik:1</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CGB!Keshik:1,CHH!Keshik:3!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2,CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CGB!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:2!Front Line:1,CGB!Keshik:3!Front Line:1,CIH!Keshik:1</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:2,CGB!Keshik:1,CHH!Keshik:3!Front Line:1,CIH!Keshik:4!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:2!Front Line:1,CGB!Keshik:1,CHH!Keshik:4!Front Line:2,CIH!Keshik:4!Front Line:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8</availability>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN:3-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4</availability>
+            </model>
+            <model name='(Mauser 960 Basic)'>
+                <availability>CHH!Keshik:5!Front Line:1</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN!Solahma:4!Provisional Garrison:7</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:2!Solahma:1</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:8!Front Line:7!Second Line:5!Solahma:1,CGB!Keshik:5!Front Line:5!Second Line:5!Solahma:1</availability>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN:3-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:6+</availability>
+            </model>
+            <model name='(Mauser 960 Basic)'>
+                <availability>CLAN!Keshik:3,CHH!Keshik:5!Front Line:1</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:6</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1</availability>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN:2-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>recon</roles>
+                <availability>CLAN:6+</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>recon</roles>
+                <availability>CLAN:7</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CGB!Keshik:8!Front Line:7!Second Line:4!Solahma:1,CIH!Keshik:3!Front Line:2!Second Line:2!Solahma:2</availability>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN:3-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4</availability>
+            </model>
+            <model name='(Mauser 960 Basic)'>
+                <availability>CGB:2+,CHH:1+</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:7</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN:6+,CIH!Keshik:4!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CIH:6,CLAN:9</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN:3-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN:4</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CLAN!Keshik:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:7</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4</availability>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:3+</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:3</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN!Solahma:1!Provisional Garrison:8</availability>
+            </model>
+            <model name='(SRM)'>
+                <availability>CLAN:4+</availability>
+            </model>
+        </chassis>
 		<chassis name='Clint' unitType='Mek'>
 			<availability>CC:6,MOC:4,CS:3-,OA:4,CLAN:3-,IS:5,NIOPS:3-,FS:6,MERC:5</availability>
 			<model name='CLNT-1-2R'>
@@ -3633,10 +3795,10 @@
 			</model>
 		</chassis>
 		<chassis name='Motorized Platoon' unitType='Infantry'>
-			<availability>CHH:4-,PP:7,IS:9,CS:7,Periphery:9,TC:3-,Periphery.Deep:9</availability>
+			<availability>PP:7,IS:9,CS:7,Periphery:9,TC:3-,Periphery.Deep:9</availability>
 			<model name='(Fieldworks)'>
 				<roles>engineer</roles>
-				<availability>CHH:8,IS:4,Periphery:2</availability>
+				<availability>IS:4,Periphery:2</availability>
 			</model>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
@@ -3658,7 +3820,7 @@
 			</model>
 			<model name='(Nonlethal)'>
 				<roles>urban,anti_infantry</roles>
-				<availability>CHH:0,PP:0,CS:7,General:4</availability>
+				<availability>PP:0,CS:7,General:4</availability>
 			</model>
 			<model name='(Rifle)'>
 				<availability>PP:8,IS:8,Periphery:8,TC:7,Periphery.Deep:8</availability>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2830-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>
@@ -1280,7 +1277,7 @@
                 <availability>CLAN!Second Line:8!Solahma:6,CGB!Second Line:6!Solahma:6,BAN:3+</availability>
             </model>
             <model name='(Wheeled CLBX10 Basic)'>
-                <roles>anti_aircraft,field_gun</roles>
+                <roles>anti_aircraft,field_gun,urban</roles>
                 <availability>CLAN!Keshik:3!Front Line:1,CGB!Keshik:4!Front Line:2,CHH!Keshik:4!Front Line:2,CIH!Keshik:1,BAN:0</availability>
             </model>
             <model name='(Wheeled CLBX2 Basic)'>
@@ -1288,7 +1285,7 @@
                 <availability>CLAN!Keshik:4!Front Line:2,CGB!Keshik:1,CHH!Keshik:3!Front Line:1,BAN:0</availability>
             </model>
             <model name='(Wheeled CLBX20 Basic)'>
-                <roles>field_gun</roles>
+                <roles>field_gun,urban</roles>
                 <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CHH!Keshik:1!Front Line:1,BAN:0</availability>
             </model>
             <model name='(Wheeled CLBX5 Basic)'>
@@ -1296,7 +1293,7 @@
                 <availability>CLAN!Keshik:4!Front Line:2,CGB!Keshik:2,BAN:0</availability>
             </model>
             <model name='(Wheeled CUAC10 Basic)'>
-                <roles>field_gun</roles>
+                <roles>field_gun,urban</roles>
                 <availability>CLAN!Keshik:2!Front Line:1,CGB!Keshik:3!Front Line:1,CIH!Keshik:1,BAN:0</availability>
             </model>
             <model name='(Wheeled CUAC2 Basic)'>
@@ -1304,7 +1301,7 @@
                 <availability>CLAN!Keshik:3!Front Line:2,CGB!Keshik:1,CHH!Keshik:3!Front Line:1,CIH!Keshik:4!Front Line:2,BAN:0</availability>
             </model>
             <model name='(Wheeled CUAC20 Basic)'>
-                <roles>field_gun</roles>
+                <roles>field_gun,urban</roles>
                 <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CHH!Keshik:1!Front Line:1,BAN:0</availability>
             </model>
             <model name='(Wheeled CUAC5 Basic)'>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2830-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>
@@ -1175,135 +1178,294 @@
 				<availability>IS:4</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CIH:5,CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CIH:7,CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:1!Second Line:4!Solahma:3!Provisional Garrison:2,CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:3!Provisional Garrison:2,CIH!Second Line:4!Solahma:3!Provisional Garrison:2,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Keshik:2!Second Line:4!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:5!Solahma:6!Provisional Garrison:4</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7!Provisional Garrison:5</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Keshik:1!Second Line:5!Solahma:2,CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7!Provisional Garrison:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:7!Solahma:8!Provisional Garrison:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CIH!Keshik:4!Front Line:3!Second Line:2!Solahma:1!Provisional Garrison:1,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Solahma:2!Provisional Garrison:8,BAN!Keshik:6!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Solahma:1!Provisional Garrison:6,BAN!Keshik:8!Front Line:4!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:2,CGB:7+,CIH!Keshik:7!Front Line:5!Second Line:2,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:4!Second Line:3!Solahma:2,CGB:3+,CIH!Keshik:4!Front Line:4!Second Line:3!Solahma:2,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CGB:4+,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:7!Front Line:6!Second Line:3!Solahma:2,CGB:6+,CIH!Keshik:8!Front Line:6!Second Line:3!Solahma:2,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Basic)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CGB!Keshik:4!Front Line:2,CHH!Keshik:2,CIH!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CGB!Keshik:1,CHH!Keshik:1,CIH!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CGB!Keshik:2,CHH!Keshik:2,CIH!Keshik:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:2!Front Line:1,CGB!Keshik:3!Front Line:1,CHH!Keshik:1,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:2,CGB!Keshik:1,CHH!Keshik:1,CIH!Keshik:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC5 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:2!Front Line:1,CGB!Keshik:1,CHH!Keshik:2,CIH!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Second Line:6!Solahma:1,CGB!Second Line:8!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:5!Solahma:5,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Second Line:1,CGB!Front Line:1!Second Line:2,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:8!Solahma:6,CGB!Second Line:6!Solahma:6,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Basic)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CGB!Keshik:4!Front Line:2,CHH!Keshik:4!Front Line:2,CIH!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CGB!Keshik:1,CHH!Keshik:3!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CHH!Keshik:1!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CGB!Keshik:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:2!Front Line:1,CGB!Keshik:3!Front Line:1,CIH!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:2,CGB!Keshik:1,CHH!Keshik:3!Front Line:1,CIH!Keshik:4!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CHH!Keshik:1!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:2!Front Line:1,CGB!Keshik:1,CHH!Keshik:4!Front Line:2,CIH!Keshik:4!Front Line:2,BAN:0</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,BAN:7</availability>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN:3-,BAN:3</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4,BAN:4+</availability>
+            </model>
+            <model name='(Mauser 960 Basic)'>
+                <availability>CHH!Keshik:5!Front Line:1</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1!Front Line:1!Second Line:1,BAN:0</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,BAN:5</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN!Solahma:4!Provisional Garrison:7,BAN:8-</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:2!Solahma:1,BAN:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:8!Front Line:7!Second Line:5!Solahma:1,CGB!Keshik:5!Front Line:5!Second Line:5!Solahma:1,BAN:4+</availability>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN:3-,BAN:2-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:6+,BAN:6+</availability>
+            </model>
+            <model name='(Mauser 960 Basic)'>
+                <availability>CLAN!Keshik:3,CHH!Keshik:5!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,BAN:4</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,BAN:3+</availability>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN:2-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>recon</roles>
+                <availability>CLAN:6+,BAN:4+</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,BAN:3</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>recon</roles>
+                <availability>CLAN:7,BAN:7</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+,BAN:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CGB!Keshik:8!Front Line:7!Second Line:4!Solahma:1,CIH!Keshik:3!Front Line:2!Second Line:2!Solahma:2,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN:3-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4,BAN:6+</availability>
+            </model>
+            <model name='(Mauser 960 Basic)'>
+                <availability>CGB:2+,CHH:1+</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1,CHH!Keshik:2!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:7,BAN:6</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+,BAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN:6+,CIH!Keshik:4!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:2,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CIH:6,CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN:3-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:3,BAN:5+</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN:4,BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CLAN!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:7,BAN:7</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:5+,BAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,BAN:8+</availability>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,BAN:4-</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:3+,BAN:4+</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:3,BAN:4</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,BAN:7</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN!Solahma:1!Provisional Garrison:8,BAN:8-</availability>
+            </model>
+            <model name='(SRM)'>
+                <availability>CLAN:4+,BAN:4+</availability>
+            </model>
+        </chassis>
 		<chassis name='Clint' unitType='Mek'>
 			<availability>CC:6,MOC:4,CS:3-,OA:4,CLAN:3-,IS:5,NIOPS:3-,FS:6,MERC:5</availability>
 			<model name='CLNT-1-2R'>
@@ -3493,10 +3655,10 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
-			<availability>CHH:3-,IS:7,CS:4,Periphery:7,TC:3-,Periphery.Deep:6+</availability>
+			<availability>IS:7,CS:4,Periphery:7,TC:3-,Periphery.Deep:6+</availability>
 			<model name='(Bridging)'>
 				<roles>engineer</roles>
-				<availability>CHH:8,IS:1,CS:3,LA:2,FS:2,Periphery:1,Periphery.Deep:0</availability>
+				<availability>IS:1,CS:3,LA:2,FS:2,Periphery:1,Periphery.Deep:0</availability>
 			</model>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
@@ -3728,10 +3890,10 @@
 			</model>
 		</chassis>
 		<chassis name='Motorized Platoon' unitType='Infantry'>
-			<availability>CHH:4-,IS:9,CS:7,Periphery:9,TC:3-,Periphery.Deep:9</availability>
+			<availability>IS:9,CS:7,Periphery:9,TC:3-,Periphery.Deep:9</availability>
 			<model name='(Fieldworks)'>
 				<roles>engineer</roles>
-				<availability>CHH:8,IS:4,Periphery:2</availability>
+				<availability>IS:4,Periphery:2</availability>
 			</model>
 			<model name='(Flamer)'>
                 <roles>urban</roles>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2835-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>
@@ -1227,7 +1224,7 @@
 			</model>
 		</chassis>
         <chassis name='Clan Field Artillery Point' unitType='Infantry'>
-            <availability>CGB!Second Line:3!Solahma:2!Provisional Garrison:1,CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:3!Provisional Garrison:2,CIH!Second Line:2!Solahma:1,BAN:0</availability>
+            <availability>CLAN!Second Line:3!Solahma:2!Provisional Garrison:1,CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:3!Provisional Garrison:2,CIH!Second Line:2!Solahma:1,BAN:0</availability>
             <model name='(Tracked Arrow IV)'>
                 <roles>mixed_artillery</roles>
                 <availability>CGB!Second Line:3!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1,CIH!Second Line:2!Solahma:1</availability>
@@ -1495,6 +1492,9 @@
         </chassis>
         <chassis name='Clan Jump Point' unitType='Infantry'>
             <availability>CLAN!Keshik:8!Front Line:7!Second Line:5!Solahma:1,CGB!Keshik:5!Front Line:5!Second Line:5!Solahma:1,BAN:4+</availability>
+            <model name='(ER Laser Basic)'>
+                <availability>CSA!Keshik:1</availability>
+            </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
                 <availability>CHH!Second Line:1</availability>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2835-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>
@@ -1223,135 +1226,490 @@
 				<availability>IS:4</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CIH:5,CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CIH:7,CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CGB!Second Line:3!Solahma:2!Provisional Garrison:1,CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:3!Provisional Garrison:2,CIH!Second Line:2!Solahma:1,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CGB!Second Line:3!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1,CIH!Second Line:2!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:5!Solahma:6!Provisional Garrison:4</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7!Provisional Garrison:5</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CGB!Second Line:4!Solahma:2,CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2,CIH!Second Line:2!Solahma:1</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7!Provisional Garrison:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:7!Solahma:8!Provisional Garrison:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CIH!Keshik:4!Front Line:3!Second Line:2!Solahma:1!Provisional Garrison:1,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Solahma:2!Provisional Garrison:8,BAN!Keshik:6!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Solahma:1!Provisional Garrison:6,BAN!Keshik:8!Front Line:4!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1</availability>
+            </model>
+            <model name='(Tracked AC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Front Line:3!Second Line:1,CGB!Second Line:5!Solahma:4!Provisional Garrison:3,CIH!Front Line:4!Second Line:2,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Front Line:2!Second Line:1!Solahma:1,CGB:0,CIH!Second Line:2!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1</availability>
+            </model>
+            <model name='(Tracked AC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Front Line:1,CGB!Front Line:2!Second Line:3!Solahma:1,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Front Line:4!Second Line:2!Solahma:1,CGB!Second Line:4!Solahma:3!Provisional Garrison:2,CIH!Front Line:6!Second Line:3!Solahma:2,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CHH!Keshik:3!Front Line:1</availability>
+            </model>
+            <model name='(Tracked CLBX10 Basic)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CIH!Keshik:3!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Tracked CLBX2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CGB!Keshik:1,CIH!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Tracked CLBX5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3,CGB!Keshik:3,CIH!Keshik:5!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Tracked CUAC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Tracked CUAC2 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CGB!Keshik:1,CIH!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:3!Front Line:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:3,CIH!Keshik:5!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled AC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Second Line:4!Solahma:1,CGB!Second Line:3!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:3!Solahma:2,CGB:0,CIH!Second Line:3!Solahma:5,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Front Line:1!Second Line:2,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Second Line:3!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:6!Solahma:4,CGB!Second Line:4!Solahma:3,CIH!Second Line:8!Solahma:6,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CHH!Keshik:3!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Basic)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:5!Front Line:2,CIH!Keshik:7!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CGB!Keshik:1,CIH!Keshik:6!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:2,CGB!Keshik:2!Front Line:1,CIH!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:3,CGB!Keshik:3,CIH!Keshik:7!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CIH!Keshik:6!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CGB!Keshik:1,CIH!Keshik:4!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:2,CGB!Keshik:2!Front Line:1,CIH!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:2!Front Line:1,CGB!Keshik:3,CIH!Keshik:8!Front Line:2,BAN:0</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CHH!Second Line:1</availability>
+            </model>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN:3-,BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CHH:3+</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH!Keshik:2!Front Line:2!Second Line:2</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1!Front Line:1!Second Line:1,BAN:0</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH!Keshik:3!Front Line:3!Second Line:3</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,BAN:5</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN!Solahma:4!Provisional Garrison:7,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH!Keshik:2!Front Line:2!Second Line:1</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:2!Solahma:1,BAN:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:8!Front Line:7!Second Line:5!Solahma:1,CGB!Keshik:5!Front Line:5!Second Line:5!Solahma:1,BAN:4+</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CHH!Second Line:1</availability>
+            </model>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN:3-,BAN:2-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CHH!Keshik:3!Front Line:2!Second Line:2!Solahma:1</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:6+,BAN:6+</availability>
+            </model>
+            <model name='(Mauser 960 Advanced)'>
+                <availability>CHH!Keshik:2</availability>
+            </model>
+            <model name='(Mauser 960 Basic)'>
+                <availability>CLAN!Keshik:3,CHH!Keshik:5!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH!Keshik:2!Front Line:2!Second Line:2</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,BAN:4</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH!Keshik:3!Front Line:3!Second Line:3</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH:3+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,BAN:3+</availability>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CIH:6,CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN:2-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CHH!Keshik:3!Front Line:2!Second Line:2!Solahma:1</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>recon</roles>
+                <availability>CLAN:6+,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH!Keshik:2!Front Line:2!Second Line:2</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,BAN:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CHH!Keshik:3!Front Line:3!Second Line:3</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>recon</roles>
+                <availability>CLAN:7,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH:3+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+,BAN:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CGB!Keshik:8!Front Line:7!Second Line:4!Solahma:1,CIH!Keshik:3!Front Line:2!Second Line:2!Solahma:2,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH!Second Line:1</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CHH!Keshik:3!Front Line:2!Second Line:2</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4,BAN:6+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH!Keshik:2!Front Line:2!Second Line:2</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1,CHH!Keshik:2!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH!Keshik:3!Front Line:3!Second Line:3!Solahma:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:7,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH:3+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+,BAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN:6+,CIH!Keshik:4!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:2,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH!Second Line:1</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH:3+</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:3,BAN:5+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CHH!Keshik:2!Front Line:2!Second Line:2</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN:4,BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CLAN!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH!Keshik:3!Front Line:3!Second Line:3!Solahma:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:7,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH:3+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:5+,BAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,BAN:8+</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH!Second Line:1</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:3+,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:3,BAN:4</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH!Keshik:3!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,BAN:7</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(SRM)'>
+                <availability>CLAN:4+,BAN:4+</availability>
+            </model>
+        </chassis>
 		<chassis name='Clint IIC' unitType='Mek'>
 			<availability>CSR:6</availability>
 			<model name=''>
@@ -3691,10 +4049,10 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
-			<availability>CHH:3-,IS:7,CS:4,Periphery:7,TC:3-,Periphery.Deep:6+</availability>
+			<availability>IS:7,CS:4,Periphery:7,TC:3-,Periphery.Deep:6+</availability>
 			<model name='(Bridging)'>
 				<roles>engineer</roles>
-				<availability>CHH:8,IS:1,CS:3,LA:2,FS:2,Periphery:1,Periphery.Deep:0</availability>
+				<availability>IS:1,CS:3,LA:2,FS:2,Periphery:1,Periphery.Deep:0</availability>
 			</model>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
@@ -3951,10 +4309,10 @@
 			</model>
 		</chassis>
 		<chassis name='Motorized Platoon' unitType='Infantry'>
-			<availability>CHH:4-,IS:9,CS:7,Periphery:9,TC:3-,Periphery.Deep:9</availability>
+			<availability>IS:9,CS:7,Periphery:9,TC:3-,Periphery.Deep:9</availability>
 			<model name='(Fieldworks)'>
 				<roles>engineer</roles>
-				<availability>CHH:8,IS:4,Periphery:2</availability>
+				<availability>IS:4,Periphery:2</availability>
 			</model>
 			<model name='(Flamer)'>
                 <roles>urban</roles>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2855-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>
@@ -1224,135 +1227,513 @@
 				<availability>IS:4</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CIH:5,CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CIH:7,CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN!Second Line:2!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CIH!Solahma:1,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CIH!Keshik:3!Front Line:2!Second Line:2!Solahma:1!Provisional Garrison:1,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Solahma:8,CGB!Solahma:2!Provisional Garrison:8,CHH!Solahma:2!Provisional Garrison:8,CIH!Solahma:2!Provisional Garrison:8,BAN!Keshik:6!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Solahma:6,CGB!Solahma:1!Provisional Garrison:6,CHH!Solahma:1!Provisional Garrison:6,CIH!Solahma:2!Provisional Garrison:8,BAN!Keshik:8!Front Line:4!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Front Line:1,CGB!Second Line:5!Solahma:4!Provisional Garrison:3,CHH:0,CIH:0,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1</availability>
+            </model>
+            <model name='(Tracked AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1!Solahma:1,CGB:0,CHH:0,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Front Line:2!Second Line:3!Solahma:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:4!Second Line:2!Solahma:1</availability>
+            </model>
+            <model name='(Tracked AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:2!Solahma:1,CGB!Second Line:4!Solahma:3!Provisional Garrison:2,CHH:0,CIH!Front Line:6!Second Line:3!Solahma:2,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CHH!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Tracked CLBX10 Basic)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CHH:0,CIH!Keshik:3!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Keshik:4!Front Line:2</availability>
+            </model>
+            <model name='(Tracked CLBX2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CGB!Keshik:1,CHH:0,CIH!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CHH:0,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Keshik:5!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3,CGB!Keshik:3,CHH:0,CIH!Keshik:5!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Keshik:5!Front Line:2</availability>
+            </model>
+            <model name='(Tracked CUAC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CHH:0,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:4!Front Line:2</availability>
+            </model>
+            <model name='(Tracked CUAC2 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CGB!Keshik:1,CHH:0,CIH!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CHH:0,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Tracked CUAC5 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:3,CHH:0,CIH!Keshik:5!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Wheeled AC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Second Line:2!Solahma:1,CGB!Second Line:3!Solahma:1,CHH:0,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Second Line:1!Solahma:1</availability>
+            </model>
+            <model name='(Wheeled AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1!Solahma:2,CGB:0,CHH:0,CIH!Second Line:3!Solahma:5,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:1</availability>
+            </model>
+            <model name='(Wheeled AC20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Front Line:1!Second Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Second Line:6!Solahma:5</availability>
+            </model>
+            <model name='(Wheeled AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:3!Solahma:1,CGB!Second Line:4!Solahma:3,CHH:0,CIH!Second Line:8!Solahma:6,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CHH!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Basic)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:5!Front Line:2,CHH:0,CIH!Keshik:7!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Keshik:3!Second Line:1</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CGB!Keshik:1,CHH:0,CIH!Keshik:6!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:2,CGB!Keshik:2!Front Line:1,CHH:0,CIH!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Keshik:5!Front Line:3</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3,CGB!Keshik:3,CHH:0,CIH!Keshik:7!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Keshik:5!Front Line:2!Second Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CHH:0,CIH!Keshik:6!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CGB!Keshik:1,CHH:0,CIH!Keshik:4!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:2,CGB!Keshik:2!Front Line:1,CHH:0,CIH!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:3,CHH:0,CIH!Keshik:8!Front Line:2,BAN:0</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CHH:3-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN:3-,CHH:0,BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CHH!Keshik:6!Front Line:5!Second Line:4</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4,CHH:0,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH:4</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1!Front Line:1!Second Line:1,CHH:0,BAN:0</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH:7</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CHH:0,BAN:5</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN!Solahma:4!Provisional Garrison:7,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH!Keshik:4!Front Line:4!Second Line:2!Provisional Garrison:1</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CHH:0,BAN:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:8!Front Line:7!Second Line:5!Solahma:1,CGB!Keshik:5!Front Line:5!Second Line:5!Solahma:1,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CSA!Keshik:1</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CHH:3-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN:3-,CHH:0,BAN:2-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CHH:6+</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:6+,CHH:0,BAN:6+</availability>
+            </model>
+            <model name='(Mauser 960 Advanced)'>
+                <availability>CLAN!Keshik:1,CHH!Keshik:5!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH:4</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH:6</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:6,CHH:0,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH:5+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+,CHH:0,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CSA!Keshik:1</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CIH:6,CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CHH!Second Line:1!Solahma:1!Provisional Garrison:1,CIH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:2-,CHH:0,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CHH:6+,CIH!Keshik:1</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>recon</roles>
+                <availability>CLAN:6+,CHH:0,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH!Keshik:4!Front Line:4!Second Line:4,CIH!Keshik:1</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CHH:0,BAN:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CHH:7,CIH!Keshik:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>recon</roles>
+                <availability>CLAN:7,CHH:0,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH:5+,CIH!Keshik:1</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+,CHH:0,BAN:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:3!Second Line:2,CGB!Keshik:8!Front Line:7!Second Line:4!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:3!Front Line:2!Second Line:2!Solahma:2,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CSA!Keshik:1</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH:3-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,CHH:0,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CGB!Keshik:1,CHH!Keshik:6!Front Line:5!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4,CHH:0,BAN:6+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH:4</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1,CHH!Keshik:2!Front Line:1,CHH:0,BAN:0</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH:7</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:7,CHH:0,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CGB!Keshik:1,CHH:5+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+,CHH:0,BAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:4!Second Line:4!Solahma:1,CGB:6+,CHH:6+,CIH!Keshik:4!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:2,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH:3-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,CHH:0,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CGB!Keshik:1,CHH:5+</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:3,CHH:0,BAN:5+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CHH:4</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN:4,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CLAN!Keshik:1,CHH:0,BAN:0</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH:7</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:7,CHH:0,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CGB!Keshik:1,CHH:5+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:5+,CHH:0,BAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,BAN:8+</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH:3-,CIH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,CHH:0,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CHH:3+,CIH!Keshik:1</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:3+,CHH:0,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH!Keshik:3,CIH!Keshik:1</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:3,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CHH:0,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,BAN:7</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH:4+,CIH!Keshik:1</availability>
+            </model>
+            <model name='(SRM)'>
+                <availability>CLAN:4+,CHH:0,BAN:4+</availability>
+            </model>
+        </chassis>
 		<chassis name='Clint IIC' unitType='Mek'>
 			<availability>CSR:6</availability>
 			<model name=''>
@@ -3706,10 +4087,10 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
-			<availability>CHH:3-,IS:7,CS:4,Periphery:7,TC:3-,Periphery.Deep:6+</availability>
+			<availability>IS:7,CS:4,Periphery:7,TC:3-,Periphery.Deep:6+</availability>
 			<model name='(Bridging)'>
 				<roles>engineer</roles>
-				<availability>CHH:8,IS:1,CS:3,LA:2,FS:2,Periphery:1,Periphery.Deep:0</availability>
+				<availability>IS:1,CS:3,LA:2,FS:2,Periphery:1,Periphery.Deep:0</availability>
 			</model>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
@@ -3960,10 +4341,10 @@
 			</model>
 		</chassis>
 		<chassis name='Motorized Platoon' unitType='Infantry'>
-			<availability>CHH:4-,IS:9,CS:7,Periphery:9,TC:3-,Periphery.Deep:9</availability>
+			<availability>IS:9,CS:7,Periphery:9,TC:3-,Periphery.Deep:9</availability>
 			<model name='(Fieldworks)'>
 				<roles>engineer</roles>
-				<availability>CHH:8,IS:4,Periphery:2</availability>
+				<availability>IS:4,Periphery:2</availability>
 			</model>
 			<model name='(Flamer)'>
                 <roles>urban</roles>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -1711,7 +1711,7 @@
             </model>
             <model name='(MG Advanced)'>
                 <roles>anti_infantry</roles>
-                <availability>CHH!Keshik:3,CIH!Keshik:1</availability>
+                <availability>CHH:3,CIH!Keshik:1</availability>
             </model>
             <model name='(MG Basic)'>
                 <roles>anti_infantry</roles>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2855-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>
@@ -1500,7 +1497,7 @@
                 <availability>CLAN!Solahma:4!Provisional Garrison:7,BAN:8-</availability>
             </model>
             <model name='(SRM Advanced)'>
-                <availability>CHH!Keshik:4!Front Line:4!Second Line:2!Provisional Garrison:1</availability>
+                <availability>CHH!Keshik:5!Front Line:4!Second Line:2!Provisional Garrison:1</availability>
             </model>
             <model name='(SRM Basic)'>
                 <availability>CLAN!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CHH:0,BAN:4+</availability>
@@ -1509,6 +1506,9 @@
         <chassis name='Clan Jump Point' unitType='Infantry'>
             <availability>CLAN!Keshik:8!Front Line:7!Second Line:5!Solahma:1,CGB!Keshik:5!Front Line:5!Second Line:5!Solahma:1,BAN:4+</availability>
             <model name='(ER Laser Advanced)'>
+                <availability>CSA!Keshik:1</availability>
+            </model>
+            <model name='(ER Laser Basic)'>
                 <availability>CSA!Keshik:1</availability>
             </model>
             <model name='(Flamer Advanced)'>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -1627,7 +1627,7 @@
             </model>
             <model name='(Rifle AA Basic)'>
                 <roles>anti_aircraft</roles>
-                <availability>CLAN!Keshik:1,CHH!Keshik:2!Front Line:1,CHH:0,BAN:0</availability>
+                <availability>CLAN!Keshik:1,CHH:0,BAN:0</availability>
             </model>
             <model name='(Rifle Advanced)'>
                 <availability>CHH:7</availability>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -1687,7 +1687,7 @@
             </model>
             <model name='(MG Advanced)'>
                 <roles>anti_infantry</roles>
-                <availability>CHH!Keshik:3,CIH!Keshik:2!Front Line:1</availability>
+                <availability>CHH:3,CIH!Keshik:2!Front Line:1</availability>
             </model>
             <model name='(MG Basic)'>
                 <roles>anti_infantry</roles>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2860-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>
@@ -1200,135 +1203,516 @@
 				<availability>IS:4</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CIH:5,CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CIH:7,CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN!Second Line:1!Solahma:1,CGB!Second Line:2!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CIH!Solahma:1,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:3!Front Line:3!Second Line:2!Solahma:1,CGB!Keshik:4!Front Line:4!Second Line:3!Solahma:1!Provisional Garrison:1,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CIH!Keshik:3!Front Line:2!Second Line:2!Solahma:1!Provisional Garrison:1,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Solahma:8,CGB!Solahma:2!Provisional Garrison:8,CHH!Solahma:2!Provisional Garrison:8,CIH!Solahma:2!Provisional Garrison:8,BAN!Keshik:6!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Solahma:6,CGB!Solahma:1!Provisional Garrison:6,CHH!Solahma:1!Provisional Garrison:6,CIH!Solahma:2!Provisional Garrison:8,BAN!Keshik:8!Front Line:4!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Second Line:1!Solahma:1,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1</availability>
+            </model>
+            <model name='(Tracked AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CIH!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:4!Second Line:2!Solahma:1</availability>
+            </model>
+            <model name='(Tracked AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CGB!Second Line:6!Solahma:3,CIH!Second Line:3!Solahma:2,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CGB!Keshik:1,CHH!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Tracked CLBX10 Basic)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CHH:0,CIH!Keshik:3!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Keshik:4!Front Line:2</availability>
+            </model>
+            <model name='(Tracked CLBX2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH:0,CIH!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CHH:0,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Keshik:5!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH:0,CIH!Keshik:5!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:1,CHH!Keshik:5!Front Line:2</availability>
+            </model>
+            <model name='(Tracked CUAC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CHH:0,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:4!Front Line:2</availability>
+            </model>
+            <model name='(Tracked CUAC2 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH:0,CIH!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CHH:0,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Tracked CUAC5 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH:0,CIH!Keshik:5!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Wheeled AC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Second Line:2!Solahma:1,CHH:0,CIH!Second Line:2!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Second Line:1!Solahma:1</availability>
+            </model>
+            <model name='(Wheeled AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1!Solahma:4,CGB:0,CHH:0,CIH!Second Line:3!Solahma:5,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:1</availability>
+            </model>
+            <model name='(Wheeled AC20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Second Line:1!Solahma:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Second Line:6!Solahma:4</availability>
+            </model>
+            <model name='(Wheeled AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1!Solahma:5,CGB!Second Line:6!Solahma:3,CHH:0,CIH!Second Line:8!Solahma:6,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CHH!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Basic)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:5!Front Line:2,CHH:0,CIH!Keshik:7!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Keshik:3!Second Line:1</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH:0,CIH!Keshik:6!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:2,CGB!Keshik:2!Front Line:1,CHH:0,CIH!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Keshik:5!Front Line:3</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH:0,CIH!Keshik:7!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Keshik:5!Front Line:2!Second Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:2!Second Line:1,CGB!Keshik:5!Front Line:2,CHH:0,CIH!Keshik:6!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH:0,CIH!Keshik:4!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:2,CGB!Keshik:2!Front Line:1,CHH:0,CIH!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH:0,CIH!Keshik:8!Front Line:2,BAN:0</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CHH:3-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN:3-,CHH:0,BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CHH!Keshik:6!Front Line:5!Second Line:4</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4,CHH:0,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH:4</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1!Front Line:1!Second Line:1,CHH:0,BAN:0</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH:7</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CHH:0,BAN:5</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN!Solahma:4!Provisional Garrison:7,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH!Keshik:5!Front Line:4!Second Line:2!Provisional Garrison:1</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CHH:0,BAN:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:8!Front Line:7!Second Line:5!Solahma:1,CGB!Keshik:5!Front Line:5!Second Line:5!Solahma:1,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CSA!Keshik:1</availability>
+            </model>
+            <model name='(ER Laser Basic)'>
+                <availability>CSA!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CHH:3-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN:3-,CHH:0,BAN:2-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CHH:6+</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:6+,CHH:0,BAN:6+</availability>
+            </model>
+            <model name='(Mauser 960 Advanced)'>
+                <availability>CLAN!Keshik:1,CHH!Keshik:5!Front Line:1,CIH!Keshik:2,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH:4</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH:6</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:6,CHH:0,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH:5+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+,CHH:0,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CSA!Keshik:1</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CIH:6,CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CHH:3-,CIH!Keshik:1!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:2-,CHH:0,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CHH:6+,CIH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>recon</roles>
+                <availability>CLAN:6+,CHH:0,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH!Keshik:4!Front Line:4!Second Line:4,CIH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CHH:0,BAN:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CHH:7,CIH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>recon</roles>
+                <availability>CLAN:7,CHH:0,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH:5+,CIH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+,CHH:0,BAN:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:3!Second Line:2,CGB!Keshik:8!Front Line:7!Second Line:4!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:3!Front Line:2!Second Line:2!Solahma:2,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CSA!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH:3-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,CHH:0,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CGB!Keshik:1,CHH!Keshik:6!Front Line:5!Second Line:4!Solahma:1,CSA!Keshik:1</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4,CHH:0,BAN:6+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH:4</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1,CHH!Keshik:2!Front Line:1,CHH:0,BAN:0</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH:7,CSA!Keshik:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:7,CHH:0,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CGB!Keshik:1,CHH:5+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+,CHH:0,BAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:4!Second Line:4!Solahma:1,CGB:6+,CHH:6+,CIH!Keshik:4!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:2,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH:3-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,CHH:0,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CGB!Keshik:1,CHH:5+</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:3,CHH:0,BAN:5+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CHH:4</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN:4,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CLAN!Keshik:1,CHH:0,BAN:0</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH:7</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:7,CHH:0,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CGB!Keshik:1,CHH:5+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:5+,CHH:0,BAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,BAN:8+</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH:3-,CIH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,CHH:0,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CHH:3+,CIH!Keshik:2</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:3+,CHH:0,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH!Keshik:3,CIH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:3,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CHH:0,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,BAN:7</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH:4+,CIH!Keshik:2</availability>
+            </model>
+            <model name='(SRM)'>
+                <availability>CLAN:4+,CHH:0,BAN:4+</availability>
+            </model>
+        </chassis>
 		<chassis name='Clint IIC' unitType='Mek'>
 			<availability>CSR:6</availability>
 			<model name=''>
@@ -3601,10 +3985,10 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
-			<availability>CHH:2-,IS:7,CS:4,Periphery:7,TC:3-,Periphery.Deep:6+</availability>
+			<availability>IS:7,CS:4,Periphery:7,TC:3-,Periphery.Deep:6+</availability>
 			<model name='(Bridging)'>
 				<roles>engineer</roles>
-				<availability>CHH:8,IS:1,CS:3,LA:2,FS:2,Periphery:1,Periphery.Deep:0</availability>
+				<availability>IS:1,CS:3,LA:2,FS:2,Periphery:1,Periphery.Deep:0</availability>
 			</model>
 			<model name='(Flamer)'>
                 <roles>urban</roles>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2860-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>
@@ -1606,7 +1603,7 @@
             </model>
             <model name='(Rifle AA Basic)'>
                 <roles>anti_aircraft</roles>
-                <availability>CLAN!Keshik:1,CHH!Keshik:2!Front Line:1,CHH:0,BAN:0</availability>
+                <availability>CLAN!Keshik:1,CHH:0,BAN:0</availability>
             </model>
             <model name='(Rifle Advanced)'>
                 <availability>CHH:7,CSA!Keshik:1</availability>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2865-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>
@@ -1207,135 +1210,516 @@
 				<availability>IS:4</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CIH:5,CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CIH:7,CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN!Second Line:1!Solahma:1,CGB!Second Line:2!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CIH!Solahma:1,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:3!Front Line:3!Second Line:2!Solahma:1,CGB!Keshik:4!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CIH!Keshik:3!Front Line:2!Second Line:2!Solahma:1!Provisional Garrison:1,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Solahma:8,CGB!Solahma:2!Provisional Garrison:8,CHH!Solahma:2!Provisional Garrison:8,CIH!Solahma:2!Provisional Garrison:8,BAN!Keshik:6!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Solahma:6,CGB!Solahma:1!Provisional Garrison:6,CHH!Solahma:1!Provisional Garrison:6,CIH!Solahma:2!Provisional Garrison:8,BAN!Keshik:8!Front Line:4!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Second Line:1!Solahma:1,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1</availability>
+            </model>
+            <model name='(Tracked AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CIH!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:4!Second Line:2!Solahma:1</availability>
+            </model>
+            <model name='(Tracked AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CGB!Second Line:6!Solahma:3,CIH!Second Line:3!Solahma:2,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CGB!Keshik:1,CHH!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Tracked CLBX10 Basic)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CHH:0,CIH!Keshik:3!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Keshik:4!Front Line:2</availability>
+            </model>
+            <model name='(Tracked CLBX2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH:0,CIH!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CHH:0,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Keshik:5!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH:0,CIH!Keshik:5!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:1,CHH!Keshik:5!Front Line:2</availability>
+            </model>
+            <model name='(Tracked CUAC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CHH:0,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:4!Front Line:2</availability>
+            </model>
+            <model name='(Tracked CUAC2 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH:0,CIH!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CHH:0,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Tracked CUAC5 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH:0,CIH!Keshik:5!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Wheeled AC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Second Line:2!Solahma:1,CHH:0,CIH!Second Line:2!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Second Line:1!Solahma:1</availability>
+            </model>
+            <model name='(Wheeled AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1!Solahma:4,CGB:0,CHH:0,CIH!Second Line:3!Solahma:5,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:1</availability>
+            </model>
+            <model name='(Wheeled AC20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Second Line:1!Solahma:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Second Line:6!Solahma:4</availability>
+            </model>
+            <model name='(Wheeled AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1!Solahma:5,CGB!Second Line:6!Solahma:3,CHH:0,CIH!Second Line:8!Solahma:6,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CHH!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Basic)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:5!Front Line:2,CHH:0,CIH!Keshik:7!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Keshik:3!Second Line:1</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH:0,CIH!Keshik:6!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:2,CGB!Keshik:2!Front Line:1,CHH:0,CIH!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Keshik:5!Front Line:3</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH:0,CIH!Keshik:7!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Keshik:5!Front Line:2!Second Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:2!Second Line:1,CGB!Keshik:5!Front Line:2,CHH:0,CIH!Keshik:6!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH:0,CIH!Keshik:4!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:2,CGB!Keshik:2!Front Line:1,CHH:0,CIH!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH:0,CIH!Keshik:8!Front Line:2,BAN:0</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CHH:3-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN:3-,CHH:0,BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CHH!Keshik:6!Front Line:5!Second Line:4</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4,CHH:0,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH:4</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1!Front Line:1!Second Line:1,CHH:0,BAN:0</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH:7</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CHH:0,BAN:5</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN!Solahma:4!Provisional Garrison:7,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH!Keshik:5!Front Line:4!Second Line:2!Provisional Garrison:1</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CHH:0,BAN:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:8!Front Line:7!Second Line:5!Solahma:1,CGB!Keshik:5!Front Line:5!Second Line:5!Solahma:1,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CSA!Keshik:1</availability>
+            </model>
+            <model name='(ER Laser Basic)'>
+                <availability>CSA!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CHH:3-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN:3-,CHH:0,BAN:2-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CHH:6+</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:6+,CHH:0,BAN:6+</availability>
+            </model>
+            <model name='(Mauser 960 Advanced)'>
+                <availability>CLAN!Keshik:1,CHH!Keshik:5!Front Line:1,CIH!Keshik:2,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH:4</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH:6</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:6,CHH:0,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH:5+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+,CHH:0,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CSA!Keshik:1</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CIH:6,CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CHH:3-,CIH!Keshik:1!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:2-,CHH:0,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CHH:6+,CIH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>recon</roles>
+                <availability>CLAN:6+,CHH:0,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH!Keshik:4!Front Line:4!Second Line:4,CIH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CHH:0,BAN:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CHH:7,CIH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>recon</roles>
+                <availability>CLAN:7,CHH:0,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH:5+,CIH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+,CHH:0,BAN:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:3!Second Line:2,CGB!Keshik:8!Front Line:7!Second Line:4!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:3!Front Line:2!Second Line:2!Solahma:2,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CSA!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH:3-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,CHH:0,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CGB!Keshik:1,CHH!Keshik:6!Front Line:5!Second Line:4!Solahma:1,CSA!Keshik:1</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4,CHH:0,BAN:6+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH:4</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1,CHH:0,BAN:0</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH:7,CSA!Keshik:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:7,CHH:0,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CGB!Keshik:1,CHH:5+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+,CHH:0,BAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:5!Front Line:4!Second Line:4!Solahma:1,CGB:6+,CHH:6+,CIH!Keshik:4!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:2,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH:3-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,CHH:0,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CGB!Keshik:1,CHH:5+</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:3,CHH:0,BAN:5+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CHH:4</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN:4,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CLAN!Keshik:1,CHH:0,BAN:0</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH:7</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:7,CHH:0,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CGB!Keshik:1,CHH:5+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:5+,CHH:0,BAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,BAN:8+</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH:3-,CIH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,CHH:0,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CHH:3+,CIH!Keshik:2</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:3+,CHH:0,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH!Keshik:3,CIH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:3,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CHH:0,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,BAN:7</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH:4+,CIH!Keshik:2</availability>
+            </model>
+            <model name='(SRM)'>
+                <availability>CLAN:4+,CHH:0,BAN:4+</availability>
+            </model>
+        </chassis>
 		<chassis name='Clint IIC' unitType='Mek'>
 			<availability>CSR:6</availability>
 			<model name=''>
@@ -3644,10 +4028,10 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
-			<availability>CHH:2-,IS:7,CS:4,Periphery:7,TC:3-,Periphery.Deep:6+</availability>
+			<availability>IS:7,CS:4,Periphery:7,TC:3-,Periphery.Deep:6+</availability>
 			<model name='(Bridging)'>
 				<roles>engineer</roles>
-				<availability>CHH:8,IS:1,CS:3,LA:2,FS:2,Periphery:1,Periphery.Deep:0</availability>
+				<availability>IS:1,CS:3,LA:2,FS:2,Periphery:1,Periphery.Deep:0</availability>
 			</model>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
@@ -3906,10 +4290,10 @@
 			</model>
 		</chassis>
 		<chassis name='Motorized Platoon' unitType='Infantry'>
-			<availability>CHH:3-,IS:9,CS:7,Periphery:9,TC:3-,Periphery.Deep:9</availability>
+			<availability>IS:9,CS:7,Periphery:9,TC:3-,Periphery.Deep:9</availability>
 			<model name='(Fieldworks)'>
 				<roles>engineer</roles>
-				<availability>CHH:8,IS:4,Periphery:2</availability>
+				<availability>IS:4,Periphery:2</availability>
 			</model>
 			<model name='(Flamer)'>
                 <roles>urban</roles>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2865-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -1694,7 +1694,7 @@
             </model>
             <model name='(MG Advanced)'>
                 <roles>anti_infantry</roles>
-                <availability>CHH!Keshik:3,CIH!Keshik:2!Front Line:1</availability>
+                <availability>CHH:3,CIH!Keshik:2!Front Line:1</availability>
             </model>
             <model name='(MG Basic)'>
                 <roles>anti_infantry</roles>

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2870-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>
@@ -1831,7 +1828,7 @@
             </model>
             <model name='(MG Advanced)'>
                 <roles>anti_infantry</roles>
-                <availability>CHH!Keshik:3,CIH!Keshik:2!Front Line:1</availability>
+                <availability>CHH:3,CIH!Keshik:2!Front Line:1</availability>
             </model>
             <model name='(MG Basic)'>
                 <roles>anti_infantry</roles>

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2870-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>
@@ -1341,135 +1344,516 @@
 				<availability>IS:4</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CIH:5,CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CIH:7,CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN!Second Line:1!Solahma:1,CGB!Second Line:2!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CIH!Solahma:1,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:3!Front Line:3!Second Line:2!Solahma:1,CGB!Keshik:4!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CIH!Keshik:3!Front Line:2!Second Line:2!Solahma:1!Provisional Garrison:1,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Solahma:8,CGB!Solahma:2!Provisional Garrison:8,CHH!Solahma:2!Provisional Garrison:8,CIH!Solahma:2!Provisional Garrison:8,BAN!Keshik:6!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Solahma:6,CGB!Solahma:1!Provisional Garrison:6,CHH!Solahma:1!Provisional Garrison:6,CIH!Solahma:2!Provisional Garrison:8,BAN!Keshik:8!Front Line:4!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Second Line:1!Solahma:1,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1</availability>
+            </model>
+            <model name='(Tracked AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CIH!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:4!Second Line:2!Solahma:1</availability>
+            </model>
+            <model name='(Tracked AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CGB!Second Line:6!Solahma:3,CIH!Second Line:3!Solahma:2,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CGB!Keshik:1,CHH!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Tracked CLBX10 Basic)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CHH:0,CIH!Keshik:3!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Keshik:4!Front Line:2</availability>
+            </model>
+            <model name='(Tracked CLBX2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH:0,CIH!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CHH:0,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Keshik:5!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH:0,CIH!Keshik:5!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:1,CHH!Keshik:5!Front Line:2</availability>
+            </model>
+            <model name='(Tracked CUAC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CHH:0,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:4!Front Line:2</availability>
+            </model>
+            <model name='(Tracked CUAC2 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH:0,CIH!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC20 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:1,CGB!Keshik:2!Front Line:1,CHH:0,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Tracked CUAC5 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH:0,CIH!Keshik:5!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Wheeled AC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Second Line:2!Solahma:1,CHH:0,CIH!Second Line:2!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Second Line:1!Solahma:1</availability>
+            </model>
+            <model name='(Wheeled AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1!Solahma:4,CGB:0,CHH:0,CIH!Second Line:3!Solahma:5,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:1</availability>
+            </model>
+            <model name='(Wheeled AC20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Second Line:1!Solahma:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Second Line:6!Solahma:4</availability>
+            </model>
+            <model name='(Wheeled AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1!Solahma:5,CGB!Second Line:6!Solahma:3,CHH:0,CIH!Second Line:8!Solahma:6,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CHH!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Basic)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:5!Front Line:2,CHH:0,CIH!Keshik:7!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Keshik:3!Second Line:1</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH:0,CIH!Keshik:6!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:2,CGB!Keshik:2!Front Line:1,CHH:0,CIH!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Keshik:5!Front Line:3</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH:0,CIH!Keshik:7!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Keshik:5!Front Line:2!Second Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:2!Second Line:1,CGB!Keshik:5!Front Line:2,CHH:0,CIH!Keshik:6!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH:0,CIH!Keshik:4!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:2,CGB!Keshik:2!Front Line:1,CHH:0,CIH!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CHH!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Basic)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH:0,CIH!Keshik:8!Front Line:2,BAN:0</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:7!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CGB!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CIH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CSA!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CHH:3-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN:3-,CHH:0,BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CHH!Keshik:6!Front Line:5!Second Line:4</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4,CHH:0,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH:4</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1!Front Line:1!Second Line:1,CHH:0,BAN:0</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH:7</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CHH:0,BAN:5</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN!Solahma:4!Provisional Garrison:7,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH!Keshik:5!Front Line:4!Second Line:2!Provisional Garrison:1</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CHH:0,BAN:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:7!Front Line:6!Second Line:5!Solahma:1,CGB!Keshik:5!Front Line:4!Second Line:4!Solahma:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CIH!Keshik:8!Front Line:7!Second Line:5!Solahma:1,CSA!Keshik:8!Front Line:7!Second Line:5!Solahma:1,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CSA!Keshik:1</availability>
+            </model>
+            <model name='(ER Laser Basic)'>
+                <availability>CSA!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CHH:3-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN:3-,CHH:0,BAN:2-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CHH:6+</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:6+,CHH:0,BAN:6+</availability>
+            </model>
+            <model name='(Mauser 960 Advanced)'>
+                <availability>CLAN!Keshik:1,CHH!Keshik:5!Front Line:1,CIH!Keshik:2,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH:4</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH:6</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:6,CHH:0,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH:5+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+,CHH:0,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:1,CGB!Keshik:5!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CSA!Keshik:1</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CIH:6,CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CHH:3-,CIH!Keshik:1!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:2-,CHH:0,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CHH:6+,CIH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>recon</roles>
+                <availability>CLAN:6+,CHH:0,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH!Keshik:4!Front Line:4!Second Line:4,CIH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CHH:0,CIH!Keshik:3!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,BAN:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CHH:7,CIH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>recon</roles>
+                <availability>CLAN:7,CHH:0,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH:5+,CIH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+,CHH:0,BAN:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN:3+,CGB!Keshik:7!Front Line:6!Second Line:4!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:3!Front Line:2!Second Line:2!Solahma:2,CSA!Keshik:4!Front Line:3!Second Line:2,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CSA!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH:3-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,CHH:0,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CGB!Keshik:1,CHH!Keshik:6!Front Line:5!Second Line:4!Solahma:1,CSA!Keshik:1</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4,CHH:0,BAN:6+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH:4</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN!Keshik:1,CHH:0,BAN:0</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH:7,CSA!Keshik:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN:7,CHH:0,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CGB!Keshik:1,CHH:5+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CLAN:5+,CHH:0,BAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB:6+,CHH:6+,CIH!Keshik:4!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:2,CSA!Keshik:5!Front Line:4!Second Line:4!Solahma:1,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH:3-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,CHH:0,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CGB!Keshik:1,CHH:5+</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:3,CHH:0,BAN:5+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CHH:4</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN:4,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Rifle AA Basic)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CLAN!Keshik:1,CHH:0,BAN:0</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH:7</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:7,CHH:0,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CGB!Keshik:1,CHH:5+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:5+,CHH:0,BAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,BAN:8+</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH:3-,CIH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,CHH:0,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CHH:3+,CIH!Keshik:2</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CLAN:3+,CHH:0,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CHH!Keshik:3,CIH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:3,CHH:0,BAN:4</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CHH:0,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,BAN:7</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CHH:4+,CIH!Keshik:2</availability>
+            </model>
+            <model name='(SRM)'>
+                <availability>CLAN:4+,CHH:0,BAN:4+</availability>
+            </model>
+        </chassis>
 		<chassis name='Clint IIC' unitType='Mek'>
 			<availability>CSR:6</availability>
 			<model name=''>
@@ -3954,10 +4338,10 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
-			<availability>CHH:2-,IS:7,CS:4,Periphery:7,TC:3-,HL:5,Periphery.Deep:6+</availability>
+			<availability>IS:7,CS:4,Periphery:7,TC:3-,HL:5,Periphery.Deep:6+</availability>
 			<model name='(Bridging)'>
 				<roles>engineer</roles>
-				<availability>CHH:8,IS:1,CS:3,LA:2,FS:2,Periphery:1,Periphery.Deep:0</availability>
+				<availability>IS:1,CS:3,LA:2,FS:2,Periphery:1,Periphery.Deep:0</availability>
 			</model>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
@@ -4212,10 +4596,10 @@
 			</model>
 		</chassis>
 		<chassis name='Motorized Platoon' unitType='Infantry'>
-			<availability>CHH:2-,IS:9,CS:7,Periphery:9,TC:3-,HL:7,Periphery.Deep:9</availability>
+			<availability>IS:9,CS:7,Periphery:9,TC:3-,HL:7,Periphery.Deep:9</availability>
 			<model name='(Fieldworks)'>
 				<roles>engineer</roles>
-				<availability>CHH:8,IS:4,Periphery:2</availability>
+				<availability>IS:4,Periphery:2</availability>
 			</model>
 			<model name='(Flamer)'>
                 <roles>urban</roles>

--- a/megamek/data/forcegenerator/2900.xml
+++ b/megamek/data/forcegenerator/2900.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2900-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>
@@ -1727,7 +1724,7 @@
             </model>
             <model name='(Rifle AA Advanced)'>
                 <roles>anti_aircraft,urban</roles>
-                <availability>CHH!Keshik:1,BAN!Keshik:2</availability>
+                <availability>CHH!Keshik:1</availability>
             </model>
             <model name='(Rifle Advanced)'>
                 <roles>urban</roles>

--- a/megamek/data/forcegenerator/2900.xml
+++ b/megamek/data/forcegenerator/2900.xml
@@ -1611,7 +1611,7 @@
             <availability>CLAN!Keshik:4!Front Line:4!Second Line:1,CGB!Keshik:4!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,BAN:3+</availability>
             <model name='(ER Laser Advanced)'>
                 <roles>recon</roles>
-                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:3!Front Line:2,BAN:0</availability>
+                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:3!Front Line:2,CSJ:0,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
@@ -1655,7 +1655,7 @@
         <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
             <availability>CLAN:3+,CGB!Keshik:5!Front Line:5!Second Line:4!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
             <model name='(ER Laser Advanced)'>
-                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:3!Front Line:1,BAN:0</availability>
+                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:3!Front Line:1,CSJ:0,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>

--- a/megamek/data/forcegenerator/2900.xml
+++ b/megamek/data/forcegenerator/2900.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2900-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>
@@ -1361,135 +1364,429 @@
 				<availability>IS:4</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CIH:5,CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CIH:7,CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:0,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN:3+,CGB!Keshik:3!Front Line:3!Second Line:1!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CIH!Keshik:3!Front Line:2!Second Line:1!Solahma:1!Provisional Garrison:1,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1!Solahma:8,CGB!Solahma:8,CHH!Solahma:2!Provisional Garrison:8,CIH!Second Line:2!Solahma:2!Provisional Garrison:8,BAN!Keshik:6!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:2!Solahma:6,CGB!Solahma:6,CHH!Solahma:1!Provisional Garrison:6,CIH!Second Line:1!Solahma:1!Provisional Garrison:6,BAN!Keshik:8!Front Line:4!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Second Line:1!Solahma:1,CHH!Front Line:3!Second Line:1,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Second Line:1,CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CGB!Second Line:6!Solahma:3!Provisional Garrison:2,CHH!Front Line:4!Second Line:2!Solahma:1,BAN:3+</availability>
+            </model>
+            <model name='(Tracked AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CIH!Keshik:3!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH!Keshik:4!Front Line:2,CIH!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:5!Front Line:3!Second Line:1,CIH!Keshik:5!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CGB!Keshik:1,CHH!Keshik:5!Front Line:2,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH!Keshik:4!Front Line:2,CIH!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:5!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Second Line:2!Solahma:1,CHH!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1!Solahma:1,CGB:0,CIH:0,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Second Line:1!Solahma:1,CHH!Second Line:1</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1!Solahma:1,CGB!Second Line:6!Solahma:3,CHH!Second Line:6!Solahma:4,CIH:0,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:5!Front Line:2,CHH!Keshik:6!Front Line:3,CIH!Keshik:7!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH!Keshik:3!Second Line:1,CIH!Keshik:6!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:5!Front Line:3,CIH!Keshik:7!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:2!Second Line:1,CGB!Keshik:5!Front Line:2,CHH!Keshik:5!Front Line:2!Second Line:1,CIH!Keshik:6!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH!Keshik:2!Front Line:1,CIH!Keshik:4!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:8!Front Line:2,BAN:0</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN:7,CGB!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CIH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CSA!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN:3-,CIH:4-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CGB:4,CHH:4,CIH:4,CSA:4,BAN!Keshik:4!Front Line:3!Second Line:3</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CGB!Keshik:1,CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CHH:7,BAN:0</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>BAN:5</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN!Solahma:4!Provisional Garrison:7,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:2!Solahma:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>BAN:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:7!Front Line:6!Second Line:3!Solahma:1,CGB:4+,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CIH!Keshik:8!Front Line:7!Second Line:5!Solahma:1,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN!Keshik:1,CSA!Keshik:3!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN:3-,CHH:4-,BAN:0</availability>
+            </model>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>BAN:2-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN:6+,CSA!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>BAN:6+</availability>
+            </model>
+            <model name='(Mauser 960 Advanced)'>
+                <availability>CHH!Keshik:5!Front Line:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>BAN:4</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN:6,BAN:0</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN:5+,BAN:3+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:1,CGB!Keshik:4!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:3!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CIH:6,CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN!Second Line:1,CGB:0,CHH:3-,CIH!Keshik:1!Front Line:1!Second Line:1,CSA:3-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN:6+,CGB:5+,CSA!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>recon</roles>
+                <availability>BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,BAN:3+</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>BAN:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN:7,BAN:0</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>recon</roles>
+                <availability>BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN:5+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>BAN:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN:3+,CGB!Keshik:5!Front Line:5!Second Line:4!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:3!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,BAN:0</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN!Keshik:6!Front Line:5!Second Line:4,CHH!Keshik:6!Front Line:5!Second Line:4!Solahma:1,CSA!Keshik:1,BAN:6+</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>BAN:6+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN:7,BAN:0</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>BAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB:6+,CHH:6+,CIH!Keshik:3!Front Line:3!Second Line:2!Solahma:1,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,BAN:0</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:3,CHH:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>urban</roles>
+                <availability>BAN:5+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN:4,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>BAN:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CHH!Keshik:1,BAN!Keshik:2</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN:7,BAN:0</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>urban</roles>
+                <availability>BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <roles>urban</roles>
+                <availability>BAN:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,BAN:8+</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,CIH!Front Line:1!Second Line:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN:3+,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>BAN:4</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,BAN:0</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>BAN:7</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN:4+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(SRM)'>
+                <availability>BAN:4+</availability>
+            </model>
+        </chassis>
 		<chassis name='Clint IIC' unitType='Mek'>
 			<availability>CSR:6</availability>
 			<model name=''>

--- a/megamek/data/forcegenerator/2950.xml
+++ b/megamek/data/forcegenerator/2950.xml
@@ -1730,7 +1730,7 @@
             </model>
         </chassis>
         <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-            <availability>Clan:3+,CBS!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CSA!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV!Keshik:4!Front Line:4!Second Line:2!Solahma:1,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <availability>CLAN:3+,CBS!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CSA!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV!Keshik:4!Front Line:4!Second Line:2!Solahma:1,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
                 <availability>CLAN:3-,CSJ:5-,BAN:5-</availability>

--- a/megamek/data/forcegenerator/2950.xml
+++ b/megamek/data/forcegenerator/2950.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2950-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>
@@ -1485,7 +1482,7 @@
 			</model>
 		</chassis>
         <chassis name='Clan Field Artillery Point' unitType='Infantry'>
-            <availability>CLAN!Solahma:1,CBS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:0,CSV!Second Line:1!Solahma:1,BAN:0</availability>
+            <availability>CLAN!Solahma:1,CBS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:0,CSJ:0,CSV!Second Line:1!Solahma:1,BAN:0</availability>
             <model name='(Tracked Arrow IV)'>
                 <roles>mixed_artillery</roles>
                 <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
@@ -1512,14 +1509,14 @@
             </model>
         </chassis>
         <chassis name='Clan Field Gun Point' unitType='Infantry'>
-            <availability>CLAN:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,BAN!Keshik:2!Front Line:1</availability>
+            <availability>CLAN:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CSJ:2+,BAN!Keshik:2!Front Line:1</availability>
             <model name='(Motorized AC2 Basic)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
-                <availability>CLAN!Second Line:1,CBS!Front Line:1!Second Line:7,CGB!Solahma:8,CHH!Solahma:2!Provisional Garrison:8,CIH!Second Line:2,CSV!Front Line:1!Second Line:7,BAN!Keshik:6!Front Line:3</availability>
+                <availability>CLAN!Front Line:1!Second Line:7,CBS!Second Line:7,CGB!Second Line:8,CHH!Solahma:2!Provisional Garrison:8,CIH!Second Line:2,CSJ!Keshik:1!Front Line:8,CSV!Front Line:1!Second Line:7,BAN!Keshik:6!Front Line:3</availability>
             </model>
             <model name='(Motorized AC5 Basic)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
-                <availability>CLAN!Second Line:2,CBS!Front Line:2!Second Line:5,CGB!Solahma:6,CHH!Solahma:1!Provisional Garrison:6,CIH!Second Line:1,CSV!Front Line:2!Second Line:5,BAN!Keshik:8!Front Line:4</availability>
+                <availability>CLAN!Front Line:2!Second Line:5,CBS!Second Line:5,CGB!Second Line:6,CHH!Solahma:1!Provisional Garrison:6,CIH!Second Line:1,CSJ!Keshik:2!Front Line:6,CSV!Front Line:2!Second Line:5,BAN!Keshik:8!Front Line:4</availability>
             </model>
             <model name='(Tracked AC10 Advanced)'>
                 <roles>field_gun</roles>
@@ -1539,11 +1536,11 @@
             </model>
             <model name='(Tracked CLBX10 Advanced)'>
                 <roles>anti_aircraft,field_gun</roles>
-                <availability>CLAN!Keshik:6!Front Line:3,CIH!Keshik:3!Front Line:1,BAN:0</availability>
+                <availability>CLAN!Keshik:6!Front Line:3,CIH!Keshik:3!Front Line:1,CSJ!Keshik:6,BAN:0</availability>
             </model>
             <model name='(Tracked CLBX2 Advanced)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
-                <availability>CLAN!Keshik:4!Front Line:2,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CIH!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:2!Second Line:2,CSV!Keshik:4!Front Line:2!Second Line:2,BAN:0</availability>
+                <availability>CLAN!Keshik:4!Front Line:2,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CIH!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:2!Second Line:2,CSJ!Keshik:4,CSV!Keshik:4!Front Line:2!Second Line:2,BAN:0</availability>
             </model>
             <model name='(Tracked CLBX20 Advanced)'>
                 <roles>field_gun</roles>
@@ -1551,15 +1548,15 @@
             </model>
             <model name='(Tracked CLBX5 Advanced)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
-                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CIH!Keshik:5!Front Line:2,CSA!Keshik:5!Front Line:3!Second Line:3,CSV!Keshik:5!Front Line:3!Second Line:3,BAN:0</availability>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CIH!Keshik:5!Front Line:2,CSA!Keshik:5!Front Line:3!Second Line:3,CSJ!Keshik:5,CSV!Keshik:5!Front Line:3!Second Line:3,BAN:0</availability>
             </model>
             <model name='(Tracked CUAC10 Advanced)'>
                 <roles>field_gun</roles>
-                <availability>CLAN!Keshik:5!Front Line:2,CIH:0,BAN:0</availability>
+                <availability>CLAN!Keshik:5!Front Line:2,CIH:0,CSJ!Keshik:5,BAN:0</availability>
             </model>
             <model name='(Tracked CUAC2 Advanced)'>
                 <roles>field_gun,fire_support</roles>
-                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH!Keshik:4!Front Line:2,CIH!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:2!Second Line:2,CSV!Keshik:4!Front Line:2!Second Line:2,BAN:0</availability>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH!Keshik:4!Front Line:2,CIH!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:2!Second Line:2,CSJ!Keshik:4,CSV!Keshik:4!Front Line:2!Second Line:2,BAN:0</availability>
             </model>
             <model name='(Tracked CUAC20 Advanced)'>
                 <roles>field_gun</roles>
@@ -1567,7 +1564,7 @@
             </model>
             <model name='(Tracked CUAC5 Advanced)'>
                 <roles>field_gun,fire_support</roles>
-                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:5!Front Line:2,BAN:0</availability>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:5!Front Line:2,CSJ!Keshik:6,BAN:0</availability>
             </model>
             <model name='(Wheeled AC10 Advanced)'>
                 <roles>field_gun,urban</roles>
@@ -1583,15 +1580,15 @@
             </model>
             <model name='(Wheeled AC5 Advanced)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
-                <availability>CLAN!Second Line:1,CGB!Second Line:4,CHH!Second Line:6!Solahma:4,CIH:0,BAN:3+</availability>
+                <availability>CLAN!Second Line:1,CGB!Second Line:4,CHH!Second Line:6!Solahma:4,CIH:0,CSJ:0,BAN:3+</availability>
             </model>
             <model name='(Wheeled CLBX10 Advanced)'>
                 <roles>anti_aircraft,field_gun,urban</roles>
-                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:5!Front Line:2,CIH!Keshik:7!Front Line:2,BAN:0</availability>
+                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:5!Front Line:2,CIH!Keshik:7!Front Line:2,CSJ!Keshik:6,BAN:0</availability>
             </model>
             <model name='(Wheeled CLBX2 Advanced)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
-                <availability>CLAN!Keshik:3!Front Line:1,CGB!Keshik:1,CIH!Keshik:6!Front Line:1,BAN:0</availability>
+                <availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CIH!Keshik:6!Front Line:1,CSA!Keshik:3!Front Line:1!Second Line:1,CSJ!Keshik:3,CSV!Keshik:3!Front Line:1!Second Line:1,BAN:0</availability>
             </model>
             <model name='(Wheeled CLBX20 Advanced)'>
                 <roles>field_gun,urban</roles>
@@ -1599,15 +1596,15 @@
             </model>
             <model name='(Wheeled CLBX5 Advanced)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
-                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:5!Front Line:3,CIH!Keshik:7!Front Line:2,CSA!Keshik:5!Front Line:3!Second Line:3,CSV!Keshik:5!Front Line:3!Second Line:3,BAN:0</availability>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:5!Front Line:3,CIH!Keshik:7!Front Line:2,CSA!Keshik:5!Front Line:3!Second Line:3,CSJ!Keshik:5,CSV!Keshik:5!Front Line:3!Second Line:3,BAN:0</availability>
             </model>
             <model name='(Wheeled CUAC10 Advanced)'>
                 <roles>field_gun,urban</roles>
-                <availability>CLAN!Keshik:5!Front Line:2,CBS!Keshik:5!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:2!Second Line:1,CIH!Keshik:6!Front Line:1,CSA!Keshik:5!Front Line:2!Second Line:1,CSV!Keshik:5!Front Line:2!Second Line:1,BAN:0</availability>
+                <availability>CLAN!Keshik:5!Front Line:2,CBS!Keshik:5!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:2!Second Line:1,CIH!Keshik:6!Front Line:1,CSA!Keshik:5!Front Line:2!Second Line:1,CSJ!Keshik:5,CSV!Keshik:5!Front Line:2!Second Line:1,BAN:0</availability>
             </model>
             <model name='(Wheeled CUAC2 Advanced)'>
                 <roles>field_gun,fire_support</roles>
-                <availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH!Keshik:2!Front Line:1,CIH!Keshik:4!Front Line:2,CSA!Keshik:3!Front Line:1!Second Line:1,CSV!Keshik:3!Front Line:1!Second Line:1,BAN:0</availability>
+                <availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH!Keshik:2!Front Line:1,CIH!Keshik:4!Front Line:2,CSA!Keshik:3!Front Line:1!Second Line:1,CSJ!Keshik:3,CSV!Keshik:3!Front Line:1!Second Line:1,BAN:0</availability>
             </model>
             <model name='(Wheeled CUAC20 Advanced)'>
                 <roles>field_gun,urban</roles>
@@ -1615,76 +1612,76 @@
             </model>
             <model name='(Wheeled CUAC5 Advanced)'>
                 <roles>field_gun,fire_support</roles>
-                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:8!Front Line:2,CSA!Keshik:6!Front Line:3!Second Line:3,CSV!Keshik:6!Front Line:3!Second Line:3,BAN:0</availability>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:8!Front Line:2,CSA!Keshik:6!Front Line:3!Second Line:3,CSJ!Keshik:6,CSV!Keshik:6!Front Line:3!Second Line:3,BAN:0</availability>
             </model>
         </chassis>
         <chassis name='Clan Foot Point' unitType='Infantry'>
             <availability>CLAN:7,CGB!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CIH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CSA!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,BAN:7</availability>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN:3-,CIH:4-,BAN:3</availability>
+                <availability>CLAN:3-,CIH:4-,CSJ:4-,BAN:3</availability>
             </model>
             <model name='(Laser Advanced)'>
-                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:4,CIH!Keshik:6!Front Line:5!Second Line:4,CSA!Keshik:6!Front Line:5!Second Line:1,CSV!Keshik:6!Front Line:5!Second Line:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:4,CIH!Keshik:6!Front Line:5!Second Line:4,CSA!Keshik:6!Front Line:5!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:6!Front Line:5!Second Line:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
             </model>
             <model name='(MG Advanced)'>
                 <roles>anti_infantry</roles>
-                <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CBS!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CHH:4,CIH!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSA!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSV!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:1,CBS!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CHH:4,CIH!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSA!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSJ:3+,CSV!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
             </model>
             <model name='(Rifle AA Advanced)'>
                 <roles>anti_aircraft</roles>
                 <availability>CHH!Keshik:1!Front Line:1</availability>
             </model>
             <model name='(Rifle Advanced)'>
-                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CHH:7,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CHH:7,CSJ!Keshik:7!Front Line:5!Second Line:2!Solahma:1,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
             </model>
             <model name='(Rifle Light)'>
                 <roles>urban</roles>
-                <availability>CLAN!Second Line:1!Solahma:4!Provisional Garrison:7,CBS!Solahma:4!Provisional Garrison:7,CGB!Solahma:4!Provisional Garrison:7,CHH!Solahma:4!Provisional Garrison:7,CIH!Solahma:4!Provisional Garrison:7,CSA!Solahma:4!Provisional Garrison:7,CSV!Solahma:4!Provisional Garrison:7,BAN:8-</availability>
+                <availability>CLAN!Second Line:1!Solahma:4!Provisional Garrison:7,CBS!Solahma:4!Provisional Garrison:7,CGB!Solahma:4!Provisional Garrison:7,CHH!Solahma:4!Provisional Garrison:7,CIH!Solahma:4!Provisional Garrison:7,CSA!Solahma:4!Provisional Garrison:7,CSJ!Front Line:1!Second Line:2!Solahma:5!Provisional Garrison:7,CSV!Solahma:4!Provisional Garrison:7,BAN:8-</availability>
             </model>
             <model name='(SRM Advanced)'>
-                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:5!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,BAN!Keshik:4!Front Line:3!Second Line:2,CSA!Keshik:5!Front Line:4!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:2!Solahma:1,BAN:4+</availability>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:5!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:5!Front Line:4!Second Line:2!Solahma:1,BAN:4+</availability>
             </model>
         </chassis>
         <chassis name='Clan Jump Point' unitType='Infantry'>
-            <availability>CLAN!Keshik:7!Front Line:4!Second Line:1,CBS!Keshik:7!Front Line:6!Second Line:3!Solahma:1,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CIH!Keshik:7!Front Line:7!Second Line:4!Solahma:1,CSA!Keshik:7!Front Line:6!Second Line:1,BAN:4+</availability>
+            <availability>CLAN!Keshik:7!Front Line:4!Second Line:1,CBS!Keshik:7!Front Line:6!Second Line:3!Solahma:1,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CIH!Keshik:7!Front Line:7!Second Line:4!Solahma:1,CSA!Keshik:7!Front Line:6!Second Line:1,CSJ!Keshik:7!Front Line:3,BAN:4+</availability>
             <model name='(ER Laser Advanced)'>
                 <availability>CLAN!Keshik:1,CSA!Keshik:4!Front Line:1,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN:3-,CIH:4-,BAN:4-</availability>
+                <availability>CLAN:3-,CIH:4-,CSJ!Front Line:1,BAN:4-</availability>
             </model>
             <model name='(Laser Advanced)'>
-                <availability>CLAN:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+                <availability>CLAN:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:6!Front Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
             </model>
             <model name='(Mauser IIC Advanced)'>
                 <availability>CHH!Keshik:1</availability>
             </model>
             <model name='(MG Advanced)'>
                 <roles>anti_infantry</roles>
-                <availability>CLAN:4,CGB!Keshik:4!Front Line:4!Second Line:3,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+                <availability>CLAN:4,CGB!Keshik:4!Front Line:4!Second Line:3,CSJ!Keshik:4!Front Line:1,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
             </model>
             <model name='(Rifle Advanced)'>
                 <availability>CLAN:6,BAN:7</availability>
             </model>
             <model name='(SRM Advanced)'>
-                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSV:5+,BAN:3+</availability>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV:5+,BAN:3+</availability>
             </model>
         </chassis>
         <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-            <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CSV!Keshik:4!Front Line:4!Second Line:1,BAN:3+</availability>
+            <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:4!Front Line:4!Second Line:1,BAN:3+</availability>
             <model name='(ER Laser Advanced)'>
                 <roles>recon</roles>
                 <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN!Second Line:1,BAN!Second Line:1</availability>
+                <availability>CLAN!Second Line:1,CSJ!Front Line:1,BAN!Second Line:1</availability>
             </model>
             <model name='(Laser Advanced)'>
                 <roles>recon</roles>
-                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS:6+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:4,CSV:6+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS:6+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:4,CSJ!Keshik:6!Front Line:1,CSV:6+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
             </model>
             <model name='(Mauser IIC Advanced)'>
                 <roles>recon</roles>
@@ -1692,55 +1689,55 @@
             </model>
             <model name='(MG Advanced)'>
                 <roles>anti_infantry</roles>
-                <availability>CLAN:4,CGB!Keshik:4!Front Line:4!Second Line:3,BAN:3+</availability>
+                <availability>CLAN:4,CGB!Keshik:4!Front Line:4!Second Line:3,CSJ!Keshik:4!Front Line:1,BAN:3+</availability>
             </model>
             <model name='(Rifle Advanced)'>
                 <roles>recon</roles>
-                <availability>CLAN:7,BAN:7</availability>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:5,BAN:7</availability>
             </model>
             <model name='(SRM Advanced)'>
-                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:5!Front Line:1,CSV!Keshik:5!Front Line:4!Second Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
             </model>
         </chassis>
         <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-            <availability>CLAN:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <availability>CLAN:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CSJ!Keshik:3!Front Line:2,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
             <model name='(ER Laser Advanced)'>
                 <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN:3-,BAN:5-</availability>
+                <availability>CLAN:3-,CSJ!Front Line:1,BAN:5-</availability>
             </model>
             <model name='(Laser Advanced)'>
-                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,BAN:6+</availability>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:6!Front Line:1,BAN:6+</availability>
             </model>
             <model name='(Mauser IIC Advanced)'>
                 <availability>CHH!Keshik:1</availability>
             </model>
             <model name='(MG Advanced)'>
                 <roles>anti_infantry</roles>
-                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3,CBS:4,CGB!Keshik:4!Front Line:4!Second Line:3!Solahma:2,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3,CBS:4,CGB!Keshik:4!Front Line:4!Second Line:3!Solahma:2,CSJ!Keshik:4!Front Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
             </model>
             <model name='(Rifle AA Advanced)'>
                 <roles>anti_aircraft</roles>
                 <availability>CHH:2+</availability>
             </model>
             <model name='(Rifle Advanced)'>
-                <availability>CLAN:7,BAN:6</availability>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:8,BAN:6</availability>
             </model>
             <model name='(SRM Advanced)'>
-                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSV:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
             </model>
         </chassis>
         <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-            <availability>Clan:3+,CBS!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CSA!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CSV!Keshik:4!Front Line:4!Second Line:2!Solahma:1,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <availability>Clan:3+,CBS!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CSA!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV!Keshik:4!Front Line:4!Second Line:2!Solahma:1,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN:3-,BAN:5-</availability>
+                <availability>CLAN:3-,CSJ:5-,BAN:5-</availability>
             </model>
             <model name='(Laser Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:3,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:3,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:3,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:3,CSV!Keshik:5!Front Line:4!Second Line:3,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
             </model>
             <model name='(Mauser IIC Advanced)'>
                 <roles>urban</roles>
@@ -1748,7 +1745,7 @@
             </model>
             <model name='(MG Advanced)'>
                 <roles>anti_infantry,urban</roles>
-                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3,CBS:4,CGB!Keshik:4!Front Line:4!Second Line:3!Solahma:2,CHH:4,CSA:4,CSV:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3,CBS:4,CGB!Keshik:4!Front Line:4!Second Line:3!Solahma:2,CHH:4,CSA:4,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
             </model>
             <model name='(Rifle AA Advanced)'>
                 <roles>anti_aircraft,urban</roles>
@@ -1756,35 +1753,35 @@
             </model>
             <model name='(Rifle Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN:7,BAN:7</availability>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:8!Second Line:8,BAN:7</availability>
             </model>
             <model name='(SRM Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSV:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:3!Front Line:1,CSV:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
             </model>
         </chassis>
         <chassis name='Clan Motorized Point' unitType='Infantry'>
-            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CHH!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,BAN:8+</availability>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CHH!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CSJ:4+,BAN:8+</availability>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN!Front Line:1!Second Line:2,CBS:3-,CHH:3-,CIH!Front Line:1!Second Line:1,CSA:3-,CSV:3-,BAN:4-</availability>
+                <availability>CLAN!Front Line:1!Second Line:2,CBS:3-,CGB!Second Line:1!Solahma:2,CHH:3-,CIH!Front Line:1!Second Line:1,CSA:3-,CSJ:5-,CSV:3-,BAN:4-</availability>
             </model>
             <model name='(Laser Advanced)'>
-                <availability>CLAN:3+,CIH!Keshik:3!Front Line:2,BAN:4+</availability>
+                <availability>CLAN:3+,CIH!Keshik:3!Front Line:2,CSJ!Keshik:1,BAN:4+</availability>
             </model>
             <model name='(MG Advanced)'>
                 <roles>anti_infantry</roles>
-                <availability>CLAN!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CBS:3,CGB:3,CHH:3,CIH!Keshik:3!Front Line:3!Second Line:3!Solahma:1,CSA!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,BAN:4+</availability>
+                <availability>CLAN!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CBS:3,CGB:3,CHH:3,CIH!Keshik:3!Front Line:3!Second Line:3!Solahma:1,CSA!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CSJ!Keshik:3!Front Line:1!Second Line:1,BAN:4+</availability>
             </model>
             <model name='(Rifle Advanced)'>
-                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CGB!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CSA:5+,CSV!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,BAN:7+</availability>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CGB!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CSA:5+,CSJ!Keshik:5!Front Line:2!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,BAN:7+</availability>
             </model>
             <model name='(Rifle Light)'>
                 <roles>urban</roles>
-                <availability>CLAN!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,BAN:8-</availability>
+                <availability>CLAN!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,CSJ!Keshik:2!Front Line:5!Second Line:7!Solahma:7!Provisional Garrison:8,BAN:8-</availability>
             </model>
             <model name='(SRM Advanced)'>
-                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS:4+,CGB!Keshik:4!Front Line:3!Second Line:1,CHH:4+,CIH!Keshik:4!Front Line:3!Second Line:1,CSA!Keshik:4!Front Line:3!Second Line:1,CSV:4+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS:4+,CGB!Keshik:4!Front Line:3!Second Line:1,CHH:4+,CIH!Keshik:4!Front Line:3!Second Line:1,CSA!Keshik:4!Front Line:3!Second Line:1,CSJ!Keshik:2!Front Line:1,CSV:4+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
             </model>
         </chassis>
 		<chassis name='Clint IIC' unitType='Mek'>

--- a/megamek/data/forcegenerator/2950.xml
+++ b/megamek/data/forcegenerator/2950.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2950-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>
@@ -1481,135 +1484,309 @@
 				<availability>IS:4</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CIH:5,CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CIH:7,CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN!Solahma:1,CBS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:0,CSV!Second Line:1!Solahma:1,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:5,CBS!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CSV!Second Line:5!Solahma:6</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CSV!Second Line:6!Solahma:7</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CSV!Second Line:6!Solahma:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:7,CBS!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CSV!Second Line:7!Solahma:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1,CBS!Front Line:1!Second Line:7,CGB!Solahma:8,CHH!Solahma:2!Provisional Garrison:8,CIH!Second Line:2,CSV!Front Line:1!Second Line:7,BAN!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:2,CBS!Front Line:2!Second Line:5,CGB!Solahma:6,CHH!Solahma:1!Provisional Garrison:6,CIH!Second Line:1,CSV!Front Line:2!Second Line:5,BAN!Keshik:8!Front Line:4</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:3!Second Line:1,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CGB!Second Line:4,CHH!Front Line:4!Second Line:2!Solahma:1,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CIH!Keshik:3!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CIH!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:2!Second Line:2,CSV!Keshik:4!Front Line:2!Second Line:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CIH!Keshik:5!Front Line:2,CSA!Keshik:5!Front Line:3!Second Line:3,CSV!Keshik:5!Front Line:3!Second Line:3,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CIH:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH!Keshik:4!Front Line:2,CIH!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:2!Second Line:2,CSV!Keshik:4!Front Line:2!Second Line:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:5!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:4!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CBS!Second Line:1,CHH!Second Line:1,CSV!Second Line:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1,CGB!Second Line:4,CHH!Second Line:6!Solahma:4,CIH:0,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:5!Front Line:2,CIH!Keshik:7!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CGB!Keshik:1,CIH!Keshik:6!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:5!Front Line:3,CIH!Keshik:7!Front Line:2,CSA!Keshik:5!Front Line:3!Second Line:3,CSV!Keshik:5!Front Line:3!Second Line:3,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CBS!Keshik:5!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:2!Second Line:1,CIH!Keshik:6!Front Line:1,CSA!Keshik:5!Front Line:2!Second Line:1,CSV!Keshik:5!Front Line:2!Second Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH!Keshik:2!Front Line:1,CIH!Keshik:4!Front Line:2,CSA!Keshik:3!Front Line:1!Second Line:1,CSV!Keshik:3!Front Line:1!Second Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:8!Front Line:2,CSA!Keshik:6!Front Line:3!Second Line:3,CSV!Keshik:6!Front Line:3!Second Line:3,BAN:0</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN:7,CGB!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CIH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CSA!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN:3-,CIH:4-,BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:4,CIH!Keshik:6!Front Line:5!Second Line:4,CSA!Keshik:6!Front Line:5!Second Line:1,CSV!Keshik:6!Front Line:5!Second Line:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CBS!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CHH:4,CIH!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSA!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSV!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CHH:7,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN!Second Line:1!Solahma:4!Provisional Garrison:7,CBS!Solahma:4!Provisional Garrison:7,CGB!Solahma:4!Provisional Garrison:7,CHH!Solahma:4!Provisional Garrison:7,CIH!Solahma:4!Provisional Garrison:7,CSA!Solahma:4!Provisional Garrison:7,CSV!Solahma:4!Provisional Garrison:7,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:5!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,BAN!Keshik:4!Front Line:3!Second Line:2,CSA!Keshik:5!Front Line:4!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:2!Solahma:1,BAN:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:7!Front Line:4!Second Line:1,CBS!Keshik:7!Front Line:6!Second Line:3!Solahma:1,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CIH!Keshik:7!Front Line:7!Second Line:4!Solahma:1,CSA!Keshik:7!Front Line:6!Second Line:1,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN!Keshik:1,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN:3-,CIH:4-,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CGB!Keshik:4!Front Line:4!Second Line:3,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSV:5+,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CSV!Keshik:4!Front Line:4!Second Line:1,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN!Second Line:1,BAN!Second Line:1</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS:6+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:4,CSV:6+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>recon</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CGB!Keshik:4!Front Line:4!Second Line:3,BAN:3+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN:7,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN:3-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,BAN:6+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3,CBS:4,CGB!Keshik:4!Front Line:4!Second Line:3!Solahma:2,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN:7,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSV:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>Clan:3+,CBS!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CSA!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CSV!Keshik:4!Front Line:4!Second Line:2!Solahma:1,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CIH:6,CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN:3-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:3,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:3,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3,CBS:4,CGB!Keshik:4!Front Line:4!Second Line:3!Solahma:2,CHH:4,CSA:4,CSV:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN:7,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSV:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CHH!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,BAN:8+</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Front Line:1!Second Line:2,CBS:3-,CHH:3-,CIH!Front Line:1!Second Line:1,CSA:3-,CSV:3-,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN:3+,CIH!Keshik:3!Front Line:2,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CBS:3,CGB:3,CHH:3,CIH!Keshik:3!Front Line:3!Second Line:3!Solahma:1,CSA!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,BAN:4+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CGB!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CSA:5+,CSV!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,BAN:7+</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS:4+,CGB!Keshik:4!Front Line:3!Second Line:1,CHH:4+,CIH!Keshik:4!Front Line:3!Second Line:1,CSA!Keshik:4!Front Line:3!Second Line:1,CSV:4+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+            </model>
+        </chassis>
 		<chassis name='Clint IIC' unitType='Mek'>
 			<availability>CSR:6</availability>
 			<model name=''>

--- a/megamek/data/forcegenerator/2950.xml
+++ b/megamek/data/forcegenerator/2950.xml
@@ -1673,7 +1673,7 @@
             <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:4!Front Line:4!Second Line:1,BAN:3+</availability>
             <model name='(ER Laser Advanced)'>
                 <roles>recon</roles>
-                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,CSJ:0,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
@@ -1702,7 +1702,7 @@
         <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
             <availability>CLAN:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CSJ!Keshik:3!Front Line:2,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
             <model name='(ER Laser Advanced)'>
-                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,CSJ:0,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>

--- a/megamek/data/forcegenerator/3019.xml
+++ b/megamek/data/forcegenerator/3019.xml
@@ -1622,141 +1622,309 @@
 				<availability>IS:4</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Infantry' unitType='Infantry'>
-			<availability>CLAN:5-</availability>
-			<model name='Ad Hoc Point'>
-				<availability>CLAN:6</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CIH:5,CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CIH:7,CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN!Solahma:1,CBS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:0,CSJ:0,CSV!Second Line:1!Solahma:1,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:5,CBS!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CSV!Second Line:5!Solahma:6</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CSV!Second Line:6!Solahma:7</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CSV!Second Line:6!Solahma:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:7,CBS!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CSV!Second Line:7!Solahma:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CSJ:2+,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Front Line:1!Second Line:7,CBS!Second Line:7,CGB!Second Line:8,CHH!Solahma:2!Provisional Garrison:8,CIH!Second Line:2,CSJ!Keshik:1!Front Line:8,CSV!Front Line:1!Second Line:7,BAN!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Front Line:2!Second Line:5,CBS!Second Line:5,CGB!Second Line:6,CHH!Solahma:1!Provisional Garrison:6,CIH!Second Line:1,CSJ!Keshik:2!Front Line:6,CSV!Front Line:2!Second Line:5,BAN!Keshik:8!Front Line:4</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:3!Second Line:1,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CGB!Second Line:4,CHH!Front Line:4!Second Line:2!Solahma:1,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CIH!Keshik:3!Front Line:1,CSJ!Keshik:6,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CIH!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:2!Second Line:2,CSJ!Keshik:4,CSV!Keshik:4!Front Line:2!Second Line:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CIH!Keshik:5!Front Line:2,CSA!Keshik:5!Front Line:3!Second Line:3,CSJ!Keshik:5,CSV!Keshik:5!Front Line:3!Second Line:3,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CIH:0,CSJ!Keshik:5,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH!Keshik:4!Front Line:2,CIH!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:2!Second Line:2,CSJ!Keshik:4,CSV!Keshik:4!Front Line:2!Second Line:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:5!Front Line:2,CSJ!Keshik:6,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:4!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CBS!Second Line:1,CHH!Second Line:1,CSV!Second Line:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1,CGB!Second Line:4,CHH!Second Line:6!Solahma:4,CIH:0,CSJ:0,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:5!Front Line:2,CIH!Keshik:7!Front Line:2,CSJ!Keshik:6,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CIH!Keshik:6!Front Line:1,CSA!Keshik:3!Front Line:1!Second Line:1,CSJ!Keshik:3,CSV!Keshik:3!Front Line:1!Second Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:5!Front Line:3,CIH!Keshik:7!Front Line:2,CSA!Keshik:5!Front Line:3!Second Line:3,CSJ!Keshik:5,CSV!Keshik:5!Front Line:3!Second Line:3,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CBS!Keshik:5!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:2!Second Line:1,CIH!Keshik:6!Front Line:1,CSA!Keshik:5!Front Line:2!Second Line:1,CSJ!Keshik:5,CSV!Keshik:5!Front Line:2!Second Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH!Keshik:2!Front Line:1,CIH!Keshik:4!Front Line:2,CSA!Keshik:3!Front Line:1!Second Line:1,CSJ!Keshik:3,CSV!Keshik:3!Front Line:1!Second Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:8!Front Line:2,CSA!Keshik:6!Front Line:3!Second Line:3,CSJ!Keshik:6,CSV!Keshik:6!Front Line:3!Second Line:3,BAN:0</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN:7,CGB!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CIH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CSA!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN:3-,CIH:4-,CSJ:4-,BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:4,CIH!Keshik:6!Front Line:5!Second Line:4,CSA!Keshik:6!Front Line:5!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:6!Front Line:5!Second Line:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:1,CBS!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CHH:4,CIH!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSA!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSJ:3+,CSV!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CHH:7,CSJ!Keshik:7!Front Line:5!Second Line:2!Solahma:1,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN!Second Line:1!Solahma:4!Provisional Garrison:7,CBS!Solahma:4!Provisional Garrison:7,CGB!Solahma:4!Provisional Garrison:7,CHH!Solahma:4!Provisional Garrison:7,CIH!Solahma:4!Provisional Garrison:7,CSA!Solahma:4!Provisional Garrison:7,CSJ!Front Line:1!Second Line:2!Solahma:5!Provisional Garrison:7,CSV!Solahma:4!Provisional Garrison:7,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:5!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:5!Front Line:4!Second Line:2!Solahma:1,BAN:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:7!Front Line:4!Second Line:1,CBS!Keshik:7!Front Line:6!Second Line:3!Solahma:1,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CIH!Keshik:7!Front Line:7!Second Line:4!Solahma:1,CSA!Keshik:7!Front Line:6!Second Line:1,CSJ!Keshik:7!Front Line:3,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN!Keshik:1,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN:3-,CIH:4-,CSJ!Front Line:1,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:6!Front Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CHH!Keshik:4!Front Line:2</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CGB!Keshik:4!Front Line:4!Second Line:3,CSJ!Keshik:4!Front Line:1,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV:5+,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:4!Front Line:4!Second Line:1,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN!Second Line:1,CSJ!Front Line:1,BAN!Second Line:1</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS:6+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:4,CSJ!Keshik:6!Front Line:1,CSV:6+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>recon</roles>
+                <availability>CHH!Keshik:4!Front Line:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CGB!Keshik:4!Front Line:4!Second Line:3,CSJ!Keshik:4!Front Line:1,BAN:3+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:5,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:5!Front Line:1,CSV!Keshik:5!Front Line:4!Second Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CSJ!Keshik:3!Front Line:2,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN:3-,CSJ!Front Line:1,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:6!Front Line:1,BAN:6+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CHH!Keshik:4!Front Line:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3,CBS:4,CGB!Keshik:4!Front Line:4!Second Line:3!Solahma:2,CSJ!Keshik:4!Front Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:8,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>Clan:3+,CBS!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CSA!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV!Keshik:4!Front Line:4!Second Line:2!Solahma:1,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CIH:6,CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN:3-,CSJ:5-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:3,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:3,CSV!Keshik:5!Front Line:4!Second Line:3,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH!Keshik:4!Front Line:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3,CBS:4,CGB!Keshik:4!Front Line:4!Second Line:3!Solahma:2,CHH:4,CSA:4,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:8!Second Line:8,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:3!Front Line:1,CSV:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CHH!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CSJ:4+,BAN:8+</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Front Line:1!Second Line:2,CBS:3-,CGB!Second Line:1!Solahma:2,CHH:3-,CIH!Front Line:1!Second Line:1,CSA:3-,CSJ:5-,CSV:3-,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN:3+,CIH!Keshik:3!Front Line:2,CSJ!Keshik:1,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CBS:3,CGB:3,CHH:3,CIH!Keshik:3!Front Line:3!Second Line:3!Solahma:1,CSA!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CSJ!Keshik:3!Front Line:1!Second Line:1,BAN:4+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CGB!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CSA:5+,CSJ!Keshik:5!Front Line:2!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,BAN:7+</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,CSJ!Keshik:2!Front Line:5!Second Line:7!Solahma:7!Provisional Garrison:8,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS:4+,CGB!Keshik:4!Front Line:3!Second Line:1,CHH:4+,CIH!Keshik:4!Front Line:3!Second Line:1,CSA!Keshik:4!Front Line:3!Second Line:1,CSJ!Keshik:2!Front Line:1,CSV:4+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+            </model>
+        </chassis>
 		<chassis name='Clint IIC' unitType='Mek'>
 			<availability>CSR:2,CBS:5</availability>
 			<model name=''>

--- a/megamek/data/forcegenerator/3019.xml
+++ b/megamek/data/forcegenerator/3019.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3019-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>5,5</pctOmni>
@@ -1871,7 +1868,7 @@
             </model>
         </chassis>
         <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-            <availability>Clan:3+,CBS!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CSA!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV!Keshik:4!Front Line:4!Second Line:2!Solahma:1,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <availability>CLAN:3+,CBS!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CSA!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV!Keshik:4!Front Line:4!Second Line:2!Solahma:1,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
                 <availability>CLAN:3-,CSJ:5-,BAN:5-</availability>

--- a/megamek/data/forcegenerator/3019.xml
+++ b/megamek/data/forcegenerator/3019.xml
@@ -1811,7 +1811,7 @@
             <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:4!Front Line:4!Second Line:1,BAN:3+</availability>
             <model name='(ER Laser Advanced)'>
                 <roles>recon</roles>
-                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,CSJ:0,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
@@ -1840,7 +1840,7 @@
         <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
             <availability>CLAN:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CSJ!Keshik:3!Front Line:2,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
             <model name='(ER Laser Advanced)'>
-                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,CSJ:0,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>

--- a/megamek/data/forcegenerator/3028.xml
+++ b/megamek/data/forcegenerator/3028.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3028-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>5,5</pctOmni>

--- a/megamek/data/forcegenerator/3028.xml
+++ b/megamek/data/forcegenerator/3028.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3028-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>5,5</pctOmni>
@@ -1712,135 +1715,309 @@
 				<availability>IS:3</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CIH:5,CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CIH:7,CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN!Solahma:1,CBS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:0,CSJ:0,CSV!Second Line:1!Solahma:1,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:5,CBS!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CSV!Second Line:5!Solahma:6</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CSV!Second Line:6!Solahma:7</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CSV!Second Line:6!Solahma:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:7,CBS!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CSV!Second Line:7!Solahma:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CSJ:2+,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Front Line:1!Second Line:7,CBS!Second Line:7,CGB!Second Line:8,CHH!Solahma:2!Provisional Garrison:8,CIH!Second Line:2,CSJ!Keshik:1!Front Line:8,CSV!Front Line:1!Second Line:7,BAN!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Front Line:2!Second Line:5,CBS!Second Line:5,CGB!Second Line:6,CHH!Solahma:1!Provisional Garrison:6,CIH!Second Line:1,CSJ!Keshik:2!Front Line:6,CSV!Front Line:2!Second Line:5,BAN!Keshik:8!Front Line:4</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:3!Second Line:1,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CGB!Second Line:4,CHH!Front Line:4!Second Line:2!Solahma:1,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CIH!Keshik:3!Front Line:1,CSJ!Keshik:6,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CIH!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:2!Second Line:2,CSJ!Keshik:4,CSV!Keshik:4!Front Line:2!Second Line:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CIH!Keshik:5!Front Line:2,CSA!Keshik:5!Front Line:3!Second Line:3,CSJ!Keshik:5,CSV!Keshik:5!Front Line:3!Second Line:3,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CIH:0,CSJ!Keshik:5,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH!Keshik:4!Front Line:2,CIH!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:2!Second Line:2,CSJ!Keshik:4,CSV!Keshik:4!Front Line:2!Second Line:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:5!Front Line:2,CSJ!Keshik:6,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:4!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CBS!Second Line:1,CHH!Second Line:1,CSV!Second Line:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1,CGB!Second Line:4,CHH!Second Line:6!Solahma:4,CIH:0,CSJ:0,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:5!Front Line:2,CIH!Keshik:7!Front Line:2,CSJ!Keshik:6,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CIH!Keshik:6!Front Line:1,CSA!Keshik:3!Front Line:1!Second Line:1,CSJ!Keshik:3,CSV!Keshik:3!Front Line:1!Second Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:5!Front Line:3,CIH!Keshik:7!Front Line:2,CSA!Keshik:5!Front Line:3!Second Line:3,CSJ!Keshik:5,CSV!Keshik:5!Front Line:3!Second Line:3,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CBS!Keshik:5!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:2!Second Line:1,CIH!Keshik:6!Front Line:1,CSA!Keshik:5!Front Line:2!Second Line:1,CSJ!Keshik:5,CSV!Keshik:5!Front Line:2!Second Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH!Keshik:2!Front Line:1,CIH!Keshik:4!Front Line:2,CSA!Keshik:3!Front Line:1!Second Line:1,CSJ!Keshik:3,CSV!Keshik:3!Front Line:1!Second Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:8!Front Line:2,CSA!Keshik:6!Front Line:3!Second Line:3,CSJ!Keshik:6,CSV!Keshik:6!Front Line:3!Second Line:3,BAN:0</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN:7,CGB!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CIH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CSA!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN:3-,CIH:4-,CSJ:4-,BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:4,CIH!Keshik:6!Front Line:5!Second Line:4,CSA!Keshik:6!Front Line:5!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:6!Front Line:5!Second Line:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:1,CBS!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CHH:4,CIH!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSA!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSJ:3+,CSV!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CHH:7,CSJ!Keshik:7!Front Line:5!Second Line:2!Solahma:1,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN!Second Line:1!Solahma:4!Provisional Garrison:7,CBS!Solahma:4!Provisional Garrison:7,CGB!Solahma:4!Provisional Garrison:7,CHH!Solahma:4!Provisional Garrison:7,CIH!Solahma:4!Provisional Garrison:7,CSA!Solahma:4!Provisional Garrison:7,CSJ!Front Line:1!Second Line:2!Solahma:5!Provisional Garrison:7,CSV!Solahma:4!Provisional Garrison:7,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:5!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:5!Front Line:4!Second Line:2!Solahma:1,BAN:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:7!Front Line:4!Second Line:1,CBS!Keshik:7!Front Line:6!Second Line:3!Solahma:1,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CIH!Keshik:7!Front Line:7!Second Line:4!Solahma:1,CSA!Keshik:7!Front Line:6!Second Line:1,CSJ!Keshik:7!Front Line:3,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN!Keshik:1,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN:3-,CIH:4-,CSJ!Front Line:1,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:6!Front Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CHH!Keshik:4!Front Line:2</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CGB!Keshik:4!Front Line:4!Second Line:3,CSJ!Keshik:4!Front Line:1,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV:5+,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:4!Front Line:4!Second Line:1,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN!Second Line:1,CSJ!Front Line:1,BAN!Second Line:1</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS:6+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:4,CSJ!Keshik:6!Front Line:1,CSV:6+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>recon</roles>
+                <availability>CHH!Keshik:4!Front Line:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CGB!Keshik:4!Front Line:4!Second Line:3,CSJ!Keshik:4!Front Line:1,BAN:3+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:5,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:5!Front Line:1,CSV!Keshik:5!Front Line:4!Second Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CSJ!Keshik:3!Front Line:2,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN:3-,CSJ!Front Line:1,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:6!Front Line:1,BAN:6+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CHH!Keshik:4!Front Line:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3,CBS:4,CGB!Keshik:4!Front Line:4!Second Line:3!Solahma:2,CSJ!Keshik:4!Front Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:8,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN:3+,CBS!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CSA!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV!Keshik:4!Front Line:4!Second Line:2!Solahma:1,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CIH:6,CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN:3-,CSJ:5-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:3,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:3,CSV!Keshik:5!Front Line:4!Second Line:3,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH!Keshik:4!Front Line:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3,CBS:4,CGB!Keshik:4!Front Line:4!Second Line:3!Solahma:2,CHH:4,CSA:4,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:8!Second Line:8,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:3!Front Line:1,CSV:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CHH!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CSJ:4+,BAN:8+</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Front Line:1!Second Line:2,CBS:3-,CGB!Second Line:1!Solahma:2,CHH:3-,CIH!Front Line:1!Second Line:1,CSA:3-,CSJ:5-,CSV:3-,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN:3+,CIH!Keshik:3!Front Line:2,CSJ!Keshik:1,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CBS:3,CGB:3,CHH:3,CIH!Keshik:3!Front Line:3!Second Line:3!Solahma:1,CSA!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CSJ!Keshik:3!Front Line:1!Second Line:1,BAN:4+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CGB!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CSA:5+,CSJ!Keshik:5!Front Line:2!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,BAN:7+</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,CSJ!Keshik:2!Front Line:5!Second Line:7!Solahma:7!Provisional Garrison:8,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS:4+,CGB!Keshik:4!Front Line:3!Second Line:1,CHH:4+,CIH!Keshik:4!Front Line:3!Second Line:1,CSA!Keshik:4!Front Line:3!Second Line:1,CSJ!Keshik:2!Front Line:1,CSV:4+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+            </model>
+        </chassis>
 		<chassis name='Clint IIC' unitType='Mek'>
 			<availability>CSR:2,CBS:5</availability>
 			<model name=''>

--- a/megamek/data/forcegenerator/3028.xml
+++ b/megamek/data/forcegenerator/3028.xml
@@ -1904,7 +1904,7 @@
             <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:4!Front Line:4!Second Line:1,BAN:3+</availability>
             <model name='(ER Laser Advanced)'>
                 <roles>recon</roles>
-                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,CSJ:0,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
@@ -1933,7 +1933,7 @@
         <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
             <availability>CLAN:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CSJ!Keshik:3!Front Line:2,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
             <model name='(ER Laser Advanced)'>
-                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,CSJ:0,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>

--- a/megamek/data/forcegenerator/3039.xml
+++ b/megamek/data/forcegenerator/3039.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3039-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>5,5</pctOmni>
@@ -1799,135 +1802,309 @@
 				<availability>IS:3</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CIH:5,CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CIH:7,CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN!Solahma:1,CBS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:0,CSJ:0,CSV!Second Line:1!Solahma:1,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:5,CBS!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CSV!Second Line:5!Solahma:6</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CSV!Second Line:6!Solahma:7</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CSV!Second Line:6!Solahma:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:7,CBS!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CSV!Second Line:7!Solahma:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CSJ:2+,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Front Line:1!Second Line:7,CBS!Second Line:7,CGB!Second Line:8,CHH!Solahma:2!Provisional Garrison:8,CIH!Second Line:2,CSJ!Keshik:1!Front Line:8,CSV!Front Line:1!Second Line:7,BAN!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Front Line:2!Second Line:5,CBS!Second Line:5,CGB!Second Line:6,CHH!Solahma:1!Provisional Garrison:6,CIH!Second Line:1,CSJ!Keshik:2!Front Line:6,CSV!Front Line:2!Second Line:5,BAN!Keshik:8!Front Line:4</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:3!Second Line:1,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CGB!Second Line:4,CHH!Front Line:4!Second Line:2!Solahma:1,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CIH!Keshik:3!Front Line:1,CSJ!Keshik:6,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CIH!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:2!Second Line:2,CSJ!Keshik:4,CSV!Keshik:4!Front Line:2!Second Line:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CIH!Keshik:5!Front Line:2,CSA!Keshik:5!Front Line:3!Second Line:3,CSJ!Keshik:5,CSV!Keshik:5!Front Line:3!Second Line:3,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CIH:0,CSJ!Keshik:5,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH!Keshik:4!Front Line:2,CIH!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:2!Second Line:2,CSJ!Keshik:4,CSV!Keshik:4!Front Line:2!Second Line:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:5!Front Line:2,CSJ!Keshik:6,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:4!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CBS!Second Line:1,CHH!Second Line:1,CSV!Second Line:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1,CGB!Second Line:4,CHH!Second Line:6!Solahma:4,CIH:0,CSJ:0,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:5!Front Line:2,CIH!Keshik:7!Front Line:2,CSJ!Keshik:6,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CIH!Keshik:6!Front Line:1,CSA!Keshik:3!Front Line:1!Second Line:1,CSJ!Keshik:3,CSV!Keshik:3!Front Line:1!Second Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:5!Front Line:3,CIH!Keshik:7!Front Line:2,CSA!Keshik:5!Front Line:3!Second Line:3,CSJ!Keshik:5,CSV!Keshik:5!Front Line:3!Second Line:3,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CBS!Keshik:5!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:2!Second Line:1,CIH!Keshik:6!Front Line:1,CSA!Keshik:5!Front Line:2!Second Line:1,CSJ!Keshik:5,CSV!Keshik:5!Front Line:2!Second Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH!Keshik:2!Front Line:1,CIH!Keshik:4!Front Line:2,CSA!Keshik:3!Front Line:1!Second Line:1,CSJ!Keshik:3,CSV!Keshik:3!Front Line:1!Second Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:8!Front Line:2,CSA!Keshik:6!Front Line:3!Second Line:3,CSJ!Keshik:6,CSV!Keshik:6!Front Line:3!Second Line:3,BAN:0</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN:7,CGB!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CIH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CSA!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN:3-,CIH:4-,CSJ:4-,BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:4,CIH!Keshik:6!Front Line:5!Second Line:4,CSA!Keshik:6!Front Line:5!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:6!Front Line:5!Second Line:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:1,CBS!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CHH:4,CIH!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSA!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSJ:3+,CSV!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CHH:7,CSJ!Keshik:7!Front Line:5!Second Line:2!Solahma:1,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN!Second Line:1!Solahma:4!Provisional Garrison:7,CBS!Solahma:4!Provisional Garrison:7,CGB!Solahma:4!Provisional Garrison:7,CHH!Solahma:4!Provisional Garrison:7,CIH!Solahma:4!Provisional Garrison:7,CSA!Solahma:4!Provisional Garrison:7,CSJ!Front Line:1!Second Line:2!Solahma:5!Provisional Garrison:7,CSV!Solahma:4!Provisional Garrison:7,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:5!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:5!Front Line:4!Second Line:2!Solahma:1,BAN:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:7!Front Line:4!Second Line:1,CBS!Keshik:7!Front Line:6!Second Line:3!Solahma:1,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CIH!Keshik:7!Front Line:7!Second Line:4!Solahma:1,CSA!Keshik:7!Front Line:6!Second Line:1,CSJ!Keshik:7!Front Line:3,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN!Keshik:1,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN:3-,CIH:4-,CSJ!Front Line:1,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:6!Front Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CHH!Keshik:4!Front Line:2</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CGB!Keshik:4!Front Line:4!Second Line:3,CSJ!Keshik:4!Front Line:1,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV:5+,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:4!Front Line:4!Second Line:1,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN!Second Line:1,CSJ!Front Line:1,BAN!Second Line:1</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS:6+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:4,CSJ!Keshik:6!Front Line:1,CSV:6+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>recon</roles>
+                <availability>CHH!Keshik:4!Front Line:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CGB!Keshik:4!Front Line:4!Second Line:3,CSJ!Keshik:4!Front Line:1,BAN:3+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:5,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:5!Front Line:1,CSV!Keshik:5!Front Line:4!Second Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CSJ!Keshik:3!Front Line:2,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN:3-,CSJ!Front Line:1,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:6!Front Line:1,BAN:6+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CHH!Keshik:4!Front Line:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3,CBS:4,CGB!Keshik:4!Front Line:4!Second Line:3!Solahma:2,CSJ!Keshik:4!Front Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:8,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN:3+,CBS!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CSA!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV!Keshik:4!Front Line:4!Second Line:2!Solahma:1,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CIH:6,CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN:3-,CSJ:5-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:3,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:3,CSV!Keshik:5!Front Line:4!Second Line:3,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH!Keshik:4!Front Line:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3,CBS:4,CGB!Keshik:4!Front Line:4!Second Line:3!Solahma:2,CHH:4,CSA:4,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:8!Second Line:8,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:3!Front Line:1,CSV:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CHH!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CSJ:4+,BAN:8+</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Front Line:1!Second Line:2,CBS:3-,CGB!Second Line:1!Solahma:2,CHH:3-,CIH!Front Line:1!Second Line:1,CSA:3-,CSJ:5-,CSV:3-,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN:3+,CIH!Keshik:3!Front Line:2,CSJ!Keshik:1,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CBS:3,CGB:3,CHH:3,CIH!Keshik:3!Front Line:3!Second Line:3!Solahma:1,CSA!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CSJ!Keshik:3!Front Line:1!Second Line:1,BAN:4+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CGB!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CSA:5+,CSJ!Keshik:5!Front Line:2!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,BAN:7+</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,CSJ!Keshik:2!Front Line:5!Second Line:7!Solahma:7!Provisional Garrison:8,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS:4+,CGB!Keshik:4!Front Line:3!Second Line:1,CHH:4+,CIH!Keshik:4!Front Line:3!Second Line:1,CSA!Keshik:4!Front Line:3!Second Line:1,CSJ!Keshik:2!Front Line:1,CSV:4+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+            </model>
+        </chassis>
 		<chassis name='Clint IIC' unitType='Mek'>
 			<availability>CSR:2,CBS:5</availability>
 			<model name=''>

--- a/megamek/data/forcegenerator/3039.xml
+++ b/megamek/data/forcegenerator/3039.xml
@@ -1991,7 +1991,7 @@
             <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:4!Front Line:4!Second Line:1,BAN:3+</availability>
             <model name='(ER Laser Advanced)'>
                 <roles>recon</roles>
-                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,CSJ:0,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
@@ -2020,7 +2020,7 @@
         <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
             <availability>CLAN:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CSJ!Keshik:3!Front Line:2,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
             <model name='(ER Laser Advanced)'>
-                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,CSJ:0,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>

--- a/megamek/data/forcegenerator/3039.xml
+++ b/megamek/data/forcegenerator/3039.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3039-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>5,5</pctOmni>

--- a/megamek/data/forcegenerator/3049.xml
+++ b/megamek/data/forcegenerator/3049.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3049-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>5,5</pctOmni>

--- a/megamek/data/forcegenerator/3049.xml
+++ b/megamek/data/forcegenerator/3049.xml
@@ -2415,7 +2415,7 @@
             <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:4!Front Line:4!Second Line:1,BAN:3+</availability>
             <model name='(ER Laser Advanced)'>
                 <roles>recon</roles>
-                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,CSJ:0,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
@@ -2444,7 +2444,7 @@
         <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
             <availability>CLAN:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CSJ!Keshik:3!Front Line:2,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
             <model name='(ER Laser Advanced)'>
-                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,CSJ:0,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>

--- a/megamek/data/forcegenerator/3049.xml
+++ b/megamek/data/forcegenerator/3049.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3049-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>5,5</pctOmni>
@@ -2220,135 +2223,312 @@
 				<availability>FWL:6+,IS:2+,MERC:5+</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CIH:5,CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CIH:7,CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN!Solahma:1,CBS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:0,CSJ:0,CSV!Second Line:1!Solahma:1,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:5,CBS!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CSV!Second Line:5!Solahma:6</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CSV!Second Line:6!Solahma:7</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CSV!Second Line:6!Solahma:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:7,CBS!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CSV!Second Line:7!Solahma:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CSJ:2+,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Front Line:1!Second Line:7,CBS!Second Line:7,CGB!Second Line:8,CHH!Solahma:2!Provisional Garrison:8,CIH!Second Line:2,CSJ!Keshik:1!Front Line:8,CSV!Front Line:1!Second Line:7,BAN!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Front Line:2!Second Line:5,CBS!Second Line:5,CGB!Second Line:6,CHH!Solahma:1!Provisional Garrison:6,CIH!Second Line:1,CSJ!Keshik:2!Front Line:6,CSV!Front Line:2!Second Line:5,BAN!Keshik:8!Front Line:4</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:3!Second Line:1,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CGB!Second Line:4,CHH!Front Line:4!Second Line:2!Solahma:1,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CIH!Keshik:3!Front Line:1,CSJ!Keshik:6,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CIH!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:2!Second Line:2,CSJ!Keshik:4,CSV!Keshik:4!Front Line:2!Second Line:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CIH!Keshik:5!Front Line:2,CSA!Keshik:5!Front Line:3!Second Line:3,CSJ!Keshik:5,CSV!Keshik:5!Front Line:3!Second Line:3,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CIH:0,CSJ!Keshik:5,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH!Keshik:4!Front Line:2,CIH!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:2!Second Line:2,CSJ!Keshik:4,CSV!Keshik:4!Front Line:2!Second Line:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:5!Front Line:2,CSJ!Keshik:6,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:4!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CBS!Second Line:1,CHH!Second Line:1,CSV!Second Line:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1,CGB!Second Line:4,CHH!Second Line:6!Solahma:4,CIH:0,CSJ:0,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:5!Front Line:2,CIH!Keshik:7!Front Line:2,CSJ!Keshik:6,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CIH!Keshik:6!Front Line:1,CSA!Keshik:3!Front Line:1!Second Line:1,CSJ!Keshik:3,CSV!Keshik:3!Front Line:1!Second Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:5!Front Line:3,CIH!Keshik:7!Front Line:2,CSA!Keshik:5!Front Line:3!Second Line:3,CSJ!Keshik:5,CSV!Keshik:5!Front Line:3!Second Line:3,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CBS!Keshik:5!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:2!Second Line:1,CIH!Keshik:6!Front Line:1,CSA!Keshik:5!Front Line:2!Second Line:1,CSJ!Keshik:5,CSV!Keshik:5!Front Line:2!Second Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH!Keshik:2!Front Line:1,CIH!Keshik:4!Front Line:2,CSA!Keshik:3!Front Line:1!Second Line:1,CSJ!Keshik:3,CSV!Keshik:3!Front Line:1!Second Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:8!Front Line:2,CSA!Keshik:6!Front Line:3!Second Line:3,CSJ!Keshik:6,CSV!Keshik:6!Front Line:3!Second Line:3,BAN:0</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN:7,CGB!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CIH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CSA!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN:3-,CIH:4-,CSJ:4-,BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:4,CIH!Keshik:6!Front Line:5!Second Line:4,CSA!Keshik:6!Front Line:5!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:6!Front Line:5!Second Line:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:1,CBS!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CHH:4,CIH!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSA!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSJ:3+,CSV!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CHH:7,CSJ!Keshik:7!Front Line:5!Second Line:2!Solahma:1,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN!Second Line:1!Solahma:4!Provisional Garrison:7,CBS!Solahma:4!Provisional Garrison:7,CGB!Solahma:4!Provisional Garrison:7,CHH!Solahma:4!Provisional Garrison:7,CIH!Solahma:4!Provisional Garrison:7,CSA!Solahma:4!Provisional Garrison:7,CSJ!Front Line:1!Second Line:2!Solahma:5!Provisional Garrison:7,CSV!Solahma:4!Provisional Garrison:7,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:5!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:5!Front Line:4!Second Line:2!Solahma:1,BAN:4+</availability>
+            </model>
+            <model name='(Watch Detachment Advanced)'>
+                <availability>CJF!Provisional Garrison:1,CW!Provisional Garrison:1</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:7!Front Line:4!Second Line:1,CBS!Keshik:7!Front Line:6!Second Line:3!Solahma:1,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CIH!Keshik:7!Front Line:7!Second Line:4!Solahma:1,CSA!Keshik:7!Front Line:6!Second Line:1,CSJ!Keshik:7!Front Line:3,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN!Keshik:1,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN:3-,CIH:4-,CSJ!Front Line:1,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:6!Front Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CHH!Keshik:4!Front Line:2</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CGB!Keshik:4!Front Line:4!Second Line:3,CSJ!Keshik:4!Front Line:1,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV:5+,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:4!Front Line:4!Second Line:1,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN!Second Line:1,CSJ!Front Line:1,BAN!Second Line:1</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS:6+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:4,CSJ!Keshik:6!Front Line:1,CSV:6+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>recon</roles>
+                <availability>CHH!Keshik:4!Front Line:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CGB!Keshik:4!Front Line:4!Second Line:3,CSJ!Keshik:4!Front Line:1,BAN:3+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:5,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:5!Front Line:1,CSV!Keshik:5!Front Line:4!Second Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CSJ!Keshik:3!Front Line:2,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN:3-,CSJ!Front Line:1,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:6!Front Line:1,BAN:6+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CHH!Keshik:4!Front Line:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3,CBS:4,CGB!Keshik:4!Front Line:4!Second Line:3!Solahma:2,CSJ!Keshik:4!Front Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:8,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN:3+,CBS!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CSA!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV!Keshik:4!Front Line:4!Second Line:2!Solahma:1,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CIH:6,CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN:3-,CSJ:5-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:3,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:3,CSV!Keshik:5!Front Line:4!Second Line:3,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>urban</roles>
+                <availability>CHH!Keshik:4!Front Line:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3,CBS:4,CGB!Keshik:4!Front Line:4!Second Line:3!Solahma:2,CHH:4,CSA:4,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:8!Second Line:8,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:3!Front Line:1,CSV:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CHH!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CSJ:4+,BAN:8+</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Front Line:1!Second Line:2,CBS:3-,CGB!Second Line:1!Solahma:2,CHH:3-,CIH!Front Line:1!Second Line:1,CSA:3-,CSJ:5-,CSV:3-,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN:3+,CIH!Keshik:3!Front Line:2,CSJ!Keshik:1,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CBS:3,CGB:3,CHH:3,CIH!Keshik:3!Front Line:3!Second Line:3!Solahma:1,CSA!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CSJ!Keshik:3!Front Line:1!Second Line:1,BAN:4+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CGB!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CSA:5+,CSJ!Keshik:5!Front Line:2!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,BAN:7+</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,CSJ!Keshik:2!Front Line:5!Second Line:7!Solahma:7!Provisional Garrison:8,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS:4+,CGB!Keshik:4!Front Line:3!Second Line:1,CHH:4+,CIH!Keshik:4!Front Line:3!Second Line:1,CSA!Keshik:4!Front Line:3!Second Line:1,CSJ!Keshik:2!Front Line:1,CSV:4+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+            </model>
+        </chassis>
 		<chassis name='Claymore' unitType='Dropship'>
 			<availability>LA:1:3054</availability>
 			<model name='(3054)'>

--- a/megamek/data/forcegenerator/3055.xml
+++ b/megamek/data/forcegenerator/3055.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3055-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>5,5</pctOmni>
@@ -2562,7 +2559,7 @@
             </model>
             <model name='(Tracked CUAC10 Advanced)'>
                 <roles>field_gun</roles>
-                <availability>CLAN!Keshik:5!Front Line:2,CIH:0,CSJ!Keshik:5,BAN:0</availability>
+                <availability>CLAN!Keshik:5!Front Line:2,CIH:0,CSJ!Keshik:5,CWIE:0,BAN:0</availability>
             </model>
             <model name='(Tracked CUAC2 Advanced)'>
                 <roles>field_gun,fire_support</roles>
@@ -2598,7 +2595,7 @@
             </model>
             <model name='(Wheeled AC5 Advanced)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
-                <availability>CLAN!Second Line:1,CGB!Second Line:4,CHH!Second Line:6!Solahma:4,CIH:0,CSJ:0,BAN:3+</availability>
+                <availability>CLAN!Second Line:1,CGB!Second Line:4,CHH!Second Line:6!Solahma:4,CIH:0,CSJ:0,CWIE:0,BAN:3+</availability>
             </model>
             <model name='(Wheeled AC5 Basic)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
@@ -2732,7 +2729,7 @@
             <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:4!Front Line:4!Second Line:1,CWIE:3+,BAN:3+</availability>
             <model name='(ER Laser Advanced)'>
                 <roles>recon</roles>
-                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,CWIE:0,BAN:0</availability>
+                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,CSJ:0,CWIE:0,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
@@ -2780,7 +2777,7 @@
         <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
             <availability>CLAN:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CSJ!Keshik:3!Front Line:2,CWIE:2+,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
             <model name='(ER Laser Advanced)'>
-                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,CWIE:0,BAN:0</availability>
+                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,CSJ:0,CWIE:0,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
@@ -2860,7 +2857,7 @@
             </model>
             <model name='(Rifle Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN:7,CSJ!Keshik:7!Front Line:8!Second Line:8,BAN:7</availability>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:8!Second Line:8,CWIE:0,BAN:7</availability>
             </model>
             <model name='(Rifle Basic)'>
                 <roles>urban</roles>
@@ -2900,7 +2897,7 @@
                 <availability>CWIE:4</availability>
             </model>
             <model name='(Rifle Advanced)'>
-                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CGB:5,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CJF:5+,CSA:5,CSJ!Keshik:5!Front Line:2!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CW:5+,CWIE:0,BAN:7+</availability>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CGB:5,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CJF:5+,CSA:5+,CSJ!Keshik:5!Front Line:2!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CW:5+,CWIE:0,BAN:7+</availability>
             </model>
             <model name='(Rifle Basic)'>
                 <availability>CWIE:7</availability>

--- a/megamek/data/forcegenerator/3055.xml
+++ b/megamek/data/forcegenerator/3055.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3055-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>5,5</pctOmni>
@@ -2488,135 +2491,431 @@
 				<availability>FWL:7+,IS:4+,MERC:5+</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CIH:5,CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CIH:7,CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN!Solahma:1,CBS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:0,CSJ:0,CSV!Second Line:1!Solahma:1,CWIE:0,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:5,CBS!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CSV!Second Line:5!Solahma:6</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CSV!Second Line:6!Solahma:7</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CSV!Second Line:6!Solahma:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:7,CBS!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CSV!Second Line:7!Solahma:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CSJ:2+,CWIE!Keshik:2!Front Line:2!Second Line:1,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Front Line:1!Second Line:7,CBS!Second Line:7,CGB!Second Line:8,CHH!Solahma:2!Provisional Garrison:8,CIH!Second Line:2,CSJ!Keshik:1!Front Line:8,CSV!Front Line:1!Second Line:7,CWIE:0,BAN!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Front Line:2!Second Line:5,CBS!Second Line:5,CGB!Second Line:6,CHH!Solahma:1!Provisional Garrison:6,CIH!Second Line:1,CSJ!Keshik:2!Front Line:6,CSV!Front Line:2!Second Line:5,CWIE:0,BAN!Keshik:8!Front Line:4</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:3!Second Line:1,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CGB!Second Line:4,CHH!Front Line:4!Second Line:2!Solahma:1,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CIH!Keshik:3!Front Line:1,CSJ!Keshik:6,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CIH!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:2!Second Line:2,CSJ!Keshik:4,CSV!Keshik:4!Front Line:2!Second Line:2,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CIH!Keshik:5!Front Line:2,CSA!Keshik:5!Front Line:3!Second Line:3,CSJ!Keshik:5,CSV!Keshik:5!Front Line:3!Second Line:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CIH:0,CSJ!Keshik:5,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH!Keshik:4!Front Line:2,CIH!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:2!Second Line:2,CSJ!Keshik:4,CSV!Keshik:4!Front Line:2!Second Line:2,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:5!Front Line:2,CSJ!Keshik:6,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:4!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CWIE!Keshik:8!Front Line:5</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CBS!Second Line:1,CHH!Second Line:1,CSV!Second Line:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CWIE!Front Line:6!Second Line:6</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1,CGB!Second Line:4,CHH!Second Line:6!Solahma:4,CIH:0,CSJ:0,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CWIE!Keshik:5!Front Line:8!Second Line:5</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:5!Front Line:2,CIH!Keshik:7!Front Line:2,CSJ!Keshik:6,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CIH!Keshik:6!Front Line:1,CSA!Keshik:3!Front Line:1!Second Line:1,CSJ!Keshik:3,CSV!Keshik:3!Front Line:1!Second Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:5!Front Line:3,CIH!Keshik:7!Front Line:2,CSA!Keshik:5!Front Line:3!Second Line:3,CSJ!Keshik:5,CSV!Keshik:5!Front Line:3!Second Line:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CBS!Keshik:5!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:2!Second Line:1,CIH!Keshik:6!Front Line:1,CSA!Keshik:5!Front Line:2!Second Line:1,CSJ!Keshik:5,CSV!Keshik:5!Front Line:2!Second Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH!Keshik:2!Front Line:1,CIH!Keshik:4!Front Line:2,CSA!Keshik:3!Front Line:1!Second Line:1,CSJ!Keshik:3,CSV!Keshik:3!Front Line:1!Second Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:8!Front Line:2,CSA!Keshik:6!Front Line:3!Second Line:3,CSJ!Keshik:6,CSV!Keshik:6!Front Line:3!Second Line:3,CWIE:0,BAN:0</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN:7,CGB!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CIH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CSA!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CWIE:7,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN:3-,CIH:4-,CSJ:4-,CWIE:0,BAN:3</availability>
+            </model>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CWIE:3-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:4,CIH!Keshik:6!Front Line:5!Second Line:4,CSA!Keshik:6!Front Line:5!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:6!Front Line:5!Second Line:4,CWIE:0,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CWIE:2+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:1,CBS!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CHH:4,CIH!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSA!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSJ:3+,CSV!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CWIE:0,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CWIE:3</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CHH:7,CSJ!Keshik:7!Front Line:5!Second Line:2!Solahma:1,CWIE:0,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CWIE:7</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN!Second Line:1!Solahma:4!Provisional Garrison:7,CBS!Solahma:4!Provisional Garrison:7,CGB!Solahma:4!Provisional Garrison:7,CHH!Solahma:4!Provisional Garrison:7,CIH!Solahma:4!Provisional Garrison:7,CSA!Solahma:4!Provisional Garrison:7,CSJ!Front Line:1!Second Line:2!Solahma:5!Provisional Garrison:7,CSV!Solahma:4!Provisional Garrison:7,CWIE:2-,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:5!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CWIE:0,BAN:4+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CWIE!Keshik:5!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='(Watch Detachment Advanced)'>
+                <availability>CGB:2-,CJF:3-,CSJ!Provisional Garrison:1,CW:2-,CWIE:2-</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:7!Front Line:4!Second Line:1,CBS!Keshik:7!Front Line:6!Second Line:3!Solahma:1,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CIH!Keshik:7!Front Line:7!Second Line:4!Solahma:1,CSA!Keshik:7!Front Line:6!Second Line:1,CSJ!Keshik:7!Front Line:3,CWIE!Keshik:5!Front Line:3!Second Line:1,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN!Keshik:1,CSA!Keshik:4!Front Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN:3-,CIH:4-,CSJ!Front Line:1,CWIE:0,BAN:4-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CWIE:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:6!Front Line:1,CWIE:0,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CWIE:6+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CGB:2+,CHH!Keshik:4!Front Line:2</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CSJ!Keshik:4!Front Line:1,CWIE:0,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CWIE:4</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN:6,CWIE:0,BAN:7</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CWIE:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV:5+,CWIE:0,BAN:3+</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CWIE!Keshik:5!Front Line:3!Second Line:1</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:4!Front Line:4!Second Line:1,CWIE:3+,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CIH:6,CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN!Second Line:1,CSJ!Front Line:1,CWIE:0,BAN!Second Line:1</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CWIE:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS:6+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:4,CSJ!Keshik:6!Front Line:1,CSV:6+,CWIE:0,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>recon</roles>
+                <availability>CWIE!Keshik:5!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>recon</roles>
+                <availability>CHH!Keshik:4!Front Line:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CSJ!Keshik:4!Front Line:1,CWIE:0,BAN:3+</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CWIE:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:5,CWIE:0,BAN:7</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>recon</roles>
+                <availability>CWIE:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:5!Front Line:1,CSV!Keshik:5!Front Line:4!Second Line:1,CWIE:0,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CWIE!Keshik:4!Front Line:2!Second Line:1</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CSJ!Keshik:3!Front Line:2,CWIE:2+,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,CSJ!Front Line:1,CWIE:0,BAN:5-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CWIE!Front Line:2</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:6!Front Line:1,CWIE:0,BAN:6+</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CWIE!Keshik:3</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CGB:2+,CHH!Keshik:4!Front Line:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3,CBS:4,CGB:4,CSJ!Keshik:4!Front Line:1,CWIE:0,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CWIE:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:8,CWIE:0,BAN:6</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CWIE:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV:5+,CWIE:0,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CWIE:5+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN:3+,CBS!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CJF!Keshik:3!Front Line:2!Second Line:1!Solahma:1,CSA!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CW!Keshik:3!Front Line:2!Second Line:1!Solahma:1,CWIE:3+,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,CSJ:5-,CWIE:0,BAN:5-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CWIE:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:3,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:3,CSV!Keshik:5!Front Line:4!Second Line:3,CWIE:0,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <roles>urban</roles>
+                <availability>CWIE!Keshik:3</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>urban</roles>
+                <availability>CGB!Keshik:1,CHH!Keshik:4!Front Line:1</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3,CBS:4,CGB:4,CHH:4,CJF:4,CSA:4,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV:4,CW:4,CWIE:0,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CWIE:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:8!Second Line:8,BAN:7</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <roles>urban</roles>
+                <availability>CWIE:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:3!Front Line:1,CSV:5+,CWIE:0,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <roles>urban</roles>
+                <availability>CWIE:4+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CHH!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CSJ:4+,CWIE!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,BAN:8+</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Front Line:1!Second Line:2,CBS:3-,CGB!Second Line:1!Solahma:2,CHH:3-,CIH!Front Line:1!Second Line:1,CSA:3-,CSJ:5-,CSV:3-,CWIE:0,BAN:4-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CWIE:3-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN:3+,CIH!Keshik:3!Front Line:2,CSJ!Keshik:1,CWIE:0,BAN:4+</availability>
+            </model>
+            <model name='(Laser Basic)'>
+                <availability>CWIE:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CBS:3,CGB:3,CHH:3,CIH!Keshik:3!Front Line:3!Second Line:3!Solahma:1,CJF:3,CSA!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CSJ!Keshik:3!Front Line:1!Second Line:1,CW:3,CWIE:0,BAN:4+</availability>
+            </model>
+            <model name='(MG Basic)'>
+                <roles>anti_infantry</roles>
+                <availability>CWIE:4</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CGB:5,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CJF:5+,CSA:5,CSJ!Keshik:5!Front Line:2!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CW:5+,CWIE:0,BAN:7+</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CWIE:7</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CBS!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CGB:3-,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,CJF!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CSJ!Keshik:2!Front Line:5!Second Line:7!Solahma:7!Provisional Garrison:8,CW!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CWIE:0,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS:4+,CGB!Keshik:4!Front Line:3!Second Line:1,CHH:4+,CIH!Keshik:4!Front Line:3!Second Line:1,CSA!Keshik:4!Front Line:3!Second Line:1,CSJ!Keshik:2!Front Line:1,CSV:4+,CWIE:0,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+            </model>
+            <model name='(SRM Basic)'>
+                <availability>CWIE:4+</availability>
+            </model>
+        </chassis>
 		<chassis name='Claymore' unitType='Dropship'>
 			<availability>LA:1</availability>
 			<model name='(3054)'>

--- a/megamek/data/forcegenerator/3058.xml
+++ b/megamek/data/forcegenerator/3058.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3058-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='ARDC'>
 			<pctOmni>0,0,2,5,10</pctOmni>
@@ -2632,147 +2635,336 @@
 				<availability>FWL:7+,IS:4+,MERC:5+</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CIH:5,CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Heavy Foot Infantry' unitType='Infantry'>
-			<availability>CLAN.GC:10</availability>
-			<model name='Ebon Keshik Point'>
-				<availability>CLAN.GC:10</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Heavy Jump Infantry' unitType='Infantry'>
-			<availability>CSA:4,CHH:5,CLAN:3,CGB:4</availability>
-			<model name='Heavy Infantry Point'>
-				<availability>CLAN:8</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CIH:7,CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN!Solahma:1,CBS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:0,CSJ:0,CSV!Second Line:1!Solahma:1,CWIE:0,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:5,CBS!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CSV!Second Line:5!Solahma:6</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CSV!Second Line:6!Solahma:7</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CSV!Second Line:6!Solahma:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:7,CBS!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CSV!Second Line:7!Solahma:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CSJ:2+,CWIE!Keshik:2!Front Line:2!Second Line:1,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Front Line:1!Second Line:7,CBS!Second Line:7,CGB!Second Line:8,CHH!Solahma:2!Provisional Garrison:8,CIH!Second Line:2,CSJ!Keshik:1!Front Line:8,CSV!Front Line:1!Second Line:7,CWIE:0,BAN!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Front Line:2!Second Line:5,CBS!Second Line:5,CGB!Second Line:6,CHH!Solahma:1!Provisional Garrison:6,CIH!Second Line:1,CSJ!Keshik:2!Front Line:6,CSV!Front Line:2!Second Line:5,CWIE:0,BAN!Keshik:8!Front Line:4</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:3!Second Line:1,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CGB!Second Line:4,CHH!Front Line:4!Second Line:2!Solahma:1,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CIH!Keshik:3!Front Line:1,CSJ!Keshik:6,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CIH!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:2!Second Line:2,CSJ!Keshik:4,CSV!Keshik:4!Front Line:2!Second Line:2,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CIH!Keshik:5!Front Line:2,CSA!Keshik:5!Front Line:3!Second Line:3,CSJ!Keshik:5,CSV!Keshik:5!Front Line:3!Second Line:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CIH:0,CSJ!Keshik:5,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH!Keshik:4!Front Line:2,CIH!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:2!Second Line:2,CSJ!Keshik:4,CSV!Keshik:4!Front Line:2!Second Line:2,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:5!Front Line:2,CSJ!Keshik:6,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:4!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CWIE!Keshik:8!Front Line:5</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CBS!Second Line:1,CHH!Second Line:1,CSV!Second Line:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CWIE!Front Line:6!Second Line:6</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1,CGB!Second Line:4,CHH!Second Line:6!Solahma:4,CIH:0,CSJ:0,CWIE:0,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CWIE!Keshik:5!Front Line:8!Second Line:5</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:5!Front Line:2,CIH!Keshik:7!Front Line:2,CSJ!Keshik:6,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CIH!Keshik:6!Front Line:1,CSA!Keshik:3!Front Line:1!Second Line:1,CSJ!Keshik:3,CSV!Keshik:3!Front Line:1!Second Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:5!Front Line:3,CIH!Keshik:7!Front Line:2,CSA!Keshik:5!Front Line:3!Second Line:3,CSJ!Keshik:5,CSV!Keshik:5!Front Line:3!Second Line:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CBS!Keshik:5!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:2!Second Line:1,CIH!Keshik:6!Front Line:1,CSA!Keshik:5!Front Line:2!Second Line:1,CSJ!Keshik:5,CSV!Keshik:5!Front Line:2!Second Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH!Keshik:2!Front Line:1,CIH!Keshik:4!Front Line:2,CSA!Keshik:3!Front Line:1!Second Line:1,CSJ!Keshik:3,CSV!Keshik:3!Front Line:1!Second Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:8!Front Line:2,CSA!Keshik:6!Front Line:3!Second Line:3,CSJ!Keshik:6,CSV!Keshik:6!Front Line:3!Second Line:3,CWIE:0,BAN:0</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN:7,CGB!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CIH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CSA!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CWIE:7,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN:3-,CIH:4-,CSJ:4-,CWIE:0,BAN:3</availability>
+            </model>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CWIE:3-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:4,CIH!Keshik:6!Front Line:5!Second Line:4,CSA!Keshik:6!Front Line:5!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:6!Front Line:5!Second Line:4,CWIE:2+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:1,CBS!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CGB:4,CHH:4,CIH!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CJF:4,CSA!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSJ:3+,CSV!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CW:4,CWIE:3,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CGB!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:5,CHH:7,CJF!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:5,CSJ!Keshik:7!Front Line:5!Second Line:2!Solahma:1,CW!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:5,CWIE:7,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN!Second Line:1!Solahma:4!Provisional Garrison:7,CBS!Solahma:4!Provisional Garrison:7,CGB!Provisional Garrison:2,CHH!Solahma:4!Provisional Garrison:7,CIH!Solahma:4!Provisional Garrison:7,CJF:2-,CSA!Solahma:4!Provisional Garrison:7,CSJ!Front Line:1!Second Line:2!Solahma:5!Provisional Garrison:7,CSV!Solahma:4!Provisional Garrison:7,CW:2-,CWIE:2-,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:5!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CWIE!Keshik:5!Front Line:3!Second Line:1,BAN:4+</availability>
+            </model>
+            <model name='(Watch Detachment Advanced)'>
+                <availability>CGB:2-,CJF:3-,CSJ!Provisional Garrison:1,CW:2-,CWIE:2-</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:7!Front Line:4!Second Line:1,CBS!Keshik:7!Front Line:6!Second Line:3!Solahma:1,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CIH!Keshik:7!Front Line:7!Second Line:4!Solahma:1,CSA!Keshik:7!Front Line:6!Second Line:1,CSJ!Keshik:7!Front Line:3,CWIE!Keshik:5!Front Line:3!Second Line:1,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN!Keshik:1,CSA!Keshik:4!Front Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN:3-,CIH:4-,CSJ!Front Line:1,CWIE:4-,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:6!Front Line:1,CWIE:6+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN!Keshik:1,CBS:2+,CGB:2+,CHH!Keshik:4!Front Line:2,CSJ:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CSJ!Keshik:4!Front Line:1,CWIE:4,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN:6,CWIE:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV:5+,CWIE:5+,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:4!Front Line:4!Second Line:1,CWIE:3+,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,CSJ:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN!Second Line:1,CSJ!Front Line:1,CWIE:4-,BAN!Second Line:1</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS:6+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:4,CSJ!Keshik:6!Front Line:1,CSV:6+,CWIE!Keshik:5!Front Line:3!Second Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN!Keshik:1,CHH!Keshik:4!Front Line:1,CIH:2+,CSJ:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN:4,CSJ!Keshik:4!Front Line:1,CWIE:3,BAN:3+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:5,CWIE:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:5!Front Line:1,CSV!Keshik:5!Front Line:4!Second Line:1,CWIE!Keshik:4!Front Line:2!Second Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CSJ!Keshik:3!Front Line:2,CWIE:2+,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN!Keshik:1,CGB!Keshik:4!Front Line:1,CSA!Keshik:4!Front Line:1,CSJ:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CIH:6,CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN:3-,CSJ!Front Line:1,CWIE!Front Line:2,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:6!Front Line:1,CWIE!Keshik:3,BAN:6+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN!Keshik:1,CBS:2+,CGB:2+,CHH!Keshik:4!Front Line:1,CSJ:0,CW:2+,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3,CBS:4,CGB:4,CJF:4,CSJ!Keshik:4!Front Line:1,CW:4,CWIE:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:8,CWIE:7,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV:5+,CWIE:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN:3+,CBS!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CJF!Keshik:3!Front Line:2!Second Line:1!Solahma:1,CSA!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CW!Keshik:3!Front Line:2!Second Line:1!Solahma:1,CWIE:3+,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN:3-,CSJ:5-,CWIE:4-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:3,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:3,CSV!Keshik:5!Front Line:4!Second Line:3,CWIE!Keshik:3,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:1,CHH!Keshik:4!Front Line:1,CSJ:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN!Keshik:4!Front Line:4!Second Line:3,CBS:4,CGB:4,CHH:4,CJF:4,CSA:4,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV:4,CW:4,CWIE:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN:7,CSJ!Keshik:7!Front Line:8!Second Line:8,CWIE:7,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:3!Front Line:1,CSV:5+,CWIE:4+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CHH!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CSJ:4+,CWIE!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,BAN:8+</availability>
+            <model name='(Bearhunter Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Front Line:1!Second Line:2,CBS:3-,CGB!Second Line:1!Solahma:2,CHH:3-,CIH!Front Line:1!Second Line:1,CSA:3-,CSJ:5-,CSV:3-,CWIE:0,BAN:4-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CWIE:3-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN:3+,CIH!Keshik:3!Front Line:2,CSJ!Keshik:1,CWIE:4+,BAN:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CBS:3,CGB:3,CHH:3,CIH!Keshik:3!Front Line:3!Second Line:3!Solahma:1,CJF:3,CSA!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CSJ!Keshik:3!Front Line:1!Second Line:1,CW:3,CWIE:4,BAN:4+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CGB:5,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CJF:5+,CSA:5+,CSJ!Keshik:5!Front Line:2!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CW:5+,CWIE:7,BAN:7+</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CBS!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CGB:3-,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,CJF!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CSJ!Keshik:2!Front Line:5!Second Line:7!Solahma:7!Provisional Garrison:8,CW!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CWIE:2-,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS:4+,CGB!Keshik:4!Front Line:3!Second Line:1,CHH:4+,CIH!Keshik:4!Front Line:3!Second Line:1,CSA!Keshik:4!Front Line:3!Second Line:1,CSJ!Keshik:2!Front Line:1,CSV:4+,CWIE:4+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+            </model>
+        </chassis>
 		<chassis name='Claymore' unitType='Dropship'>
 			<availability>LA:1,FS:1</availability>
 			<model name='(3054)'>

--- a/megamek/data/forcegenerator/3058.xml
+++ b/megamek/data/forcegenerator/3058.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3058-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='ARDC'>
 			<pctOmni>0,0,2,5,10</pctOmni>

--- a/megamek/data/forcegenerator/3060.xml
+++ b/megamek/data/forcegenerator/3060.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3060-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='ARDC'>
 			<pctOmni>0,0,2,5,10</pctOmni>
@@ -3466,7 +3463,7 @@
             </model>
             <model name='(Laser Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:3,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:3,CSV!Keshik:5!Front Line:4!Second Line:3,CWIE!Keshik:5!Front Line:3!Second Line:1,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:3,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CNC!Keshik:3,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:3,CSV!Keshik:5!Front Line:4!Second Line:3,CWIE!Keshik:3,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
             </model>
             <model name='(LRM Advanced)'>
                 <roles>fire_support</roles>

--- a/megamek/data/forcegenerator/3060.xml
+++ b/megamek/data/forcegenerator/3060.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3060-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='ARDC'>
 			<pctOmni>0,0,2,5,10</pctOmni>
@@ -3160,135 +3163,372 @@
 				<availability>FWL:8,IS:6,MERC:6</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CIH:5,CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CIH:7,CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN!Solahma:1,CBS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:0,CNC:0,CSJ:0,CSV!Second Line:1!Solahma:1,CWIE:0,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:5,CBS!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CSV!Second Line:5!Solahma:6</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CSV!Second Line:6!Solahma:7</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CSV!Second Line:6!Solahma:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:7,CBS!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CSV!Second Line:7!Solahma:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CNC!Keshik:2!Front Line:2!Second Line:1,CSJ:2+,CWIE!Keshik:2!Front Line:2!Second Line:1,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Front Line:1!Second Line:7,CBS!Second Line:7,CGB!Second Line:8,CHH!Solahma:2!Provisional Garrison:8,CIH!Second Line:2,CNC:0,CSJ!Keshik:1!Front Line:8,CSV!Front Line:1!Second Line:7,CWIE:0,BAN!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Front Line:2!Second Line:5,CBS!Second Line:5,CGB!Second Line:6,CHH!Solahma:1!Provisional Garrison:6,CIH!Second Line:1,CNC:0,CSJ!Keshik:2!Front Line:6,CSV!Front Line:2!Second Line:5,CWIE:0,BAN!Keshik:8!Front Line:4</availability>
+            </model>
+            <model name='(Motorized AP Gauss Advanced)'>
+                <roles>anti_infantry,field_gun</roles>
+                <availability>CJF!Keshik:2</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:3!Second Line:1,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC10 Basic)'>
+                <roles>field_gun</roles>
+                <availability>CWIE!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CGB!Second Line:4,CHH!Front Line:4!Second Line:2!Solahma:1,BAN:3+</availability>
+            </model>
+            <model name='(Tracked AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CWIE:6+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CIH!Keshik:3!Front Line:1,CNC:0,CSJ!Keshik:6,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CIH!Keshik:4!Front Line:1,CNC:0,CSA!Keshik:4!Front Line:2!Second Line:2,CSJ!Keshik:4,CSV!Keshik:4!Front Line:2!Second Line:2,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CIH!Keshik:5!Front Line:2,CNC:0,CSA!Keshik:5!Front Line:3!Second Line:3,CSJ!Keshik:5,CSV!Keshik:5!Front Line:3!Second Line:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CIH:0,CNC:0,CSJ!Keshik:5,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH!Keshik:4!Front Line:2,CIH!Keshik:4!Front Line:1,CNC:0,CSA!Keshik:4!Front Line:2!Second Line:2,CSJ!Keshik:4,CSV!Keshik:4!Front Line:2!Second Line:2,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:5!Front Line:2,CNC:0,CSJ!Keshik:6,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:4!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CNC!Keshik:8!Front Line:5,CWIE!Keshik:8!Front Line:5</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CBS!Second Line:1,CHH!Second Line:1,CSV!Second Line:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CNC!Front Line:6!Second Line:6,CWIE!Front Line:6!Second Line:6</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Second Line:1,CGB!Second Line:4,CHH!Second Line:6!Solahma:4,CIH:0,CNC:0,CSJ:0,CWIE:0,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CNC!Keshik:5!Front Line:8!Second Line:5,CWIE!Keshik:5!Front Line:8!Second Line:5</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN!Keshik:6!Front Line:3,CGB!Keshik:5!Front Line:2,CIH!Keshik:7!Front Line:2,CNC:0,CSJ!Keshik:6,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CIH!Keshik:6!Front Line:1,CNC:0,CSA!Keshik:3!Front Line:1!Second Line:1,CSJ!Keshik:3,CSV!Keshik:3!Front Line:1!Second Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:5!Front Line:3,CIH!Keshik:7!Front Line:2,CNC:0,CSA!Keshik:5!Front Line:3!Second Line:3,CSJ!Keshik:5,CSV!Keshik:5!Front Line:3!Second Line:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:2,CBS!Keshik:5!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:2!Second Line:1,CIH!Keshik:6!Front Line:1,CNC:0,CSA!Keshik:5!Front Line:2!Second Line:1,CSJ!Keshik:5,CSV!Keshik:5!Front Line:2!Second Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH!Keshik:2!Front Line:1,CIH!Keshik:4!Front Line:2,CNC:0,CSA!Keshik:3!Front Line:1!Second Line:1,CSJ!Keshik:3,CSV!Keshik:3!Front Line:1!Second Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:8!Front Line:2,CNC:0,CSA!Keshik:6!Front Line:3!Second Line:3,CSJ!Keshik:6,CSV!Keshik:6!Front Line:3!Second Line:3,CWIE:0,BAN:0</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN:7,CGB!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CIH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CSA!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CWIE:7,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN:3-,CIH:4-,CSJ:4-,CNC:0,CWIE:0,BAN:3</availability>
+            </model>
+            <model name='(Flamer Basic)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CNC:3-,CWIE:3-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:4,CIH!Keshik:6!Front Line:5!Second Line:4,CNC:2+,CSA!Keshik:6!Front Line:5!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:6!Front Line:5!Second Line:4,CWIE:2+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CJF:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3!Solahma:1,CLAN.IS:4,CBS!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CIH!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CNC:3,CSA!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSJ:3+,CSV!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CWIE:3,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CLAN.IS!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:5,CHH:7,CNC:7,CSJ!Keshik:7!Front Line:5!Second Line:2!Solahma:1,CWIE:7,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN.HW!Second Line:1!Solahma:4!Provisional Garrison:7,CLAN.IS:2-,CBS!Solahma:4!Provisional Garrison:7,CGB!Provisional Garrison:2,CHH!Solahma:4!Provisional Garrison:7,CIH!Solahma:4!Provisional Garrison:7,CSA!Solahma:4!Provisional Garrison:7,CSJ!Front Line:1!Second Line:2!Solahma:5!Provisional Garrison:7,CSV!Solahma:4!Provisional Garrison:7,CWIE:2-,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CWIE!Keshik:5!Front Line:3!Second Line:1,BAN:4+</availability>
+            </model>
+            <model name='(Watch Detachment Advanced)'>
+                <availability>CGB:2-,CJF:3-,CNC!Provisional Garrison:1,CSJ!Provisional Garrison:1,CW:2-,CWIE:2-</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:7!Front Line:4!Second Line:1,CBS!Keshik:7!Front Line:6!Second Line:3!Solahma:1,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CIH!Keshik:7!Front Line:7!Second Line:4!Solahma:1,CNC!Keshik:5!Front Line:3!Second Line:1,CSA!Keshik:7!Front Line:6!Second Line:1,CSJ!Keshik:7!Front Line:3,CWIE!Keshik:5!Front Line:3!Second Line:1,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CSA!Keshik:4!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN:3-,CIH:4-,CSJ!Front Line:1,CNC:4-,CWIE:4-,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW:6+,CLAN.IS:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:6!Front Line:1,CWIE:6+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:2+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CBS:2+,CGB:2+,CHH!Keshik:4!Front Line:2,CNC:0,CSJ:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW:4,CLAN.IS:4,CSJ!Keshik:4!Front Line:1,CWIE:4,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW:6,CLAN.IS:6,CWIE:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:1,CBS:5+,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CNC:5+,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV:5+,CWIE:5+,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CNC:3+,CSJ!Keshik:4!Front Line:1,CSV!Keshik:4!Front Line:4!Second Line:1,CWIE:3+,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,CNC:0,CSJ:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN.HW!Second Line:1,CLAN.IS!Second Line:1,CNC:4-,CSJ!Front Line:1,CWIE:4-,BAN!Second Line:1</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CBS:6+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:4,CSJ!Keshik:6!Front Line:1,CSV:6+,CWIE!Keshik:5!Front Line:3!Second Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CWIE:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CIH:2+,CNC:0,CSJ:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW:4,CLAN.IS:4,CNC:3,CSJ!Keshik:4!Front Line:1,CWIE:3,BAN:3+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW:7,CLAN.IS:7,CNC:6,CSJ!Keshik:7!Front Line:5,CWIE:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CNC!Keshik:4!Front Line:2!Second Line:1,CSJ!Keshik:5!Front Line:1,CWIE!Keshik:4!Front Line:2!Second Line:1,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN.HW:3+,CLAN.IS:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CNC:2+,CSJ!Keshik:3!Front Line:2,CWIE:3+,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CGB!Keshik:4!Front Line:1,CNC:0,CSA!Keshik:4!Front Line:1,CSJ:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CIH:6,CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC!Front Line:2,CSJ!Front Line:1,CWIE!Front Line:2,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CIH!Keshik:6!Front Line:5!Second Line:1,CNC!Keshik:3,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:6!Front Line:1,CWIE!Keshik:6!Front Line:3!Second Line:1,BAN:6+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:4+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CBS:2+,CGB:2+,CHH!Keshik:4!Front Line:1,CNC:0,CSJ:0,CW:2+,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3,CLAN.IS:4,CBS:4,CSJ!Keshik:4!Front Line:1,CWIE:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW:7,CLAN.IS:7,CSJ!Keshik:7!Front Line:8,CWIE:7,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:1,CBS:5+,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:4!Front Line:1,CSV:5+,CWIE!Keshik:5!Front Line:4,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN.HW:3+,CLAN.IS!Keshik:3!Front Line:2!Second Line:1!Solahma:1,CBS!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CNC:3+,CSA!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CWIE:4+,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:4-,CSJ:5-,CWIE!Front Line:1!Second Line:2,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:3,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSJ!Keshik:3,CSV!Keshik:5!Front Line:4!Second Line:3,CWIE!Keshik:5!Front Line:3!Second Line:1,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CNC:0,CSJ:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3,CLAN.IS:4,CBS:4,CHH:4,CSA:4,CSJ!Keshik:4!Front Line:2!Second Line:1,CSV:4,CWIE:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW:7,CLAN.IS:7,CSJ!Keshik:7!Front Line:8!Second Line:8,CWIE:7,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:1,CBS:5+,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CNC:4+,CSJ!Keshik:3!Front Line:1,CSV:5+,CWIE!Keshik:5!Front Line:3!Second Line:1,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CHH!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CSJ:4+,CWIE!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,BAN:8+</availability>
+            <model name='(Bearhunter Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CGB!Keshik:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Front Line:1!Second Line:2,CLAN.IS!Front Line:1!Second Line:2!Solahma:3,CBS:3-,CGB!Second Line:1!Solahma:2,CHH:3-,CIH!Front Line:1!Second Line:1,CNC:0,CSA:3-,CSJ:5-,CSV:3-,CWIE:0,BAN:4-</availability>
+            </model>
+            <model name='(Flamer Basic)'>
+                <roles>urban</roles>
+                <availability>CNC:3-,CWIE:3-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW:3+,CLAN.IS:3+,CIH!Keshik:3!Front Line:2,CNC:4+,CSJ!Keshik:1,CWIE:4+,BAN:4+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CNC:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CLAN.IS:3,CBS:3,CHH:3,CIH!Keshik:3!Front Line:3!Second Line:3!Solahma:1,CNC:4,CSJ!Keshik:3!Front Line:1!Second Line:1,CWIE:4,BAN:4+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CBS!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CGB:5,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CNC:7,CSA:5+,CSJ!Keshik:5!Front Line:2!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CWIE:7,BAN:7+</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CLAN.IS!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CBS!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CGB:3-,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,CNC:2-,CSJ!Keshik:2!Front Line:5!Second Line:7!Solahma:7!Provisional Garrison:8,CWIE:2-,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS!Keshik:4!Front Line:3!Second Line:1,CBS:4+,CHH:4+,CIH!Keshik:4!Front Line:3!Second Line:1,CNC:4+,CSA!Keshik:4!Front Line:3!Second Line:1,CSJ!Keshik:2!Front Line:1,CSV:4+,CWIE:4+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+            </model>
+        </chassis>
 		<chassis name='Claymore' unitType='Dropship'>
 			<availability>LA:3,FS:2</availability>
 			<model name='(3054)'>

--- a/megamek/data/forcegenerator/3067.xml
+++ b/megamek/data/forcegenerator/3067.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3067-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='ARDC'>
 			<pctOmni>0,0,4,10,20</pctOmni>
@@ -3780,139 +3783,396 @@
 				<availability>FWL:4,WOB:4</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CIH:5,CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CIH:7,CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CIH:8,CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN.HW!Solahma:1,CLAN.IS!Solahma:1,CBS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:0,CNC:0,CSV!Second Line:1!Solahma:1,CWIE:0,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:5,CBS!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CSV!Second Line:5!Solahma:6</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CSV!Second Line:6!Solahma:7</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CSV!Second Line:6!Solahma:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN!Solahma:7,CBS!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CSV!Second Line:7!Solahma:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN.HW:3+,CLAN.IS:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CNC!Keshik:2!Front Line:2!Second Line:1,CWIE!Keshik:2!Front Line:2!Second Line:1,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Front Line:1!Second Line:7,CBS!Second Line:7,CGB!Second Line:8,CHH!Solahma:2!Provisional Garrison:8,CIH!Second Line:2,CNC:0,CSV!Front Line:1!Second Line:7,CWIE:0,BAN!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN!Front Line:2!Second Line:5,CBS!Second Line:5,CGB!Second Line:6,CHH!Solahma:1!Provisional Garrison:6,CIH!Second Line:1,CNC:0,CSV!Front Line:2!Second Line:5,CWIE:0,BAN!Keshik:8!Front Line:4</availability>
+            </model>
+            <model name='(Motorized AP Gauss Advanced)'>
+                <roles>anti_infantry,field_gun</roles>
+                <availability>CJF!Keshik:2</availability>
+            </model>
+            <model name='(Motorized PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Second Line:3,CBS!Second Line:6,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Motorized PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Second Line:2,CBS!Second Line:5,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Motorized PAC8 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN.HW!Second Line:2,CBS!Second Line:5,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:3!Second Line:1,CNC!Keshik:5!Front Line:1,CWIE:4+,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CGB!Second Line:4,CHH!Front Line:4!Second Line:2!Solahma:1,CNC!Keshik:8!Front Line:3!Solahma:1,CWIE:6+,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3,CLAN.IS!Keshik:6!Front Line:3,CIH!Keshik:3!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:2,CLAN.IS!Keshik:4!Front Line:2,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CIH!Keshik:4!Front Line:1,CNC:0,CSA!Keshik:4!Front Line:2!Second Line:2,CSV!Keshik:4!Front Line:2!Second Line:2,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CIH!Keshik:5!Front Line:2,CNC:0,CSA!Keshik:5!Front Line:3!Second Line:3,CSV!Keshik:5!Front Line:3!Second Line:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:2,CLAN.IS!Keshik:5!Front Line:2,CIH:0,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CHH!Keshik:4!Front Line:2,CIH!Keshik:4!Front Line:1,CNC:0,CSA!Keshik:4!Front Line:2!Second Line:2,CSV!Keshik:4!Front Line:2!Second Line:2,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:5!Front Line:2,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked PAC2 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>CLAN.HW!Front Line:3,CBS!Front Line:2,CSA!Front Line:2!Second Line:5</availability>
+            </model>
+            <model name='(Tracked PAC4 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>CLAN.HW!Front Line:2,CBS!Front Line:1,CSA!Front Line:2!Second Line:3</availability>
+            </model>
+            <model name='(Tracked PAC8 Advanced)'>
+                <roles>field gun</roles>
+                <availability>CLAN.HW!Front Line:2,CBS!Front Line:1,CSA!Front Line:2!Second Line:3</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:4!Solahma:1,CWIE!Keshik:8!Front Line:5,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CNC!Keshik:6!Front Line:5!Second Line:1</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CBS!Second Line:1,CHH!Second Line:1,Solahma:1,CSV!Second Line:1,CWIE!Front Line:6!Second Line:6,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CNC!Front Line:4!Second Line:4</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CHH!Second Line:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Second Line:1,CLAN.IS!Second Line:1,CGB!Second Line:4,CHH!Second Line:6!Solahma:4,CIH:0,CNC:0,CWIE!Keshik:5!Front Line:8!Second Line:5,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CNC!Keshik:5!Front Line:8!Second Line:5</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3,CLAN.IS!Keshik:6!Front Line:3,CGB!Keshik:5!Front Line:2,CIH!Keshik:7!Front Line:2,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:3!Front Line:1,CLAN.IS!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CIH!Keshik:6!Front Line:1,CNC:0,CSA!Keshik:3!Front Line:1!Second Line:1,CSV!Keshik:3!Front Line:1!Second Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:5!Front Line:3,CIH!Keshik:7!Front Line:2,CNC:0,CSA!Keshik:5!Front Line:3!Second Line:3,CSV!Keshik:5!Front Line:3!Second Line:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:2,CLAN.IS!Keshik:5!Front Line:2,CBS!Keshik:5!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:2!Second Line:1,CIH!Keshik:6!Front Line:1,CNC:0,CSA!Keshik:5!Front Line:2!Second Line:1,CSV!Keshik:5!Front Line:2!Second Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:3!Front Line:1,CLAN.IS!Keshik:3!Front Line:1,CBS!Keshik:3!Front Line:1!Second Line:1,CGB!Keshik:1,CHH!Keshik:2!Front Line:1,CIH!Keshik:4!Front Line:2,CNC:0,CSA!Keshik:3!Front Line:1!Second Line:1,CSV!Keshik:3!Front Line:1!Second Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:8!Front Line:2,CNC:0,CSA!Keshik:6!Front Line:3!Second Line:3,CSV!Keshik:6!Front Line:3!Second Line:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>CLAN.HW!Front Line:3,CBS!Front Line:2,CJF!Second Line:4,CSA!Front Line:2!Second Line:3</availability>
+            </model>
+            <model name='(Wheeled PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>CLAN.HW!Front Line:2,CBS!Front Line:2,CJF!Second Line:3,CSA!Front Line:2!Second Line:3</availability>
+            </model>
+            <model name='(Wheeled PAC8 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN.HW!Front Line:2,CBS!Front Line:2,CJF!Second Line:3,CSA!Front Line:2!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN.HW:7,CLAN.IS:7,CGB!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CIH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CSA!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CWIE:7,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CIH:4-,CNC:3-,CWIE:3-,BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CHH!Keshik:6!Front Line:5!Second Line:4,CIH!Keshik:6!Front Line:5!Second Line:4,CNC:3+,CSA!Keshik:6!Front Line:5!Second Line:1,CSV!Keshik:6!Front Line:5!Second Line:4,CWIE:3+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CJF:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3!Solahma:1,CLAN.IS:4,CBS!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CIH!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CNC:3,CSA!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSV!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CWIE:3,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CLAN.IS!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:5,CHH:7,CNC:7,CWIE:7,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN.HW!Second Line:1!Solahma:4!Provisional Garrison:7,CLAN.IS:2-,CBS!Solahma:4!Provisional Garrison:7,CGB!Provisional Garrison:2,CHH!Solahma:4!Provisional Garrison:7,CIH!Solahma:4!Provisional Garrison:7,CSA!Solahma:4!Provisional Garrison:7,CSV!Solahma:4!Provisional Garrison:7,CWIE:2-,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CWIE:5+,BAN:4+</availability>
+            </model>
+            <model name='(Watch Detachment Advanced)'>
+                <availability>CLAN.IS:2-,CHH!Provisional Garrison:1,CJF:3-,CNC!Provisional Garrison:1,CWIE:2-</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:7!Front Line:4!Second Line:1,CBS!Keshik:7!Front Line:6!Second Line:3!Solahma:1,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CIH!Keshik:7!Front Line:7!Second Line:4!Solahma:1,CNC!Keshik:5!Front Line:3!Second Line:1,CSA!Keshik:7!Front Line:6!Second Line:1,CWIE!Keshik:5!Front Line:3!Second Line:1,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CSA!Keshik:4!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CIH:4-,CNC:4-,CWIE:4-,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW:6+,CLAN.IS:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CWIE:6+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:2+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CBS:2+,CGB:2+,CHH!Keshik:4!Front Line:2,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW:4,CLAN.IS:4,CWIE:4,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW:6,CLAN.IS:6,CWIE:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:1,CBS:5+,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CNC:5+,CSA!Keshik:5!Front Line:4!Second Line:1,CSV:5+,CWIE:5+,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CNC:3+,CSV!Keshik:4!Front Line:4!Second Line:1,CWIE:3+,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN.HW!Second Line:1,CLAN.IS!Second Line:1,CNC:4-,CWIE:4-,BAN!Second Line:1</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CBS:6+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CNC:5+,CSA!Keshik:5!Front Line:4!Second Line:4,CSV:6+,CWIE:5+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CWIE:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CIH:2+,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW:4,CLAN.IS:4,CNC:3,CWIE:3,BAN:3+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW:7,CLAN.IS:7,CNC:6,CWIE:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CNC:4+,CWIE:4+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN.HW:3+,CLAN.IS:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CNC:3+,CWIE:3+,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CGB!Keshik:4!Front Line:1,CNC:0,CSA!Keshik:4!Front Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:4-,CWIE:4-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CIH!Keshik:6!Front Line:5!Second Line:1,CNC:3+,CSA!Keshik:5!Front Line:4!Second Line:1,CWIE:3+,BAN:6+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:4+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CBS:2+,CGB:2+,CHH!Keshik:4!Front Line:1,CNC:0,CW:2+,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3,CLAN.IS:4,CBS:4,CWIE:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW:7,CLAN.IS:7,CWIE:7,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:1,CBS:5+,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CNC:5+,CSA!Keshik:5!Front Line:4!Second Line:1,CSV:5+,CWIE:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN.HW:3+,CLAN.IS!Keshik:3!Front Line:2!Second Line:1!Solahma:1,CBS!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CNC:4+,CSA!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CSV!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CWIE:4+,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:4-,CWIE:4-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:3,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CNC:3+,CSA!Keshik:5!Front Line:4!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:3,CWIE:3+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3,CLAN.IS:4,CBS:4,CHH:4,CSA:4,CSV:4,CWIE:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CHH!Keshik:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW:7,CLAN.IS:7,CWIE:7,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:1,CBS:5+,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CNC:4+,CSV:5+,CWIE:4+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CHH!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CWIE!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,BAN:8+</availability>
+            <model name='(Bearhunter Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CGB:2+,CHH:3+</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Front Line:1!Second Line:2,CLAN.IS!Front Line:1!Second Line:2!Solahma:3,CBS:3-,CGB!Second Line:1!Solahma:2,CHH:3-,CIH!Front Line:1!Second Line:1,CNC:3-,CSA:3-,CSV:3-,CWIE:3-,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW:3+,CLAN.IS:3+,CIH!Keshik:3!Front Line:2,CNC:4+,CWIE:4+,BAN:4+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CNC:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CLAN.IS:3,CBS:3,CHH:3,CIH!Keshik:3!Front Line:3!Second Line:3!Solahma:1,CNC:4,CWIE:4,BAN:4+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CBS!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CGB:5,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CNC:7,CSA:5+,CSV!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CWIE:7,BAN:7+</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CLAN.IS!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CBS!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CGB:3-,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,CNC:2-,CWIE:2-,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS!Keshik:4!Front Line:3!Second Line:1,CBS:4+,CHH:4+,CIH!Keshik:4!Front Line:3!Second Line:1,CNC:4+,CSA!Keshik:4!Front Line:3!Second Line:1,CSV:4+,CWIE:4+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+            </model>
+        </chassis>
 		<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
 			<availability>CNC:5</availability>
 			<model name='(Rabid)(Sqd5)' mechanized='true'>
 				<availability>CNC:8</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CIH:6,CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
 			</model>
 		</chassis>
 		<chassis name='Claymore' unitType='Dropship'>

--- a/megamek/data/forcegenerator/3067.xml
+++ b/megamek/data/forcegenerator/3067.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3067-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='ARDC'>
 			<pctOmni>0,0,4,10,20</pctOmni>
@@ -3906,7 +3903,7 @@
             </model>
             <model name='(Wheeled AC2 Advanced)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
-                <availability>CBS!Second Line:1,CHH!Second Line:1,Solahma:1,CSV!Second Line:1,CWIE!Front Line:6!Second Line:6,BAN:2+</availability>
+                <availability>CBS!Second Line:1,CHH!Second Line:1!Solahma:1,CSV!Second Line:1,CWIE!Front Line:6!Second Line:6,BAN:2+</availability>
             </model>
             <model name='(Wheeled AC2 Basic)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
@@ -3998,7 +3995,7 @@
                 <availability>CLAN.HW!Second Line:1!Solahma:4!Provisional Garrison:7,CLAN.IS:2-,CBS!Solahma:4!Provisional Garrison:7,CGB!Provisional Garrison:2,CHH!Solahma:4!Provisional Garrison:7,CIH!Solahma:4!Provisional Garrison:7,CSA!Solahma:4!Provisional Garrison:7,CSV!Solahma:4!Provisional Garrison:7,CWIE:2-,BAN:8-,SOC:5</availability>
             </model>
             <model name='(SRM Advanced)'>
-                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CWIE:5+,BAN:4+,SOC:3+</availability>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CNC:4+,CSA!Keshik:5!Front Line:4!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CWIE:5+,BAN:4+,SOC:3+</availability>
             </model>
             <model name='(Watch Detachment Advanced)'>
                 <availability>CLAN.IS:2-,CHH!Provisional Garrison:1,CJF:3-,CNC!Provisional Garrison:1,CWIE:2-</availability>
@@ -4137,6 +4134,12 @@
                 <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:1,CBS:5+,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CNC:4+,CSV:5+,CWIE:4+,BAN!Keshik:5!Front Line:4!Second Line:3,SOC:2+</availability>
             </model>
         </chassis>
+        <chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
+            <availability>CNC:5</availability>
+            <model name='(Rabid)(Sqd5)' mechanized='true'>
+                <availability>CNC:8</availability>
+            </model>
+        </chassis>
         <chassis name='Clan Motorized Point' unitType='Infantry'>
             <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CHH!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CWIE!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,BAN:8+,SOC:6</availability>
             <model name='(Bearhunter Advanced)'>
@@ -4169,12 +4172,6 @@
                 <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS!Keshik:4!Front Line:3!Second Line:1,CBS:4+,CHH:4+,CIH!Keshik:4!Front Line:3!Second Line:1,CNC:4+,CSA!Keshik:4!Front Line:3!Second Line:1,CSV:4+,CWIE:4+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1,SOC:2+</availability>
             </model>
         </chassis>
-		<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
-			<availability>CNC:5</availability>
-			<model name='(Rabid)(Sqd5)' mechanized='true'>
-				<availability>CNC:8</availability>
-			</model>
-		</chassis>
 		<chassis name='Claymore' unitType='Dropship'>
 			<availability>LA:3,FS:2</availability>
 			<model name='(3054)'>

--- a/megamek/data/forcegenerator/3067.xml
+++ b/megamek/data/forcegenerator/3067.xml
@@ -3811,14 +3811,14 @@
             </model>
         </chassis>
         <chassis name='Clan Field Gun Point' unitType='Infantry'>
-            <availability>CLAN.HW:3+,CLAN.IS:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CNC!Keshik:2!Front Line:2!Second Line:1,CWIE!Keshik:2!Front Line:2!Second Line:1,BAN!Keshik:2!Front Line:1</availability>
+            <availability>CLAN.HW:3+,CLAN.IS:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CNC!Keshik:2!Front Line:2!Second Line:1,CWIE!Keshik:2!Front Line:2!Second Line:1,BAN!Keshik:2!Front Line:1,SOC!Keshik:3</availability>
             <model name='(Motorized AC2 Basic)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
-                <availability>CLAN!Front Line:1!Second Line:7,CBS!Second Line:7,CGB!Second Line:8,CHH!Solahma:2!Provisional Garrison:8,CIH!Second Line:2,CNC:0,CSV!Front Line:1!Second Line:7,CWIE:0,BAN!Keshik:6!Front Line:3</availability>
+                <availability>CLAN!Front Line:1!Second Line:7,CBS!Second Line:7,CGB!Second Line:8,CHH!Solahma:2!Provisional Garrison:8,CIH!Second Line:2,CNC:0,CSV!Front Line:1!Second Line:7,CWIE:0,BAN!Keshik:6!Front Line:3,SOC!Keshik:4</availability>
             </model>
             <model name='(Motorized AC5 Basic)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
-                <availability>CLAN!Front Line:2!Second Line:5,CBS!Second Line:5,CGB!Second Line:6,CHH!Solahma:1!Provisional Garrison:6,CIH!Second Line:1,CNC:0,CSV!Front Line:2!Second Line:5,CWIE:0,BAN!Keshik:8!Front Line:4</availability>
+                <availability>CLAN!Front Line:2!Second Line:5,CBS!Second Line:5,CGB!Second Line:6,CHH!Solahma:1!Provisional Garrison:6,CIH!Second Line:1,CNC:0,CSV!Front Line:2!Second Line:5,CWIE:0,BAN!Keshik:8!Front Line:4,SOC!Keshik:5</availability>
             </model>
             <model name='(Motorized AP Gauss Advanced)'>
                 <roles>anti_infantry,field_gun</roles>
@@ -3826,15 +3826,15 @@
             </model>
             <model name='(Motorized PAC2 Advanced)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
-                <availability>CLAN.HW!Second Line:3,CBS!Second Line:6,BAN!Keshik:1</availability>
+                <availability>CLAN.HW!Second Line:3,CBS!Second Line:6,BAN!Keshik:1,SOC!Keshik:8</availability>
             </model>
             <model name='(Motorized PAC4 Advanced)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
-                <availability>CLAN.HW!Second Line:2,CBS!Second Line:5,BAN!Keshik:1</availability>
+                <availability>CLAN.HW!Second Line:2,CBS!Second Line:5,BAN!Keshik:1,SOC!Keshik:6</availability>
             </model>
             <model name='(Motorized PAC8 Advanced)'>
                 <roles>field_gun</roles>
-                <availability>CLAN.HW!Second Line:2,CBS!Second Line:5,BAN!Keshik:1</availability>
+                <availability>CLAN.HW!Second Line:2,CBS!Second Line:5,BAN!Keshik:1,SOC!Keshik:6</availability>
             </model>
             <model name='(Tracked AC10 Advanced)'>
                 <roles>field_gun</roles>
@@ -3866,7 +3866,7 @@
             </model>
             <model name='(Tracked CLBX5 Advanced)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
-                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CIH!Keshik:5!Front Line:2,CNC:0,CSA!Keshik:5!Front Line:3!Second Line:3,CSV!Keshik:5!Front Line:3!Second Line:3,CWIE:0,BAN:0</availability>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CIH!Keshik:5!Front Line:2,CNC:0,CSA!Keshik:5!Front Line:3!Second Line:3,CSV!Keshik:5!Front Line:3!Second Line:3,CWIE:0,BAN:0,SOC!Keshik:3</availability>
             </model>
             <model name='(Tracked CUAC10 Advanced)'>
                 <roles>field_gun</roles>
@@ -3886,15 +3886,15 @@
             </model>
             <model name='(Tracked PAC2 Advanced)'>
                 <roles>anti_aircraft,field gun,fire_support</roles>
-                <availability>CLAN.HW!Front Line:3,CBS!Front Line:2,CSA!Front Line:2!Second Line:5</availability>
+                <availability>CLAN.HW!Front Line:3,CBS!Front Line:2,CSA!Front Line:2!Second Line:5,SOC!Keshik:4</availability>
             </model>
             <model name='(Tracked PAC4 Advanced)'>
                 <roles>anti_aircraft,field gun,fire_support</roles>
-                <availability>CLAN.HW!Front Line:2,CBS!Front Line:1,CSA!Front Line:2!Second Line:3</availability>
+                <availability>CLAN.HW!Front Line:2,CBS!Front Line:1,CSA!Front Line:2!Second Line:3,SOC!Keshik:4</availability>
             </model>
             <model name='(Tracked PAC8 Advanced)'>
                 <roles>field gun</roles>
-                <availability>CLAN.HW!Front Line:2,CBS!Front Line:1,CSA!Front Line:2!Second Line:3</availability>
+                <availability>CLAN.HW!Front Line:2,CBS!Front Line:1,CSA!Front Line:2!Second Line:3,SOC!Keshik:4</availability>
             </model>
             <model name='(Wheeled AC10 Advanced)'>
                 <roles>field_gun,urban</roles>
@@ -3934,7 +3934,7 @@
             </model>
             <model name='(Wheeled CLBX20 Advanced)'>
                 <roles>field_gun,urban</roles>
-                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2</availability>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2,SOC!Keshik:2</availability>
             </model>
             <model name='(Wheeled CLBX5 Advanced)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
@@ -3958,25 +3958,25 @@
             </model>
             <model name='(Wheeled PAC2 Advanced)'>
                 <roles>anti_aircraft,field_gun,fire_support,urban</roles>
-                <availability>CLAN.HW!Front Line:3,CBS!Front Line:2,CJF!Second Line:4,CSA!Front Line:2!Second Line:3</availability>
+                <availability>CLAN.HW!Front Line:3,CBS!Front Line:2,CJF!Second Line:4,CSA!Front Line:2!Second Line:3,SOC!Keshik:6</availability>
             </model>
             <model name='(Wheeled PAC4 Advanced)'>
                 <roles>anti_aircraft,field_gun,fire_support,urban</roles>
-                <availability>CLAN.HW!Front Line:2,CBS!Front Line:2,CJF!Second Line:3,CSA!Front Line:2!Second Line:3</availability>
+                <availability>CLAN.HW!Front Line:2,CBS!Front Line:2,CJF!Second Line:3,CSA!Front Line:2!Second Line:3,SOC!Keshik:6</availability>
             </model>
             <model name='(Wheeled PAC8 Advanced)'>
                 <roles>field_gun,urban</roles>
-                <availability>CLAN.HW!Front Line:2,CBS!Front Line:2,CJF!Second Line:3,CSA!Front Line:2!Second Line:3</availability>
+                <availability>CLAN.HW!Front Line:2,CBS!Front Line:2,CJF!Second Line:3,CSA!Front Line:2!Second Line:3,SOC!Keshik:8</availability>
             </model>
         </chassis>
         <chassis name='Clan Foot Point' unitType='Infantry'>
-            <availability>CLAN.HW:7,CLAN.IS:7,CGB!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CIH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CSA!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CWIE:7,BAN:7</availability>
+            <availability>CLAN.HW:7,CLAN.IS:7,CGB!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CIH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CSA!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:8,CWIE:7,BAN:7,SOC:8</availability>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN.HW:3-,CLAN.IS:3-,CIH:4-,CNC:3-,CWIE:3-,BAN:3</availability>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CIH:4-,CNC:3-,CWIE:3-,BAN:3,SOC:3</availability>
             </model>
             <model name='(Laser Advanced)'>
-                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CHH!Keshik:6!Front Line:5!Second Line:4,CIH!Keshik:6!Front Line:5!Second Line:4,CNC:3+,CSA!Keshik:6!Front Line:5!Second Line:1,CSV!Keshik:6!Front Line:5!Second Line:4,CWIE:3+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CHH!Keshik:6!Front Line:5!Second Line:4,CIH!Keshik:6!Front Line:5!Second Line:4,CNC:3+,CSA!Keshik:6!Front Line:5!Second Line:1,CSV!Keshik:6!Front Line:5!Second Line:4,CWIE:3+,BAN!Keshik:4!Front Line:3!Second Line:2,SOC:2+</availability>
             </model>
             <model name='(LRM Advanced)'>
                 <roles>fire_support</roles>
@@ -3984,37 +3984,37 @@
             </model>
             <model name='(MG Advanced)'>
                 <roles>anti_infantry</roles>
-                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3!Solahma:1,CLAN.IS:4,CBS!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CIH!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CNC:3,CSA!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSV!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CWIE:3,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3!Solahma:1,CLAN.IS:4,CBS!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CIH!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CNC:3,CSA!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CSV!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CWIE:3,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,SOC:3</availability>
             </model>
             <model name='(Rifle AA Advanced)'>
                 <roles>anti_aircraft</roles>
-                <availability>CHH!Keshik:1!Front Line:1</availability>
+                <availability>CHH!Keshik:1!Front Line:1,SOC:1</availability>
             </model>
             <model name='(Rifle Advanced)'>
-                <availability>CLAN.HW!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CLAN.IS!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:5,CHH:7,CNC:7,CWIE:7,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+                <availability>CLAN.HW!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CLAN.IS!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:5,CHH:7,CNC:7,CWIE:7,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2,SOC!Keshik:7!Front Line:7!Second Line:7!Solahma:6!Provisional Garrison:1</availability>
             </model>
             <model name='(Rifle Light)'>
                 <roles>urban</roles>
-                <availability>CLAN.HW!Second Line:1!Solahma:4!Provisional Garrison:7,CLAN.IS:2-,CBS!Solahma:4!Provisional Garrison:7,CGB!Provisional Garrison:2,CHH!Solahma:4!Provisional Garrison:7,CIH!Solahma:4!Provisional Garrison:7,CSA!Solahma:4!Provisional Garrison:7,CSV!Solahma:4!Provisional Garrison:7,CWIE:2-,BAN:8-</availability>
+                <availability>CLAN.HW!Second Line:1!Solahma:4!Provisional Garrison:7,CLAN.IS:2-,CBS!Solahma:4!Provisional Garrison:7,CGB!Provisional Garrison:2,CHH!Solahma:4!Provisional Garrison:7,CIH!Solahma:4!Provisional Garrison:7,CSA!Solahma:4!Provisional Garrison:7,CSV!Solahma:4!Provisional Garrison:7,CWIE:2-,BAN:8-,SOC:5</availability>
             </model>
             <model name='(SRM Advanced)'>
-                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CWIE:5+,BAN:4+</availability>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CSA!Keshik:5!Front Line:4!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CWIE:5+,BAN:4+,SOC:3+</availability>
             </model>
             <model name='(Watch Detachment Advanced)'>
                 <availability>CLAN.IS:2-,CHH!Provisional Garrison:1,CJF:3-,CNC!Provisional Garrison:1,CWIE:2-</availability>
             </model>
         </chassis>
         <chassis name='Clan Jump Point' unitType='Infantry'>
-            <availability>CLAN!Keshik:7!Front Line:4!Second Line:1,CBS!Keshik:7!Front Line:6!Second Line:3!Solahma:1,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CIH!Keshik:7!Front Line:7!Second Line:4!Solahma:1,CNC!Keshik:5!Front Line:3!Second Line:1,CSA!Keshik:7!Front Line:6!Second Line:1,CWIE!Keshik:5!Front Line:3!Second Line:1,BAN:4+</availability>
+            <availability>CLAN!Keshik:7!Front Line:4!Second Line:1,CBS!Keshik:7!Front Line:6!Second Line:3!Solahma:1,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CIH!Keshik:7!Front Line:7!Second Line:4!Solahma:1,CNC!Keshik:5!Front Line:3!Second Line:1,CSA!Keshik:7!Front Line:6!Second Line:1,CWIE!Keshik:5!Front Line:3!Second Line:1,BAN:4+,SOC!Keshik:3</availability>
             <model name='(ER Laser Advanced)'>
                 <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CSA!Keshik:4!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN.HW:3-,CLAN.IS:3-,CIH:4-,CNC:4-,CWIE:4-,BAN:4-</availability>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CIH:4-,CNC:4-,CWIE:4-,BAN:4-,SOC!Keshik:3</availability>
             </model>
             <model name='(Laser Advanced)'>
-                <availability>CLAN.HW:6+,CLAN.IS:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CWIE:6+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+                <availability>CLAN.HW:6+,CLAN.IS:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CWIE:6+,BAN!Keshik:4!Front Line:3!Second Line:2,SOC!Keshik:7</availability>
             </model>
             <model name='(LRM Advanced)'>
                 <roles>fire_support</roles>
@@ -4025,17 +4025,17 @@
             </model>
             <model name='(MG Advanced)'>
                 <roles>anti_infantry</roles>
-                <availability>CLAN.HW:4,CLAN.IS:4,CWIE:4,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+                <availability>CLAN.HW:4,CLAN.IS:4,CWIE:4,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3,SOC:3</availability>
             </model>
             <model name='(Rifle Advanced)'>
-                <availability>CLAN.HW:6,CLAN.IS:6,CWIE:6,BAN:7</availability>
+                <availability>CLAN.HW:6,CLAN.IS:6,CWIE:6,BAN:7,SOC:5</availability>
             </model>
             <model name='(SRM Advanced)'>
-                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:1,CBS:5+,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CNC:5+,CSA!Keshik:5!Front Line:4!Second Line:1,CSV:5+,CWIE:5+,BAN:3+</availability>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:1,CBS:5+,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CNC:5+,CSA!Keshik:5!Front Line:4!Second Line:1,CSV:5+,CWIE:5+,BAN:3+,SOC!Keshik:4</availability>
             </model>
         </chassis>
         <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-            <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CNC:3+,CSV!Keshik:4!Front Line:4!Second Line:1,CWIE:3+,BAN:3+</availability>
+            <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:4!Front Line:4!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CSA!Keshik:4!Front Line:4!Second Line:1,CNC:3+,CSV!Keshik:4!Front Line:4!Second Line:1,CWIE:3+,BAN:3+,SOC:3+</availability>
             <model name='(ER Laser Advanced)'>
                 <roles>recon</roles>
                 <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
@@ -4046,7 +4046,7 @@
             </model>
             <model name='(Laser Advanced)'>
                 <roles>recon</roles>
-                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CBS:6+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CNC:5+,CSA!Keshik:5!Front Line:4!Second Line:4,CSV:6+,CWIE:5+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CBS:6+,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CNC:5+,CSA!Keshik:5!Front Line:4!Second Line:4,CSV:6+,CWIE:5+,BAN!Keshik:4!Front Line:3!Second Line:2,SOC:3+</availability>
             </model>
             <model name='(LRM Advanced)'>
                 <roles>fire_support</roles>
@@ -4058,27 +4058,27 @@
             </model>
             <model name='(MG Advanced)'>
                 <roles>anti_infantry</roles>
-                <availability>CLAN.HW:4,CLAN.IS:4,CNC:3,CWIE:3,BAN:3+</availability>
+                <availability>CLAN.HW:4,CLAN.IS:4,CNC:3,CWIE:3,BAN:3+,SOC:3</availability>
             </model>
             <model name='(Rifle Advanced)'>
                 <roles>recon</roles>
-                <availability>CLAN.HW:7,CLAN.IS:7,CNC:6,CWIE:6,BAN:7</availability>
+                <availability>CLAN.HW:7,CLAN.IS:7,CNC:6,CWIE:6,BAN:7,SOC:6</availability>
             </model>
             <model name='(SRM Advanced)'>
-                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CNC:4+,CWIE:4+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS:5+,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CNC:4+,CWIE:4+,BAN!Keshik:4!Front Line:3!Second Line:2,SOC:2+</availability>
             </model>
         </chassis>
         <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-            <availability>CLAN.HW:3+,CLAN.IS:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CNC:3+,CWIE:3+,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <availability>CLAN.HW:3+,CLAN.IS:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CNC:3+,CWIE:3+,BAN!Keshik:2!Front Line:2!Second Line:1,SOC:3+</availability>
             <model name='(ER Laser Advanced)'>
                 <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CGB!Keshik:4!Front Line:1,CNC:0,CSA!Keshik:4!Front Line:1,CWIE:0,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:4-,CWIE:4-,BAN:5-</availability>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:4-,CWIE:4-,BAN:5-,SOC:3</availability>
             </model>
             <model name='(Laser Advanced)'>
-                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CIH!Keshik:6!Front Line:5!Second Line:1,CNC:3+,CSA!Keshik:5!Front Line:4!Second Line:1,CWIE:3+,BAN:6+</availability>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:5!Second Line:4,CGB!Keshik:6!Front Line:5!Second Line:1,CHH!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CIH!Keshik:6!Front Line:5!Second Line:1,CNC:3+,CSA!Keshik:5!Front Line:4!Second Line:1,CWIE:3+,BAN:6+,SOC:2+</availability>
             </model>
             <model name='(LRM Advanced)'>
                 <roles>fire_support</roles>
@@ -4089,28 +4089,28 @@
             </model>
             <model name='(MG Advanced)'>
                 <roles>anti_infantry</roles>
-                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3,CLAN.IS:4,CBS:4,CWIE:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3,CLAN.IS:4,CBS:4,CWIE:4,BAN!Keshik:4!Front Line:3!Second Line:2,SOC:4</availability>
             </model>
             <model name='(Rifle AA Advanced)'>
                 <roles>anti_aircraft</roles>
-                <availability>CHH:2+</availability>
+                <availability>CHH:2+,SOC:1</availability>
             </model>
             <model name='(Rifle Advanced)'>
-                <availability>CLAN.HW:7,CLAN.IS:7,CWIE:7,BAN:6</availability>
+                <availability>CLAN.HW:7,CLAN.IS:7,CWIE:7,BAN:6,SOC:7</availability>
             </model>
             <model name='(SRM Advanced)'>
-                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:1,CBS:5+,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CNC:5+,CSA!Keshik:5!Front Line:4!Second Line:1,CSV:5+,CWIE:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:1,CBS:5+,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CNC:5+,CSA!Keshik:5!Front Line:4!Second Line:1,CSV:5+,CWIE:5+,BAN!Keshik:5!Front Line:4!Second Line:3,SOC:3+</availability>
             </model>
         </chassis>
         <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-            <availability>CLAN.HW:3+,CLAN.IS!Keshik:3!Front Line:2!Second Line:1!Solahma:1,CBS!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CNC:4+,CSA!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CSV!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CWIE:4+,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <availability>CLAN.HW:3+,CLAN.IS!Keshik:3!Front Line:2!Second Line:1!Solahma:1,CBS!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CNC:4+,CSA!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CSV!Keshik:4!Front Line:4!Second Line:2!Solahma:1,CWIE:4+,BAN!Keshik:3!Front Line:3!Second Line:2,SOC:4+</availability>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:4-,CWIE:4-,BAN:5-</availability>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:4-,CWIE:4-,BAN:5-,SOC:4</availability>
             </model>
             <model name='(Laser Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:3,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CNC:3+,CSA!Keshik:5!Front Line:4!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:3,CWIE:3+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:4!Second Line:3,CGB!Keshik:5!Front Line:4!Second Line:1,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CNC:3+,CSA!Keshik:5!Front Line:4!Second Line:1,CSV!Keshik:5!Front Line:4!Second Line:3,CWIE:3+,BAN!Keshik:5!Front Line:4!Second Line:3,SOC:2+</availability>
             </model>
             <model name='(LRM Advanced)'>
                 <roles>fire_support</roles>
@@ -4122,33 +4122,33 @@
             </model>
             <model name='(MG Advanced)'>
                 <roles>anti_infantry,urban</roles>
-                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3,CLAN.IS:4,CBS:4,CHH:4,CSA:4,CSV:4,CWIE:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3,CLAN.IS:4,CBS:4,CHH:4,CSA:4,CSV:4,CWIE:4,BAN!Keshik:4!Front Line:3!Second Line:2,SOC:4</availability>
             </model>
             <model name='(Rifle AA Advanced)'>
                 <roles>anti_aircraft,urban</roles>
-                <availability>CHH!Keshik:1</availability>
+                <availability>CHH!Keshik:1,SOC:1</availability>
             </model>
             <model name='(Rifle Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN.HW:7,CLAN.IS:7,CWIE:7,BAN:7</availability>
+                <availability>CLAN.HW:7,CLAN.IS:7,CWIE:7,BAN:7,SOC:6</availability>
             </model>
             <model name='(SRM Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:1,CBS:5+,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CNC:4+,CSV:5+,CWIE:4+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:1,CBS:5+,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CNC:4+,CSV:5+,CWIE:4+,BAN!Keshik:5!Front Line:4!Second Line:3,SOC:2+</availability>
             </model>
         </chassis>
         <chassis name='Clan Motorized Point' unitType='Infantry'>
-            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CHH!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CWIE!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,BAN:8+</availability>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CHH!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CWIE!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,BAN:8+,SOC:6</availability>
             <model name='(Bearhunter Advanced)'>
                 <roles>anti_infantry,urban</roles>
                 <availability>CGB:2+,CHH:3+</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN.HW!Front Line:1!Second Line:2,CLAN.IS!Front Line:1!Second Line:2!Solahma:3,CBS:3-,CGB!Second Line:1!Solahma:2,CHH:3-,CIH!Front Line:1!Second Line:1,CNC:3-,CSA:3-,CSV:3-,CWIE:3-,BAN:4-</availability>
+                <availability>CLAN.HW!Front Line:1!Second Line:2,CLAN.IS!Front Line:1!Second Line:2!Solahma:3,CBS:3-,CGB!Second Line:1!Solahma:2,CHH:3-,CIH!Front Line:1!Second Line:1,CNC:3-,CSA:3-,CSV:3-,CWIE:3-,BAN:4-,SOC:3</availability>
             </model>
             <model name='(Laser Advanced)'>
-                <availability>CLAN.HW:3+,CLAN.IS:3+,CIH!Keshik:3!Front Line:2,CNC:4+,CWIE:4+,BAN:4+</availability>
+                <availability>CLAN.HW:3+,CLAN.IS:3+,CIH!Keshik:3!Front Line:2,CNC:4+,CWIE:4+,BAN:4+,SOC:1+</availability>
             </model>
             <model name='(LRM Advanced)'>
                 <roles>fire_support</roles>
@@ -4156,17 +4156,17 @@
             </model>
             <model name='(MG Advanced)'>
                 <roles>anti_infantry</roles>
-                <availability>CLAN.HW!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CLAN.IS:3,CBS:3,CHH:3,CIH!Keshik:3!Front Line:3!Second Line:3!Solahma:1,CNC:4,CWIE:4,BAN:4+</availability>
+                <availability>CLAN.HW!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CLAN.IS:3,CBS:3,CHH:3,CIH!Keshik:3!Front Line:3!Second Line:3!Solahma:1,CNC:4,CWIE:4,BAN:4+,SOC:3</availability>
             </model>
             <model name='(Rifle Advanced)'>
-                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CBS!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CGB:5,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CNC:7,CSA:5+,CSV!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CWIE:7,BAN:7+</availability>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CBS!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CGB:5,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CNC:7,CSA:5+,CSV!Keshik:5!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,CWIE:7,BAN:7+,SOC!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2</availability>
             </model>
             <model name='(Rifle Light)'>
                 <roles>urban</roles>
-                <availability>CLAN.HW!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CLAN.IS!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CBS!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CGB:3-,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,CNC:2-,CWIE:2-,BAN:8-</availability>
+                <availability>CLAN.HW!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CLAN.IS!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CBS!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:8,CGB:3-,CHH!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,CNC:2-,CWIE:2-,BAN:8-,SOC!Keshik:5!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:8</availability>
             </model>
             <model name='(SRM Advanced)'>
-                <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS!Keshik:4!Front Line:3!Second Line:1,CBS:4+,CHH:4+,CIH!Keshik:4!Front Line:3!Second Line:1,CNC:4+,CSA!Keshik:4!Front Line:3!Second Line:1,CSV:4+,CWIE:4+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+                <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS!Keshik:4!Front Line:3!Second Line:1,CBS:4+,CHH:4+,CIH!Keshik:4!Front Line:3!Second Line:1,CNC:4+,CSA!Keshik:4!Front Line:3!Second Line:1,CSV:4+,CWIE:4+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1,SOC:2+</availability>
             </model>
         </chassis>
 		<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>

--- a/megamek/data/forcegenerator/3075.xml
+++ b/megamek/data/forcegenerator/3075.xml
@@ -4179,114 +4179,352 @@
 				<availability>FWL:6,WOB:6</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN.IS!Second Line:1!Solahma:1,CBS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CSL!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CNC:0,CWIE:1,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1,CSL!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:5!Solahma:5,CBS!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CSL!Second Line:5!Solahma:6!Provisional Garrison:4</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:6!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CSL!Second Line:6!Solahma:7!Provisional Garrison:5</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2,CSL!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:6!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CSL!Second Line:6!Solahma:7!Provisional Garrison:7</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:7!Solahma:7,CBS!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CSL!Second Line:7!Solahma:8!Provisional Garrison:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN.HW:3+,CLAN.IS:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CNC!Keshik:2!Front Line:2!Second Line:1,CWIE:3+,BAN!Keshik:2!Front Line:1,SOC!Keshik:3</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Front Line:1!Second Line:7,CLAN.IS!Front Line:1!Second Line:7,CBS!Second Line:7,CHH!Solahma:2!Provisional Garrison:8,CIH!Second Line:2,CNC:0,CWIE:0,BAN!Keshik:6!Front Line:3,SOC!Keshik:4</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Front Line:2!Second Line:5,CLAN.IS!Front Line:2!Second Line:5,CBS!Second Line:5,CHH!Solahma:1!Provisional Garrison:6,CIH!Second Line:1,CNC:0,CWIE:0,BAN!Keshik:8!Front Line:4,SOC!Keshik:5</availability>
+            </model>
+            <model name='(Motorized AP Gauss Advanced)'>
+                <roles>anti_infantry,field_gun</roles>
+                <availability>CJF!Keshik:2</availability>
+            </model>
+            <model name='(Motorized PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Second Line:3,CBS!Second Line:6,CJF!Second Line:2,BAN!Keshik:1,SOC!Keshik:8</availability>
+            </model>
+            <model name='(Motorized PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Second Line:2,CBS!Second Line:5,CJF!Second Line:1,BAN!Keshik:1,SOC!Keshik:6</availability>
+            </model>
+            <model name='(Motorized PAC8 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN.HW!Second Line:2,CBS!Second Line:5,CJF!Second Line:1,BAN!Keshik:1,SOC!Keshik:6</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Second Line:8,CHH!Front Line:3!Second Line:1,CNC!Keshik:5!Front Line:1,CWIE:4+,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Front Line:5!Second Line:3,CGB!Second Line:6,CHH!Front Line:4!Second Line:2!Solahma:1,CNC!Keshik:8!Front Line:3!Solahma:1,CWIE:6+,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3,CLAN.IS!Keshik:6!Front Line:3,CIH!Keshik:3!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:2,CLAN.IS!Keshik:4!Front Line:2,CBS!Keshik:4!Front Line:2!Second Line:2,CGB!Keshik:1,CIH!Keshik:4!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1,CSL!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:3!Second Line:3,CGB!Keshik:3,CIH!Keshik:5!Front Line:2,CNC:0,CWIE:0,BAN:0,SOC!Keshik:3</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:2,CLAN.IS!Keshik:5!Front Line:2,CIH:0,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS!Keshik:4!Front Line:2!Second Line:1,CGB!Keshik:1,CIH!Keshik:4!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1,CSL!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CGB!Keshik:3,CIH!Keshik:5!Front Line:2,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked PAC2 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>CLAN.HW!Front Line:3,CBS!Front Line:2,CSA!Front Line:2!Second Line:5,SOC!Keshik:4</availability>
+            </model>
+            <model name='(Tracked PAC4 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>CLAN.HW!Front Line:2,CBS!Front Line:1,CSA!Front Line:2!Second Line:3,SOC!Keshik:4</availability>
+            </model>
+            <model name='(Tracked PAC8 Advanced)'>
+                <roles>field gun</roles>
+                <availability>CLAN.HW!Front Line:2,CBS!Front Line:1,CSA!Front Line:2!Second Line:3,SOC!Keshik:4</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Second Line:8,CHH!Second Line:4!Solahma:1,CWIE!Keshik:8!Front Line:5,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CNC!Keshik:6!Front Line:5!Second Line:1</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CBS!Second Line:1,CHH!Second Line:1!Solahma:1,CNC!Front Line:4!Second Line:4,CSV!Second Line:1,CWIE!Front Line:6!Second Line:6,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Second Line:2,CHH!Second Line:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Second Line:1,CLAN.IS!Second Line:5,CHH!Second Line:6!Solahma:4,CIH:0,CJF!Second Line:1,CNC!Keshik:5!Front Line:8!Second Line:5,CW!Second Line:1,CWIE!Keshik:5!Front Line:8!Second Line:5,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3,CLAN.IS!Keshik:6!Front Line:3,CIH!Keshik:7!Front Line:2,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:3!Front Line:1,CLAN.IS!Keshik:3!Front Line:1,CGB!Keshik:1,CIH!Keshik:6!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2,CSL!Keshik:2,SOC!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CGB!Keshik:3,CHH!Keshik:5!Front Line:3,CIH!Keshik:7!Front Line:2,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:2,CLAN.IS!Keshik:5!Front Line:2,CHH!Keshik:5!Front Line:2!Second Line:1,CIH!Keshik:6!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:3!Front Line:1,CLAN.IS!Keshik:3!Front Line:1,CGB!Keshik:1,CHH!Keshik:2!Front Line:1,CIH!Keshik:4!Front Line:2,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1,CSL!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:6!Front Line:3!Second Line:3,CGB!Keshik:3,CHH!Keshik:6!Front Line:3,CIH!Keshik:8!Front Line:2,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>CLAN.HW!Front Line:3,CBS!Front Line:2,CJF!Second Line:4,CSA!Front Line:2!Second Line:3,SOC!Keshik:6</availability>
+            </model>
+            <model name='(Wheeled PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>CLAN.HW!Front Line:2,CBS!Front Line:2,CJF!Second Line:3,CSA!Front Line:2!Second Line:3,SOC!Keshik:6</availability>
+            </model>
+            <model name='(Wheeled PAC8 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN.HW!Front Line:2,CBS!Front Line:2,CJF!Second Line:3,CSA!Front Line:2!Second Line:3,SOC!Keshik:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN.HW:7,CLAN.IS:7,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CSL!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CIH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CWIE:7,BAN:7,SOC:8</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CIH:4-,CNC:3-,CWIE:3-,BAN:3,SOC:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:6!Front Line:5!Second Line:4,CSL!Keshik:6!Front Line:5!Second Line:4,CIH!Keshik:6!Front Line:5!Second Line:4,CNC:3+,CWIE:3+,BAN!Keshik:4!Front Line:3!Second Line:2,SOC:2+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CJF:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3!Solahma:1,CLAN.IS:4,CIH!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:2,CNC:3,CWIE:3,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1,SOC:3</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CGB!Keshik:1,CHH!Keshik:1!Front Line:1,SOC:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CLAN.IS!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:5,CHH:7,CNC:7,CWIE:7,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2,SOC!Keshik:7!Front Line:7!Second Line:7!Solahma:6!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN.HW!Second Line:1!Solahma:4!Provisional Garrison:7,CLAN.IS:2-,CHH!Solahma:4!Provisional Garrison:7,CSL!Solahma:4!Provisional Garrison:7,CIH!Solahma:4!Provisional Garrison:7,CWIE:2-,BAN:8-,SOC:5</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CSL!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CNC:4+,CWIE:5+,BAN:4+,SOC:3+</availability>
+            </model>
+            <model name='(Watch Detachment Advanced)'>
+                <availability>CLAN.IS:2-,CHH!Provisional Garrison:1,CJF:3-,CNC!Provisional Garrison:1,CWIE:2-</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:7!Front Line:4!Second Line:1,CBS!Keshik:7!Front Line:6!Second Line:3!Solahma:1,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CSL!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CIH!Keshik:7!Front Line:7!Second Line:4!Solahma:1,CNC!Keshik:5!Front Line:3!Second Line:1,CWIE!Keshik:5!Front Line:3!Second Line:1,BAN:4+,SOC!Keshik:3</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CSA!Keshik:4!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CIH:4-,CNC:4-,CWIE:4-,BAN:4-,SOC!Keshik:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW:6+,CLAN.IS:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CSA!Keshik:5!Front Line:4!Second Line:1,CWIE:6+,BAN!Keshik:4!Front Line:3!Second Line:2,SOC!Keshik:7</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:2+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CGB:2+,CHH!Keshik:4!Front Line:2,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW:4,CLAN.IS:4,CWIE:4,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3,SOC:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW:6,CLAN.IS:6,CWIE:6,BAN:7,SOC:5</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CBS:5+,CHH:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CWIE:5+,BAN:3+,SOC!Keshik:4</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CSL!Keshik:5!Front Line:4!Second Line:1,CIH!Keshik:7!Front Line:4!Second Line:1,CNC:3+,CWIE:3+,BAN:3+,SOC:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CIH:2+,CSA!Keshik:4!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN.HW!Second Line:1,CLAN.IS!Second Line:1,CNC:4-,CWIE:4-,BAN!Second Line:1</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS:6+,CHH:6+,CSL:6+,CIH!Keshik:6!Front Line:5!Second Line:1,CNC:5+,CWIE:5+,BAN!Keshik:4!Front Line:3!Second Line:2,SOC:3+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CWIE:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CIH:2+,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW:4,CLAN.IS:4,CNC:3,CWIE:3,BAN:3+,SOC:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW:7,CLAN.IS:7,CNC:6,CWIE:6,BAN:7,SOC:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CBS:5+,CHH:5+,CSL:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CNC:4+,CWIE:4+,BAN!Keshik:4!Front Line:3!Second Line:2,SOC:2+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN.HW:3+,CLAN.IS:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CNC:3+,CWIE:3+,BAN!Keshik:2!Front Line:2!Second Line:1,SOC:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CGB!Keshik:4!Front Line:1,CNC:0,CSA!Keshik:4!Front Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:4-,CWIE:4-,BAN:5-,SOC:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS:6+,CHH!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CSL!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CIH!Keshik:6!Front Line:5!Second Line:1,CNC:3+,CWIE:3+,BAN:6+,SOC:2+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:4+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CGB:2+,CHH!Keshik:4!Front Line:1,CNC:0,CW:2+,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3,CLAN.IS:4,CWIE:4,BAN!Keshik:4!Front Line:3!Second Line:2,SOC:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CGB!Keshik:1,CHH:2+,SOC:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW:7,CLAN.IS:7,CWIE:7,BAN:6,SOC:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CHH:5+,CSL:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CWIE:5+,BAN!Keshik:5!Front Line:4!Second Line:3,SOC:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN.HW:3+,CLAN.IS!Keshik:3!Front Line:2!Second Line:1!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CSL:6+,CNC:4+,CWIE:4+,BAN!Keshik:3!Front Line:3!Second Line:2,SOC:4+</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:4-,CWIE:4-,BAN:5-,SOC:4</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CHH:5+,CSL:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CNC:3+,CWIE:3+,BAN!Keshik:5!Front Line:4!Second Line:3,SOC:2+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3,CLAN.IS:4,CHH:4,CWIE:4,BAN!Keshik:4!Front Line:3!Second Line:2,SOC:4</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CGB!Keshik:1,CHH!Keshik:1,SOC:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW:7,CLAN.IS:7,CWIE:7,BAN:7,SOC:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CHH:5+,CSL:5+,CIH!Keshik:5!Front Line:4!Second Line:1,CNC:4+,CWIE:4+,BAN!Keshik:5!Front Line:4!Second Line:3,SOC:2+</availability>
+            </model>
+        </chassis>
 		<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
 			<availability>CDS:4,CW:4-,CNC:6,CLAN.IS:3-,CGB:5-,CWIE:5</availability>
 			<model name='(Laser) &apos;Volk&apos; (Sqd5)' mechanized='true'>
@@ -4303,27 +4541,38 @@
 				<availability>CLAN.IS:6:3077</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CGB!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CHH!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CIH!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CWIE!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,BAN:8+,SOC:6</availability>
+            <model name='(Bearhunter Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CGB:2+,CHH:3+</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Front Line:1!Second Line:2,CLAN.IS!Front Line:1!Second Line:2!Solahma:3,CBS:3-,CGB:3-,CHH:3-,CSL:3-,CIH!Front Line:1!Second Line:1,CNC:3-,CWIE:3-,BAN:4-,SOC:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW:3+,CLAN.IS:3+,CIH!Keshik:3!Front Line:2,CNC:4+,CWIE:4+,BAN:4+,SOC:1+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CNC:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CLAN.IS:3,CHH:3,CSL:3,CIH!Keshik:3!Front Line:3!Second Line:3!Solahma:1,CNC:4,CWIE:4,BAN:4+,SOC:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CGB:5,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CSL!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CIH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CNC:7,CWIE:7,BAN:7+,SOC!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CLAN.IS!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CGB:3-,CHH!Solahma:1!Provisional Garrison:8,CSL!Solahma:1!Provisional Garrison:8,CIH!Solahma:1!Provisional Garrison:8,CNC:2-,CWIE:2-,BAN:8-,SOC!Keshik:5!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:8</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS:4+,CBS:4+,CHH:4+,CIH!Keshik:4!Front Line:3!Second Line:1,CNC:4+,CWIE:4+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1,SOC:2+</availability>
+            </model>
+        </chassis>
 		<chassis name='Claymore' unitType='Dropship'>
 			<availability>LA:4,FS:3</availability>
 			<model name='(3054)'>

--- a/megamek/data/forcegenerator/3075.xml
+++ b/megamek/data/forcegenerator/3075.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3075-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='AB'>
 			<omniMargin>1</omniMargin>
@@ -4187,11 +4184,11 @@
             </model>
             <model name='(Tracked Sniper)'>
                 <roles>mixed_artillery</roles>
-                <availability>CLAN.IS!Second Line:5!Solahma:5,CBS!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CSL!Second Line:5!Solahma:6!Provisional Garrison:4</availability>
+                <availability>CLAN.IS!Second Line:5!Solahma:5,CBS!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CSL!Second Line:5!Solahma:6!Provisional Garrison:4,CWIE:5</availability>
             </model>
             <model name='(Tracked Thumper)'>
                 <roles>mixed_artillery</roles>
-                <availability>CLAN.IS!Second Line:6!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CSL!Second Line:6!Solahma:7!Provisional Garrison:5</availability>
+                <availability>CLAN.IS!Second Line:6!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CSL!Second Line:6!Solahma:7!Provisional Garrison:5,CWIE:6</availability>
             </model>
             <model name='(Wheeled Arrow IV)'>
                 <roles>mixed_artillery</roles>
@@ -4199,11 +4196,11 @@
             </model>
             <model name='(Wheeled Sniper)'>
                 <roles>mixed_artillery</roles>
-                <availability>CLAN.IS!Second Line:6!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CSL!Second Line:6!Solahma:7!Provisional Garrison:7</availability>
+                <availability>CLAN.IS!Second Line:6!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CSL!Second Line:6!Solahma:7!Provisional Garrison:7,CWIE:6</availability>
             </model>
             <model name='(Wheeled Thumper)'>
                 <roles>mixed_artillery</roles>
-                <availability>CLAN.IS!Second Line:7!Solahma:7,CBS!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CSL!Second Line:7!Solahma:8!Provisional Garrison:8</availability>
+                <availability>CLAN.IS!Second Line:7!Solahma:7,CBS!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CSL!Second Line:7!Solahma:8!Provisional Garrison:8,CWIE:8</availability>
             </model>
         </chassis>
         <chassis name='Clan Field Gun Point' unitType='Infantry'>
@@ -4302,7 +4299,7 @@
             </model>
             <model name='(Wheeled AC2 Advanced)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
-                <availability>CBS!Second Line:1,CHH!Second Line:1!Solahma:1,CNC!Front Line:4!Second Line:4,CSV!Second Line:1,CWIE!Front Line:6!Second Line:6,BAN:2+</availability>
+                <availability>CBS!Second Line:1,CHH!Second Line:1!Solahma:1,CNC!Front Line:4!Second Line:4,CWIE!Front Line:6!Second Line:6,BAN:2+</availability>
             </model>
             <model name='(Wheeled AC20 Advanced)'>
                 <roles>field_gun,urban</roles>
@@ -4457,7 +4454,7 @@
             </model>
         </chassis>
         <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-            <availability>CLAN.HW:3+,CLAN.IS:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CNC:3+,CWIE:3+,BAN!Keshik:2!Front Line:2!Second Line:1,SOC:3+</availability>
+            <availability>CLAN.HW:3+,CLAN.IS:3+,CGB!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CSL!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CIH!Keshik:2!Front Line:2!Second Line:1,CNC:3+,CWIE:3+,BAN!Keshik:2!Front Line:2!Second Line:1,SOC:3+</availability>
             <model name='(ER Laser Advanced)'>
                 <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CGB!Keshik:4!Front Line:1,CNC:0,CSA!Keshik:4!Front Line:1,CWIE:0,BAN:0</availability>
             </model>

--- a/megamek/data/forcegenerator/3075.xml
+++ b/megamek/data/forcegenerator/3075.xml
@@ -4204,7 +4204,7 @@
             </model>
         </chassis>
         <chassis name='Clan Field Gun Point' unitType='Infantry'>
-            <availability>CLAN.HW:3+,CLAN.IS:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CNC!Keshik:2!Front Line:2!Second Line:1,CWIE:3+,BAN!Keshik:2!Front Line:1,SOC!Keshik:3</availability>
+            <availability>CLAN.HW:3+,CLAN.IS:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CSL!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CNC!Keshik:2!Front Line:2!Second Line:1,CWIE:3+,BAN!Keshik:2!Front Line:1,SOC!Keshik:3</availability>
             <model name='(Motorized AC2 Basic)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
                 <availability>CLAN.HW!Front Line:1!Second Line:7,CLAN.IS!Front Line:1!Second Line:7,CBS!Second Line:7,CHH!Solahma:2!Provisional Garrison:8,CIH!Second Line:2,CNC:0,CWIE:0,BAN!Keshik:6!Front Line:3,SOC!Keshik:4</availability>

--- a/megamek/data/forcegenerator/3078.xml
+++ b/megamek/data/forcegenerator/3078.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3078-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='AB'>
 			<omniMargin>2</omniMargin>
@@ -4416,7 +4413,7 @@
             </model>
         </chassis>
         <chassis name='Clan Field Gun Point' unitType='Infantry'>
-            <availability>CLAN.HW:3+,CLAN.IS:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CNC!Keshik:2!Front Line:2!Second Line:1,CWIE:3+,BAN!Keshik:2!Front Line:1</availability>
+            <availability>CLAN.HW:3+,CLAN.IS:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CSL!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CNC!Keshik:2!Front Line:2!Second Line:1,CWIE:3+,BAN!Keshik:2!Front Line:1</availability>
             <model name='(Motorized AC2 Basic)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>
                 <availability>CLAN.HW!Front Line:1!Second Line:7,CLAN.IS!Front Line:1!Second Line:7,CHH!Solahma:2!Provisional Garrison:8,CNC:0,CWIE:0,BAN!Keshik:6!Front Line:3</availability>

--- a/megamek/data/forcegenerator/3078.xml
+++ b/megamek/data/forcegenerator/3078.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3078-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='AB'>
 			<omniMargin>2</omniMargin>
@@ -4385,117 +4388,352 @@
 				<availability>SC:4,PR:5,MCM:4,PG:5,FWL:7,WOB:6,DGM:4,RFS:5</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:1</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN.IS!Second Line:1!Solahma:1,CBS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CSL!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CNC:0,CWIE:1,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1,CSL!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:5!Solahma:5,CBS!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CSL!Second Line:5!Solahma:6!Provisional Garrison:4,CWIE:5</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:6!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CSL!Second Line:6!Solahma:7!Provisional Garrison:5,CWIE:6</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2,CSL!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:6!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CSL!Second Line:6!Solahma:7!Provisional Garrison:7,CWIE:6</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:7!Solahma:7,CBS!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CSL!Second Line:7!Solahma:8!Provisional Garrison:8,CWIE:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN.HW:3+,CLAN.IS:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CNC!Keshik:2!Front Line:2!Second Line:1,CWIE:3+,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Front Line:1!Second Line:7,CLAN.IS!Front Line:1!Second Line:7,CHH!Solahma:2!Provisional Garrison:8,CNC:0,CWIE:0,BAN!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Front Line:2!Second Line:5,CLAN.IS!Front Line:2!Second Line:5,CHH!Solahma:1!Provisional Garrison:6,CNC:0,CWIE:0,BAN!Keshik:8!Front Line:4</availability>
+            </model>
+            <model name='(Motorized AP Gauss Advanced)'>
+                <roles>anti_infantry,field_gun</roles>
+                <availability>CJF!Keshik:2</availability>
+            </model>
+            <model name='(Motorized PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Second Line:3,CBS!Second Line:6,CJF!Second Line:2,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Motorized PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Second Line:2,CBS!Second Line:5,CJF!Second Line:1,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Motorized PAC8 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN.HW!Second Line:2,CBS!Second Line:5,CJF!Second Line:1,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Second Line:8,CHH!Front Line:3!Second Line:1,CNC!Keshik:5!Front Line:1,CWIE:4+,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Front Line:5!Second Line:3,CGB!Second Line:6,CHH!Front Line:4!Second Line:2!Solahma:1,CNC!Keshik:8!Front Line:3!Solahma:1,CWIE:6+,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3,CLAN.IS!Keshik:6!Front Line:3,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:2,CLAN.IS!Keshik:4!Front Line:2,CGB!Keshik:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1,CSL!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CGB!Keshik:3,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:2,CLAN.IS!Keshik:5!Front Line:2,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS!Keshik:4!Front Line:2!Second Line:1,CGB!Keshik:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1,CSL!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CGB!Keshik:3,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked PAC2 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>CLAN.HW!Front Line:3,CBS!Front Line:2,CSA!Front Line:2!Second Line:5</availability>
+            </model>
+            <model name='(Tracked PAC4 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>CLAN.HW!Front Line:2,CBS!Front Line:1,CSA!Front Line:2!Second Line:3</availability>
+            </model>
+            <model name='(Tracked PAC8 Advanced)'>
+                <roles>field gun</roles>
+                <availability>CLAN.HW!Front Line:2,CBS!Front Line:1,CSA!Front Line:2!Second Line:3</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Second Line:8,CHH!Second Line:4!Solahma:1,CWIE!Keshik:8!Front Line:5,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC10 Basic)'>
+                <roles>field_gun,urban</roles>
+                <availability>CNC!Keshik:6!Front Line:5!Second Line:1</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Second Line:1!Solahma:1,CNC!Front Line:4!Second Line:4,CWIE!Front Line:6!Second Line:6,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Second Line:2,CHH!Second Line:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Second Line:1,CLAN.IS!Second Line:5,CHH!Second Line:6!Solahma:4,CJF!Second Line:1,CNC!Keshik:5!Front Line:8!Second Line:5,CW!Second Line:1,CWIE!Keshik:5!Front Line:8!Second Line:5,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3,CLAN.IS!Keshik:6!Front Line:3,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:3!Front Line:1,CLAN.IS!Keshik:3!Front Line:1,CGB!Keshik:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2,CSL!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CGB!Keshik:3,CHH!Keshik:5!Front Line:3,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:2,CLAN.IS!Keshik:5!Front Line:2,CHH!Keshik:5!Front Line:2!Second Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:3!Front Line:1,CLAN.IS!Keshik:3!Front Line:1,CGB!Keshik:1,CHH!Keshik:2!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1,CSL!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CHH!Keshik:6!Front Line:3,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>CLAN.HW!Front Line:3,CBS!Front Line:2,CJF!Second Line:4,CSA!Front Line:2!Second Line:3</availability>
+            </model>
+            <model name='(Wheeled PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>CLAN.HW!Front Line:2,CBS!Front Line:2,CJF!Second Line:3,CSA!Front Line:2!Second Line:3</availability>
+            </model>
+            <model name='(Wheeled PAC8 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN.HW!Front Line:2,CBS!Front Line:2,CJF!Second Line:3,CSA!Front Line:2!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN.HW:7,CLAN.IS:7,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CSL!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CWIE:7,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:3-,CWIE:3-,BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:6!Front Line:5!Second Line:4,CSL!Keshik:6!Front Line:5!Second Line:4,CNC:3+,CWIE:3+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CJF:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3!Solahma:1,CLAN.IS:4,CNC:3,CWIE:3,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CGB!Keshik:1,CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CLAN.IS!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:5,CHH:7,CNC:7,CWIE:7,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN.HW!Second Line:1!Solahma:4!Provisional Garrison:7,CLAN.IS:2-,CHH!Solahma:4!Provisional Garrison:7,CSL!Solahma:4!Provisional Garrison:7,CWIE:2-,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CSL!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CNC:4+,CWIE:5+,BAN:4+</availability>
+            </model>
+            <model name='(Watch Detachment Advanced)'>
+                <availability>CLAN.IS:2-,CHH!Provisional Garrison:1,CJF:3-,CNC!Provisional Garrison:1,CWIE:2-</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:7!Front Line:4!Second Line:1,CBS!Keshik:7!Front Line:6!Second Line:3!Solahma:1,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CSL!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CNC!Keshik:5!Front Line:3!Second Line:1,CWIE!Keshik:5!Front Line:3!Second Line:1,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CSA!Keshik:4!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:4-,CWIE:4-,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW:6+,CLAN.IS:6+,CSA!Keshik:5!Front Line:4!Second Line:1,CWIE:6+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:2+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CGB:2+,CHH!Keshik:4!Front Line:2,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW:4,CLAN.IS:4,CWIE:4,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW:6,CLAN.IS:6,CWIE:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CBS:5+,CHH:5+,CWIE:5+,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS!Keshik:4!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CSL!Keshik:5!Front Line:4!Second Line:1,CNC:3+,CWIE:3+,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CSA!Keshik:4!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN.HW!Second Line:1,CLAN.IS!Second Line:1,CNC:4-,CWIE:4-,BAN!Second Line:1</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS:6+,CHH:6+,CSL:6+,CNC:5+,CWIE:5+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CWIE:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW:4,CLAN.IS:4,CNC:3,CWIE:3,BAN:3+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW:7,CLAN.IS:7,CNC:6,CWIE:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CBS:5+,CHH:5+,CSL:5+,CNC:4+,CWIE:4+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN.HW:3+,CLAN.IS:3+,CGB:5+,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CSL!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CNC:3+,CWIE:3+,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CGB!Keshik:4!Front Line:1,CNC:0,CSA!Keshik:4!Front Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:4-,CWIE:4-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS:6+,CHH!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CSL!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CNC:3+,CWIE:3+,BAN:6+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:4+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS:2+,CGB:2+,CHH!Keshik:4!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3,CLAN.IS:4,CWIE:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CGB!Keshik:1,CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW:7,CLAN.IS:7,CWIE:7,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CHH:5+,CSL:5+,CWIE:5+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN.HW:3+,CLAN.IS!Keshik:3!Front Line:2!Second Line:1!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CSL:6+,CNC:4+,CWIE:4+,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:4-,CWIE:4-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CHH:5+,CSL:5+,CNC:3+,CWIE:3+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3,CLAN.IS:4,CHH:4,CWIE:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CGB!Keshik:1,CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW:7,CLAN.IS:7,CWIE:7,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CHH:5+,CSL:5+,CNC:4+,CWIE:4+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
 		<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
 			<availability>CDS:4,CW:4-,CNC:7,CLAN.IS:3-,CGB:5-,CWIE:5</availability>
 			<model name='(Laser) &apos;Volk&apos; (Sqd5)' mechanized='true'>
@@ -4512,27 +4750,38 @@
 				<availability>CLAN.IS:6</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CLAN.IS!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CWIE!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,BAN:8+</availability>
+            <model name='(Bearhunter Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CGB:2+,CHH:3+</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Front Line:1!Second Line:2,CLAN.IS!Front Line:1!Second Line:2!Solahma:3,CBS:3-,CGB:3-,CHH:3-,CSL:3-,CNC:3-,CWIE:3-,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW:3+,CLAN.IS:3+,CNC:4+,CWIE:4+,BAN:4+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CNC:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CLAN.IS:3,CHH:3,CSL:3,CNC:4,CWIE:4,BAN:4+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CGB:5,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CSL!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CNC:7,CWIE:7,BAN:7+</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CLAN.IS!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CGB:3-,CHH!Solahma:1!Provisional Garrison:8,CSL!Solahma:1!Provisional Garrison:8,CNC:2-,CWIE:2-,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS:4+,CBS:4+,CHH:4+,CNC:4+,CWIE:4+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+            </model>
+        </chassis>
 		<chassis name='Claymore' unitType='Dropship'>
 			<availability>LA:4,FS:3</availability>
 			<model name='(3054)'>
@@ -6569,13 +6818,6 @@
 			<model name='FLC-9R'>
                 <roles>cavalry</roles>
 				<availability>IS:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Fast Recon' unitType='Infantry'>
-			<availability>CHH:5,CLAN:3</availability>
-			<model name='Cavalry Point'>
-				<roles>recon</roles>
-				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Feng Huang Cruiser' unitType='Warship'>

--- a/megamek/data/forcegenerator/3082.xml
+++ b/megamek/data/forcegenerator/3082.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3082-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>10</pctOmni>
@@ -4315,7 +4312,7 @@
             <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS!Keshik:4!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CSL!Keshik:5!Front Line:4!Second Line:1,CNC:3+,CWIE:3+,CEI:2+,BAN:3+</availability>
             <model name='(ER Laser Advanced)'>
                 <roles>recon</roles>
-                <availability>CLAN.HW!Keshik:1,CSA!Keshik:4!Front Line:1,CNC:0,CWIE:0,CEI!Keshik:1,BAN:0</availability>
+                <availability>CLAN.HW!Keshik:1,CSA!Keshik:4!Front Line:1,CEI!Keshik:1,BAN:0</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
@@ -4465,7 +4462,7 @@
                 <availability>CLAN.HW!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CLAN.IS!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CGB:3-,CHH!Solahma:1!Provisional Garrison:8,CSL!Solahma:1!Provisional Garrison:8,CNC:2-,CWIE:2-,CEI:5,BAN:8-</availability>
             </model>
             <model name='(SRM Advanced)'>
-                <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS:4+,CBS:4+,CHH:4+,CNC:4+,CWIE:4+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+                <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS:4+,CBS:4+,CHH:4+,CNC:4+,CWIE:4+,CEI!Keshik:3!Front Line:2,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
             </model>
         </chassis>
 		<chassis name='Claymore' unitType='Dropship'>

--- a/megamek/data/forcegenerator/3082.xml
+++ b/megamek/data/forcegenerator/3082.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3082-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>10</pctOmni>
@@ -4066,117 +4069,354 @@
 				<availability>SC:6,PR:6,MCM:6,PG:6,FWL:7,DGM:6,MSC:6,RFS:6</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:1</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN.IS!Second Line:1!Solahma:1,CBS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CSL!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CNC:0,CWIE:1,CEI:0,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1,CSL!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:5!Solahma:5,CBS!Second Line:5!Solahma:6,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CSL!Second Line:5!Solahma:6!Provisional Garrison:4,CWIE:5</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:6!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CSL!Second Line:6!Solahma:7!Provisional Garrison:5,CWIE:6</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2,CSL!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:6!Solahma:6,CBS!Second Line:6!Solahma:7,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CSL!Second Line:6!Solahma:7!Provisional Garrison:7,CWIE:6</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:7!Solahma:7,CBS!Second Line:7!Solahma:8,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CSL!Second Line:7!Solahma:8!Provisional Garrison:8,CWIE:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN.HW:3+,CLAN.IS:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CSL!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CNC!Keshik:2!Front Line:2!Second Line:1,CWIE:3+,CEI!Keshik:1,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Front Line:1!Second Line:7,CLAN.IS!Front Line:1!Second Line:7,CHH!Solahma:2!Provisional Garrison:8,CNC:0,CWIE:0,BAN!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Front Line:2!Second Line:5,CLAN.IS!Front Line:2!Second Line:5,CHH!Solahma:1!Provisional Garrison:6,CNC:0,CWIE:0,BAN!Keshik:8!Front Line:4</availability>
+            </model>
+            <model name='(Motorized AP Gauss Advanced)'>
+                <roles>anti_infantry,field_gun</roles>
+                <availability>CJF!Keshik:2</availability>
+            </model>
+            <model name='(Motorized PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Second Line:3,CBS!Second Line:6,CJF!Second Line:2,CEI!Keshik:6,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Motorized PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Second Line:2,CBS!Second Line:5,CJF!Second Line:1,CEI!Keshik:8,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Motorized PAC8 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN.HW!Second Line:2,CBS!Second Line:5,CJF!Second Line:1,CEI!Keshik:6,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Second Line:8,CHH!Front Line:3!Second Line:1,CNC!Keshik:5!Front Line:1,CWIE:4+,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Front Line:5!Second Line:3,CGB!Second Line:6,CHH!Front Line:4!Second Line:2!Solahma:1,CNC!Keshik:8!Front Line:3!Solahma:1,CWIE:6+,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3,CLAN.IS!Keshik:6!Front Line:3,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:2,CLAN.IS!Keshik:4!Front Line:2,CGB!Keshik:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1,CSL!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CGB!Keshik:3,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:2,CLAN.IS!Keshik:5!Front Line:2,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS!Keshik:4!Front Line:2!Second Line:1,CGB!Keshik:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1,CSL!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CGB!Keshik:3,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked PAC2 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>CLAN.HW!Front Line:3,CBS!Front Line:2,CSA!Front Line:2!Second Line:5,CEI:0</availability>
+            </model>
+            <model name='(Tracked PAC4 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>CLAN.HW!Front Line:2,CBS!Front Line:1,CSA!Front Line:2!Second Line:3,CEI:0</availability>
+            </model>
+            <model name='(Tracked PAC8 Advanced)'>
+                <roles>field gun</roles>
+                <availability>CLAN.HW!Front Line:2,CBS!Front Line:1,CSA!Front Line:2!Second Line:3,CEI:0</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Second Line:8,CHH!Second Line:4!Solahma:1,CNC!Keshik:6!Front Line:5!Second Line:1,CWIE!Keshik:8!Front Line:5,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Second Line:1!Solahma:1,CNC!Front Line:4!Second Line:4,CWIE!Front Line:6!Second Line:6,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Second Line:2,CHH!Second Line:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Second Line:1,CLAN.IS!Second Line:5,CHH!Second Line:6!Solahma:4,CJF!Second Line:1,CNC!Keshik:5!Front Line:8!Second Line:5,CW!Second Line:1,CWIE!Keshik:5!Front Line:8!Second Line:5,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3,CLAN.IS!Keshik:6!Front Line:3,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:3!Front Line:1,CLAN.IS!Keshik:3!Front Line:1,CGB!Keshik:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2,CSL!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CGB!Keshik:3,CHH!Keshik:5!Front Line:3,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:2,CLAN.IS!Keshik:5!Front Line:2,CHH!Keshik:5!Front Line:2!Second Line:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:3!Front Line:1,CLAN.IS!Keshik:3!Front Line:1,CGB!Keshik:1,CHH!Keshik:2!Front Line:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1,CSL!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CHH!Keshik:6!Front Line:3,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>CLAN.HW!Front Line:3,CJF!Second Line:4,CSA!Front Line:2!Second Line:3,CEI:0</availability>
+            </model>
+            <model name='(Wheeled PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>CLAN.HW!Front Line:2,CJF!Second Line:3,CSA!Front Line:2!Second Line:3,CEI:0</availability>
+            </model>
+            <model name='(Wheeled PAC8 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN.HW!Front Line:2,CJF!Second Line:3,CSA!Front Line:2!Second Line:3,CEI:0</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN.HW:7,CLAN.IS:7,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CSL!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CWIE:7,CEI!Keshik:7!Front Line:7,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:3-,CWIE:3-,CEI:4,BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:6!Front Line:5!Second Line:4,CSL!Keshik:6!Front Line:5!Second Line:4,CNC:3+,CWIE:3+,CEI!Keshik:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CJF:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3!Solahma:1,CLAN.IS:4,CNC:3,CWIE:3,CEI:4,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN.IS!Keshik:1,CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CLAN.IS!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:5,CHH:7,CNC:7,CWIE:7,CEI:7,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CEI:3</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN.HW!Second Line:1!Solahma:4!Provisional Garrison:7,CLAN.IS:2-,CHH!Solahma:4!Provisional Garrison:7,CSL!Solahma:4!Provisional Garrison:7,CWIE:2-,CEI:0,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CSL!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CNC:4+,CWIE:5+,CEI:2,BAN:4+</availability>
+            </model>
+            <model name='(Watch Detachment Advanced)'>
+                <availability>CLAN.IS:2-,CHH!Provisional Garrison:1,CJF:3-,CNC!Provisional Garrison:1,CWIE:2-</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:7!Front Line:4!Second Line:1,CBS!Keshik:7!Front Line:6!Second Line:3!Solahma:1,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CSL!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CNC!Keshik:5!Front Line:3!Second Line:1,CWIE!Keshik:5!Front Line:3!Second Line:1,CEI!Keshik:2,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CGB!Keshik:1,CSA!Keshik:4!Front Line:1,CEI!Keshik:2,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:4-,CWIE:4-,CEI:0,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW:6+,CLAN.IS:6+,CSA!Keshik:5!Front Line:4!Second Line:1,CWIE:6+,CEI!Keshik:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:2+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CGB:2+,CHH!Keshik:4!Front Line:2,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW:4,CLAN.IS:4,CWIE:4,CEI!Keshik:3,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW:6,CLAN.IS:6,CWIE:6,CEI!Keshik:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CBS:5+,CHH:5+,CWIE:5+,CEI!Keshik:4,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS!Keshik:4!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CSL!Keshik:5!Front Line:4!Second Line:1,CNC:3+,CWIE:3+,CEI:2+,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW!Keshik:1,CSA!Keshik:4!Front Line:1,CNC:0,CWIE:0,CEI!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN.HW!Second Line:1,CLAN.IS!Second Line:1,CNC:4-,CWIE:4-,CEI!Front Line:1,BAN!Second Line:1</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS:6+,CGB:5+,CHH:6+,CSL:6+,CNC:5+,CWIE:5+,CEI!Keshik:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CWIE:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW:4,CLAN.IS:4,CNC:3,CWIE:3,CEI:3,BAN:3+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW:7,CLAN.IS:7,CNC:6,CWIE:6,CEI:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CBS:5+,CHH:5+,CSL:5+,CNC:4+,CWIE:4+,CEI!Keshik:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN.HW:3+,CLAN.IS:3+,CGB:5+,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CSL!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CNC:3+,CWIE:3+,CEI!Keshik:1,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CSA!Keshik:4!Front Line:1,CEI!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:4-,CWIE:4-,CEI:0,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS:6+,CHH!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CSL!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CNC:3+,CWIE:3+,CEI!Keshik:4,BAN:6+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:4+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS:2+,CHH!Keshik:4!Front Line:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3,CLAN.IS:4,CWIE:4,CEI!Keshik:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN.IS!Keshik:1,CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW:7,CLAN.IS:7,CWIE:7,CEI!Keshik:7,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CHH:5+,CSL:5+,CWIE:5+,CEI!Keshik:4,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN.HW:3+,CLAN.IS!Keshik:3!Front Line:2!Second Line:1!Solahma:1,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CSL:6+,CNC:4+,CWIE:4+,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:4-,CWIE:4-,CEI!Keshik:1!Front Line:2,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CHH:5+,CSL:5+,CNC:3+,CWIE:3+,CEI!Keshik:3!Front Line:2,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3,CLAN.IS:4,CHH:4,CWIE:4,CEI:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CLAN.IS!Keshik:1,CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW:7,CLAN.IS:7,CWIE:7,CEI!Keshik:7!Front Line:7,BAN:7</availability>
+            </model>
+            <model name='(Rifle Basic)'>
+                <availability>CEI!Keshik:5!Front Line:5</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CHH:5+,CSL:5+,CNC:4+,CWIE:4+,CEI!Keshik:3!Front Line:2,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
 		<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
 			<availability>CDS:4,CW:4-,CNC:7,CLAN.IS:4-,CGB:6-,CWIE:6,FS:3+,ROS:4+</availability>
 			<model name='(Laser) &apos;Volk&apos; (Sqd5)' mechanized='true'>
@@ -4196,27 +4436,38 @@
 				<availability>CLAN.IS:6</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CLAN.IS!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CWIE!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CEI!Keshik:4!Front Line:4,BAN:8+</availability>
+            <model name='(Bearhunter Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CGB:2+,CHH:3+</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Front Line:1!Second Line:2,CLAN.IS!Front Line:1!Second Line:2!Solahma:3,CBS:3-,CGB:3-,CHH:3-,CSL:3-,CNC:3-,CWIE:3-,CEI!Keshik:3!Front Line:3,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW:3+,CLAN.IS:3+,CNC:4+,CWIE:4+,CEI!Keshik:3!Front Line:2,BAN:4+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CNC:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CLAN.IS:3,CHH:3,CSL:3,CNC:4,CWIE:4,CEI:3,BAN:4+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CGB:5,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CSL!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CNC:7,CWIE:7,CEI:7,BAN:7+</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CLAN.IS!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CGB:3-,CHH!Solahma:1!Provisional Garrison:8,CSL!Solahma:1!Provisional Garrison:8,CNC:2-,CWIE:2-,CEI:5,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS:4+,CBS:4+,CHH:4+,CNC:4+,CWIE:4+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+            </model>
+        </chassis>
 		<chassis name='Claymore' unitType='Dropship'>
 			<availability>LA:4,FS:4</availability>
 			<model name='(3054)'>
@@ -6097,13 +6348,6 @@
 				<availability>IS:5</availability>
 			</model>
 		</chassis>
-		<chassis name='Fast Recon' unitType='Infantry'>
-			<availability>CHH:5,CLAN:3</availability>
-			<model name='Cavalry Point'>
-				<roles>recon</roles>
-				<availability>CLAN:8</availability>
-			</model>
-		</chassis>
 		<chassis name='Feng Huang Cruiser' unitType='Warship'>
 			<availability>CC:2</availability>
 			<model name=''>
@@ -6843,7 +7087,7 @@
             </model>
         </chassis>
 		<chassis name='Foot Platoon' unitType='Infantry'>
-			<availability>IS:10,CS:3,WOB:2,WOB.SD:0,Periphery:10,TC:3-,MH:0,CDP:4-,HL:9,Periphery.Deep:10</availability>
+			<availability>IS:10,CS:3,WOB:2,WOB.SD:0,Periphery:10,TC:3-,MH:0,CDP:4-,CEI!Second Line:10!Solahma:10!Provisional Garrison:10,HL:9,Periphery.Deep:10</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,CS:2-,WOB:2-,Periphery:8,TC:6-,CDP:6-,HL:8,Periphery.Deep:8</availability>
@@ -9900,7 +10144,7 @@
             </model>
         </chassis>
 		<chassis name='Jump Platoon' unitType='Infantry'>
-			<availability>IS:8,CS:1-,WOB:2-,WOB.SD:0,Periphery:7,TC:2-,MH:0,CDP:2-,HL:6,Periphery.Deep:5+</availability>
+			<availability>IS:8,CS:1-,WOB:2-,WOB.SD:0,Periphery:7,TC:2-,MH:0,CDP:2-,CEI!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,HL:6,Periphery.Deep:5+</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,CS:0,WOB:2,Periphery:8,TC:3-,CDP:3-,HL:8,Periphery.Deep:8</availability>
@@ -12022,7 +12266,7 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
-			<availability>IS:5,CS:2,WOB:2-,WOB.SD:0,Periphery:5,TC:1-,MH:0,CDP:1-,HL:4,Periphery.Deep:4+</availability>
+			<availability>IS:5,CS:2,WOB:2-,WOB.SD:0,Periphery:5,TC:1-,MH:0,CDP:1-,CEI!Second Line:3!Solahma:2,HL:4,Periphery.Deep:4+</availability>
 			<model name='(Demolition)'>
 				<roles>recon,engineer</roles>
 				<availability>General:3,CS:0</availability>
@@ -12163,7 +12407,7 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
-			<availability>IS:7,CS:3,WOB:3,WOB.SD:0,Periphery:7,TC:3-,MH:0,CDP:4-,HL:6,Periphery.Deep:6+</availability>
+			<availability>IS:7,CS:3,WOB:3,WOB.SD:0,Periphery:7,TC:3-,MH:0,CDP:4-,CEI!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,HL:6,Periphery.Deep:6+</availability>
 			<model name='(Bridging)'>
 				<roles>engineer</roles>
 				<availability>IS:2,CS:7,WOB:6,Periphery:1,Periphery.Deep:0</availability>
@@ -12309,7 +12553,7 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
-			<availability>IS:7,CS:3,WOB:3,WOB.SD:0,Periphery:7,TC:2-,MH:0,CDP:3-,HL:6,Periphery.Deep:8+</availability>
+			<availability>IS:7,CS:3,WOB:3,WOB.SD:0,Periphery:7,TC:2-,MH:0,CDP:3-,CEI!Second Line:6!Solahma:5!Provisional Garrison:4,HL:6,Periphery.Deep:8+</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,CS:2-,WOB:3-,Periphery:8,TC:4-,CDP:4-,HL:8,Periphery.Deep:8</availability>
@@ -12873,7 +13117,7 @@
             </model>
         </chassis>
 		<chassis name='Motorized Platoon' unitType='Infantry'>
-			<availability>IS:9,CS:3,WOB:2,WOB.SD:0,Periphery:9,TC:3-,MH:0,CDP:4-,HL:8,Periphery.Deep:8</availability>
+			<availability>IS:9,CS:3,WOB:2,WOB.SD:0,Periphery:9,TC:3-,MH:0,CDP:4-,CEI!Second Line:8!Solahma:8!Provisional Garrison:8,HL:8,Periphery.Deep:8</availability>
 			<model name='(Fieldworks)'>
 				<roles>engineer</roles>
 				<availability>IS:4,CS:7,WOB:5,Periphery:2</availability>

--- a/megamek/data/forcegenerator/3085.xml
+++ b/megamek/data/forcegenerator/3085.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3085-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>10</pctOmni>

--- a/megamek/data/forcegenerator/3085.xml
+++ b/megamek/data/forcegenerator/3085.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3085-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>10</pctOmni>
@@ -4194,117 +4197,348 @@
 				<availability>General:4,FWL:0</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:1</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN.IS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CSL!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CNC:0,CWIE:1,CEI:0,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1,CSL!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:5!Solahma:5,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CSL!Second Line:5!Solahma:6!Provisional Garrison:4,CWIE:5</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:6!Solahma:6,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CSL!Second Line:6!Solahma:7!Provisional Garrison:5,CWIE:6</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2,CSL!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:6!Solahma:6,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CSL!Second Line:6!Solahma:7!Provisional Garrison:7,CWIE:6</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:7!Solahma:7,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CSL!Second Line:7!Solahma:8!Provisional Garrison:8,CWIE:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN.HW:3+,CLAN.IS:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CSL!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CNC!Keshik:2!Front Line:2!Second Line:1,CWIE:3+,CEI!Keshik:1,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Front Line:1!Second Line:7,CLAN.IS!Front Line:1!Second Line:7,CHH!Solahma:2!Provisional Garrison:8,CNC:0,CWIE:0,BAN!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Front Line:2!Second Line:5,CLAN.IS!Front Line:2!Second Line:5,CHH!Solahma:1!Provisional Garrison:6,CNC:0,CWIE:0,BAN!Keshik:8!Front Line:4</availability>
+            </model>
+            <model name='(Motorized AP Gauss Advanced)'>
+                <roles>anti_infantry,field_gun</roles>
+                <availability>CJF!Keshik:2</availability>
+            </model>
+            <model name='(Motorized PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Second Line:3,CJF!Second Line:2,CEI!Keshik:6,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Motorized PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Second Line:2,CJF!Second Line:1,CEI!Keshik:8,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Motorized PAC8 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN.HW!Second Line:2,CJF!Second Line:1,CEI!Keshik:6,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Second Line:8,CHH!Front Line:3!Second Line:1,CNC!Keshik:5!Front Line:1,CWIE:4+,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Front Line:5!Second Line:3,CGB!Second Line:6,CHH!Front Line:4!Second Line:2!Solahma:1,CNC!Keshik:8!Front Line:3!Solahma:1,CWIE:6+,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3,CLAN.IS!Keshik:6!Front Line:3,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:2,CLAN.IS!Keshik:4!Front Line:2,CGB!Keshik:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1,CSL!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CGB!Keshik:3,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:2,CLAN.IS!Keshik:5!Front Line:2,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS!Keshik:4!Front Line:2!Second Line:1,CGB!Keshik:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:1,CSL!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CGB!Keshik:3,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked PAC2 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>CLAN.HW!Front Line:3,CSA!Front Line:2!Second Line:5,CEI:0</availability>
+            </model>
+            <model name='(Tracked PAC4 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>CLAN.HW!Front Line:2,CSA!Front Line:2!Second Line:3,CEI:0</availability>
+            </model>
+            <model name='(Tracked PAC8 Advanced)'>
+                <roles>field gun</roles>
+                <availability>CLAN.HW!Front Line:2,CSA!Front Line:2!Second Line:3,CEI:0</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Second Line:8,CHH!Second Line:4!Solahma:1,CNC!Keshik:6!Front Line:5!Second Line:1,CWIE!Keshik:8!Front Line:5,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Second Line:1!Solahma:1,CNC!Front Line:4!Second Line:4,CWIE!Front Line:6!Second Line:6,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Second Line:2,CHH!Second Line:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Second Line:1,CLAN.IS!Second Line:5,CHH!Second Line:6!Solahma:4,CJF!Second Line:1,CNC!Keshik:5!Front Line:8!Second Line:5,CW!Second Line:1,CWIE!Keshik:5!Front Line:8!Second Line:5,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3,CLAN.IS!Keshik:6!Front Line:3,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:3!Front Line:1,CLAN.IS!Keshik:3!Front Line:1,CGB!Keshik:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2,CSL!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CGB!Keshik:3,CHH!Keshik:5!Front Line:3,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:2,CLAN.IS!Keshik:5!Front Line:2,CHH!Keshik:5!Front Line:2!Second Line:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:3!Front Line:1,CLAN.IS!Keshik:3!Front Line:1,CGB!Keshik:1,CHH!Keshik:2!Front Line:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1,CSL!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CHH!Keshik:6!Front Line:3,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>CLAN.HW!Front Line:3,CJF!Second Line:4,CSA!Front Line:2!Second Line:3,CEI:0</availability>
+            </model>
+            <model name='(Wheeled PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>CLAN.HW!Front Line:2,CJF!Second Line:3,CSA!Front Line:2!Second Line:3,CEI:0</availability>
+            </model>
+            <model name='(Wheeled PAC8 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN.HW!Front Line:2,CJF!Second Line:3,CSA!Front Line:2!Second Line:3,CEI:0</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN.HW:7,CLAN.IS:7,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CSL!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CWIE:7,CEI!Keshik:7!Front Line:7!Second Line:7,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:3-,CWIE:3-,CEI:7-,BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:6!Front Line:5!Second Line:4,CSL!Keshik:6!Front Line:5!Second Line:4,CNC:3+,CWIE:3+,CEI:3+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CJF:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3!Solahma:1,CLAN.IS:4,CNC:3,CWIE:3,CEI:4,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN.IS!Keshik:1,CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW!Keshik:7!Front Line:7!Second Line:7!Solahma:5!Provisional Garrison:2,CLAN.IS!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:5,CHH:7,CNC:7,CWIE:7,CEI!Keshik:7!Front Line:5!Second Line:2,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN.HW!Second Line:1!Solahma:4!Provisional Garrison:7,CLAN.IS:2-,CHH!Solahma:4!Provisional Garrison:7,CSL!Solahma:4!Provisional Garrison:7,CWIE:2-,CEI!Keshik:3!Front Line:5!Second Line:7,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CSL!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CNC:4+,CWIE:5+,CEI:2,BAN:4+</availability>
+            </model>
+            <model name='(Watch Detachment Advanced)'>
+                <availability>CLAN.IS:2-,CHH!Provisional Garrison:1,CJF:3-,CNC!Provisional Garrison:1,CWIE:2-</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN!Keshik:7!Front Line:4!Second Line:1,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CSL!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CNC!Keshik:5!Front Line:3!Second Line:1,CWIE!Keshik:5!Front Line:3!Second Line:1,CEI!Keshik:2!Front Line:1,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CGB!Keshik:1,CSA!Keshik:4!Front Line:1,CEI!Keshik:2,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:4-,CWIE:4-,CEI:0,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW:6+,CLAN.IS:6+,CSA!Keshik:5!Front Line:4!Second Line:1,CWIE:6+,CEI!Keshik:4!Front Line:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:2+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CGB:2+,CHH!Keshik:4!Front Line:2,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW:4,CLAN.IS:4,CWIE:4,CEI:3,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW:6,CLAN.IS:6,CWIE:6,CEI:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CHH:5+,CWIE:5+,CEI!Keshik:4!Front Line:3,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS!Keshik:4!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CSL!Keshik:5!Front Line:4!Second Line:1,CNC:3+,CWIE:3+,CEI:2+,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW!Keshik:1,CSA!Keshik:4!Front Line:1,CEI!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN.HW!Second Line:1,CLAN.IS!Second Line:1,CNC:4-,CWIE:4-,CEI!Front Line:1,BAN!Second Line:1</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS:6+,CGB:5+,CHH:6+,CSL:6+,CNC:5+,CWIE:5+,CEI!Keshik:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CWIE:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW:4,CLAN.IS:4,CNC:3,CWIE:3,CEI:3,BAN:3+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.HW:7,CLAN.IS:7,CNC:6,CWIE:6,CEI:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CHH:5+,CSL:5+,CNC:4+,CWIE:4+,CEI!Keshik:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN.HW:3+,CLAN.IS:3+,CGB:5+,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CSL!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CNC:3+,CWIE:3+,CEI:2+,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CSA!Keshik:4!Front Line:1,CEI!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:4-,CWIE:4-,CEI:0,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW!Keshik:6!Front Line:3!Second Line:1,CLAN.IS:6+,CHH!Keshik:6!Front Line:5!Second Line:4!Solahma:1,CSL!Keshik:6!Front Line:5!Second Line:1!Solahma:1,CNC:3+,CWIE:3+,CEI!Keshik:4,BAN:6+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:4+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS:2+,CHH!Keshik:4!Front Line:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3,CLAN.IS:4,CWIE:4,CEI!Keshik:3!Front Line:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN.IS!Keshik:1,CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW:7,CLAN.IS:7,CWIE:7,CEI:7,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CHH:5+,CSL:5+,CWIE:5+,CEI!Keshik:4,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN.HW:3+,CLAN.IS:4+,CGB!Keshik:6!Front Line:5!Second Line:3!Solahma:1,CHH:6+,CSL:6+,CEI:3+,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN.HW:3-,CLAN.IS:3-,CNC:4-,CWIE:4-,CEI:5-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CHH:5+,CSL:5+,CNC:3+,CWIE:3+,CEI:3+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Keshik:1,CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:3,CLAN.IS:4,CHH:4,CWIE:4,CEI:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CLAN.IS!Keshik:1,CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW:7,CLAN.IS:7,CWIE:7,CEI:7,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CHH:5+,CSL:5+,CNC:4+,CWIE:4+,CEI:3+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
 		<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
 			<availability>CDS:4,CW:4-,CNC:8,CLAN.IS:4-,CGB:6-,CWIE:6,FS:3+,ROS:4+</availability>
 			<model name='(Laser) &apos;Volk&apos; (Sqd5)' mechanized='true'>
@@ -4324,27 +4558,38 @@
 				<availability>CLAN.IS:6</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN.HW!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CLAN.IS!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CWIE!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CEI!Keshik:4!Front Line:4!Second Line:4,BAN:8+</availability>
+            <model name='(Bearhunter Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CGB:2+,CHH:3+</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Front Line:1!Second Line:2,CLAN.IS!Front Line:1!Second Line:2!Solahma:3,CGB:3-,CHH:3-,CSL:3-,CNC:3-,CWIE:3-,CEI:3,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.HW:3+,CLAN.IS:3+,CNC:4+,CWIE:4+,CEI:3+,BAN:4+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CNC:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.HW!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CLAN.IS:3,CHH:3,CSL:3,CNC:4,CWIE:4,CEI:3,BAN:4+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.HW!Keshik:5!Front Line:3!Second Line:1,CLAN.IS:5+,CGB:5,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CSL!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CNC:7,CWIE:7,CEI:7,BAN:7+</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN.HW!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CLAN.IS!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CGB:3-,CHH!Solahma:1!Provisional Garrison:8,CSL!Solahma:1!Provisional Garrison:8,CNC:2-,CWIE:2-,CEI:5,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.HW!Keshik:4!Front Line:2!Second Line:1,CLAN.IS:4+,CHH:4+,CNC:4+,CWIE:4+,CEI:3+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+            </model>
+        </chassis>
 		<chassis name='Claymore' unitType='Dropship'>
 			<availability>LA:4,FS:4,ROS:5</availability>
 			<model name='(3054)'>
@@ -6952,7 +7197,7 @@
             </model>
         </chassis>
 		<chassis name='Foot Platoon' unitType='Infantry'>
-			<availability>IS:10,Periphery:10,TC:3-,MH:0,CDP:4-,HL:9,Periphery.Deep:10</availability>
+			<availability>IS:10,Periphery:10,TC:3-,MH:0,CDP:4-,CEI!Solahma:10!Provisional Garrison:10,HL:9,Periphery.Deep:10</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,Periphery:8,TC:6-,CDP:6-,HL:8,Periphery.Deep:8</availability>
@@ -10070,7 +10315,7 @@
             </model>
         </chassis>
 		<chassis name='Jump Platoon' unitType='Infantry'>
-			<availability>IS:8,Periphery:7,TC:2-,MH:0,CDP:2-,HL:6,Periphery.Deep:5+</availability>
+			<availability>IS:8,Periphery:7,TC:2-,MH:0,CDP:2-,CEI!Second Line:4!Solahma:3!Provisional Garrison:2,HL:6,Periphery.Deep:5+</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,Periphery:8,TC:3-,CDP:3-,HL:8,Periphery.Deep:8</availability>
@@ -12282,7 +12527,7 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
-			<availability>IS:5,Periphery:5,TC:1-,MH:0,CDP:1-,HL:4,Periphery.Deep:4+</availability>
+			<availability>IS:5,Periphery:5,TC:1-,MH:0,CDP:1-,CEI!Second Line:2!Solahma:1,HL:4,Periphery.Deep:4+</availability>
 			<model name='(Demolition)'>
 				<roles>recon,engineer</roles>
 				<availability>General:3</availability>
@@ -12375,7 +12620,7 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
-			<availability>IS:7,Periphery:7,TC:3-,MH:0,CDP:4-,HL:6,Periphery.Deep:6+</availability>
+			<availability>IS:7,Periphery:7,TC:3-,MH:0,CDP:4-,CEI!Second Line:4!Solahma:3!Provisional Garrison:2,HL:6,Periphery.Deep:6+</availability>
             <model name='(Bridging)'>
                 <roles>engineer</roles>
                 <availability>IS:2,Periphery:1,Periphery.Deep:0</availability>
@@ -12474,7 +12719,7 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
-			<availability>IS:7,Periphery:7,TC:2-,MH:0,CDP:3-,HL:6,Periphery.Deep:8+</availability>
+			<availability>IS:7,Periphery:7,TC:2-,MH:0,CDP:3-,CEI!Solahma:5!Provisional Garrison:4,HL:6,Periphery.Deep:8+</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,Periphery:8,TC:4-,CDP:4-,HL:8,Periphery.Deep:8</availability>
@@ -13009,7 +13254,7 @@
             </model>
         </chassis>
 		<chassis name='Motorized Platoon' unitType='Infantry'>
-			<availability>IS:9,Periphery:9,TC:3-,MH:0,CDP:4-,HL:8,Periphery.Deep:8</availability>
+			<availability>IS:9,Periphery:9,TC:3-,MH:0,CDP:4-,CEI!Solahma:8!Provisional Garrison:8,HL:8,Periphery.Deep:8</availability>
 			<model name='(Fieldworks)'>
 				<roles>engineer</roles>
 				<availability>IS:4,Periphery:2</availability>

--- a/megamek/data/forcegenerator/3100.xml
+++ b/megamek/data/forcegenerator/3100.xml
@@ -4542,7 +4542,7 @@
             </model>
             <model name='(Wheeled CLBX20 Advanced)'>
                 <roles>field_gun,urban</roles>
-                <availability>CGB!Keshik:2!Front Line:1,RD!Keshik:2!Front Line:1,CHH!Keshik:2</availability>
+                <availability>CGB!Keshik:2!Front Line:1,CHH!Keshik:2</availability>
             </model>
             <model name='(Wheeled CLBX5 Advanced)'>
                 <roles>anti_aircraft,field_gun,fire_support</roles>

--- a/megamek/data/forcegenerator/3100.xml
+++ b/megamek/data/forcegenerator/3100.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3100-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>10</pctOmni>
@@ -4400,117 +4403,348 @@
 				<availability>General:4,FWL:0</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:1</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN.IS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CNC:0,CWIE:1,CEI:0,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:5!Solahma:5,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CWIE:5</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:6!Solahma:6,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CWIE:6</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:6!Solahma:6,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CWIE:6</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:7!Solahma:7,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CWIE:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN.IS:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CNC!Keshik:2!Front Line:2!Second Line:1,CWIE:3+,CEI!Keshik:1,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Front Line:1!Second Line:7,CHH!Solahma:2!Provisional Garrison:8,CNC:0,CWIE:0,BAN!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Front Line:2!Second Line:5,CHH!Solahma:1!Provisional Garrison:6,CNC:0,CWIE:0,BAN!Keshik:8!Front Line:4</availability>
+            </model>
+            <model name='(Motorized AP Gauss Advanced)'>
+                <roles>anti_infantry,field_gun</roles>
+                <availability>CJF!Keshik:2</availability>
+            </model>
+            <model name='(Motorized PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CJF!Second Line:2,CEI!Keshik:6,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Motorized PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CJF!Second Line:1,CEI!Keshik:8,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Motorized PAC8 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CJF!Second Line:1,CEI!Keshik:6,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Second Line:8,RD!Second Line:8,CHH!Front Line:3!Second Line:1,CNC!Keshik:5!Front Line:1,CWIE:4+,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Front Line:5!Second Line:3,CGB!Second Line:6,RD!Second Line:6,CHH!Front Line:4!Second Line:2!Solahma:1,CNC!Keshik:8!Front Line:3!Solahma:1,CWIE:6+,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN.IS!Keshik:6!Front Line:3,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:4!Front Line:2,CGB!Keshik:1,RD!Keshik:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,RD!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CGB!Keshik:3,RD!Keshik:3,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN.IS!Keshik:5!Front Line:2,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:4!Front Line:2!Second Line:1,CGB!Keshik:1,RD!Keshik:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CGB!Keshik:2!Front Line:1,RD!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CGB!Keshik:3,RD!Keshik:3,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked PAC2 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>CLAN.IS!Second Line:1,CGB:0,RD:0,CEI!Keshik:1</availability>
+            </model>
+            <model name='(Tracked PAC4 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>CLAN.IS!Second Line:1,CGB:0,RD:0,CNC:0,CEI!Keshik:1</availability>
+            </model>
+            <model name='(Tracked PAC8 Advanced)'>
+                <roles>field gun</roles>
+                <availability>CLAN.IS!Second Line:1,CNC:0,CEI!Keshik:1</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Second Line:8,RD!Second Line:8,CHH!Second Line:4!Solahma:1,CNC!Keshik:6!Front Line:5!Second Line:1,CWIE!Keshik:8!Front Line:5,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Second Line:1!Solahma:1,CNC!Front Line:4!Second Line:4,CWIE!Front Line:6!Second Line:6,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Second Line:2,RD!Second Line:2,CHH!Second Line:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Second Line:5,CHH!Second Line:6!Solahma:4,CNC!Keshik:5!Front Line:8!Second Line:5,CW!Second Line:1,CWIE!Keshik:5!Front Line:8!Second Line:5,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN.IS!Keshik:6!Front Line:3,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:3!Front Line:1,CGB!Keshik:1,RD!Keshik:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,RD!Keshik:2!Front Line:1,CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:5!Front Line:3!Second Line:1,CGB!Keshik:3,RD!Keshik:3,CHH!Keshik:5!Front Line:3,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN.IS!Keshik:5!Front Line:2,CHH!Keshik:5!Front Line:2!Second Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:3!Front Line:1,CGB!Keshik:1,RD!Keshik:1,CHH!Keshik:2!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CGB!Keshik:2!Front Line:1,RD!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CHH!Keshik:6!Front Line:3,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>CLAN.IS!Second Line:1,CJF!Second Line:4,CGB:0,RD:0,CNC:0,CEI!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>CLAN.IS!Second Line:1,CJF!Second Line:3,CGB:0,RD:0,CNC:0,CEI!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled PAC8 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN.IS!Second Line:1,CJF!Second Line:3,CNC:0,CEI!Keshik:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN.IS:7,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CWIE:7,CEI!Keshik:7!Front Line:7!Second Line:7,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN.IS:3-,CNC:3-,CWIE:3-,CEI:7-,BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.IS!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:6!Front Line:5!Second Line:4,CNC:3+,CWIE:3+,CEI:3+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CJF:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:4,CNC:3,CWIE:3,CEI:4,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN.IS!Keshik:1,CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.IS!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:5,CHH:7,CNC:7,CWIE:7,CEI!Keshik:7!Front Line:5!Second Line:2,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN.IS:2-,CWIE:2-,CEI!Keshik:3!Front Line:5!Second Line:7,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CNC:4+,CWIE:5+,CEI:2,BAN:4+</availability>
+            </model>
+            <model name='(Watch Detachment Advanced)'>
+                <availability>CLAN.IS:2-,CHH!Provisional Garrison:1,CJF:3-,CNC!Provisional Garrison:1,CWIE:2-</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN.IS!Keshik:7!Front Line:4!Second Line:1,CGB!Keshik:4!Front Line:3!Second Line:1,RD!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CNC!Keshik:5!Front Line:3!Second Line:1,CWIE!Keshik:5!Front Line:3!Second Line:1,CEI!Keshik:2!Front Line:1,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CGB!Keshik:1,RD!Keshik:1,CEI!Keshik:2</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN.IS:3-,CNC:4-,CWIE:4-,CEI:0,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.IS:6+,CWIE:6+,CEI!Keshik:4!Front Line:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:2+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.IS!Keshik:1,CGB:2+,RD:2+,CHH!Keshik:4!Front Line:2,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:4,CWIE:4,CEI:3,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.IS:6,CWIE:6,CEI:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS:5+,CWIE:5+,CEI!Keshik:4!Front Line:3,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN.IS!Keshik:4!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CNC:3+,CWIE:3+,CEI:2+,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CEI!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN.IS!Second Line:1,CNC:4-,CWIE:4-,CEI!Front Line:1,BAN!Second Line:1</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.IS:6+,CGB:5+,RD:5+,CHH:6+,CNC:5+,CWIE:5+,CEI!Keshik:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CWIE:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:4,CNC:3,CWIE:3,CEI:3,BAN:3+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.IS:7,CNC:6,CWIE:6,CEI:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS:5+,CHH:5+,CNC:4+,CWIE:4+,CEI!Keshik:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN.IS:3+,CGB:5+,RD:5+,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CNC:3+,CWIE:3+,CEI:2+,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CEI!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN.IS:3-,CNC:4-,CWIE:4-,CEI:0,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.IS:6+,CHH!Keshik:6!Front Line:5!Second Line:4!Solahma:1,CNC:3+,CWIE:3+,CEI!Keshik:4,BAN:6+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:4+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.IS:2+,CHH!Keshik:4!Front Line:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:4,CWIE:4,CEI!Keshik:3!Front Line:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN.IS!Keshik:1,CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.IS:7,CWIE:7,CEI:7,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS:5+,CWIE:5+,CEI!Keshik:4,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN.IS:4+,CGB!Keshik:6!Front Line:5!Second Line:4!Solahma:2!Provisional Garrison:1,RD!Keshik:6!Front Line:5!Second Line:4!Solahma:2!Provisional Garrison:1,CHH:6+,CEI:3+,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN.IS:3-,CNC:4-,CWIE:4-,CEI:5-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS:5+,CHH:5+,CNC:3+,CWIE:3+,CEI:3+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CNC:0,CWIE:0,CEI:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN.IS:4,CHH:4,CWIE:4,CEI:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CLAN.IS!Keshik:1,CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS:7,CWIE:7,CEI:7,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS:5+,CHH:5+,CNC:4+,CWIE:4+,CEI:3+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
 		<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
 			<availability>CDS:5,CW:4-,CNC:8,CLAN.IS:5-,CGB:6-,RD:6-,CWIE:6,FS:3+,LA:3,DC:2,ROS:3+</availability>
 			<model name='(Laser) &apos;Volk&apos; (Sqd5)' mechanized='true'>
@@ -4530,27 +4764,38 @@
 				<availability>CLAN.IS:7</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN.IS!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CWIE!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CEI!Keshik:4!Front Line:4!Second Line:4,BAN:8+</availability>
+            <model name='(Bearhunter Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CGB:2+,RD:2+,CHH:3+</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS!Front Line:1!Second Line:2!Solahma:3,CGB:3-,RD:3-,CHH:3-,CNC:3-,CWIE:3-,CEI:3,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.IS:3+,CNC:4+,CWIE:4+,CEI:3+,BAN:4+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CNC:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:3,CHH:3,CNC:4,CWIE:4,CEI:3,BAN:4+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.IS:5+,CGB:5,RD:5,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CNC:7,CWIE:7,CEI:7,BAN:7+</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,CGB:2-,RD:2-,CHH!Solahma:1!Provisional Garrison:8,CNC:2-,CWIE:2-,CEI:5,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS:4+,CHH:4+,CNC:4+,CWIE:4+,CEI:3+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+            </model>
+        </chassis>
 		<chassis name='Claymore' unitType='Dropship'>
 			<availability>LA:4,FS:4,ROS:4,MERC:3+</availability>
 			<model name='(3054)'>
@@ -7304,7 +7549,7 @@
             </model>
         </chassis>
 		<chassis name='Foot Platoon' unitType='Infantry'>
-			<availability>IS:10,Periphery:10,TC:3-,MH:0,CDP:4-,HL:10,Periphery.Deep:10</availability>
+			<availability>IS:10,Periphery:10,TC:3-,MH:0,CDP:4-,CEI!Solahma:10!Provisional Garrison:10,HL:10,Periphery.Deep:10</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,Periphery:8,TC:6-,CDP:6-,HL:8,Periphery.Deep:8</availability>
@@ -10647,7 +10892,7 @@
             </model>
         </chassis>
 		<chassis name='Jump Platoon' unitType='Infantry'>
-			<availability>IS:8,Periphery:7,TC:2-,MH:0,CDP:2-,HL:7,Periphery.Deep:5+</availability>
+			<availability>IS:8,Periphery:7,TC:2-,MH:0,CDP:2-,CEI!Second Line:4!Solahma:3!Provisional Garrison:2,HL:7,Periphery.Deep:5+</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,Periphery:8,TC:3-,CDP:3-,HL:8,Periphery.Deep:8</availability>
@@ -13040,7 +13285,7 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
-			<availability>IS:5,Periphery:5,TC:1-,MH:0,CDP:1-,HL:5,Periphery.Deep:4+</availability>
+			<availability>IS:5,Periphery:5,TC:1-,MH:0,CDP:1-,CEI!Second Line:2!Solahma:1,HL:5,Periphery.Deep:4+</availability>
 			<model name='(Demolition)'>
 				<roles>recon,engineer</roles>
 				<availability>General:3</availability>
@@ -13133,7 +13378,7 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
-			<availability>IS:7,Periphery:7,TC:3-,MH:0,CDP:4-,HL:7,Periphery.Deep:6+</availability>
+			<availability>IS:7,Periphery:7,TC:3-,MH:0,CDP:4-,CEI!Second Line:4!Solahma:3!Provisional Garrison:2,HL:7,Periphery.Deep:6+</availability>
             <model name='(Bridging)'>
                 <roles>engineer</roles>
                 <availability>IS:2,Periphery:1,Periphery.Deep:0</availability>
@@ -13232,7 +13477,7 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
-			<availability>IS:7,Periphery:7,TC:2-,MH:0,CDP:3-,HL:7,Periphery.Deep:8+</availability>
+			<availability>IS:7,Periphery:7,TC:2-,MH:0,CDP:3-,CEI!Solahma:5!Provisional Garrison:4,HL:7,Periphery.Deep:8+</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,Periphery:8,TC:4-,CDP:4-,HL:8,Periphery.Deep:8</availability>
@@ -13780,7 +14025,7 @@
             </model>
         </chassis>
 		<chassis name='Motorized Platoon' unitType='Infantry'>
-			<availability>IS:9,Periphery:9,TC:3-,MH:0,CDP:4-,HL:8,Periphery.Deep:8</availability>
+			<availability>IS:9,Periphery:9,TC:3-,MH:0,CDP:4-,CEI!Solahma:8!Provisional Garrison:8,HL:8,Periphery.Deep:8</availability>
 			<model name='(Fieldworks)'>
 				<roles>engineer</roles>
 				<availability>IS:4,Periphery:2</availability>

--- a/megamek/data/forcegenerator/3131.xml
+++ b/megamek/data/forcegenerator/3131.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3131-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='AA'>
 			<omniMargin>12</omniMargin>
@@ -4794,117 +4797,348 @@
 				<availability>General:4,FWL:0</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:1</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN.IS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CNC:0,CWIE:1,CEI:0,SE!Second Line:2,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:5!Solahma:5,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CWIE:5,SE!Second Line:3</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:6!Solahma:6,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CWIE:6,SE!Second Line:3</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:6!Solahma:6,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CWIE:6,SE!Second Line:5</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:7!Solahma:7,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CWIE:8,SE!Second Line:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN.IS:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CNC!Keshik:2!Front Line:2!Second Line:1,CWIE:3+,CEI!Keshik:1,SE!Keshik:1,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Front Line:1!Second Line:7,CHH!Solahma:2!Provisional Garrison:8,CNC:0,CWIE:0,BAN!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Front Line:2!Second Line:5,CHH!Solahma:1!Provisional Garrison:6,CNC:0,CWIE:0,BAN!Keshik:8!Front Line:4</availability>
+            </model>
+            <model name='(Motorized AP Gauss Advanced)'>
+                <roles>anti_infantry,field_gun</roles>
+                <availability>CJF!Keshik:2</availability>
+            </model>
+            <model name='(Motorized PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CJF!Second Line:2,CEI!Keshik:6,SE!Keshik:6,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Motorized PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CJF!Second Line:1,CEI!Keshik:8,SE!Keshik:8,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Motorized PAC8 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CJF!Second Line:1,CEI!Keshik:6,SE!Keshik:6,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>RD!Second Line:8,CHH!Front Line:3!Second Line:1,CNC!Keshik:5!Front Line:1,CWIE:4+,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Front Line:5!Second Line:3,RD!Second Line:6,CHH!Front Line:4!Second Line:2!Solahma:1,CNC!Keshik:8!Front Line:3!Solahma:1,CWIE:6+,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN.IS!Keshik:6!Front Line:3,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:4!Front Line:2,RD!Keshik:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>RD!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:5!Front Line:3!Second Line:1,RD!Keshik:3,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN.IS!Keshik:5!Front Line:2,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:4!Front Line:2!Second Line:1,RD!Keshik:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>RD!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:6!Front Line:3!Second Line:1,RD!Keshik:3,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked PAC2 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>CLAN.IS!Second Line:1,RD:0,CEI!Keshik:1,SE!Keshik:1</availability>
+            </model>
+            <model name='(Tracked PAC4 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>CLAN.IS!Second Line:1,RD:0,CNC:0,CEI!Keshik:1,SE!Keshik:1</availability>
+            </model>
+            <model name='(Tracked PAC8 Advanced)'>
+                <roles>field gun</roles>
+                <availability>CLAN.IS!Second Line:1,CNC:0,CEI!Keshik:1,SE!Keshik:1</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>RD!Second Line:8,CHH!Second Line:4!Solahma:1,CNC!Keshik:6!Front Line:5!Second Line:1,CWIE!Keshik:8!Front Line:5,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Second Line:1!Solahma:1,CNC!Front Line:4!Second Line:4,CWIE!Front Line:6!Second Line:6,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>RD!Second Line:2,CHH!Second Line:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Second Line:5,CHH!Second Line:6!Solahma:4,CNC!Keshik:5!Front Line:8!Second Line:5,CW!Second Line:1,CWIE!Keshik:5!Front Line:8!Second Line:5,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN.IS!Keshik:6!Front Line:3,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:3!Front Line:1,RD!Keshik:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>RD!Keshik:2!Front Line:1,CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:5!Front Line:3!Second Line:1,RD!Keshik:3,CHH!Keshik:5!Front Line:3,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN.IS!Keshik:5!Front Line:2,CHH!Keshik:5!Front Line:2!Second Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:3!Front Line:1,RD!Keshik:1,CHH!Keshik:2!Front Line:1,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>RD!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CHH!Keshik:6!Front Line:3,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>CLAN.IS!Second Line:1,CJF!Second Line:4,RD:0,CNC:0,CEI!Keshik:2,SE!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>CLAN.IS!Second Line:1,CJF!Second Line:3,RD:0,CNC:0,CEI!Keshik:2,SE!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled PAC8 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN.IS!Second Line:1,CJF!Second Line:3,CNC:0,CEI!Keshik:2,SE!Keshik:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN.IS:7,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CWIE:7,CEI!Keshik:7!Front Line:7!Second Line:7,SE!Keshik:7!Front Line:7!Second Line:7,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN.IS:3-,CNC:3-,CWIE:3-,CEI:7-,SE:7-,BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.IS!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:6!Front Line:5!Second Line:4,CNC:3+,CWIE:3+,CEI:3+,SE:3+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CJF:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:4,CNC:3,CWIE:3,CEI:4,SE:4,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN.IS!Keshik:1,CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.IS!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:5,CHH:7,CNC:7,CWIE:7,CEI!Keshik:7!Front Line:5!Second Line:2,SE!Keshik:7!Front Line:5!Second Line:2,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN.IS:2-,CWIE:2-,CEI!Keshik:3!Front Line:5!Second Line:7,SE!Keshik:3!Front Line:5!Second Line:7,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CNC:4+,CWIE:5+,CEI:2,SE:2,BAN:4+</availability>
+            </model>
+            <model name='(Watch Detachment Advanced)'>
+                <availability>CLAN.IS:2-,CHH!Provisional Garrison:1,CJF:3-,CNC!Provisional Garrison:1,CWIE:2-</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN.IS!Keshik:7!Front Line:4!Second Line:1,RD!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CNC!Keshik:5!Front Line:3!Second Line:1,CWIE!Keshik:5!Front Line:3!Second Line:1,CEI!Keshik:2!Front Line:1,SE!Keshik:2!Front Line:1,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>RD!Keshik:1,CEI!Keshik:2,SE!Keshik:2</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN.IS:3-,CNC:4-,CWIE:4-,CEI:0,SE:0,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.IS:6+,CWIE:6+,CEI!Keshik:4!Front Line:3,SE!Keshik:4!Front Line:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:2+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.IS!Keshik:1,RD:2+,CHH!Keshik:4!Front Line:2,CNC:0,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:4,CWIE:4,CEI:3,SE:3,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.IS:6,CWIE:6,CEI:6,SE:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS:5+,CWIE:5+,CEI!Keshik:4!Front Line:3,SE!Keshik:4!Front Line:3,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN.IS!Keshik:4!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CNC:3+,CWIE:3+,CEI:2+,SE:2+,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CEI!Keshik:1,SE!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN.IS!Second Line:1,CNC:4-,CWIE:4-,CEI!Front Line:1,SE!Front Line:1,BAN!Second Line:1</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.IS:6+,RD:5+,CHH:6+,CNC:5+,CWIE:5+,CEI!Keshik:4,SE!Keshik:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CWIE:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CNC:0,CWIE:0,CEI:0,SE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:4,CNC:3,CWIE:3,CEI:3,SE:3,BAN:3+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.IS:7,CNC:6,CWIE:6,CEI:6,SE:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS:5+,CHH:5+,CNC:4+,CWIE:4+,CEI!Keshik:4,SE!Keshik:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN.IS:3+,RD:5+,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CNC:3+,CWIE:3+,CEI:2+,SE:2+,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>CEI!Keshik:1,SE!Keshik:1</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN.IS:3-,CNC:4-,CWIE:4-,CEI:0,SE:0,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.IS:6+,CHH!Keshik:6!Front Line:5!Second Line:4!Solahma:1,CNC:3+,CWIE:3+,CEI!Keshik:4,SE!Keshik:4,BAN:6+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:4+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.IS:2+,CHH!Keshik:4!Front Line:1,CNC:0,CWIE:0,CEI:0,SE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:4,CWIE:4,CEI!Keshik:3!Front Line:3,SE!Keshik:3!Front Line:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN.IS!Keshik:1,CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.IS:7,CWIE:7,CEI:7,SE:7,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS:5+,CWIE:5+,CEI!Keshik:4,SE!Keshik:4,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN.IS:4+,RD!Keshik:6!Front Line:5!Second Line:4!Solahma:2!Provisional Garrison:1,CHH:6+,CEI:3+,SE:3+,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN.IS:3-,CNC:4-,CWIE:4-,CEI:5-,SE:5-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS:5+,CHH:5+,CNC:3+,CWIE:3+,CEI:3+,SE:3+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CNC:0,CWIE:0,CEI:0,SE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN.IS:4,CHH:4,CWIE:4,CEI:3,SE:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CLAN.IS!Keshik:1,CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS:7,CWIE:7,CEI:7,SE:7,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS:5+,CHH:5+,CNC:4+,CWIE:4+,CEI:3+,SE:3+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
 		<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
 			<availability>CWE:4-,RD:6-,CDS:5,CW:4-,CNC:8,CLAN.IS:5-,CP:6,CWIE:6,FS:3+,LA:3,DC:2,FWL:3+,ROS:3+</availability>
 			<model name='(Laser) &apos;Volk&apos; (Sqd5)' mechanized='true'>
@@ -4924,27 +5158,38 @@
 				<availability>CLAN.IS:8</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN.IS!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CWIE!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,CEI!Keshik:4!Front Line:4!Second Line:4,SE!Keshik:4!Front Line:4!Second Line:4,BAN:8+</availability>
+            <model name='(Bearhunter Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>RD:2+,CHH:3+</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS!Front Line:1!Second Line:2!Solahma:3,RD:3-,CHH:3-,CNC:3-,CWIE:3-,CEI:3,SE:3,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.IS:3+,CNC:4+,CWIE:4+,CEI:3+,SE:3+,BAN:4+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CNC:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:3,CHH:3,CNC:4,CWIE:4,CEI:3,SE:3,BAN:4+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.IS:5+,RD:5,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CNC:7,CWIE:7,CEI:7,SE:7,BAN:7+</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,RD:2-,CHH!Solahma:1!Provisional Garrison:8,CNC:2-,CWIE:2-,CEI:5,SE:5,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS:4+,CHH:4+,CNC:4+,CWIE:4+,CEI:3+,SE:3+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+            </model>
+        </chassis>
 		<chassis name='Claymore' unitType='Dropship'>
 			<availability>LA:4,FS:4,ROS:3,MERC:3+,CJF:3</availability>
 			<model name='(3054)'>
@@ -7788,7 +8033,7 @@
             </model>
         </chassis>
 		<chassis name='Foot Platoon' unitType='Infantry'>
-			<availability>IS:10,Periphery:10,TC:3-,MH:0,CDP:4-,HL:10,Periphery.Deep:10</availability>
+			<availability>IS:10,Periphery:10,TC:3-,MH:0,CDP:4-,CEI!Solahma:10!Provisional Garrison:10,HL:10,Periphery.Deep:10</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,Periphery:8,TC:6-,CDP:6-,HL:8,Periphery.Deep:8</availability>
@@ -11340,7 +11585,7 @@
             </model>
         </chassis>
 		<chassis name='Jump Platoon' unitType='Infantry'>
-			<availability>IS:8,Periphery:7,TC:2-,MH:0,CDP:2-,HL:7,Periphery.Deep:5+</availability>
+			<availability>IS:8,Periphery:7,TC:2-,MH:0,CDP:2-,CEI!Second Line:4!Solahma:3!Provisional Garrison:2,HL:7,Periphery.Deep:5+</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,Periphery:8,TC:3-,CDP:3-,HL:8,Periphery.Deep:8</availability>
@@ -13910,7 +14155,7 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
-			<availability>IS:5,Periphery:5,TC:1-,MH:0,CDP:1-,HL:5,Periphery.Deep:4+</availability>
+			<availability>IS:5,Periphery:5,TC:1-,MH:0,CDP:1-,CEI!Second Line:2!Solahma:1,HL:5,Periphery.Deep:4+</availability>
 			<model name='(Demolition)'>
 				<roles>recon,engineer</roles>
 				<availability>General:3</availability>
@@ -14003,7 +14248,7 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
-			<availability>IS:7,Periphery:7,TC:3-,MH:0,CDP:4-,HL:7,Periphery.Deep:6+</availability>
+			<availability>IS:7,Periphery:7,TC:3-,MH:0,CDP:4-,CEI!Second Line:4!Solahma:3!Provisional Garrison:2,HL:7,Periphery.Deep:6+</availability>
             <model name='(Bridging)'>
                 <roles>engineer</roles>
                 <availability>IS:2,Periphery:1,Periphery.Deep:0</availability>
@@ -14102,7 +14347,7 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
-			<availability>IS:7,Periphery:7,TC:2-,MH:0,CDP:3-,HL:7,Periphery.Deep:8+</availability>
+			<availability>IS:7,Periphery:7,TC:2-,MH:0,CDP:3-,CEI!Solahma:5!Provisional Garrison:4,HL:7,Periphery.Deep:8+</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,Periphery:8,TC:4-,CDP:4-,HL:8,Periphery.Deep:8</availability>
@@ -14648,7 +14893,7 @@
             </model>
         </chassis>
 		<chassis name='Motorized Platoon' unitType='Infantry'>
-			<availability>IS:9,Periphery:9,TC:3-,MH:0,CDP:4-,HL:8,Periphery.Deep:8</availability>
+			<availability>IS:9,Periphery:9,TC:3-,MH:0,CDP:4-,CEI!Solahma:8!Provisional Garrison:8,HL:8,Periphery.Deep:8</availability>
 			<model name='(Fieldworks)'>
 				<roles>engineer</roles>
 				<availability>IS:4,Periphery:2</availability>

--- a/megamek/data/forcegenerator/3131.xml
+++ b/megamek/data/forcegenerator/3131.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3131-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='AA'>
 			<omniMargin>12</omniMargin>

--- a/megamek/data/forcegenerator/3145.xml
+++ b/megamek/data/forcegenerator/3145.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3145-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='AA'>
 			<omniMargin>15</omniMargin>

--- a/megamek/data/forcegenerator/3145.xml
+++ b/megamek/data/forcegenerator/3145.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3145-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='AA'>
 			<omniMargin>15</omniMargin>
@@ -4655,117 +4658,348 @@
 				<availability>General:4,FWL:0</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:1</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN.IS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CWIE:1,SE!Second Line:2,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:5!Solahma:5,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CWIE:5,SE!Second Line:3</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:6!Solahma:6,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CWIE:6,SE!Second Line:3</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:6!Solahma:6,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CWIE:6,SE!Second Line:5</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:7!Solahma:7,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CWIE:8,SE!Second Line:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN.IS:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CWIE:3+,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Front Line:1!Second Line:7,CHH!Solahma:2!Provisional Garrison:8,CWIE:0,BAN!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Front Line:2!Second Line:5,CHH!Solahma:1!Provisional Garrison:6,CWIE:0,BAN!Keshik:8!Front Line:4</availability>
+            </model>
+            <model name='(Motorized AP Gauss Advanced)'>
+                <roles>anti_infantry,field_gun</roles>
+                <availability>CJF!Keshik:2</availability>
+            </model>
+            <model name='(Motorized PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CJF!Second Line:2,SE!Keshik:6,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Motorized PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CJF!Second Line:1,SE!Keshik:8,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Motorized PAC8 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CJF!Second Line:1,SE!Keshik:6,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>RD!Second Line:8,CHH!Front Line:3!Second Line:1,CWIE:4+,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Front Line:5!Second Line:3,RD!Second Line:6,CHH!Front Line:4!Second Line:2!Solahma:1,CWIE:6+,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN.IS!Keshik:6!Front Line:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:4!Front Line:2,RD!Keshik:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>RD!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:5!Front Line:3!Second Line:1,RD!Keshik:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN.IS!Keshik:5!Front Line:2,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:4!Front Line:2!Second Line:1,RD!Keshik:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>RD!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:6!Front Line:3!Second Line:1,RD!Keshik:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked PAC2 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>CLAN.IS!Second Line:1,RD:0,SE!Keshik:1</availability>
+            </model>
+            <model name='(Tracked PAC4 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>CLAN.IS!Second Line:1,RD:0,SE!Keshik:1</availability>
+            </model>
+            <model name='(Tracked PAC8 Advanced)'>
+                <roles>field gun</roles>
+                <availability>CLAN.IS!Second Line:1,SE!Keshik:1</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>RD!Second Line:8,CHH!Second Line:4!Solahma:1,CWIE!Keshik:8!Front Line:5,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Second Line:1!Solahma:1,CWIE!Front Line:6!Second Line:6,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>RD!Second Line:2,CHH!Second Line:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Second Line:5,CHH!Second Line:6!Solahma:4,CW!Second Line:1,CWIE!Keshik:5!Front Line:8!Second Line:5,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN.IS!Keshik:6!Front Line:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:3!Front Line:1,RD!Keshik:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>RD!Keshik:2!Front Line:1,CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:5!Front Line:3!Second Line:1,RD!Keshik:3,CHH!Keshik:5!Front Line:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN.IS!Keshik:5!Front Line:2,CHH!Keshik:5!Front Line:2!Second Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:3!Front Line:1,RD!Keshik:1,CHH!Keshik:2!Front Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>RD!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CHH!Keshik:6!Front Line:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>CLAN.IS!Second Line:1,CJF!Second Line:4,RD:0,SE!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>CLAN.IS!Second Line:1,CJF!Second Line:3,RD:0,SE!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled PAC8 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN.IS!Second Line:1,CJF!Second Line:3,SE!Keshik:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>CLAN.IS:7,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CWIE:7,SE!Keshik:7!Front Line:7!Second Line:7,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>CLAN.IS:3-,CWIE:3-,SE:7-,BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.IS!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:6!Front Line:5!Second Line:4,CWIE:3+,SE:3+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CJF:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:4,CWIE:3,SE:4,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN.IS!Keshik:1,CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.IS!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:5,CHH:7,CWIE:7,SE!Keshik:7!Front Line:5!Second Line:2,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>CLAN.IS:2-,CWIE:2-,SE!Keshik:3!Front Line:5!Second Line:7,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CWIE:5+,SE:2,BAN:4+</availability>
+            </model>
+            <model name='(Watch Detachment Advanced)'>
+                <availability>CLAN.IS:2-,CHH!Provisional Garrison:1,CJF:3-,CWIE:2-</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>CLAN.IS!Keshik:7!Front Line:4!Second Line:1,RD!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CWIE!Keshik:5!Front Line:3!Second Line:1,SE!Keshik:2!Front Line:1,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>RD!Keshik:1,SE!Keshik:2</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>CLAN.IS:3-,CWIE:4-,SE:0,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.IS:6+,CWIE:6+,SE!Keshik:4!Front Line:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:2+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.IS!Keshik:1,RD:2+,CHH!Keshik:4!Front Line:2,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:4,CWIE:4,SE:3,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.IS:6,CWIE:6,SE:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS:5+,CWIE:5+,SE!Keshik:4!Front Line:3,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>CLAN.IS!Keshik:4!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CWIE:3+,SE:2+,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>SE!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>CLAN.IS!Second Line:1,CWIE:4-,SE!Front Line:1,BAN!Second Line:1</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.IS:6+,RD:5+,CHH:6+,CWIE:5+,SE!Keshik:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CWIE:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CWIE:0,SE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:4,CWIE:3,SE:3,BAN:3+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.IS:7,CWIE:6,SE:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS:5+,CHH:5+,CWIE:4+,SE!Keshik:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>CLAN.IS:3+,RD:5+,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CWIE:3+,SE:2+,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>SE!Keshik:1</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>CLAN.IS:3-,CWIE:4-,SE:0,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.IS:6+,CHH!Keshik:6!Front Line:5!Second Line:4!Solahma:1,CWIE:3+,SE!Keshik:4,BAN:6+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:4+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.IS:2+,CHH!Keshik:4!Front Line:1,CWIE:0,SE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:4,CWIE:4,SE!Keshik:3!Front Line:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN.IS!Keshik:1,CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.IS:7,CWIE:7,SE:7,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS:5+,CWIE:5+,SE!Keshik:4,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>CLAN.IS:4+,RD!Keshik:6!Front Line:5!Second Line:4!Solahma:2!Provisional Garrison:1,CHH:6+,SE:3+,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>CLAN.IS:3-,CWIE:4-,SE:5-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS:5+,CHH:5+,CWIE:3+,SE:3+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CWIE:0,SE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN.IS:4,CHH:4,CWIE:4,SE:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CLAN.IS!Keshik:1,CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS:7,CWIE:7,SE:7,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS:5+,CHH:5+,CWIE:4+,SE:3+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
 		<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
 			<availability>CWE:4-,RD:6-,CDS:5,CLAN.IS:5-,CP:6,CWIE:6,FS:3+,LA:3,DC:2,FWL:3+,ROS:3+</availability>
 			<model name='(Laser) &apos;Volk&apos; (Sqd5)' mechanized='true'>
@@ -4785,27 +5019,38 @@
 				<availability>CLAN.IS:8</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>CLAN.IS!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CWIE!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,SE!Keshik:4!Front Line:4!Second Line:4,BAN:8+</availability>
+            <model name='(Bearhunter Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>RD:2+,CHH:3+</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS!Front Line:1!Second Line:2!Solahma:3,RD:3-,CHH:3-,CWIE:3-,SE:3,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.IS:3+,CWIE:4+,SE:3+,BAN:4+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:3,CHH:3,CWIE:4,SE:3,BAN:4+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.IS:5+,RD:5,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CWIE:7,SE:7,BAN:7+</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,RD:2-,CHH!Solahma:1!Provisional Garrison:8,CWIE:2-,SE:5,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS:4+,CHH:4+,CWIE:4+,SE:3+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+            </model>
+        </chassis>
 		<chassis name='Claymore' unitType='Dropship'>
 			<availability>LA:4,FS:4,ROS:3,MERC:3+,CJF:3</availability>
 			<model name='(3054)'>
@@ -7711,7 +7956,7 @@
             </model>
         </chassis>
 		<chassis name='Foot Platoon' unitType='Infantry'>
-			<availability>IS:10,Periphery:10,TC:3-,MH:0,CDP:4-,Periphery.Deep:10</availability>
+			<availability>IS:10,Periphery:10,TC:3-,MH:0,CDP:4-,SE!Solahma:10!Provisional Garrison:10,HL:10,Periphery.Deep:10</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,Periphery:8,TC:6-,CDP:6-,Periphery.Deep:8</availability>
@@ -11357,7 +11602,7 @@
             </model>
         </chassis>
 		<chassis name='Jump Platoon' unitType='Infantry'>
-			<availability>IS:8,Periphery:7,TC:2-,MH:0,CDP:2-,Periphery.Deep:5+</availability>
+			<availability>IS:8,Periphery:7,TC:2-,MH:0,CDP:2-,SE!Second Line:4!Solahma:3!Provisional Garrison:2,Periphery.Deep:5+</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,Periphery:8,TC:3-,CDP:3-,Periphery.Deep:8</availability>
@@ -13956,7 +14201,7 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
-			<availability>IS:5,Periphery:5,TC:1-,MH:0,CDP:1-,Periphery.Deep:4+</availability>
+			<availability>IS:5,Periphery:5,TC:1-,MH:0,CDP:1-,SE!Second Line:2!Solahma:1,Periphery.Deep:4+</availability>
 			<model name='(Demolition)'>
 				<roles>recon,engineer</roles>
 				<availability>General:3</availability>
@@ -14049,7 +14294,7 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
-			<availability>IS:7,Periphery:7,TC:3-,MH:0,CDP:4-,Periphery.Deep:6+</availability>
+			<availability>IS:7,Periphery:7,TC:3-,MH:0,CDP:4-,SE!Second Line:4!Solahma:3!Provisional Garrison:2,Periphery.Deep:6+</availability>
             <model name='(Bridging)'>
                 <roles>engineer</roles>
                 <availability>IS:2,Periphery:1,Periphery.Deep:0</availability>
@@ -14148,7 +14393,7 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
-			<availability>IS:7,Periphery:7,TC:2-,MH:0,CDP:3-,Periphery.Deep:8+</availability>
+			<availability>IS:7,Periphery:7,TC:2-,MH:0,CDP:3-,SE!Solahma:5!Provisional Garrison:4,Periphery.Deep:8+</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,Periphery:8,TC:4-,CDP:4-,Periphery.Deep:8</availability>
@@ -14705,7 +14950,7 @@
             </model>
         </chassis>
 		<chassis name='Motorized Platoon' unitType='Infantry'>
-			<availability>IS:9,Periphery:9,TC:3-,MH:0,CDP:4-,Periphery.Deep:8</availability>
+			<availability>IS:9,Periphery:9,TC:3-,MH:0,CDP:4-,SE!Solahma:8!Provisional Garrison:8,Periphery.Deep:8</availability>
 			<model name='(Fieldworks)'>
 				<roles>engineer</roles>
 				<availability>IS:4,Periphery:2</availability>

--- a/megamek/data/forcegenerator/3150.xml
+++ b/megamek/data/forcegenerator/3150.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3150-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
     <factions>
         <faction key='AML'>
             <techMargin>16</techMargin>
@@ -4921,7 +4918,7 @@
         <chassis name='Clan Jump Point' unitType='Infantry'>
             <availability>CLAN.IS!Keshik:7!Front Line:4!Second Line:1,RD!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CWIE!Keshik:5!Front Line:3!Second Line:1,SE!Keshik:2!Front Line:1,BAN:4+</availability>
             <model name='(ER Laser Advanced)'>
-                <availability>RD!Keshik:1,SE!Keshik:2</availability>
+                <availability>SE!Keshik:2</availability>
             </model>
             <model name='(Flamer Advanced)'>
                 <roles>urban</roles>

--- a/megamek/data/forcegenerator/3150.xml
+++ b/megamek/data/forcegenerator/3150.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 3150-->
-<ratgen>
+<ratgen
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
     <factions>
         <faction key='AML'>
             <techMargin>16</techMargin>
@@ -4706,115 +4709,346 @@
                 <availability>General:4,FWL:0</availability>
             </model>
         </chassis>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>CLAN.IS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,CWIE:1,SE!Second Line:2,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:5!Solahma:5,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,CWIE:5,SE!Second Line:3</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:6!Solahma:6,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,CWIE:6,SE!Second Line:3</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:6!Solahma:6,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,CWIE:6,SE!Second Line:5</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>CLAN.IS!Second Line:7!Solahma:7,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,CWIE:8,SE!Second Line:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>CLAN.IS:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,CWIE:3+,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Front Line:1!Second Line:7,CHH!Solahma:2!Provisional Garrison:8,CWIE:0,BAN!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Front Line:2!Second Line:5,CHH!Solahma:1!Provisional Garrison:6,CWIE:0,BAN!Keshik:8!Front Line:4</availability>
+            </model>
+            <model name='(Motorized AP Gauss Advanced)'>
+                <roles>anti_infantry,field_gun</roles>
+                <availability>CJF!Keshik:2</availability>
+            </model>
+            <model name='(Motorized PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CJF!Second Line:2,SE!Keshik:6,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Motorized PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CJF!Second Line:1,SE!Keshik:8,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Motorized PAC8 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CJF!Second Line:1,SE!Keshik:6,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>RD!Second Line:8,CHH!Front Line:3!Second Line:1,CWIE:4+,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Front Line:5!Second Line:3,RD!Second Line:6,CHH!Front Line:4!Second Line:2!Solahma:1,CWIE:6+,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>CLAN.IS!Keshik:6!Front Line:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:4!Front Line:2,RD!Keshik:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>RD!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:5!Front Line:3!Second Line:1,RD!Keshik:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CLAN.IS!Keshik:5!Front Line:2,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:4!Front Line:2!Second Line:1,RD!Keshik:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>RD!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:6!Front Line:3!Second Line:1,RD!Keshik:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Tracked PAC2 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>CLAN.IS!Second Line:1,RD:0,SE!Keshik:1</availability>
+            </model>
+            <model name='(Tracked PAC4 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>CLAN.IS!Second Line:1,RD:0,SE!Keshik:1</availability>
+            </model>
+            <model name='(Tracked PAC8 Advanced)'>
+                <roles>field gun</roles>
+                <availability>CLAN.IS!Second Line:1,SE!Keshik:1</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>RD!Second Line:8,CHH!Second Line:4!Solahma:1,CWIE!Keshik:8!Front Line:5,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Second Line:1!Solahma:1,CWIE!Front Line:6!Second Line:6,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>RD!Second Line:2,CHH!Second Line:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Second Line:5,CHH!Second Line:6!Solahma:4,CW!Second Line:1,CWIE!Keshik:5!Front Line:8!Second Line:5,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>CLAN.IS!Keshik:6!Front Line:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:3!Front Line:1,RD!Keshik:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>RD!Keshik:2!Front Line:1,CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:5!Front Line:3!Second Line:1,RD!Keshik:3,CHH!Keshik:5!Front Line:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN.IS!Keshik:5!Front Line:2,CHH!Keshik:5!Front Line:2!Second Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:3!Front Line:1,RD!Keshik:1,CHH!Keshik:2!Front Line:1,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>RD!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CHH!Keshik:6!Front Line:3,CWIE:0,BAN:0</availability>
+            </model>
+            <model name='(Wheeled PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>CLAN.IS!Second Line:1,CJF!Second Line:4,RD:0,SE!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>CLAN.IS!Second Line:1,CJF!Second Line:3,RD:0,SE!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled PAC8 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>CLAN.IS!Second Line:1,CJF!Second Line:3,SE!Keshik:2</availability>
+            </model>
+        </chassis>
         <chassis name='Clan Foot Point' unitType='Infantry'>
-            <availability>CLAN:10,BAN:10</availability>
-            <model name='(Flamer)'>
-                <availability>CLAN:4</availability>
+            <availability>CLAN.IS:7,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,CWIE:7,SE!Keshik:7!Front Line:7!Second Line:7,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS:3-,CWIE:3-,SE:7-,BAN:3</availability>
             </model>
-            <model name='(LRM)'>
-                <availability>CLAN:1</availability>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.IS!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:6!Front Line:5!Second Line:4,CWIE:3+,SE:3+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
             </model>
-            <model name='(Laser)'>
-                <availability>CLAN:8</availability>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CJF:4+</availability>
             </model>
-            <model name='(MG)'>
-                <availability>CLAN:4</availability>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:4,CWIE:3,SE:4,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
             </model>
-            <model name='(Rifle)'>
-                <availability>CLAN:9-</availability>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN.IS!Keshik:1,CHH!Keshik:1!Front Line:1</availability>
             </model>
-            <model name='(SRM)'>
-                <availability>CLAN:2</availability>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.IS!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:5,CHH:7,CWIE:7,SE!Keshik:7!Front Line:5!Second Line:2,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS:2-,CWIE:2-,SE!Keshik:3!Front Line:5!Second Line:7,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,CWIE:5+,SE:2,BAN:4+</availability>
+            </model>
+            <model name='(Watch Detachment Advanced)'>
+                <availability>CLAN.IS:2-,CHH!Provisional Garrison:1,CJF:3-,CWIE:2-</availability>
             </model>
         </chassis>
         <chassis name='Clan Jump Point' unitType='Infantry'>
-            <availability>CLAN:8,BAN:6</availability>
-            <model name='(Flamer)'>
-                <availability>CLAN:8</availability>
+            <availability>CLAN.IS!Keshik:7!Front Line:4!Second Line:1,RD!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,CWIE!Keshik:5!Front Line:3!Second Line:1,SE!Keshik:2!Front Line:1,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>RD!Keshik:1,SE!Keshik:2</availability>
             </model>
-            <model name='(LRM)'>
-                <availability>CLAN:5</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS:3-,CWIE:4-,SE:0,BAN:4-</availability>
             </model>
-            <model name='(Laser)'>
-                <availability>CLAN:6</availability>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.IS:6+,CWIE:6+,SE!Keshik:4!Front Line:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
             </model>
-            <model name='(MG)'>
-                <availability>CLAN:7</availability>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:2+</availability>
             </model>
-            <model name='(Rifle)'>
-                <availability>CLAN:8</availability>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.IS!Keshik:1,RD:2+,CHH!Keshik:4!Front Line:2,CWIE:0,BAN:0</availability>
             </model>
-            <model name='(SRM)'>
-                <availability>CLAN:5</availability>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:4,CWIE:4,SE:3,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.IS:6,CWIE:6,SE:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS:5+,CWIE:5+,SE!Keshik:4!Front Line:3,BAN:3+</availability>
             </model>
         </chassis>
         <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-            <availability>CLAN:6,BAN:3</availability>
-            <model name='(Flamer)'>
-                <availability>CLAN:8</availability>
+            <availability>CLAN.IS!Keshik:4!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,CWIE:3+,SE:2+,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>SE!Keshik:1,BAN:0</availability>
             </model>
-            <model name='(LRM)'>
-                <availability>CLAN:5</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS!Second Line:1,CWIE:4-,SE!Front Line:1,BAN!Second Line:1</availability>
             </model>
-            <model name='(Laser)'>
-                <availability>CLAN:6</availability>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.IS:6+,RD:5+,CHH:6+,CWIE:5+,SE!Keshik:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
             </model>
-            <model name='(MG)'>
-                <availability>CLAN:7</availability>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+,CWIE:3+</availability>
             </model>
-            <model name='(Rifle)'>
-                <availability>CLAN:8</availability>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CWIE:0,SE:0,BAN:0</availability>
             </model>
-            <model name='(SRM)'>
-                <availability>CLAN:5</availability>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:4,CWIE:3,SE:3,BAN:3+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>CLAN.IS:7,CWIE:6,SE:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS:5+,CHH:5+,CWIE:4+,SE!Keshik:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
             </model>
         </chassis>
         <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-            <availability>CLAN:7,BAN:4</availability>
-            <model name='(Flamer)'>
-                <availability>CLAN:8</availability>
+            <availability>CLAN.IS:3+,RD:5+,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,CWIE:3+,SE:2+,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>SE!Keshik:1</availability>
             </model>
-            <model name='(LRM)'>
-                <availability>CLAN:5</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS:3-,CWIE:4-,SE:0,BAN:5-</availability>
             </model>
-            <model name='(Laser)'>
-                <availability>CLAN:6</availability>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.IS:6+,CHH!Keshik:6!Front Line:5!Second Line:4!Solahma:1,CWIE:3+,SE!Keshik:4,BAN:6+</availability>
             </model>
-            <model name='(MG)'>
-                <availability>CLAN:7</availability>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:4+</availability>
             </model>
-            <model name='(Rifle)'>
-                <availability>CLAN:8</availability>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>CLAN.IS:2+,CHH!Keshik:4!Front Line:1,CWIE:0,SE:0,BAN:0</availability>
             </model>
-            <model name='(SRM)'>
-                <availability>CLAN:5</availability>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:4,CWIE:4,SE!Keshik:3!Front Line:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>CLAN.IS!Keshik:1,CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.IS:7,CWIE:7,SE:7,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS:5+,CWIE:5+,SE!Keshik:4,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
             </model>
         </chassis>
         <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-            <availability>CLAN:7,BAN:5</availability>
-            <model name='(Flamer)'>
+            <availability>CLAN.IS:4+,RD!Keshik:6!Front Line:5!Second Line:4!Solahma:2!Provisional Garrison:1,CHH:6+,SE:3+,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN:8</availability>
+                <availability>CLAN.IS:3-,CWIE:4-,SE:5-,BAN:5-</availability>
             </model>
-            <model name='(LRM)'>
+            <model name='(Laser Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN:5</availability>
+                <availability>CLAN.IS:5+,CHH:5+,CWIE:3+,SE:3+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
             </model>
-            <model name='(Laser)'>
-                <roles>urban</roles>
-                <availability>CLAN:6</availability>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+</availability>
             </model>
-            <model name='(MG)'>
+            <model name='(Mauser IIC Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN:7</availability>
+                <availability>CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,CWIE:0,SE:0,BAN:0</availability>
             </model>
-            <model name='(Rifle)'>
-                <roles>urban</roles>
-                <availability>CLAN:8</availability>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>CLAN.IS:4,CHH:4,CWIE:4,SE:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
             </model>
-            <model name='(SRM)'>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>CLAN.IS!Keshik:1,CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
                 <roles>urban</roles>
-                <availability>CLAN:5</availability>
+                <availability>CLAN.IS:7,CWIE:7,SE:7,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS:5+,CHH:5+,CWIE:4+,SE:3+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
             </model>
         </chassis>
         <chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
@@ -4837,24 +5071,35 @@
             </model>
         </chassis>
         <chassis name='Clan Motorized Point' unitType='Infantry'>
-            <availability>CLAN:9,BAN:7</availability>
-            <model name='(Flamer)'>
-                <availability>CLAN:8</availability>
+            <availability>CLAN.IS!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,CWIE!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:5,SE!Keshik:4!Front Line:4!Second Line:4,BAN:8+</availability>
+            <model name='(Bearhunter Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>RD:2+,CHH:3+</availability>
             </model>
-            <model name='(LRM)'>
-                <availability>CLAN:5</availability>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS!Front Line:1!Second Line:2!Solahma:3,RD:3-,CHH:3-,CWIE:3-,SE:3,BAN:4-</availability>
             </model>
-            <model name='(Laser)'>
-                <availability>CLAN:6</availability>
+            <model name='(Laser Advanced)'>
+                <availability>CLAN.IS:3+,CWIE:4+,SE:3+,BAN:4+</availability>
             </model>
-            <model name='(MG)'>
-                <availability>CLAN:7</availability>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>CLAN.IS:3+</availability>
             </model>
-            <model name='(Rifle)'>
-                <availability>CLAN:8</availability>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>CLAN.IS:3,CHH:3,CWIE:4,SE:3,BAN:4+</availability>
             </model>
-            <model name='(SRM)'>
-                <availability>CLAN:5</availability>
+            <model name='(Rifle Advanced)'>
+                <availability>CLAN.IS:5+,RD:5,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,CWIE:7,SE:7,BAN:7+</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>CLAN.IS!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,RD:2-,CHH!Solahma:1!Provisional Garrison:8,CWIE:2-,SE:5,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>CLAN.IS:4+,CHH:4+,CWIE:4+,SE:3+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
             </model>
         </chassis>
         <chassis name='Claymore' unitType='Dropship'>
@@ -7770,7 +8015,7 @@
             </model>
         </chassis>
         <chassis name='Foot Platoon' unitType='Infantry'>
-			<availability>IS:10,Periphery:10,TC:3-,MH:0,CDP:4-,Periphery.Deep:10</availability>
+			<availability>IS:10,Periphery:10,TC:3-,MH:0,CDP:4-,SE!Solahma:10!Provisional Garrison:10,Periphery.Deep:10</availability>
             <model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,Periphery:8,TC:6-,CDP:6-,Periphery.Deep:8</availability>
@@ -11413,7 +11658,7 @@
             </model>
         </chassis>
         <chassis name='Jump Platoon' unitType='Infantry'>
-			<availability>IS:8,Periphery:7,TC:2-,MH:0,CDP:2-,Periphery.Deep:5+</availability>
+			<availability>IS:8,Periphery:7,TC:2-,MH:0,CDP:2-,SE!Second Line:4!Solahma:3!Provisional Garrison:2,Periphery.Deep:5+</availability>
             <model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,Periphery:8,TC:3-,CDP:3-,Periphery.Deep:8</availability>
@@ -14001,7 +14246,7 @@
             </model>
         </chassis>
         <chassis name='Mechanized Hover Platoon' unitType='Infantry'>
-			<availability>IS:5,Periphery:5,TC:1-,MH:0,CDP:1-,Periphery.Deep:4+</availability>
+			<availability>IS:5,Periphery:5,TC:1-,MH:0,CDP:1-,SE!Second Line:2!Solahma:1,Periphery.Deep:4+</availability>
             <model name='(Demolition)'>
                 <roles>recon,engineer</roles>
                 <availability>General:3</availability>
@@ -14094,7 +14339,7 @@
             </model>
         </chassis>
         <chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
-			<availability>IS:7,Periphery:7,TC:3-,MH:0,CDP:4-,Periphery.Deep:6+</availability>
+			<availability>IS:7,Periphery:7,TC:3-,MH:0,CDP:4-,SE!Second Line:4!Solahma:3!Provisional Garrison:2,Periphery.Deep:6+</availability>
             <model name='(Bridging)'>
                 <roles>engineer</roles>
                 <availability>IS:2,Periphery:1,Periphery.Deep:0</availability>
@@ -14193,7 +14438,7 @@
             </model>
         </chassis>
         <chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
-			<availability>IS:7,Periphery:7,TC:2-,MH:0,CDP:3-,Periphery.Deep:8+</availability>
+			<availability>IS:7,Periphery:7,TC:2-,MH:0,CDP:3-,SE!Solahma:5!Provisional Garrison:4,Periphery.Deep:8+</availability>
             <model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,Periphery:8,TC:4-,CDP:4-,Periphery.Deep:8</availability>
@@ -14750,7 +14995,7 @@
             </model>
         </chassis>
         <chassis name='Motorized Platoon' unitType='Infantry'>
-			<availability>IS:9,Periphery:9,TC:3-,MH:0,CDP:4-,Periphery.Deep:8</availability>
+			<availability>IS:9,Periphery:9,TC:3-,MH:0,CDP:4-,SE!Solahma:8!Provisional Garrison:8,Periphery.Deep:8</availability>
             <model name='(Fieldworks)'>
                 <roles>engineer</roles>
                 <availability>IS:4,Periphery:2</availability>

--- a/megamek/data/forcegenerator/3160.xml
+++ b/megamek/data/forcegenerator/3160.xml
@@ -4562,117 +4562,348 @@
 				<availability>General:4,FWL:0</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Foot Point' unitType='Infantry'>
-			<availability>CLAN:10,BAN:10</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:4-</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:1</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:4</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:9-</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:2</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Jump Point' unitType='Infantry'>
-			<availability>CLAN:8,BAN:6</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
-			<availability>CLAN:6,BAN:3</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
-			<availability>CLAN:7,BAN:4</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
-		<chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
-			<availability>CLAN:7,BAN:5</availability>
-			<model name='(Flamer)'>
+        <chassis name='Clan Field Artillery Point' unitType='Infantry'>
+            <availability>SL3!B:1!C:1,CLAN.IS!Second Line:1!Solahma:1,CHH!Keshik:2!Front Line:1!Second Line:3!Solahma:2!Provisional Garrison:1,SE!Second Line:2,BAN:0</availability>
+            <model name='(Tracked Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:2!Front Line:1!Second Line:4!Solahma:1</availability>
+            </model>
+            <model name='(Tracked Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>SL3!B:5!C:5,CLAN.IS!Second Line:5!Solahma:5,CHH!Second Line:5!Solahma:6!Provisional Garrison:4,SE!Second Line:3</availability>
+            </model>
+            <model name='(Tracked Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>SL3!B:6!C:6,CLAN.IS!Second Line:6!Solahma:6,CHH!Second Line:6!Solahma:7!Provisional Garrison:5,SE!Second Line:3</availability>
+            </model>
+            <model name='(Wheeled Arrow IV)'>
+                <roles>mixed_artillery</roles>
+                <availability>CHH!Keshik:1!Front Line:1!Second Line:5!Solahma:2</availability>
+            </model>
+            <model name='(Wheeled Sniper)'>
+                <roles>mixed_artillery</roles>
+                <availability>SL3!B:6!C:6,CLAN.IS!Second Line:6!Solahma:6,CHH!Second Line:6!Solahma:7!Provisional Garrison:7,SE!Second Line:5</availability>
+            </model>
+            <model name='(Wheeled Thumper)'>
+                <roles>mixed_artillery</roles>
+                <availability>SL3!B:7!C:7,CLAN.IS!Second Line:7!Solahma:7,CHH!Second Line:7!Solahma:8!Provisional Garrison:8,SE!Second Line:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Field Gun Point' unitType='Infantry'>
+            <availability>SL3:3+,CLAN.IS:3+,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:1!Provisional Garrison:1,BAN!Keshik:2!Front Line:1</availability>
+            <model name='(Motorized AC2 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>SL3!B:1!C:7,CLAN.IS!Front Line:1!Second Line:7,CHH!Solahma:2!Provisional Garrison:8,BAN!Keshik:6!Front Line:3</availability>
+            </model>
+            <model name='(Motorized AC5 Basic)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>SL3!B:2!C:5,CLAN.IS!Front Line:2!Second Line:5,CHH!Solahma:1!Provisional Garrison:6,BAN!Keshik:8!Front Line:4</availability>
+            </model>
+            <model name='(Motorized AP Gauss Advanced)'>
+                <roles>anti_infantry,field_gun</roles>
+                <availability>SL3!A:2!B:1,CJF!Keshik:2</availability>
+            </model>
+            <model name='(Motorized PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CJF!Second Line:2,SE!Keshik:6,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Motorized PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CJF!Second Line:1,SE!Keshik:8,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Motorized PAC8 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CJF!Second Line:1,SE!Keshik:6,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>RD!Second Line:8,CHH!Front Line:3!Second Line:1,BAN!Keshik:1</availability>
+            </model>
+            <model name='(Tracked AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Front Line:2!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Tracked AC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>CHH!Front Line:1!Second Line:1</availability>
+            </model>
+            <model name='(Tracked AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>SL3!A:5!B:3,CLAN.IS!Front Line:5!Second Line:3,RD!Second Line:6,CHH!Front Line:4!Second Line:2!Solahma:1,BAN:3+</availability>
+            </model>
+            <model name='(Tracked CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun</roles>
+                <availability>SL3!A:6,CLAN.IS!Keshik:6!Front Line:3,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>SL3!A:2,RD!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CLBX20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>RD!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>SL3!A:5!B:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,RD!Keshik:3,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC10 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>SL3!A:5,CLAN.IS!Keshik:5!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>SL3!A:2,CLAN.IS!Keshik:4!Front Line:2!Second Line:1,RD!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Tracked CUAC20 Advanced)'>
+                <roles>field_gun</roles>
+                <availability>RD!Keshik:2!Front Line:1,CHH!Keshik:1</availability>
+            </model>
+            <model name='(Tracked CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>SL3!A:6,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,RD!Keshik:3,BAN:0</availability>
+            </model>
+            <model name='(Tracked PAC2 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>SL3!C:1,CLAN.IS!Second Line:1,RD:0,SE!Keshik:1</availability>
+            </model>
+            <model name='(Tracked PAC4 Advanced)'>
+                <roles>anti_aircraft,field gun,fire_support</roles>
+                <availability>SL3!C:1,CLAN.IS!Second Line:1,RD:0,SE!Keshik:1</availability>
+            </model>
+            <model name='(Tracked PAC8 Advanced)'>
+                <roles>field gun</roles>
+                <availability>SL3!C:1,CLAN.IS!Second Line:1,SE!Keshik:1</availability>
+            </model>
+            <model name='(Wheeled AC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>RD!Second Line:8,CHH!Second Line:4!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>CHH!Second Line:1!Solahma:1,BAN:2+</availability>
+            </model>
+            <model name='(Wheeled AC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>RD!Second Line:2,CHH!Second Line:2</availability>
+            </model>
+            <model name='(Wheeled AC5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>SL3!B:5!C:1,CLAN.IS!Second Line:5,CHH!Second Line:6!Solahma:4,CW!Second Line:1,BAN:3+</availability>
+            </model>
+            <model name='(Wheeled CLBX10 Advanced)'>
+                <roles>anti_aircraft,field_gun,urban</roles>
+                <availability>SL3!A:6,CLAN.IS!Keshik:6!Front Line:3,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>SL3!A:3,CLAN.IS!Keshik:3!Front Line:1,RD!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CLBX20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>RD!Keshik:2!Front Line:1,CHH!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled CLBX5 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support</roles>
+                <availability>SL3!A:5!B:1,CLAN.IS!Keshik:5!Front Line:3!Second Line:1,RD!Keshik:3,CHH!Keshik:5!Front Line:3,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC10 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>SL3!Keshik:5!Front Line:2,CLAN.IS!Keshik:5!Front Line:2,CHH!Keshik:5!Front Line:2!Second Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC2 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>SL3!A:3,CLAN.IS!Keshik:3!Front Line:1,RD!Keshik:1,CHH!Keshik:2!Front Line:1,BAN:0</availability>
+            </model>
+            <model name='(Wheeled CUAC20 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>RD!Keshik:2!Front Line:1,CHH!Keshik:2!Front Line:1</availability>
+            </model>
+            <model name='(Wheeled CUAC5 Advanced)'>
+                <roles>field_gun,fire_support</roles>
+                <availability>SL3!A:6!B:1,CLAN.IS!Keshik:6!Front Line:3!Second Line:1,CHH!Keshik:6!Front Line:3,BAN:0</availability>
+            </model>
+            <model name='(Wheeled PAC2 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>SL3!C:1,CLAN.IS!Second Line:1,CJF!Second Line:4,RD:0,SE!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled PAC4 Advanced)'>
+                <roles>anti_aircraft,field_gun,fire_support,urban</roles>
+                <availability>SL3!C:1,CLAN.IS!Second Line:1,CJF!Second Line:3,RD:0,SE!Keshik:2</availability>
+            </model>
+            <model name='(Wheeled PAC8 Advanced)'>
+                <roles>field_gun,urban</roles>
+                <availability>SL3!C:1,CLAN.IS!Second Line:1,CJF!Second Line:3,SE!Keshik:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Foot Point' unitType='Infantry'>
+            <availability>SL3:7,CLAN.IS:7,CHH!Keshik:6!Front Line:6!Second Line:7!Solahma:7!Provisional Garrison:8,SE!Keshik:7!Front Line:7!Second Line:7,BAN:7</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
+                <availability>SL3:2-,CLAN.IS:3-,SE:7-,BAN:3</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>SL3!A:5!B:4!C:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:6!Front Line:5!Second Line:4,SE:3+,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>SL3:3+,CLAN.IS:3+,CJF:4+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>SL3!A:4!B:4!C:1,CLAN.IS:4,SE:4,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3!Provisional Garrison:1</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>SL3!A:1,CLAN.IS!Keshik:1,CHH!Keshik:1!Front Line:1</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>SL3!A:7!B:7!C:5,CLAN.IS!Keshik:7!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:5,CHH:7,SE!Keshik:7!Front Line:5!Second Line:2,BAN!Keshik:5!Front Line:5!Second Line:3!Solahma:3!Provisional Garrison:2</availability>
+            </model>
+            <model name='(Rifle Light)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
+                <availability>SL3!C:4,CLAN.IS:2-,SE!Keshik:3!Front Line:5!Second Line:7,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>SL3!A:5!B:3!C:1,CLAN.IS!Keshik:5!Front Line:4!Second Line:3!Solahma:1,CHH!Keshik:5!Front Line:4!Second Line:2!Solahma:1,SE:2,BAN:4+</availability>
+            </model>
+            <model name='(Watch Detachment Advanced)'>
+                <availability>SL3!C:1,CLAN.IS:2-,CHH!Provisional Garrison:1,CJF:3-</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Jump Point' unitType='Infantry'>
+            <availability>SL3!A:7!B:4!C:1,CLAN.IS!Keshik:7!Front Line:4!Second Line:1,RD!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:7!Front Line:7!Second Line:5!Solahma:1,SE!Keshik:2!Front Line:1,BAN:4+</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>SE!Keshik:2</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
+                <availability>SL3:0,CLAN.IS:3-,SE:0,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>SL3!A:6!B:5!C:1,CLAN.IS:6+,SE!Keshik:4!Front Line:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>SL3:2+,CLAN.IS:2+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>SL3!A:1,CLAN.IS!Keshik:1,RD:2+,CHH!Keshik:4!Front Line:2,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>SL3!A:4!B:4!C:1,CLAN.IS:4,SE:3,BAN!Keshik:4!Front Line:4!Second Line:4!Solahma:3</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>SL3:6,CLAN.IS:6,SE:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>SL3!A:5!B:4!C:1,CLAN.IS:5+,SE!Keshik:4!Front Line:3,BAN:3+</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Hover Point' unitType='Infantry'>
+            <availability>SL3!A:4!B:2!C:1,CLAN.IS!Keshik:4!Front Line:2!Second Line:1,CHH!Keshik:5!Front Line:4!Second Line:1,SE:2+,BAN:3+</availability>
+            <model name='(ER Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>SE!Keshik:1,BAN:0</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
+                <availability>SL3!C:1,CLAN.IS!Second Line:1,SE!Front Line:1,BAN!Second Line:1</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>recon</roles>
+                <availability>SL3!A:6!B:5!C:1,CLAN.IS:6+,RD:5+,CHH:6+,SE!Keshik:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>SL3:3+,CLAN.IS:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>recon</roles>
+                <availability>SL3!A:1,CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,SE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>SL3!A:4!B:4!C:1,CLAN.IS:4,SE:3,BAN:3+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>recon</roles>
+                <availability>SL3:7,CLAN.IS:7,SE:6,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>SL3!A:5!B:4!C:1,CLAN.IS:5+,CHH:5+,SE!Keshik:4,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Tracked Point' unitType='Infantry'>
+            <availability>SL3:3+,CLAN.IS:3+,RD:5+,CHH!Keshik:5!Front Line:5!Second Line:3!Solahma:1,SE:2+,BAN!Keshik:2!Front Line:2!Second Line:1</availability>
+            <model name='(ER Laser Advanced)'>
+                <availability>SE!Keshik:1</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
+                <availability>SL3:3-,CLAN.IS:3-,SE:0,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>SL3!A:6!B:4!C:1,CLAN.IS:6+,CHH!Keshik:6!Front Line:5!Second Line:4!Solahma:1,SE!Keshik:4,BAN:6+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>SL3:4+,CLAN.IS:4+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <availability>SL3!A:2,CLAN.IS:2+,CHH!Keshik:4!Front Line:1,SE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>SL3!A:4!B:4!C:1,CLAN.IS:4,SE!Keshik:3!Front Line:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft</roles>
+                <availability>SL3!A:1,CLAN.IS!Keshik:1,CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>SL3:7,CLAN.IS:7,SE:7,BAN:6</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>SL3!A:5!B:4!C:1,CLAN.IS:5+,SE!Keshik:4,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Clan Mechanized Wheeled Point' unitType='Infantry'>
+            <availability>SL3:4+,CLAN.IS:4+,RD!Keshik:6!Front Line:5!Second Line:4!Solahma:2!Provisional Garrison:1,CHH:6+,SE:3+,BAN!Keshik:3!Front Line:3!Second Line:2</availability>
+            <model name='(Flamer Advanced)'>
                 <roles>urban</roles>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+                <availability>SL3:3-,CLAN.IS:3-,SE:5-,BAN:5-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <roles>urban</roles>
+                <availability>SL3!A:5!B:3!C:1,CLAN.IS:5+,CHH:5+,SE:3+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>SL3:3+,CLAN.IS:3+</availability>
+            </model>
+            <model name='(Mauser IIC Advanced)'>
+                <roles>urban</roles>
+                <availability>SL3!A:1,CLAN.IS!Keshik:1,CHH!Keshik:4!Front Line:1,SE:0,BAN:0</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>SL3!A:4!B:4!C:1,CLAN.IS:4,CHH:4,SE:3,BAN!Keshik:4!Front Line:3!Second Line:2</availability>
+            </model>
+            <model name='(Rifle AA Advanced)'>
+                <roles>anti_aircraft,urban</roles>
+                <availability>SL3!A:1,CLAN.IS!Keshik:1,CHH:2+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <roles>urban</roles>
+                <availability>SL3:7,CLAN.IS:7,SE:7,BAN:7</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <roles>urban</roles>
+                <availability>SL3!A:5!B:3!C:1,CLAN.IS:5+,CHH:5+,SE:3+,BAN!Keshik:5!Front Line:4!Second Line:3</availability>
+            </model>
+        </chassis>
 		<chassis name='Clan Medium Battle Armor' unitType='BattleArmor'>
 			<availability>CWE:4-,RD:6-,CDS:5,CLAN.IS:5-,CP:6,FS:3+,LA:3,DC:2,FWL:3+</availability>
 			<model name='(Laser) &apos;Volk&apos; (Sqd5)' mechanized='true'>
@@ -4692,27 +4923,38 @@
 				<availability>CLAN.IS:8</availability>
 			</model>
 		</chassis>
-		<chassis name='Clan Motorized Point' unitType='Infantry'>
-			<availability>CLAN:9,BAN:7</availability>
-			<model name='(Flamer)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(LRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-			<model name='(Laser)'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='(MG)'>
-				<availability>CLAN:7</availability>
-			</model>
-			<model name='(Rifle)'>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='(SRM)'>
-				<availability>CLAN:5</availability>
-			</model>
-		</chassis>
+        <chassis name='Clan Motorized Point' unitType='Infantry'>
+            <availability>SL3!A:3!B:4!C:5,CLAN.IS!Keshik:4!Front Line:4!Second Line:4!Solahma:5!Provisional Garrison:6,SE!Keshik:4!Front Line:4!Second Line:4,BAN:8+</availability>
+            <model name='(Bearhunter Advanced)'>
+                <roles>anti_infantry,urban</roles>
+                <availability>RD:2+,CHH:3+</availability>
+            </model>
+            <model name='(Flamer Advanced)'>
+                <roles>urban</roles>
+                <availability>SL3:3-,CLAN.IS!Front Line:1!Second Line:2!Solahma:3,RD:3-,CHH:3-,SE:3,BAN:4-</availability>
+            </model>
+            <model name='(Laser Advanced)'>
+                <availability>SL3!A:3!B:1,CLAN.IS:3+,SE:3+,BAN:4+</availability>
+            </model>
+            <model name='(LRM Advanced)'>
+                <roles>fire_support</roles>
+                <availability>SL3!A:3!B:1,CLAN.IS:3+</availability>
+            </model>
+            <model name='(MG Advanced)'>
+                <roles>anti_infantry</roles>
+                <availability>SL3!A:3!B:2!C:1,CLAN.IS:3,CHH:3,SE:3,BAN:4+</availability>
+            </model>
+            <model name='(Rifle Advanced)'>
+                <availability>SL3!A:5!B:4!C:3,CLAN.IS:5+,RD:5,CHH!Keshik:8!Front Line:8!Second Line:8!Solahma:6!Provisional Garrison:1,SE:7,BAN:7+</availability>
+            </model>
+            <model name='(Rifle Light)'>
+                <roles>urban</roles>
+                <availability>SL3!B:2!C:7,CLAN.IS!Keshik:2!Front Line:2!Second Line:3!Solahma:4!Provisional Garrison:8,RD:2-,CHH!Solahma:1!Provisional Garrison:8,SE:5,BAN:8-</availability>
+            </model>
+            <model name='(SRM Advanced)'>
+                <availability>SL3!A:4!B:2,CLAN.IS:4+,CHH:4+,SE:3+,BAN!Keshik:4!Front Line:3!Second Line:2!Solahma:1</availability>
+            </model>
+        </chassis>
 		<chassis name='Claymore' unitType='Dropship'>
 			<availability>LA:4,FS:4,MERC:3+,CJF:3</availability>
 			<model name='(3054)'>
@@ -7077,7 +7319,7 @@
 			</model>
 		</chassis>
 		<chassis name='Field Artillery' unitType='Infantry'>
-			<availability>IS:3,Periphery:3,MH:0</availability>
+			<availability>SL3:0,IS:3,Periphery:3,MH:0</availability>
 			<model name='(Arrow IV)'>
 				<roles>missile_artillery</roles>
 				<availability>CC:5,MOC:3,RA.OA:2,PIR:2,IS:4</availability>
@@ -7218,7 +7460,7 @@
             </model>
         </chassis>
 		<chassis name='Field Gunners' unitType='Infantry'>
-			<availability>IS:4,Periphery:2,MH:0</availability>
+			<availability>SL3:0,IS:4,Periphery:2,MH:0</availability>
 			<model name='(AC10)'>
 				<roles>field_gun</roles>
 				<availability>General:8-</availability>
@@ -7576,7 +7818,7 @@
             </model>
         </chassis>
 		<chassis name='Foot Platoon' unitType='Infantry'>
-			<availability>IS:10,Periphery:10,TC:3-,MH:0,CDP:4-,Periphery.Deep:10</availability>
+			<availability>SL3!C:1,IS:10,Periphery:10,TC:3-,MH:0,CDP:4-,SE!Solahma:10!Provisional Garrison:10,Periphery.Deep:10</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,Periphery:8,TC:6-,CDP:6-,Periphery.Deep:8</availability>
@@ -7667,14 +7909,14 @@
             </model>
         </chassis>
 		<chassis name='Foot Stealth Platoon' unitType='Infantry'>
-			<availability>IS:2+,Periphery:1+,MH:0</availability>
+			<availability>SL3!A:1,IS:2+,Periphery:1+,MH:0</availability>
 			<model name='(Rifle Paratrooper)'>
 				<roles>recon,specops,paratrooper</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Foot Stealth Squad' unitType='Infantry'>
-			<availability>IS:2+,Periphery:1+,MH:0</availability>
+			<availability>SL3!A:1,IS:2+,Periphery:1+,MH:0</availability>
 			<model name='(Sniper Paratrooper)'>
 				<roles>recon,specops,paratrooper</roles>
 				<availability>General:8</availability>
@@ -11173,7 +11415,7 @@
             </model>
         </chassis>
 		<chassis name='Jump Platoon' unitType='Infantry'>
-			<availability>IS:8,Periphery:7,TC:2-,MH:0,CDP:2-,Periphery.Deep:5+</availability>
+			<availability>SL3:0,IS:8,Periphery:7,TC:2-,MH:0,CDP:2-,SE!Second Line:4!Solahma:3!Provisional Garrison:2,Periphery.Deep:5+</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,Periphery:8,TC:3-,CDP:3-,Periphery.Deep:8</availability>
@@ -11231,7 +11473,7 @@
             </model>
         </chassis>
 		<chassis name='Jump Stealth Platoon' unitType='Infantry'>
-			<availability>IS:2</availability>
+			<availability>SL3!A:1,IS:2</availability>
 			<model name='(Laser)'>
 				<roles>specops</roles>
 				<availability>IS:5,DC:7</availability>
@@ -13686,7 +13928,7 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Hover Platoon' unitType='Infantry'>
-			<availability>IS:5,Periphery:5,TC:1-,MH:0,CDP:1-,Periphery.Deep:4+</availability>
+			<availability>SL3:0,IS:5,Periphery:5,TC:1-,MH:0,CDP:1-,SE!Second Line:2!Solahma:1,Periphery.Deep:4+</availability>
 			<model name='(Demolition)'>
 				<roles>recon,engineer</roles>
 				<availability>General:3</availability>
@@ -13779,7 +14021,7 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Tracked Platoon' unitType='Infantry'>
-			<availability>IS:7,Periphery:7,TC:3-,MH:0,CDP:4-,Periphery.Deep:6+</availability>
+			<availability>SL3!C:1,IS:7,Periphery:7,TC:3-,MH:0,CDP:4-,SE!Second Line:4!Solahma:3!Provisional Garrison:2,Periphery.Deep:6+</availability>
             <model name='(Bridging)'>
                 <roles>engineer</roles>
                 <availability>IS:2,Periphery:1,Periphery.Deep:0</availability>
@@ -13878,7 +14120,7 @@
             </model>
         </chassis>
 		<chassis name='Mechanized Wheeled Platoon' unitType='Infantry'>
-			<availability>IS:7,Periphery:7,TC:2-,MH:0,CDP:3-,Periphery.Deep:8+</availability>
+			<availability>SL3!C:1,IS:7,Periphery:7,TC:2-,MH:0,CDP:3-,SE!Solahma:5!Provisional Garrison:4,Periphery.Deep:8+</availability>
 			<model name='(Flamer)'>
                 <roles>urban</roles>
 				<availability>IS:8,Periphery:8,TC:4-,CDP:4-,Periphery.Deep:8</availability>
@@ -14423,7 +14665,7 @@
             </model>
         </chassis>
 		<chassis name='Motorized Platoon' unitType='Infantry'>
-			<availability>IS:9,Periphery:9,TC:3-,MH:0,CDP:4-,Periphery.Deep:8</availability>
+			<availability>SL3!C:1,IS:9,Periphery:9,TC:3-,MH:0,CDP:4-,SE!Solahma:8!Provisional Garrison:8,Periphery.Deep:8</availability>
 			<model name='(Fieldworks)'>
 				<roles>engineer</roles>
 				<availability>IS:4,Periphery:2</availability>

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Tracked Arrow IV).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Tracked Arrow IV).blk
@@ -1,0 +1,66 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Artillery Point
+</Name>
+
+<Model>
+(Tracked Arrow IV)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 3
+</type>
+
+<role>
+Missile Boat
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+ISArrowIV
+ISArrowIVAmmo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+1
+</secondn>
+
+<Primary>
+Submachine Gun
+</Primary>
+
+<Secondary>
+InfantryAssaultRifle
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Tracked Sniper).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Tracked Sniper).blk
@@ -1,0 +1,66 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Artillery Point
+</Name>
+
+<Model>
+(Tracked Sniper)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 3
+</type>
+
+<role>
+Missile Boat
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+ISSniper
+ISSniperAmmo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+1
+</secondn>
+
+<Primary>
+Submachine Gun
+</Primary>
+
+<Secondary>
+InfantryAssaultRifle
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Tracked Thumper).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Tracked Thumper).blk
@@ -1,0 +1,66 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Artillery Point
+</Name>
+
+<Model>
+(Tracked Thumper)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 3
+</type>
+
+<role>
+Missile Boat
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+ISThumper
+ISThumperAmmo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+1
+</secondn>
+
+<Primary>
+Submachine Gun
+</Primary>
+
+<Secondary>
+InfantryAssaultRifle
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Wheeled Arrow IV).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Wheeled Arrow IV).blk
@@ -1,0 +1,66 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Artillery Point
+</Name>
+
+<Model>
+(Wheeled Arrow IV)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 3
+</type>
+
+<role>
+Missile Boat
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+ISArrowIV
+ISArrowIVAmmo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+1
+</secondn>
+
+<Primary>
+Submachine Gun
+</Primary>
+
+<Secondary>
+InfantryAssaultRifle
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Wheeled Sniper).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Wheeled Sniper).blk
@@ -1,0 +1,66 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Artillery Point
+</Name>
+
+<Model>
+(Wheeled Sniper)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 3
+</type>
+
+<role>
+Missile Boat
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+ISSniper
+ISSniperAmmo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+1
+</secondn>
+
+<Primary>
+Submachine Gun
+</Primary>
+
+<Secondary>
+InfantryAssaultRifle
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Wheeled Thumper).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Artillery Point (Wheeled Thumper).blk
@@ -1,0 +1,66 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Artillery Point
+</Name>
+
+<Model>
+(Wheeled Thumper)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 3
+</type>
+
+<role>
+Missile Boat
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+ISThumper
+ISThumperAmmo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+1
+</secondn>
+
+<Primary>
+Submachine Gun
+</Primary>
+
+<Secondary>
+InfantryAssaultRifle
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized AC2 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized AC2 Basic).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Motorized AC2 Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+Autocannon/2
+IS Ammo AC/2
+Autocannon/2
+IS Ammo AC/2
+Autocannon/2
+IS Ammo AC/2
+Autocannon/2
+IS Ammo AC/2
+</Field Guns Equipment>
+
+<history>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</history>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized AC5 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized AC5 Basic).blk
@@ -1,0 +1,62 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Motorized AC5 Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+Autocannon/5
+IS Ammo AC/5
+Autocannon/5
+IS Ammo AC/5
+Autocannon/5
+IS Ammo AC/5
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized AP Gauss Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized AP Gauss Advanced).blk
@@ -1,0 +1,76 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Motorized AP Gauss Advanced)
+</Model>
+
+<year>
+3065
+</year>
+
+<originalBuildYear>
+3065
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLAPGaussRifle
+CLAPGaussRifle Ammo
+CLAPGaussRifle
+CLAPGaussRifle Ammo
+CLAPGaussRifle
+CLAPGaussRifle Ammo
+CLAPGaussRifle
+CLAPGaussRifle Ammo
+CLAPGaussRifle
+CLAPGaussRifle Ammo
+CLAPGaussRifle
+CLAPGaussRifle Ammo
+CLAPGaussRifle
+CLAPGaussRifle Ammo
+CLAPGaussRifle
+CLAPGaussRifle Ammo
+CLAPGaussRifle
+CLAPGaussRifle Ammo
+CLAPGaussRifle
+CLAPGaussRifle Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized PAC2 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized PAC2 Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-13
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Motorized PAC2 Advanced)
+</Model>
+
+<year>
+3070
+</year>
+
+<originalBuildYear>
+3070
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLProtoMechAC2
+Clan ProtoMech AC/2 Ammo
+CLProtoMechAC2
+Clan ProtoMech AC/2 Ammo
+CLProtoMechAC2
+Clan ProtoMech AC/2 Ammo
+CLProtoMechAC2
+Clan ProtoMech AC/2 Ammo
+CLProtoMechAC2
+Clan ProtoMech AC/2 Ammo
+CLProtoMechAC2
+Clan ProtoMech AC/2 Ammo
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized PAC4 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized PAC4 Advanced).blk
@@ -1,0 +1,62 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-13
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Motorized PAC4 Advanced)
+</Model>
+
+<year>
+3070
+</year>
+
+<originalBuildYear>
+3070
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLProtoMechAC4
+Clan ProtoMech AC/4 Ammo
+CLProtoMechAC4
+Clan ProtoMech AC/4 Ammo
+CLProtoMechAC4
+Clan ProtoMech AC/4 Ammo
+CLProtoMechAC4
+Clan ProtoMech AC/4 Ammo
+CLProtoMechAC4
+Clan ProtoMech AC/4 Ammo
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized PAC8 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Motorized PAC8 Advanced).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-13
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Motorized PAC8 Advanced)
+</Model>
+
+<year>
+3070
+</year>
+
+<originalBuildYear>
+3070
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLProtoMechAC8
+Clan ProtoMech AC/8 Ammo
+CLProtoMechAC8
+Clan ProtoMech AC/8 Ammo
+CLProtoMechAC8
+Clan ProtoMech AC/8 Ammo
+CLProtoMechAC8
+Clan ProtoMech AC/8 Ammo
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC10 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC10 Advanced).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked AC10 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+Autocannon/10
+IS Ammo AC/10
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC10 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC10 Basic).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked AC10 Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+Autocannon/10
+IS Ammo AC/10
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC2 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC2 Advanced).blk
@@ -1,0 +1,62 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked AC2 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+Autocannon/2
+IS Ammo AC/2
+Autocannon/2
+IS Ammo AC/2
+Autocannon/2
+IS Ammo AC/2
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC2 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC2 Basic).blk
@@ -1,0 +1,62 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked AC2 Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+Autocannon/2
+IS Ammo AC/2
+Autocannon/2
+IS Ammo AC/2
+Autocannon/2
+IS Ammo AC/2
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC20 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC20 Advanced).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked AC20 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+Autocannon/20
+IS Ammo AC/20
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC20 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC20 Basic).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked AC20 Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+Autocannon/20
+IS Ammo AC/20
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC5 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC5 Advanced).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked AC5 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+Autocannon/5
+IS Ammo AC/5
+Autocannon/5
+IS Ammo AC/5
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC5 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked AC5 Basic).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked AC5 Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+Autocannon/5
+IS Ammo AC/5
+Autocannon/5
+IS Ammo AC/5
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX10 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX10 Advanced).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked CLBX10 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLLBXAC10
+IS LB 10-X Cluster Ammo
+CLLBXAC10
+IS LB 10-X Cluster Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX10 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX10 Basic).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked CLBX10 Basic)
+</Model>
+
+<year>
+2821
+</year>
+
+<originalBuildYear>
+2821
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLLBXAC10
+IS LB 10-X Cluster Ammo
+CLLBXAC10
+IS LB 10-X Cluster Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date is based on when the weapon becomes an Advanced weapon. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX2 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX2 Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked CLBX2 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLLBXAC2
+IS LB 2-X Cluster Ammo
+CLLBXAC2
+IS LB 2-X Cluster Ammo
+CLLBXAC2
+IS LB 2-X Cluster Ammo
+CLLBXAC2
+IS LB 2-X Cluster Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX2 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX2 Basic).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked CLBX2 Basic)
+</Model>
+
+<year>
+2821
+</year>
+
+<originalBuildYear>
+2821
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLLBXAC2
+IS LB 2-X Cluster Ammo
+CLLBXAC2
+IS LB 2-X Cluster Ammo
+CLLBXAC2
+IS LB 2-X Cluster Ammo
+CLLBXAC2
+IS LB 2-X Cluster Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date is based on when the weapon becomes an Advanced weapon. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX20 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX20 Advanced).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked CLBX20 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLLBXAC20
+IS LB 20-X Cluster Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX20 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX20 Basic).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked CLBX20 Basic)
+</Model>
+
+<year>
+2821
+</year>
+
+<originalBuildYear>
+2821
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLLBXAC20
+IS LB 20-X Cluster Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date is based on when the weapon becomes an Advanced weapon. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX5 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX5 Advanced).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked CLBX5 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLLBXAC5
+IS LB 5-X Cluster Ammo
+CLLBXAC5
+IS LB 5-X Cluster Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX5 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CLBX5 Basic).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked CLBX5 Basic)
+</Model>
+
+<year>
+2821
+</year>
+
+<originalBuildYear>
+2821
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLLBXAC5
+IS LB 5-X Cluster Ammo
+CLLBXAC5
+IS LB 5-X Cluster Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date is based on when the weapon becomes an Advanced weapon. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC10 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC10 Advanced).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked CUAC10 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLUltraAC10
+IS Ultra AC/10 Ammo
+CLUltraAC10
+IS Ultra AC/10 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC10 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC10 Basic).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked CUAC10 Basic)
+</Model>
+
+<year>
+2822
+</year>
+
+<originalBuildYear>
+2822
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLUltraAC10
+IS Ultra AC/10 Ammo
+CLUltraAC10
+IS Ultra AC/10 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date is based on when the weapon becomes an Advanced weapon. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC2 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC2 Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked CUAC2 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLUltraAC2
+IS Ultra AC/2 Ammo
+CLUltraAC2
+IS Ultra AC/2 Ammo
+CLUltraAC2
+IS Ultra AC/2 Ammo
+CLUltraAC2
+IS Ultra AC/2 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC2 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC2 Basic).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked CUAC2 Basic)
+</Model>
+
+<year>
+2822
+</year>
+
+<originalBuildYear>
+2822
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLUltraAC2
+IS Ultra AC/2 Ammo
+CLUltraAC2
+IS Ultra AC/2 Ammo
+CLUltraAC2
+IS Ultra AC/2 Ammo
+CLUltraAC2
+IS Ultra AC/2 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date is based on when the weapon becomes an Advanced weapon. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC20 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC20 Advanced).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked CUAC20 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLUltraAC20
+IS Ultra AC/20 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC20 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC20 Basic).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked CUAC20 Basic)
+</Model>
+
+<year>
+2822
+</year>
+
+<originalBuildYear>
+2822
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLUltraAC20
+IS Ultra AC/20 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date is based on when the weapon becomes an Advanced weapon. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC5 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC5 Advanced).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked CUAC5 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLUltraAC5
+IS Ultra AC/5 Ammo
+CLUltraAC5
+IS Ultra AC/5 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC5 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked CUAC5 Basic).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked CUAC5 Basic)
+</Model>
+
+<year>
+2822
+</year>
+
+<originalBuildYear>
+2822
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLUltraAC5
+IS Ultra AC/5 Ammo
+CLUltraAC5
+IS Ultra AC/5 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date is based on when the weapon becomes an Advanced weapon. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked LBX10 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked LBX10 Basic).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked LBX10 Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+ISLBXAC10
+IS LB 10-X Cluster Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked PAC2 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked PAC2 Advanced).blk
@@ -1,0 +1,66 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked PAC2 Advanced)
+</Model>
+
+<year>
+3070
+</year>
+
+<originalBuildYear>
+3070
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLProtoMechAC2
+Clan ProtoMech AC/2 Ammo
+CLProtoMechAC2
+Clan ProtoMech AC/2 Ammo
+CLProtoMechAC2
+Clan ProtoMech AC/2 Ammo
+CLProtoMechAC2
+Clan ProtoMech AC/2 Ammo
+CLProtoMechAC2
+Clan ProtoMech AC/2 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked PAC4 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked PAC4 Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked PAC4 Advanced)
+</Model>
+
+<year>
+3070
+</year>
+
+<originalBuildYear>
+3070
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLProtoMechAC4
+Clan ProtoMech AC/4 Ammo
+CLProtoMechAC4
+Clan ProtoMech AC/4 Ammo
+CLProtoMechAC4
+Clan ProtoMech AC/4 Ammo
+CLProtoMechAC4
+Clan ProtoMech AC/4 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked PAC8 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked PAC8 Advanced).blk
@@ -1,0 +1,62 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked PAC8 Advanced)
+</Model>
+
+<year>
+3070
+</year>
+
+<originalBuildYear>
+3070
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLProtoMechAC8
+Clan ProtoMech AC/8 Ammo
+CLProtoMechAC8
+Clan ProtoMech AC/8 Ammo
+CLProtoMechAC8
+Clan ProtoMech AC/8 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked UAC5 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Tracked UAC5 Basic).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Tracked UAC5 Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+ISUltraAC5
+IS Ultra AC/5 Ammo
+ISUltraAC5
+IS Ultra AC/5 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC10 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC10 Advanced).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled AC10 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+Autocannon/10
+IS Ammo AC/10
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC10 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC10 Basic).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled AC10 Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+Autocannon/10
+IS Ammo AC/10
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC2 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC2 Advanced).blk
@@ -1,0 +1,62 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled AC2 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+Autocannon/2
+IS Ammo AC/2
+Autocannon/2
+IS Ammo AC/2
+Autocannon/2
+IS Ammo AC/2
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC2 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC2 Basic).blk
@@ -1,0 +1,62 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled AC2 Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+Autocannon/2
+IS Ammo AC/2
+Autocannon/2
+IS Ammo AC/2
+Autocannon/2
+IS Ammo AC/2
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC20 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC20 Advanced).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled AC20 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+Autocannon/20
+IS Ammo AC/20
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC20 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC20 Basic).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled AC20 Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+Autocannon/20
+IS Ammo AC/20
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC5 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC5 Advanced).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled AC5 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+Autocannon/5
+IS Ammo AC/5
+Autocannon/5
+IS Ammo AC/5
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC5 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled AC5 Basic).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled AC5 Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+Autocannon/5
+IS Ammo AC/5
+Autocannon/5
+IS Ammo AC/5
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX10 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX10 Advanced).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled CLBX10 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLLBXAC10
+CLLBXAC10
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX10 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX10 Basic).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled CLBX10 Basic)
+</Model>
+
+<year>
+2821
+</year>
+
+<originalBuildYear>
+2821
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLLBXAC10
+IS LB 10-X Cluster Ammo
+CLLBXAC10
+IS LB 10-X Cluster Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date is based on when the weapon becomes an Advanced weapon. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX2 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX2 Advanced).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled CLBX2 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLLBXAC2
+CLLBXAC2
+CLLBXAC2
+CLLBXAC2
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX2 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX2 Basic).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled CLBX2 Basic)
+</Model>
+
+<year>
+2821
+</year>
+
+<originalBuildYear>
+2821
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLLBXAC2
+IS LB 2-X Cluster Ammo
+CLLBXAC2
+IS LB 2-X Cluster Ammo
+CLLBXAC2
+IS LB 2-X Cluster Ammo
+CLLBXAC2
+IS LB 2-X Cluster Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date is based on when the weapon becomes an Advanced weapon. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX20 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX20 Advanced).blk
@@ -1,0 +1,57 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled CLBX20 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLLBXAC20
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX20 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX20 Basic).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled CLBX20 Basic)
+</Model>
+
+<year>
+2821
+</year>
+
+<originalBuildYear>
+2821
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLLBXAC20
+IS LB 20-X Cluster Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date is based on when the weapon becomes an Advanced weapon. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX5 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX5 Advanced).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled CLBX5 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLLBXAC5
+CLLBXAC5
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX5 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CLBX5 Basic).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled CLBX5 Basic)
+</Model>
+
+<year>
+2821
+</year>
+
+<originalBuildYear>
+2821
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLLBXAC5
+IS LB 5-X Cluster Ammo
+CLLBXAC5
+IS LB 5-X Cluster Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date is based on when the weapon becomes an Advanced weapon. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC10 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC10 Advanced).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled CUAC10 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLUltraAC10
+CLUltraAC10
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC10 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC10 Basic).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled CUAC10 Basic)
+</Model>
+
+<year>
+2822
+</year>
+
+<originalBuildYear>
+2822
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLUltraAC10
+IS Ultra AC/10 Ammo
+CLUltraAC10
+IS Ultra AC/10 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date is based on when the weapon becomes an Advanced weapon. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC2 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC2 Advanced).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled CUAC2 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLUltraAC2
+CLUltraAC2
+CLUltraAC2
+CLUltraAC2
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC2 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC2 Basic).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled CUAC2 Basic)
+</Model>
+
+<year>
+2822
+</year>
+
+<originalBuildYear>
+2822
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLUltraAC2
+IS Ultra AC/2 Ammo
+CLUltraAC2
+IS Ultra AC/2 Ammo
+CLUltraAC2
+IS Ultra AC/2 Ammo
+CLUltraAC2
+IS Ultra AC/2 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date is based on when the weapon becomes an Advanced weapon. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC20 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC20 Advanced).blk
@@ -1,0 +1,57 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled CUAC20 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLUltraAC20
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC20 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC20 Basic).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled CUAC20 Basic)
+</Model>
+
+<year>
+2822
+</year>
+
+<originalBuildYear>
+2822
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLUltraAC20
+IS Ultra AC/20 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date is based on when the weapon becomes an Advanced weapon. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC5 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC5 Advanced).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled CUAC5 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLUltraAC5
+IS Ultra AC/5 Ammo
+CLUltraAC5
+IS Ultra AC/5 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC5 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled CUAC5 Basic).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled CUAC5 Basic)
+</Model>
+
+<year>
+2822
+</year>
+
+<originalBuildYear>
+2822
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLUltraAC5
+IS Ultra AC/5 Ammo
+CLUltraAC5
+IS Ultra AC/5 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date is based on when the weapon becomes an Advanced weapon. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled LBX10 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled LBX10 Basic).blk
@@ -1,0 +1,58 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled LBX10 Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+ISLBXAC10
+IS LB 10-X Cluster Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled PAC2 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled PAC2 Advanced).blk
@@ -1,0 +1,66 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled PAC2 Advanced)
+</Model>
+
+<year>
+3070
+</year>
+
+<originalBuildYear>
+3070
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLProtoMechAC2
+Clan ProtoMech AC/2 Ammo
+CLProtoMechAC2
+Clan ProtoMech AC/2 Ammo
+CLProtoMechAC2
+Clan ProtoMech AC/2 Ammo
+CLProtoMechAC2
+Clan ProtoMech AC/2 Ammo
+CLProtoMechAC2
+Clan ProtoMech AC/2 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled PAC4 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled PAC4 Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled PAC4 Advanced)
+</Model>
+
+<year>
+3070
+</year>
+
+<originalBuildYear>
+3070
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLProtoMechAC4
+Clan ProtoMech AC/4 Ammo
+CLProtoMechAC4
+Clan ProtoMech AC/4 Ammo
+CLProtoMechAC4
+Clan ProtoMech AC/4 Ammo
+CLProtoMechAC4
+Clan ProtoMech AC/4 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled PAC8 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled PAC8 Advanced).blk
@@ -1,0 +1,62 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled PAC8 Advanced)
+</Model>
+
+<year>
+3070
+</year>
+
+<originalBuildYear>
+3070
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+CLProtoMechAC8
+Clan ProtoMech AC/8 Ammo
+CLProtoMechAC8
+Clan ProtoMech AC/8 Ammo
+CLProtoMechAC8
+Clan ProtoMech AC/8 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on Clan infantry kit intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled UAC5 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Field Gun Point (Wheeled UAC5 Basic).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Field Gun Point
+</Name>
+
+<Model>
+(Wheeled UAC5 Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Sniper
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+ISUltraAC5
+IS Ultra AC/5 Ammo
+ISUltraAC5
+IS Ultra AC/5 Ammo
+</Field Guns Equipment>
+
+<notes>
+Intro date based on General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Flamer Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Flamer Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Foot Point
+</Name>
+
+<Model>
+(Flamer Advanced)
+</Model>
+
+<mul id:>
+602
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Flamer (Man-Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Flamer Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Flamer Basic).blk
@@ -1,0 +1,68 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Foot Point
+</Name>
+
+<Model>
+(Flamer Basic)
+</Model>
+
+<mul id:>
+9588
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<notes>
+Intro date is earlier than MUL to match General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Flamer (Man-Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (LRM Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (LRM Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Foot Point
+</Name>
+
+<Model>
+(LRM Advanced)
+</Model>
+
+<mul id:>
+604
+</mul id:>
+
+<year>
+3064
+</year>
+
+<originalBuildYear>
+3064
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+InfantryLRM
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Laser Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Laser Advanced).blk
@@ -1,0 +1,56 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Foot Point
+</Name>
+
+<Model>
+(Laser Advanced)
+</Model>
+
+<mul id:>
+603
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<Primary>
+Laser Rifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Laser Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Laser Basic).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Foot Point
+</Name>
+
+<Model>
+(Laser Basic)
+</Model>
+
+<mul id:>
+9592
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<notes>
+Intro date is earlier than MUL to match General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<Primary>
+Laser Rifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Laser Marine).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Laser Marine).blk
@@ -1,0 +1,68 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-15
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Foot Point
+</Name>
+
+<Model>
+(Laser Marine)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+Environment Suit, Marine
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<notes>
+Intro date is earlier than MUL to match General Clan faction intro date
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+Laser Rifle
+</Primary>
+
+<spacesuit>
+true
+</spacesuit>
+
+<specialization>
+64
+</specialization>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (MG Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (MG Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Foot Point
+</Name>
+
+<Model>
+(MG Advanced)
+</Model>
+
+<mul id:>
+605
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Machine Gun (Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (MG Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (MG Basic).blk
@@ -1,0 +1,68 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Foot Point
+</Name>
+
+<Model>
+(MG Basic)
+</Model>
+
+<mul id:>
+9590
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<notes>
+Intro date is earlier than MUL to match General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Machine Gun (Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Mauser 960 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Mauser 960 Basic).blk
@@ -1,0 +1,57 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Foot Point
+</Name>
+
+<Model>
+(Mauser 960 Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+AntiMekGear
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<notes>
+Intro date is earlier than MUL to match General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<Primary>
+Laser Rifle (Mauser 960)
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle AA Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle AA Advanced).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Foot Point
+</Name>
+
+<Model>
+(Rifle AA Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+AA Weapon (Mk. 1, Light)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle AA Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle AA Basic).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Foot Point
+</Name>
+
+<Model>
+(Rifle AA Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<notes>
+Intro date is earlier than MUL to match General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+AA Weapon (Mk. 1, Light)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle Advanced).blk
@@ -1,0 +1,56 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Foot Point
+</Name>
+
+<Model>
+(Rifle Advanced)
+</Model>
+
+<mul id:>
+606
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle Basic).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Foot Point
+</Name>
+
+<Model>
+(Rifle Basic)
+</Model>
+
+<mul id:>
+9591
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<notes>
+Intro date is earlier than MUL to match General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle Light).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Rifle Light).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Foot Point
+</Name>
+
+<Model>
+(Rifle Light)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+1
+</secondn>
+
+<Primary>
+Rifle (Zeus Heavy)
+</Primary>
+
+<Secondary>
+Grenade Launcher
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (SRM Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (SRM Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Foot Point
+</Name>
+
+<Model>
+(SRM Advanced)
+</Model>
+
+<mul id:>
+607
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+InfantryHeavySRM
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (SRM Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (SRM Basic).blk
@@ -1,0 +1,68 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Foot Point
+</Name>
+
+<Model>
+(SRM Basic)
+</Model>
+
+<mul id:>
+9593
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<notes>
+Intro date is earlier than MUL to match General Clan faction intro date. Uses Generic Infantry kit due to much later intro date of standard Clan kit.
+</notes>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+InfantryHeavySRM
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Watch Detachment Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Foot Point (Watch Detachment Advanced).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Foot Point
+</Name>
+
+<Model>
+(Watch Detachment Advanced)
+</Model>
+
+<year>
+3049
+</year>
+
+<originalBuildYear>
+3049
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Leg
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+1
+</secondn>
+
+<Primary>
+Gauss Submachinegun
+</Primary>
+
+<Secondary>
+Grenade Launcher (Compact)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (ER Laser Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (ER Laser Advanced).blk
@@ -1,0 +1,52 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Jump Point
+</Name>
+
+<Model>
+(ER Laser Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Jump
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle (ER)
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (ER Laser Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (ER Laser Basic).blk
@@ -1,0 +1,52 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Jump Point
+</Name>
+
+<Model>
+(ER Laser Basic)
+</Model>
+
+<year>
+2840
+</year>
+
+<originalBuildYear>
+2840
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis)
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Jump
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle (ER)
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (Flamer Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (Flamer Advanced).blk
@@ -1,0 +1,65 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Jump Point
+</Name>
+
+<Model>
+(Flamer Advanced)
+</Model>
+
+<mul id:>
+610
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Jump
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+AntiMekGear
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Flamer (Man-Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (Flamer Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (Flamer Basic).blk
@@ -1,0 +1,65 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Jump Point
+</Name>
+
+<Model>
+(Flamer Basic)
+</Model>
+
+<mul id:>
+9594
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Jump
+</motion_type>
+
+<Troopers Equipment>
+AntiMekGear
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Flamer (Man-Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (LRM Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (LRM Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Jump Point
+</Name>
+
+<Model>
+(LRM Advanced)
+</Model>
+
+<mul id:>
+612
+</mul id:>
+
+<year>
+3064
+</year>
+
+<originalBuildYear>
+3064
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Jump
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+InfantryLRM
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (Laser Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (Laser Advanced).blk
@@ -1,0 +1,57 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Jump Point
+</Name>
+
+<Model>
+(Laser Advanced)
+</Model>
+
+<mul id:>
+611
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Jump
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+AntiMekGear
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (Laser Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (Laser Basic).blk
@@ -1,0 +1,57 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Jump Point
+</Name>
+
+<Model>
+(Laser Basic)
+</Model>
+
+<mul id:>
+9598
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Jump
+</motion_type>
+
+<Troopers Equipment>
+AntiMekGear
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (MG Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (MG Advanced).blk
@@ -1,0 +1,65 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Jump Point
+</Name>
+
+<Model>
+(MG Advanced)
+</Model>
+
+<mul id:>
+613
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Jump
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+AntiMekGear
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Machine Gun (Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (MG Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (MG Basic).blk
@@ -1,0 +1,65 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Jump Point
+</Name>
+
+<Model>
+(MG Basic)
+</Model>
+
+<mul id:>
+9596
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Jump
+</motion_type>
+
+<Troopers Equipment>
+AntiMekGear
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Machine Gun (Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (Mauser 960 Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (Mauser 960 Advanced).blk
@@ -1,0 +1,53 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Jump Point
+</Name>
+
+<Model>
+(Mauser 960 Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Jump
+</motion_type>
+
+<Troopers Equipment>
+AntiMekGear
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle (Mauser 960)
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (Mauser 960 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (Mauser 960 Basic).blk
@@ -1,0 +1,53 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Jump Point
+</Name>
+
+<Model>
+(Mauser 960 Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Jump
+</motion_type>
+
+<Troopers Equipment>
+AntiMekGear
+SLDF Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle (Mauser 960)
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (Mauser IIC Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (Mauser IIC Advanced).blk
@@ -1,0 +1,52 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Jump Point
+</Name>
+
+<Model>
+(Mauser IIC Advanced)
+</Model>
+
+<year>
+3013
+</year>
+
+<originalBuildYear>
+3013
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Jump
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle (Mauser IIC IAS)
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (Rifle Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (Rifle Advanced).blk
@@ -1,0 +1,57 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Jump Point
+</Name>
+
+<Model>
+(Rifle Advanced)
+</Model>
+
+<mul id:>
+614
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Jump
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+AntiMekGear
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (Rifle Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (Rifle Basic).blk
@@ -1,0 +1,57 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Jump Point
+</Name>
+
+<Model>
+(Rifle Basic)
+</Model>
+
+<mul id:>
+9597
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Jump
+</motion_type>
+
+<Troopers Equipment>
+AntiMekGear
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (SRM Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (SRM Advanced).blk
@@ -1,0 +1,65 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Jump Point
+</Name>
+
+<Model>
+(SRM Advanced)
+</Model>
+
+<mul id:>
+615
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Jump
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+AntiMekGear
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+InfantryHeavySRM
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (SRM Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Jump Point (SRM Basic).blk
@@ -1,0 +1,65 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Jump Point
+</Name>
+
+<Model>
+(SRM Basic)
+</Model>
+
+<mul id:>
+9599
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Jump
+</motion_type>
+
+<Troopers Equipment>
+AntiMekGear
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+InfantryHeavySRM
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (ER Laser Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (ER Laser Advanced).blk
@@ -1,0 +1,52 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Hover Point
+</Name>
+
+<Model>
+(ER Laser Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Striker
+</role>
+
+<motion_type>
+Hover
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle (ER)
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Flamer Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Flamer Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Hover Point
+</Name>
+
+<Model>
+(Flamer Advanced)
+</Model>
+
+<mul id:>
+616
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Hover
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Flamer (Man-Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Flamer Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Flamer Basic).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Hover Point
+</Name>
+
+<Model>
+(Flamer Basic)
+</Model>
+
+<mul id:>
+9617
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Hover
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Flamer (Man-Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (LRM Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (LRM Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Hover Point
+</Name>
+
+<Model>
+(LRM Advanced)
+</Model>
+
+<mul id:>
+618
+</mul id:>
+
+<year>
+3064
+</year>
+
+<originalBuildYear>
+3064
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Scout
+</role>
+
+<motion_type>
+Hover
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+InfantryLRM
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Laser Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Laser Advanced).blk
@@ -1,0 +1,56 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Hover Point
+</Name>
+
+<Model>
+(Laser Advanced)
+</Model>
+
+<mul id:>
+617
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Striker
+</role>
+
+<motion_type>
+Hover
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Laser Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Laser Basic).blk
@@ -1,0 +1,56 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Hover Point
+</Name>
+
+<Model>
+(Laser Basic)
+</Model>
+
+<mul id:>
+9612
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Striker
+</role>
+
+<motion_type>
+Hover
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (MG Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (MG Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Hover Point
+</Name>
+
+<Model>
+(MG Advanced)
+</Model>
+
+<mul id:>
+619
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Hover
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Machine Gun (Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (MG Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (MG Basic).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Hover Point
+</Name>
+
+<Model>
+(MG Basic)
+</Model>
+
+<mul id:>
+9615
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Hover
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Machine Gun (Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Mauser IIC Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Mauser IIC Advanced).blk
@@ -1,0 +1,52 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Hover Point
+</Name>
+
+<Model>
+(Mauser IIC Advanced)
+</Model>
+
+<year>
+3013
+</year>
+
+<originalBuildYear>
+3013
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Scout
+</role>
+
+<motion_type>
+Hover
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle (Mauser IIC IAS)
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Rifle Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Rifle Advanced).blk
@@ -1,0 +1,56 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Hover Point
+</Name>
+
+<Model>
+(Rifle Advanced)
+</Model>
+
+<mul id:>
+620
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Scout
+</role>
+
+<motion_type>
+Hover
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Rifle Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (Rifle Basic).blk
@@ -1,0 +1,56 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Hover Point
+</Name>
+
+<Model>
+(Rifle Basic)
+</Model>
+
+<mul id:>
+9614
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Scout
+</role>
+
+<motion_type>
+Hover
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (SRM Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (SRM Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Hover Point
+</Name>
+
+<Model>
+(SRM Advanced)
+</Model>
+
+<mul id:>
+621
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Hover
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+InfantryHeavySRM
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (SRM Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Hover Point (SRM Basic).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Hover Point
+</Name>
+
+<Model>
+(SRM Basic)
+</Model>
+
+<mul id:>
+9613
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Hover
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+InfantryHeavySRM
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (ER Laser Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (ER Laser Advanced).blk
@@ -1,0 +1,52 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Tracked Point
+</Name>
+
+<Model>
+(ER Laser Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle (ER)
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Flamer Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Flamer Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Tracked Point
+</Name>
+
+<Model>
+(Flamer Advanced)
+</Model>
+
+<mul id:>
+623
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Flamer (Man-Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Flamer Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Flamer Basic).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Tracked Point
+</Name>
+
+<Model>
+(Flamer Basic)
+</Model>
+
+<mul id:>
+9617
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Flamer (Man-Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (LRM Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (LRM Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Tracked Point
+</Name>
+
+<Model>
+(LRM Advanced)
+</Model>
+
+<mul id:>
+625
+</mul id:>
+
+<year>
+3064
+</year>
+
+<originalBuildYear>
+3064
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+InfantryLRM
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Laser Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Laser Advanced).blk
@@ -1,0 +1,56 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Tracked Point
+</Name>
+
+<Model>
+(Laser Advanced)
+</Model>
+
+<mul id:>
+624
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Laser Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Laser Basic).blk
@@ -1,0 +1,56 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Tracked Point
+</Name>
+
+<Model>
+(Laser Basic)
+</Model>
+
+<mul id:>
+9612
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (MG Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (MG Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Tracked Point
+</Name>
+
+<Model>
+(MG Advanced)
+</Model>
+
+<mul id:>
+626
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Machine Gun (Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (MG Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (MG Basic).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Tracked Point
+</Name>
+
+<Model>
+(MG Basic)
+</Model>
+
+<mul id:>
+9615
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Machine Gun (Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Mauser 960 Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Mauser 960 Basic).blk
@@ -1,0 +1,52 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Tracked Point
+</Name>
+
+<Model>
+(Mauser 960 Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle (Mauser 960)
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Mauser IIC Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Mauser IIC Advanced).blk
@@ -1,0 +1,52 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Tracked Point
+</Name>
+
+<Model>
+(Mauser IIC Advanced)
+</Model>
+
+<year>
+3013
+</year>
+
+<originalBuildYear>
+3013
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle (Mauser IIC IAS)
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Rifle AA Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Rifle AA Advanced).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Tracked Point
+</Name>
+
+<Model>
+(Rifle AA Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+AA Weapon (Mk. 2, Man-Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Rifle AA Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Rifle AA Basic).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Tracked Point
+</Name>
+
+<Model>
+(Rifle AA Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+AA Weapon (Mk. 2, Man-Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Rifle Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Rifle Advanced).blk
@@ -1,0 +1,56 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Tracked Point
+</Name>
+
+<Model>
+(Rifle Advanced)
+</Model>
+
+<mul id:>
+627
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Rifle Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (Rifle Basic).blk
@@ -1,0 +1,56 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Tracked Point
+</Name>
+
+<Model>
+(Rifle Basic)
+</Model>
+
+<mul id:>
+9614
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (SRM Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (SRM Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Tracked Point
+</Name>
+
+<Model>
+(SRM Advanced)
+</Model>
+
+<mul id:>
+628
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+InfantryHeavySRM
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (SRM Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Tracked Point (SRM Basic).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Tracked Point
+</Name>
+
+<Model>
+(SRM Basic)
+</Model>
+
+<mul id:>
+9613
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Tracked
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+InfantryHeavySRM
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Flamer Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Flamer Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Wheeled Point
+</Name>
+
+<Model>
+(Flamer Advanced)
+</Model>
+
+<mul id:>
+629
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Flamer (Man-Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Flamer Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Flamer Basic).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Wheeled Point
+</Name>
+
+<Model>
+(Flamer Basic)
+</Model>
+
+<mul id:>
+9618
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Flamer (Man-Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (LRM Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (LRM Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Wheeled Point
+</Name>
+
+<Model>
+(LRM Advanced)
+</Model>
+
+<mul id:>
+631
+</mul id:>
+
+<year>
+3064
+</year>
+
+<originalBuildYear>
+3064
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+InfantryLRM
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Laser Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Laser Advanced).blk
@@ -1,0 +1,56 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Wheeled Point
+</Name>
+
+<Model>
+(Laser Advanced)
+</Model>
+
+<mul id:>
+630
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Laser Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Laser Basic).blk
@@ -1,0 +1,56 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Wheeled Point
+</Name>
+
+<Model>
+(Laser Basic)
+</Model>
+
+<mul id:>
+9622
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (MG Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (MG Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Wheeled Point
+</Name>
+
+<Model>
+(MG Advanced)
+</Model>
+
+<mul id:>
+632
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Machine Gun (Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (MG Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (MG Basic).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Wheeled Point
+</Name>
+
+<Model>
+(MG Basic)
+</Model>
+
+<mul id:>
+9620
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Machine Gun (Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Mauser IIC Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Mauser IIC Advanced).blk
@@ -1,0 +1,52 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Wheeled Point
+</Name>
+
+<Model>
+(Mauser IIC Advanced)
+</Model>
+
+<year>
+3013
+</year>
+
+<originalBuildYear>
+3013
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+Laser Rifle (Mauser IIC IAS)
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Rifle AA Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Rifle AA Advanced).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Wheeled Point
+</Name>
+
+<Model>
+(Rifle AA Advanced)
+</Model>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+AA Weapon (Mk. 2, Man-Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Rifle AA Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Rifle AA Basic).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Wheeled Point
+</Name>
+
+<Model>
+(Rifle AA Basic)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+AA Weapon (Mk. 2, Man-Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Rifle Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Rifle Advanced).blk
@@ -1,0 +1,56 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Wheeled Point
+</Name>
+
+<Model>
+(Rifle Advanced)
+</Model>
+
+<mul id:>
+633
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Rifle Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (Rifle Basic).blk
@@ -1,0 +1,56 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Wheeled Point
+</Name>
+
+<Model>
+(Rifle Basic)
+</Model>
+
+<mul id:>
+9621
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (SRM Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (SRM Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Wheeled Point
+</Name>
+
+<Model>
+(SRM Advanced)
+</Model>
+
+<mul id:>
+634
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+InfantryHeavySRM
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (SRM Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Mechanized Wheeled Point (SRM Basic).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Mechanized Wheeled Point
+</Name>
+
+<Model>
+(SRM Basic)
+</Model>
+
+<mul id:>
+9623
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Wheeled
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+4
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+InfantryHeavySRM
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (Bearhunter Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (Bearhunter Advanced).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-04
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Motorized Point
+</Name>
+
+<Model>
+(Bearhunter Advanced)
+</Model>
+
+<year>
+3059
+</year>
+
+<originalBuildYear>
+3059
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Autocannon (Bearhunter Superheavy)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (Flamer Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (Flamer Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Motorized Point
+</Name>
+
+<Model>
+(Flamer Advanced)
+</Model>
+
+<mul id:>
+636
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Flamer (Man-Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (Flamer Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (Flamer Basic).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Motorized Point
+</Name>
+
+<Model>
+(Flamer Basic)
+</Model>
+
+<mul id:>
+9600
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Flamer (Man-Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (LRM Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (LRM Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Motorized Point
+</Name>
+
+<Model>
+(LRM Advanced)
+</Model>
+
+<mul id:>
+638
+</mul id:>
+
+<year>
+3064
+</year>
+
+<originalBuildYear>
+3064
+</originalBuildYear>
+
+<type>
+Mixed (Clan Chassis) Advanced
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+InfantryLRM
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (Laser Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (Laser Advanced).blk
@@ -1,0 +1,56 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Motorized Point
+</Name>
+
+<Model>
+(Laser Advanced)
+</Model>
+
+<mul id:>
+637
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<Primary>
+Laser Rifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (Laser Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (Laser Basic).blk
@@ -1,0 +1,56 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Motorized Point
+</Name>
+
+<Model>
+(Laser Basic)
+</Model>
+
+<mul id:>
+9604
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<Primary>
+Laser Rifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (MG Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (MG Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Motorized Point
+</Name>
+
+<Model>
+(MG Advanced)
+</Model>
+
+<mul id:>
+639
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Machine Gun (Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (MG Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (MG Basic).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Motorized Point
+</Name>
+
+<Model>
+(MG Basic)
+</Model>
+
+<mul id:>
+9602
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+Machine Gun (Portable)
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (Rifle Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (Rifle Advanced).blk
@@ -1,0 +1,56 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Motorized Point
+</Name>
+
+<Model>
+(Rifle Advanced)
+</Model>
+
+<mul id:>
+640
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (Rifle Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (Rifle Basic).blk
@@ -1,0 +1,56 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Motorized Point
+</Name>
+
+<Model>
+(Rifle Basic)
+</Model>
+
+<mul id:>
+9603
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (Rifle Light).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (Rifle Light).blk
@@ -1,0 +1,60 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Motorized Point
+</Name>
+
+<Model>
+(Rifle Light)
+</Model>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+Clan Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+1
+</secondn>
+
+<Primary>
+Rifle (Zeus Heavy)
+</Primary>
+
+<Secondary>
+Grenade Launcher
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (SRM Advanced).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (SRM Advanced).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-02
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Motorized Point
+</Name>
+
+<Model>
+(SRM Advanced)
+</Model>
+
+<mul id:>
+641
+</mul id:>
+
+<year>
+2845
+</year>
+
+<originalBuildYear>
+2845
+</originalBuildYear>
+
+<type>
+Clan Level 3
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Clan Armor Kit (All)
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+InfantryHeavySRM
+</Secondary>
+

--- a/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (SRM Basic).blk
+++ b/megamek/data/mekfiles/infantry/Clan/Clan Motorized Point (SRM Basic).blk
@@ -1,0 +1,64 @@
+#Saved from version 0.50.04-SNAPSHOT on 2025-03-03
+<UnitType>
+Infantry
+</UnitType>
+
+<Name>
+Clan Motorized Point
+</Name>
+
+<Model>
+(SRM Basic)
+</Model>
+
+<mul id:>
+9605
+</mul id:>
+
+<year>
+2807
+</year>
+
+<originalBuildYear>
+2807
+</originalBuildYear>
+
+<type>
+IS Level 2
+</type>
+
+<role>
+Ambusher
+</role>
+
+<motion_type>
+Motorized
+</motion_type>
+
+<Troopers Equipment>
+Generic Infantry Kit
+</Troopers Equipment>
+
+<Field Guns Equipment>
+</Field Guns Equipment>
+
+<squad_size>
+5
+</squad_size>
+
+<squadn>
+5
+</squadn>
+
+<secondn>
+2
+</secondn>
+
+<Primary>
+InfantryAssaultRifle
+</Primary>
+
+<Secondary>
+InfantryHeavySRM
+</Secondary>
+


### PR DESCRIPTION
This PR adjust the availabilities of Clan conventional infantry along three general axis:

- equipment rating
- faction
- era

First, a quick note about naming.  Because the advanced Clan infantry kit is not available until several decades after Operation KLONDIKE had concluded, I have borrowed the naming conventions from MUL.  Units with the generic infantry armor kit use the 'Basic' moniker such as Clan Foot Point (Rifle Basic).  Units with the advanced Clan armor kit use the 'Advanced' moniker such as Clan Jump Point (Laser Advanced).

Initially Clan infantry distribution is based on the assault forces of the remaining SLDF Royal Jump and Mechanized infantry brigades for the best equipped forces.  The worst equipped forces are built around the forces used to secure and provide general enforcement on Strana Mechty.  After KLONDIKE as Mek dueling became the primary form of fighting the best-equipped infantry decline in capability somewhat while the lowest are treated as the paramilitary/police sub-caste - armed more for law and order/riot control rather than combat.  Once Elemental battle armor takes over the main combat duties from standard infantry, the capabilities of the best equipped infantry sink even further.  Over this same time Clan Hell's Horses introduces the advanced infantry armor kit and it is gradually phased in across the other Clans.

Once the invading Clans establish their holdings in the Inner Sphere they start reversing this trend, needing better equipped infantry to handle the restive populations.  With little change in the Clan homeworlds the remaining Clans continue with the lower quality distributions until they close off all contact post-Jihad/Wars of Reaving.

A few of the more noteworthy Clans have slightly different distributions than the others.  Hell's Horses, of course, well known for their conventional and infantry forces maintain a more balanced approach, which also applies to their inheritors in Clan Stone Lion.  Clan Ghost Bear is tilted slightly in favor of heavier mechanized tracked and wheeled infantry due to their preference for heavier units and access to resources from extensive asteroid mining.  Clan Ice Hellion favors jump and mechanized hover infantry in line with their preferences for fast and light units.  Clan Smoke Jaguar has some of the worst equipped infantry, using it as little more than a dumping ground for failed warriors (not to mention riot control for when the workers are short of rations yet again...).  Some of the other Clans noted for infantry use have smaller adjustments.