### PR TITLE
Update the Packet Class with type specific getters.

### DIFF
--- a/megamek/src/megamek/client/AbstractClient.java
+++ b/megamek/src/megamek/client/AbstractClient.java
@@ -250,9 +250,9 @@ public abstract class AbstractClient implements IClient {
      * @param packet The packet we received.
      */
     protected void receivePlayerInfo(Packet packet) {
-        int packetIndex = packet.getIntValue(0);
+        int packetIndex = packet.getInt(0);
 
-        Player newPlayer = packet.getPlayerValue(1);
+        Player newPlayer = packet.getPlayer(1);
 
         if (newPlayer == null) {
             return;
@@ -328,7 +328,7 @@ public abstract class AbstractClient implements IClient {
     }
 
     protected void correctName(Packet inP) {
-        setName(inP.getStringValue(0));
+        setName(inP.getString(0));
     }
 
     protected void setName(String newName) {
@@ -348,10 +348,10 @@ public abstract class AbstractClient implements IClient {
     }
 
     protected void receiveUnitReplace(Packet packet) {
-        List<Force> forces = packet.getForceListValue(1);
+        List<Force> forces = packet.getForceList(1);
         forces.forEach(force -> getGame().getForces().replace(force.getId(), force));
 
-        List<InGameObject> units = packet.getInGameObjectListValue(0);
+        List<InGameObject> units = packet.getInGameObjectList(0);
         getGame().replaceUnits(units);
     }
 
@@ -379,7 +379,7 @@ public abstract class AbstractClient implements IClient {
         try {
             if (packet.command() == PacketCommand.MULTI_PACKET) {
                 // TODO gather any fired events and fire them only at the end of the packets, possibly only for SBF
-                var includedPackets = packet.getPackteListValue(0);
+                var includedPackets = packet.getPackteList(0);
                 for (Packet includedPacket : includedPackets) {
                     handlePacket(includedPacket);
                 }
@@ -434,7 +434,7 @@ public abstract class AbstractClient implements IClient {
                 send(new Packet(PacketCommand.CLIENT_VERSIONS, SuiteConstants.VERSION, MegaMek.getMegaMekSHA256()));
                 break;
             case ILLEGAL_CLIENT_VERSION:
-                final Version serverVersion = packet.getVersionValue(0);
+                final Version serverVersion = packet.getVersion(0);
                 LOGGER.errorDialog("Connection Failure: Version Difference",
                       "Failed to connect to the server at {} because of version differences. " +
                             "Cannot connect to a server running {} with a {} install.",
@@ -444,26 +444,26 @@ public abstract class AbstractClient implements IClient {
                 disconnected();
                 break;
             case LOCAL_PN:
-                localPlayerNumber = packet.getIntValue(0);
+                localPlayerNumber = packet.getInt(0);
                 break;
             case PLAYER_UPDATE:
             case PLAYER_ADD:
                 receivePlayerInfo(packet);
                 break;
             case PLAYER_READY:
-                Player player = getPlayer(packet.getIntValue(0));
+                Player player = getPlayer(packet.getInt(0));
                 if (player != null) {
-                    player.setDone(packet.getBooleanValue(1));
+                    player.setDone(packet.getBoolean(1));
                     getGame().fireGameEvent(new GamePlayerChangeEvent(player, player));
                 }
                 break;
             case PLAYER_REMOVE:
-                int playerNumber = packet.getIntValue(0);
+                int playerNumber = packet.getInt(0);
                 bots.values().removeIf(bot -> bot.localPlayerNumber == playerNumber);
                 getGame().removePlayer(playerNumber);
                 break;
             case CHAT:
-                String message = packet.getStringValue(0);
+                String message = packet.getString(0);
                 possiblyWriteToLog(message);
                 getGame().fireGameEvent(new GamePlayerChatEvent(this, null, message));
                 break;
@@ -474,16 +474,16 @@ public abstract class AbstractClient implements IClient {
                 getGame().receiveBoards(packet.getMapOfIntegerAndBoard(0));
                 break;
             case ROUND_UPDATE:
-                getGame().setCurrentRound(packet.getIntValue(0));
+                getGame().setCurrentRound(packet.getInt(0));
                 break;
             case PHASE_CHANGE:
-                changePhase(packet.getGamePhaseValue(0));
+                changePhase(packet.getGamePhase(0));
                 break;
             case SCRIPTED_MESSAGE:
                 getGame().fireGameEvent(new GameScriptedMessageEvent(this,
-                      packet.getStringValue(0),
-                      packet.getStringValue(1),
-                      packet.getBase64ImageValue(2)));
+                      packet.getString(0),
+                      packet.getString(1),
+                      packet.getBase64Image(2)));
                 break;
             default:
                 return false;

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -25,7 +25,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStreamReader;
 import java.util.*;
-
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
@@ -68,16 +67,14 @@ public abstract class BotClient extends Client {
     public JFrame frame;
 
     /**
-     * Keeps track of whether this client has started to calculate a turn this
-     * phase.
+     * Keeps track of whether this client has started to calculate a turn this phase.
      */
     boolean calculatedTurnThisPhase = false;
     int calculatedTurnsThisPhase = 0;
 
     /**
-     * Store a reference to the ClientGUI for the client who created this bot.
-     * This is used to ensure keep the ClientGUI synchronized with changes to
-     * this BotClient (particularly the bot's name).
+     * Store a reference to the ClientGUI for the client who created this bot. This is used to ensure keep the ClientGUI
+     * synchronized with changes to this BotClient (particularly the bot's name).
      */
     private ClientGUI clientGUI = null;
 
@@ -108,16 +105,16 @@ public abstract class BotClient extends Client {
                 // change
                 // We want to ignore turns from other players and only listen to events we
                 // generated
-                boolean ignoreSimTurn = getGame().getPhase().isSimultaneous(getGame())
-                        && (e.getPreviousPlayerId() != localPlayerNumber)
-                        && calculatedTurnThisPhase;
+                boolean ignoreSimTurn = getGame().getPhase().isSimultaneous(getGame()) &&
+                                              (e.getPreviousPlayerId() != localPlayerNumber) &&
+                                              calculatedTurnThisPhase;
 
                 if (isMyTurn() && !ignoreSimTurn) {
                     calculatedTurnThisPhase = true;
                     // Run bot's turn processing in a separate thread.
                     // So calling thread is free to process the other actions.
                     Thread worker = new Thread(new CalculateBotTurn(),
-                            getName() + " Turn " + game.getTurnIndex() + " Calc Thread");
+                          getName() + " Turn " + game.getTurnIndex() + " Calc Thread");
                     worker.start();
                     calculatedTurnsThisPhase++;
                 }
@@ -133,12 +130,11 @@ public abstract class BotClient extends Client {
             public void gamePhaseChange(GamePhaseChangeEvent e) {
                 calculatedTurnThisPhase = false;
                 if (e.getOldPhase().isSimultaneous(getGame())) {
-                    logger.info(
-                        String.format("%s: Calculated %d / %d turns for phase %s",
-                            getName(), calculatedTurnsThisPhase,
-                            getGame().getEntitiesOwnedBy(getLocalPlayer()), e.getOldPhase()
-                        )
-                    );
+                    logger.info(String.format("%s: Calculated %d / %d turns for phase %s",
+                          getName(),
+                          calculatedTurnsThisPhase,
+                          getGame().getEntitiesOwnedBy(getLocalPlayer()),
+                          e.getOldPhase()));
                 }
                 calculatedTurnsThisPhase = 0;
             }
@@ -177,7 +173,7 @@ public abstract class BotClient extends Client {
                     case CFR_HIDDEN_PBS:
                         try {
                             Vector<EntityAction> pointBlankShots = calculatePointBlankShot(evt.getEntityId(),
-                                    evt.getTargetId());
+                                  evt.getTargetId());
 
                             if (pointBlankShots.isEmpty()) {
                                 sendHiddenPBSCFRResponse(null);
@@ -220,11 +216,11 @@ public abstract class BotClient extends Client {
     protected abstract void initFiring();
 
     /**
-     * Determines which entity should be moved next and then calls to
-     * {@link #continueMovementFor(Entity)}
-     * with that entity.
+     * Determines which entity should be moved next and then calls to {@link #continueMovementFor(Entity)} with that
+     * entity.
      *
      * @return The calculated move path.
+     *
      * @throws NullPointerException if no entity can be found to move.
      */
     protected abstract MovePath calculateMoveTurn();
@@ -237,19 +233,16 @@ public abstract class BotClient extends Client {
     }
 
     /**
-     * Calculates the targeting/off board turn
-     * This includes firing TAG and non-direct-fire artillery
-     * Does nothing in this implementation.
+     * Calculates the targeting/off board turn This includes firing TAG and non-direct-fire artillery Does nothing in
+     * this implementation.
      */
     protected void calculateTargetingOffBoardTurn() {
-        sendAttackData(game.getFirstEntityNum(getMyTurn()),
-                new Vector<>(0));
+        sendAttackData(game.getFirstEntityNum(getMyTurn()), new Vector<>(0));
         sendDone(true);
     }
 
     /**
-     * Calculates the pre phase turn
-     * currently does nothing other than end turn
+     * Calculates the pre phase turn currently does nothing other than end turn
      */
     protected void calculatePrePhaseTurn() {
         sendPrePhaseData(game.getFirstEntityNum(getMyTurn()));
@@ -271,7 +264,9 @@ public abstract class BotClient extends Client {
      * Calculates the full {@link MovePath} for the given {@link Entity}.
      *
      * @param entity The entity who is to move.
+     *
      * @return The calculated move path.
+     *
      * @throws NullPointerException if entity is NULL.
      */
     protected abstract MovePath continueMovementFor(Entity entity);
@@ -288,8 +283,7 @@ public abstract class BotClient extends Client {
     }
 
     /**
-     * Helper function that determines which of this bot's entities are stranded
-     * inside immobilized transports.
+     * Helper function that determines which of this bot's entities are stranded inside immobilized transports.
      *
      * @return Array of entity IDs.
      */
@@ -300,16 +294,19 @@ public abstract class BotClient extends Client {
         // And if the entity happens to be in a disabled transport, then we unload it
         // unless doing so would kill it or be illegal due to stacking violation
         for (Entity currentEntity : getGame().getPlayerEntities(getLocalPlayer(), true)) {
-            Entity transport = currentEntity.getTransportId() != Entity.NONE
-                    ? getGame().getEntity(currentEntity.getTransportId())
-                    : null;
+            Entity transport = currentEntity.getTransportId() != Entity.NONE ?
+                                     getGame().getEntity(currentEntity.getTransportId()) :
+                                     null;
 
             if (transport != null && transport.isPermanentlyImmobilized(true)) {
-                boolean stackingViolation = null != Compute.stackingViolation(game, currentEntity.getId(),
-                        transport.getPosition(), currentEntity.climbMode());
-                boolean unloadFatal = currentEntity.isBoardProhibited(getGame().getBoard().getType())
-                        || currentEntity.isLocationProhibited(transport.getPosition())
-                        || currentEntity.isLocationDeadly(transport.getPosition());
+                boolean stackingViolation = null !=
+                                                  Compute.stackingViolation(game,
+                                                        currentEntity.getId(),
+                                                        transport.getPosition(),
+                                                        currentEntity.climbMode());
+                boolean unloadFatal = currentEntity.isBoardProhibited(getGame().getBoard().getType()) ||
+                                            currentEntity.isLocationProhibited(transport.getPosition()) ||
+                                            currentEntity.isLocationDeadly(transport.getPosition());
 
                 if (!stackingViolation && !unloadFatal) {
                     entitiesToUnload.add(currentEntity.getId());
@@ -328,8 +325,7 @@ public abstract class BotClient extends Client {
     public List<Entity> getEntitiesOwned() {
         ArrayList<Entity> result = new ArrayList<>();
         for (Entity entity : game.getEntitiesVector()) {
-            if (entity.getOwner().equals(getLocalPlayer())
-                    && (entity.getPosition() != null) && !entity.isOffBoard()) {
+            if (entity.getOwner().equals(getLocalPlayer()) && (entity.getPosition() != null) && !entity.isOffBoard()) {
                 result.add(entity);
             }
         }
@@ -347,18 +343,19 @@ public abstract class BotClient extends Client {
     }
 
     /**
-     * Lazy-loaded list of enemy entities that we should consider firing at.
-     * Only good for the current entity turn calculation, as this list can change
-     * between individual entity turns.
+     * Lazy-loaded list of enemy entities that we should consider firing at. Only good for the current entity turn
+     * calculation, as this list can change between individual entity turns.
      */
     public List<Entity> getEnemyEntities() {
         if (currentTurnEnemyEntities == null) {
             currentTurnEnemyEntities = new ArrayList<>();
             for (Entity entity : game.getEntitiesVector()) {
-                if (entity.getOwner().isEnemyOf(getLocalPlayer())
-                    && (entity.getPosition() != null) && !entity.isOffBoard()
-                    && (entity.getCrew() != null) && !entity.getCrew().isDead()
-                    && !entity.isHidden()) {
+                if (entity.getOwner().isEnemyOf(getLocalPlayer()) &&
+                          (entity.getPosition() != null) &&
+                          !entity.isOffBoard() &&
+                          (entity.getCrew() != null) &&
+                          !entity.getCrew().isDead() &&
+                          !entity.isHidden()) {
                     currentTurnEnemyEntities.add(entity);
                 }
             }
@@ -368,16 +365,16 @@ public abstract class BotClient extends Client {
     }
 
     /**
-     * Lazy-loaded list of friendly entities.
-     * Only good for the current entity turn calculation, as this list can change
+     * Lazy-loaded list of friendly entities. Only good for the current entity turn calculation, as this list can change
      * between individual entity turns.
      */
     public List<Entity> getFriendEntities() {
         if (currentTurnFriendlyEntities == null) {
             currentTurnFriendlyEntities = new ArrayList<>();
             for (Entity entity : game.getEntitiesVector()) {
-                if (!entity.getOwner().isEnemyOf(getLocalPlayer()) && (entity.getPosition() != null)
-                        && !entity.isOffBoard()) {
+                if (!entity.getOwner().isEnemyOf(getLocalPlayer()) &&
+                          (entity.getPosition() != null) &&
+                          !entity.isOffBoard()) {
                     currentTurnFriendlyEntities.add(entity);
                 }
             }
@@ -416,9 +413,8 @@ public abstract class BotClient extends Client {
                      */
                     // if the game is not double blind and I can't see anyone
                     // else on the board I should kill myself.
-                    if (!(game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND))
-                            && ((game.getEntitiesOwnedBy(getLocalPlayer())
-                                    - game.getNoOfEntities()) == 0)) {
+                    if (!(game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND)) &&
+                              ((game.getEntitiesOwnedBy(getLocalPlayer()) - game.getNoOfEntities()) == 0)) {
                         die();
                     }
 
@@ -477,7 +473,7 @@ public abstract class BotClient extends Client {
         ArrayList<Entity> living = game.getPlayerEntities(getLocalPlayer(), false);
 
         // Be sure to include all units that have retreated.
-        for (Enumeration<Entity> iter = game.getRetreatedEntities(); iter.hasMoreElements();) {
+        for (Enumeration<Entity> iter = game.getRetreatedEntities(); iter.hasMoreElements(); ) {
             Entity ent = iter.nextElement();
             if (ent.getOwnerId() == getLocalPlayer().getId()) {
                 living.add(ent);
@@ -520,8 +516,7 @@ public abstract class BotClient extends Client {
     }
 
     /**
-     * Calculate what to do on my turn.
-     * Has a retry mechanism for when the turn calculation fails due to concurrency
+     * Calculate what to do on my turn. Has a retry mechanism for when the turn calculation fails due to concurrency
      * issues
      */
     private synchronized void calculateMyTurn() {
@@ -577,9 +572,7 @@ public abstract class BotClient extends Client {
                 } else {
                     // This attempt to calculate the turn failed, but we don't want to log
                     // an exception here.
-                    logger.warn(
-                          "Null move path; entity was {}", ((moverId != -1) ? "ID " + moverId : "Unknown")
-                    );
+                    logger.warn("Null move path; entity was {}", ((moverId != -1) ? "ID " + moverId : "Unknown"));
                     return false;
                 }
             } else if (game.getPhase().isFiring()) {
@@ -641,16 +634,19 @@ public abstract class BotClient extends Client {
     }
 
     /**
-     * Gets valid and empty starting coords around the specified point. This
-     * method iterates through the list of Coords and returns the first Coords
-     * that does not have a stacking violation.
+     * Gets valid and empty starting coords around the specified point. This method iterates through the list of Coords
+     * and returns the first Coords that does not have a stacking violation.
      */
-    protected @Nullable Coords getFirstValidCoords(Entity deployedUnit,
-            List<Coords> possibleDeployCoords) {
+    protected @Nullable Coords getFirstValidCoords(Entity deployedUnit, List<Coords> possibleDeployCoords) {
         // Check all of the hexes in order.
         for (Coords dest : possibleDeployCoords) {
-            Entity violation = Compute.stackingViolation(game, deployedUnit,
-                    dest, deployedUnit.getElevation(), dest, null, deployedUnit.climbMode());
+            Entity violation = Compute.stackingViolation(game,
+                  deployedUnit,
+                  dest,
+                  deployedUnit.getElevation(),
+                  dest,
+                  null,
+                  deployedUnit.climbMode());
             // Ignore coords that could cause a stacking violation
             if (violation != null) {
                 continue;
@@ -688,11 +684,12 @@ public abstract class BotClient extends Client {
         for (int x = 0; x <= board.getWidth(); x++) {
             for (int y = 0; y <= board.getHeight(); y++) {
                 Coords c = new Coords(x, y);
-                if (board.isLegalDeployment(c, deployed_ent)
-                        && !deployed_ent.isLocationProhibited(c,
-                            ((deployed_ent.isAirborne() || deployed_ent.getMovementMode().isHoverVTOLOrWiGE())
-                                ? deployed_ent.getElevation() : 0))
-                        && !deployed_ent.isLocationDeadly(c)) {
+                if (board.isLegalDeployment(c, deployed_ent) &&
+                          !deployed_ent.isLocationProhibited(c,
+                                ((deployed_ent.isAirborne() || deployed_ent.getMovementMode().isHoverVTOLOrWiGE()) ?
+                                       deployed_ent.getElevation() :
+                                       0)) &&
+                          !deployed_ent.isLocationDeadly(c)) {
                     validCoords.add(new RankedCoords(c, 0));
                 }
             }
@@ -723,10 +720,10 @@ public abstract class BotClient extends Client {
         weapon_count = 0;
         for (Mounted<?> mounted : deployed_ent.getWeaponList()) {
             WeaponType weaponType = (WeaponType) mounted.getType();
-            if ((!weaponType.getName().equals("ATM 3"))
-                    && (!weaponType.getName().equals("ATM 6"))
-                    && (!weaponType.getName().equals("ATM 9"))
-                    && (!weaponType.getName().equals("ATM 12"))) {
+            if ((!weaponType.getName().equals("ATM 3")) &&
+                      (!weaponType.getName().equals("ATM 6")) &&
+                      (!weaponType.getName().equals("ATM 9")) &&
+                      (!weaponType.getName().equals("ATM 12"))) {
                 if (deployed_ent.getC3Master() != null) {
                     av_range += weaponType.getLongRange() * 1.25;
                 } else {
@@ -760,12 +757,10 @@ public abstract class BotClient extends Client {
         // Calculate ideal elevation as a factor of average range of 18 being
         // highest elevation. Fast, non-jumping units should deploy towards
         // the middle elevations to avoid getting stuck up a cliff.
-        if ((deployed_ent.getAnyTypeMaxJumpMP() == 0) &&
-                (deployed_ent.getWalkMP() > 5)) {
+        if ((deployed_ent.getAnyTypeMaxJumpMP() == 0) && (deployed_ent.getWalkMP() > 5)) {
             ideal_elev = lowest_elev + ((highest_elev - lowest_elev) / 3.0);
         } else {
-            ideal_elev = lowest_elev
-                    + ((av_range / 18) * (highest_elev - lowest_elev));
+            ideal_elev = lowest_elev + ((av_range / 18) * (highest_elev - lowest_elev));
         }
         if (ideal_elev > highest_elev) {
             ideal_elev = highest_elev;
@@ -789,10 +784,8 @@ public abstract class BotClient extends Client {
             for (Entity e : potentialAttackers) {
 
                 // Unit must be deployed and not off board, with valid position
-                if ((e.isDeployed()) && !e.isOffBoard()
-                        && e.getPosition() != null) {
-                    int dist = deployed_ent.getPosition().distance(
-                            e.getPosition());
+                if ((e.isDeployed()) && !e.isOffBoard() && e.getPosition() != null) {
+                    int dist = deployed_ent.getPosition().distance(e.getPosition());
                     // Approximation of effective range, we could use av_range,
                     // however that could bad if deploy_ent is short ranged
                     // and a potential target is long range
@@ -807,10 +800,9 @@ public abstract class BotClient extends Client {
             for (Entity test_ent : valid_attackers) {
                 for (Mounted<?> mounted : test_ent.getWeaponList()) {
                     test_attack = new WeaponAttackAction(test_ent.getId(),
-                            deployed_ent.getId(),
-                            test_ent.getEquipmentNum(mounted));
-                    adjusted_damage = BotClient.getDeployDamage(game,
-                            test_attack, allECMInfo);
+                          deployed_ent.getId(),
+                          test_ent.getEquipmentNum(mounted));
+                    adjusted_damage = BotClient.getDeployDamage(game, test_attack, allECMInfo);
                     total_damage += adjusted_damage;
                 }
             }
@@ -825,10 +817,9 @@ public abstract class BotClient extends Client {
                 max_damage = 0.0;
                 for (Entity test_ent : valid_attackers) {
                     test_attack = new WeaponAttackAction(deployed_ent.getId(),
-                            test_ent.getId(),
-                            deployed_ent.getEquipmentNum(mounted));
-                    adjusted_damage = BotClient.getDeployDamage(game,
-                            test_attack, allECMInfo);
+                          test_ent.getId(),
+                          deployed_ent.getEquipmentNum(mounted));
+                    adjusted_damage = BotClient.getDeployDamage(game, test_attack, allECMInfo);
                     if (adjusted_damage > max_damage) {
                         max_damage = adjusted_damage;
                     }
@@ -844,8 +835,8 @@ public abstract class BotClient extends Client {
                 // ground space for infantry/vehicles (minor)
                 int x = coord.getX();
                 int y = coord.getY();
-                if (board.getHex(x, y).containsTerrain(Terrains.WOODS)
-                        && board.getHex(x, y).terrainLevel(Terrains.FOLIAGE_ELEV) > 1) {
+                if (board.getHex(x, y).containsTerrain(Terrains.WOODS) &&
+                          board.getHex(x, y).terrainLevel(Terrains.FOLIAGE_ELEV) > 1) {
                     coord.fitness += 1;
                 }
                 if (board.getHex(x, y).containsTerrain(Terrains.WATER)) {
@@ -854,8 +845,7 @@ public abstract class BotClient extends Client {
                     }
                 }
                 // If building, make sure not too heavy to safely move out of
-                coord.fitness -= potentialBuildingDamage(coord.getX(), coord.getY(),
-                        deployed_ent);
+                coord.fitness -= potentialBuildingDamage(coord.getX(), coord.getY(), deployed_ent);
             }
 
             // Infantry
@@ -865,22 +855,18 @@ public abstract class BotClient extends Client {
                 // infantry
                 // rough is nice, too
                 // -> Massed infantry is more effective, so try to cluster them
-                if (board.getHex(coord.getX(), coord.getY()).containsTerrain(
-                        Terrains.ROUGH)) {
+                if (board.getHex(coord.getX(), coord.getY()).containsTerrain(Terrains.ROUGH)) {
                     coord.fitness += 1.5;
                 }
-                if (board.getHex(coord.getX(), coord.getY()).containsTerrain(
-                        Terrains.WOODS)) {
+                if (board.getHex(coord.getX(), coord.getY()).containsTerrain(Terrains.WOODS)) {
                     coord.fitness += 2;
                 }
-                if (board.getHex(coord.getX(), coord.getY()).containsTerrain(
-                        Terrains.BUILDING)) {
+                if (board.getHex(coord.getX(), coord.getY()).containsTerrain(Terrains.BUILDING)) {
                     coord.fitness += 4;
                 }
                 highestHex = coord.getCoords();
                 for (Entity test_ent : game.getEntitiesVector(highestHex)) {
-                    if ((deployed_ent.getOwner().equals(test_ent.getOwner()))
-                            && !deployed_ent.equals(test_ent)) {
+                    if ((deployed_ent.getOwner().equals(test_ent.getOwner())) && !deployed_ent.equals(test_ent)) {
                         if (test_ent instanceof Infantry) {
                             coord.fitness += 2;
                             break;
@@ -892,9 +878,9 @@ public abstract class BotClient extends Client {
                 for (int x = 0; x < 6 && !foundAdj; x++) {
                     highestHex = coord.getCoords().translated(x);
                     for (Entity test_ent : game.getEntitiesVector(highestHex)) {
-                        if ((owner.equals(test_ent.getOwner()))
-                                && !deployed_ent.equals(test_ent)
-                                && (test_ent instanceof Infantry)) {
+                        if ((owner.equals(test_ent.getOwner())) &&
+                                  !deployed_ent.equals(test_ent) &&
+                                  (test_ent instanceof Infantry)) {
 
                             coord.fitness += 1;
                             foundAdj = true;
@@ -906,15 +892,13 @@ public abstract class BotClient extends Client {
                 // Not sure why bot tries to deploy infantry in water, it SHOULD
                 // be caught by the isHexProhibited method when
                 // selecting hexes, but sometimes it has a mind of its own so...
-                if (board.getHex(coord.getX(), coord.getY()).containsTerrain(
-                        Terrains.WATER)) {
+                if (board.getHex(coord.getX(), coord.getY()).containsTerrain(Terrains.WATER)) {
                     coord.fitness -= 10;
                 }
             }
 
             // some criteria for deploying non-vtol tanks
-            if (deployed_ent.hasETypeFlag(Entity.ETYPE_TANK) &&
-                    !deployed_ent.hasETypeFlag(Entity.ETYPE_VTOL)) {
+            if (deployed_ent.hasETypeFlag(Entity.ETYPE_TANK) && !deployed_ent.hasETypeFlag(Entity.ETYPE_VTOL)) {
                 // Tracked vehicle
                 // -> Trees increase fitness
                 if (deployed_ent.getMovementMode() == EntityMovementMode.TRACKED) {
@@ -942,8 +926,7 @@ public abstract class BotClient extends Client {
             // ->
             // -> Trees increase fitness by +2 (minor)
             if (deployed_ent instanceof ProtoMek) {
-                if (board.getHex(coord.getX(), coord.getY()).containsTerrain(
-                        Terrains.WOODS)) {
+                if (board.getHex(coord.getX(), coord.getY()).containsTerrain(Terrains.WOODS)) {
                     coord.fitness += 2;
                 }
             }
@@ -980,12 +963,9 @@ public abstract class BotClient extends Client {
     }
 
     /**
-     * Determines if the given entity has reasonable access to the "opposite" edge
-     * of the board from its
-     * current position. Returns 0 if this can be accomplished without destroying
-     * any terrain,
-     * -50 if this can be accomplished but terrain must be destroyed,
-     * -100 if this cannot be accomplished at all
+     * Determines if the given entity has reasonable access to the "opposite" edge of the board from its current
+     * position. Returns 0 if this can be accomplished without destroying any terrain, -50 if this can be accomplished
+     * but terrain must be destroyed, -100 if this cannot be accomplished at all
      */
     private int calculateEdgeAccessFitness(Entity entity, Board board) {
         // Flying units can always get anywhere
@@ -1022,15 +1002,14 @@ public abstract class BotClient extends Client {
     // Missile hits table
     // Some of these are interpolated for odd weapons sizes found in Protos and
     // new BAs
-    private static float[] expectedHitsByRackSize = { 0.0f, 1.0f, 1.58f, 2.0f,
-            2.63f, 3.17f, 4.0f, 4.49f, 4.98f, 5.47f, 6.31f, 7.23f, 8.14f,
-            8.59f, 9.04f, 9.5f, 0.0f, 0.0f, 0.0f, 0.0f, 12.7f };
+    private static float[] expectedHitsByRackSize = { 0.0f, 1.0f, 1.58f, 2.0f, 2.63f, 3.17f, 4.0f, 4.49f, 4.98f, 5.47f,
+                                                      6.31f, 7.23f, 8.14f, 8.59f, 9.04f, 9.5f, 0.0f, 0.0f, 0.0f, 0.0f,
+                                                      12.7f };
 
     /**
-     * Determines the expected damage of a weapon attack, based on to-hit, salvo
-     * sizes, etc. This has been copied almost wholesale from
-     * Compute.getExpectedDamage; the log file print commands were removed due to
-     * excessive data generated
+     * Determines the expected damage of a weapon attack, based on to-hit, salvo sizes, etc. This has been copied almost
+     * wholesale from Compute.getExpectedDamage; the log file print commands were removed due to excessive data
+     * generated
      */
     private static float getDeployDamage(Game g, WeaponAttackAction waa, List<ECMInfo> allECMInfo) {
         Entity attacker = g.getEntity(waa.getEntityId());
@@ -1059,8 +1038,7 @@ public abstract class BotClient extends Client {
             AmmoType at = (AmmoType) weapon.getLinked().getType();
 
             float fHits;
-            if ((wt.getAmmoType() == AmmoType.T_SRM_STREAK)
-                    || (wt.getAmmoType() == AmmoType.T_LRM_STREAK)) {
+            if ((wt.getAmmoType() == AmmoType.T_SRM_STREAK) || (wt.getAmmoType() == AmmoType.T_LRM_STREAK)) {
                 fHits = wt.getRackSize();
             } else if ((wt.getRackSize() == 40) || (wt.getRackSize() == 30)) {
                 fHits = 2.0f * expectedHitsByRackSize[wt.getRackSize() / 2];
@@ -1089,9 +1067,8 @@ public abstract class BotClient extends Client {
     }
 
     /**
-     * If the unit has stealth armor, turning it off is probably a good idea if
-     * most of the enemy force is at 'short' range or if in danger of
-     * overheating
+     * If the unit has stealth armor, turning it off is probably a good idea if most of the enemy force is at 'short'
+     * range or if in danger of overheating
      */
 
     private void toggleStealth() {
@@ -1139,15 +1116,11 @@ public abstract class BotClient extends Client {
 
                                     for (Entity test_ent : game.getEntitiesVector()) {
                                         if (check_ent.isEnemyOf(test_ent)) {
-                                            total_bv += test_ent
-                                                    .calculateBattleValue();
+                                            total_bv += test_ent.calculateBattleValue();
                                             if (test_ent.isVisibleToEnemy()) {
                                                 known_count++;
-                                                known_bv += test_ent
-                                                        .calculateBattleValue();
-                                                known_range += Compute
-                                                        .effectiveDistance(game,
-                                                                check_ent, test_ent);
+                                                known_bv += test_ent.calculateBattleValue();
+                                                known_range += Compute.effectiveDistance(game, check_ent, test_ent);
                                             }
                                         }
                                     }
@@ -1181,8 +1154,7 @@ public abstract class BotClient extends Client {
         String message = null;
 
         try (FileInputStream fis = new FileInputStream("./mmconf/botmessages.txt"); // TODO : Remove inline file path
-                InputStreamReader isr = new InputStreamReader(fis);
-                BufferedReader br = new BufferedReader(isr)) {
+              InputStreamReader isr = new InputStreamReader(fis); BufferedReader br = new BufferedReader(isr)) {
             while (br.ready()) {
                 message = br.readLine();
                 if (Compute.randomInt(10) == 1) {
@@ -1209,8 +1181,8 @@ public abstract class BotClient extends Client {
 
         textArea.setEditable(false);
         JScrollPane scrollPane = new JScrollPane(textArea,
-                ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
-                ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+              ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
+              ScrollPaneConstants.HORIZONTAL_SCROLLBAR_AS_NEEDED);
         textArea.setText("<pre>" + message + "</pre>");
         JOptionPane.showMessageDialog(frame, scrollPane, title, JOptionPane.ERROR_MESSAGE);
     }
@@ -1222,7 +1194,7 @@ public abstract class BotClient extends Client {
         if (getClientGUI() != null) {
             Map<String, AbstractClient> bots = getClientGUI().getLocalBots();
             String oldName = getName();
-            String newName = (String) (inP.getObject(0));
+            String newName = inP.getStringValue(0);
             if (!this.equals(bots.get(oldName))) {
                 logger.error("Name correction arrived at incorrect BotClient!");
                 return;
@@ -1230,7 +1202,7 @@ public abstract class BotClient extends Client {
             bots.remove(oldName);
             bots.put(newName, this);
         }
-        setName((String) (inP.getObject(0)));
+        setName(inP.getStringValue(0));
     }
 
     private ClientGUI getClientGUI() {
@@ -1245,7 +1217,8 @@ public abstract class BotClient extends Client {
         // Do nothing;
     }
 
-    private record MinefieldNumbers(int number, int type) {}
+    private record MinefieldNumbers(int number, int type) {
+    }
 
     /**
      * Deploy minefields for the bot
@@ -1263,6 +1236,7 @@ public abstract class BotClient extends Client {
 
     /**
      * Deploy the specified number of minefields
+     *
      * @param deployedMinefields the vector to add the deployed minefields to
      */
     private void performMinefieldDeployment(Vector<Minefield> deployedMinefields) {
@@ -1284,17 +1258,21 @@ public abstract class BotClient extends Client {
 
     /**
      * Deploy the specified number of minefields of the specified type
-     * @param minefieldNumber the number of minefields to deploy and the type of minefield to deploy
-     * @param coordsSet the set of coordinates to deploy the minefields to
+     *
+     * @param minefieldNumber    the number of minefields to deploy and the type of minefield to deploy
+     * @param coordsSet          the set of coordinates to deploy the minefields to
      * @param deployedMinefields the vector to add the deployed minefields to
      */
-    private void deployMinefields(MinefieldNumbers minefieldNumber, Deque<Coords> coordsSet, Vector<Minefield> deployedMinefields) {
+    private void deployMinefields(MinefieldNumbers minefieldNumber, Deque<Coords> coordsSet,
+                                  Vector<Minefield> deployedMinefields) {
         int minesToDeploy = minefieldNumber.number();
-        while(!coordsSet.isEmpty() && minesToDeploy > 0) {
+        while (!coordsSet.isEmpty() && minesToDeploy > 0) {
             Coords coords = coordsSet.poll();
             int density = Compute.randomIntInclusive(30) + 5;
-            Minefield minefield = Minefield.createMinefield(
-                  coords, getLocalPlayer().getId(), minefieldNumber.type(), density);
+            Minefield minefield = Minefield.createMinefield(coords,
+                  getLocalPlayer().getId(),
+                  minefieldNumber.type(),
+                  density);
             deployedMinefields.add(minefield);
             minesToDeploy--;
         }
@@ -1302,37 +1280,36 @@ public abstract class BotClient extends Client {
 
     /**
      * Get the number of minefields of each type that the bot should deploy
+     *
      * @return an array of MinefieldNumbers, each representing the number of a specific type of minefield to deploy
      */
     private MinefieldNumbers[] getMinefieldNumbers() {
-        return new MinefieldNumbers[]{
-              new MinefieldNumbers(getLocalPlayer().getNbrMFActive(), Minefield.TYPE_ACTIVE),
-              new MinefieldNumbers(getLocalPlayer().getNbrMFInferno(), Minefield.TYPE_INFERNO),
-              new MinefieldNumbers(getLocalPlayer().getNbrMFConventional(), Minefield.TYPE_CONVENTIONAL),
-              new MinefieldNumbers(getLocalPlayer().getNbrMFVibra(), Minefield.TYPE_VIBRABOMB),
-              // the following are added for completeness, but are not used by the bot
-              new MinefieldNumbers(0, Minefield.TYPE_COMMAND_DETONATED), // no command detonated mines
-              new MinefieldNumbers(0, Minefield.TYPE_EMP), // no field for EMP mines exists
+        return new MinefieldNumbers[] { new MinefieldNumbers(getLocalPlayer().getNbrMFActive(), Minefield.TYPE_ACTIVE),
+                                        new MinefieldNumbers(getLocalPlayer().getNbrMFInferno(),
+                                              Minefield.TYPE_INFERNO),
+                                        new MinefieldNumbers(getLocalPlayer().getNbrMFConventional(),
+                                              Minefield.TYPE_CONVENTIONAL),
+                                        new MinefieldNumbers(getLocalPlayer().getNbrMFVibra(),
+                                              Minefield.TYPE_VIBRABOMB),
+                                        // the following are added for completeness, but are not used by the bot
+                                        new MinefieldNumbers(0, Minefield.TYPE_COMMAND_DETONATED),
+                                        // no command detonated mines
+                                        new MinefieldNumbers(0, Minefield.TYPE_EMP), // no field for EMP mines exists
         };
     }
 
     /**
      * Get the minefield deployment planner to use for this bot
+     *
      * @return the minefield deployment planner
      */
     protected MinefieldDeploymentPlanner getMinefieldDeploymentPlanner() {
         return new RandomMinefieldDeploymentPlanner(getBoard());
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
-    protected void receiveBuildingCollapse(Packet packet) {
-        game.getBoard().collapseBuilding((Vector<Coords>) packet.getObject(0));
-    }
-
     /**
-     * The bot client doesn't really need a text report
-     * Let's save ourselves a little processing time and not deal with any of it
+     * The bot client doesn't really need a text report Let's save ourselves a little processing time and not deal with
+     * any of it
      */
     @Override
     public String receiveReport(List<Report> reports) {
@@ -1340,8 +1317,7 @@ public abstract class BotClient extends Client {
     }
 
     /**
-     * The bot client has no need of image tag caching
-     * Let's save ourselves some CPU and memory and not deal with it
+     * The bot client has no need of image tag caching Let's save ourselves some CPU and memory and not deal with it
      */
     @Override
     protected void cacheImgTag(Entity entity) {

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -26,9 +26,6 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import megamek.client.ui.swing.TowLinkWarning;
-import org.apache.logging.log4j.Level;
-
 import megamek.client.bot.BotClient;
 import megamek.client.bot.ChatProcessor;
 import megamek.client.bot.PhysicalCalculator;
@@ -38,6 +35,7 @@ import megamek.client.bot.princess.FiringPlanCalculationParameters.Builder;
 import megamek.client.bot.princess.PathRanker.PathRankerType;
 import megamek.client.bot.princess.UnitBehavior.BehaviorType;
 import megamek.client.ui.SharedUtility;
+import megamek.client.ui.swing.TowLinkWarning;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.*;
 import megamek.common.BulldozerMovePath.MPCostComparator;
@@ -66,6 +64,7 @@ import megamek.common.weapons.AmmoWeapon;
 import megamek.common.weapons.StopSwarmAttack;
 import megamek.common.weapons.Weapon;
 import megamek.logging.MMLogger;
+import org.apache.logging.log4j.Level;
 
 public class Princess extends BotClient {
     private static final MMLogger logger = MMLogger.create(Princess.class);
@@ -152,8 +151,8 @@ public class Princess extends BotClient {
     private final Precognition precognition;
     private final Thread precognitionThread;
     /**
-     * Mapping to hold the damage allocated to each targetable, stored by ID.
-     * Used to allocate damage more intelligently and avoid overkill.
+     * Mapping to hold the damage allocated to each targetable, stored by ID. Used to allocate damage more intelligently
+     * and avoid overkill.
      */
     private final ConcurrentHashMap<Integer, Double> damageMap = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<Integer, Integer> teamTagTargetsMap = new ConcurrentHashMap<>();
@@ -184,9 +183,10 @@ public class Princess extends BotClient {
     private EnemyTracker enemyTracker;
     private CoverageValidator coverageValidator;
     private SwarmCenterManager swarmCenterManager;
+
     /**
-     * Returns a new Princess Bot with the given behavior and name, configured for the given
-     * host and port. The new Princess Bot outputs its settings to its own logger.
+     * Returns a new Princess Bot with the given behavior and name, configured for the given host and port. The new
+     * Princess Bot outputs its settings to its own logger.
      */
     public static Princess createPrincess(String name, String host, int port, BehaviorSettings behavior) {
         Princess result = new Princess(name, host, port);
@@ -197,6 +197,7 @@ public class Princess extends BotClient {
 
     /**
      * Constructor - initializes a new instance of the Princess bot.
+     *
      * @param name The display name.
      * @param host The host address to which to connect.
      * @param port The port on the host where to connect.
@@ -220,6 +221,7 @@ public class Princess extends BotClient {
 
     /**
      * Lazy-loading accessor for the artillery targeting control.
+     *
      * @return
      */
     public ArtilleryTargetingControl getArtilleryTargetingControl() {
@@ -231,10 +233,11 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Gets the appropriate path ranker instance given an entity
-     * Uses the entity's EType flags to figure out which one to return
-     * Returns BasicPathRanker by default.
+     * Gets the appropriate path ranker instance given an entity Uses the entity's EType flags to figure out which one
+     * to return Returns BasicPathRanker by default.
+     *
      * @param entity The entity whose ETYPE to check
+     *
      * @return Path ranker instance
      */
     IPathRanker getPathRanker(Entity entity) {
@@ -262,8 +265,8 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Picks a tag target based on the data contained within the given GameCFREvent
-     * Expects the event to have some tag targets and tag target types.
+     * Picks a tag target based on the data contained within the given GameCFREvent Expects the event to have some tag
+     * targets and tag target types.
      */
     @Override
     protected int pickTagTarget(GameCFREvent evt) {
@@ -300,7 +303,11 @@ public class Princess extends BotClient {
             //  note: technically we should,
             // we don't care about specific firing entity, we just want one on our side
             //      since we only use it to determine friendliness
-            double currentDamage = getArtilleryTargetingControl().calculateDamageValue(10, targetHex, arbitraryEntity, game, this);
+            double currentDamage = getArtilleryTargetingControl().calculateDamageValue(10,
+                  targetHex,
+                  arbitraryEntity,
+                  game,
+                  this);
             if (currentDamage > maxDamage) {
                 maxDamage = currentDamage;
                 maxDamageHex = targetHex;
@@ -341,16 +348,17 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Retrieves maximum weapon range for the given entity.
-     * Cached version of entity.getMaxWeaponRange()
-     * @param entity Entity we're checking
-     * @param airborneTarget Whether the potential target is in the air, only relevant for
-     *          aircraft shooting at other aircraft on ground maps.
+     * Retrieves maximum weapon range for the given entity. Cached version of entity.getMaxWeaponRange()
+     *
+     * @param entity         Entity we're checking
+     * @param airborneTarget Whether the potential target is in the air, only relevant for aircraft shooting at other
+     *                       aircraft on ground maps.
+     *
      * @return
      */
     public int getMaxWeaponRange(Entity entity, boolean airborneTarget) {
-        return getFireControlState().getWeaponRanges(airborneTarget).
-            computeIfAbsent(entity.getId(), ent -> entity.getMaxWeaponRange(airborneTarget));
+        return getFireControlState().getWeaponRanges(airborneTarget)
+                     .computeIfAbsent(entity.getId(), ent -> entity.getMaxWeaponRange(airborneTarget));
     }
 
     public void setFallBack(final boolean fallBack, final String reason) {
@@ -359,8 +367,7 @@ public class Princess extends BotClient {
     }
 
     public void setBehaviorSettings(final BehaviorSettings behaviorSettings) {
-        logger.info("New behavior settings for " + getName() +
-            "\n" + behaviorSettings.toLog());
+        logger.info("New behavior settings for " + getName() + "\n" + behaviorSettings.toLog());
         try {
             this.behaviorSettings = behaviorSettings.getCopy();
         } catch (final PrincessException e) {
@@ -378,16 +385,14 @@ public class Princess extends BotClient {
         }
 
         for (final String targetCoords : behaviorSettings.getStrategicBuildingTargets()) {
-            if (!StringUtil.isPositiveInteger(targetCoords) ||
-                (4 != targetCoords.length())) {
+            if (!StringUtil.isPositiveInteger(targetCoords) || (4 != targetCoords.length())) {
                 continue;
             }
             final String x = targetCoords.substring(0, 2);
             final String y = targetCoords.replaceFirst(x, "");
             // Need to subtract 1, since we are given a Hex number string,
             // which is Coords X + 1Y + 1
-            final Coords coords = new Coords(Integer.parseInt(x) - 1,
-                    Integer.parseInt(y) - 1);
+            final Coords coords = new Coords(Integer.parseInt(x) - 1, Integer.parseInt(y) - 1);
             getStrategicBuildingTargets().add(coords);
         }
 
@@ -396,18 +401,20 @@ public class Princess extends BotClient {
 
     /**
      * Get the appropriate instance of a FireControl object for the given entity.
+     *
      * @param entity The entity in question.
+     *
      * @return Instance of FireControl
      */
     FireControl getFireControl(Entity entity) {
         if (entity.hasETypeFlag(Entity.ETYPE_INFANTRY)) {
             return fireControls.get(FireControlType.Infantry);
-        // some entities can shoot at multiple targets without undergoing too much penalty
-        // so let's get them doing that.
+            // some entities can shoot at multiple targets without undergoing too much penalty
+            // so let's get them doing that.
         } else if (entity.getCrew().getCrewType().getMaxPrimaryTargets() > 1 ||
-                entity.hasQuirk(OptionsConstants.QUIRK_POS_MULTI_TRAC) ||
-                entity.hasAbility(OptionsConstants.GUNNERY_MULTI_TASKER) ||
-                entity.getCrew().getCrewType().getMaxPrimaryTargets() < 0) {
+                         entity.hasQuirk(OptionsConstants.QUIRK_POS_MULTI_TRAC) ||
+                         entity.hasAbility(OptionsConstants.GUNNERY_MULTI_TASKER) ||
+                         entity.getCrew().getCrewType().getMaxPrimaryTargets() < 0) {
             return fireControls.get(FireControlType.MultiTarget);
         }
 
@@ -496,8 +503,7 @@ public class Princess extends BotClient {
         // if we are using forced withdrawal, and the entity being considered is crippled
         // we will opt to not re-deploy the entity
         if (getForcedWithdrawal() && getEntity(entityNum).isCrippled()) {
-            logger.info("Declining to deploy crippled unit: "
-                    + getEntity(entityNum).getChassis() + ". Removing unit.");
+            logger.info("Declining to deploy crippled unit: " + getEntity(entityNum).getChassis() + ". Removing unit.");
             sendDeleteEntity(entityNum);
             return;
         }
@@ -512,8 +518,9 @@ public class Princess extends BotClient {
         final Coords deployCoords = getFirstValidCoords(getEntity(entityNum), startingCoords);
         if (null == deployCoords) {
             // if I cannot deploy anywhere, then I get rid of the entity instead so that we may go about our business
-            logger.error("getCoordsAround gave no location for "
-                    + getEntity(entityNum).getChassis() + ". Removing unit.");
+            logger.error("getCoordsAround gave no location for " +
+                               getEntity(entityNum).getChassis() +
+                               ". Removing unit.");
 
             sendDeleteEntity(entityNum);
             return;
@@ -534,8 +541,7 @@ public class Princess extends BotClient {
         // if I haven't found a decent facing, then at least face towards
         // the center of the board
         if (-1 == decentFacing) {
-            final Coords center = new Coords(game.getBoard().getWidth() / 2,
-                                       game.getBoard().getHeight() / 2);
+            final Coords center = new Coords(game.getBoard().getWidth() / 2, game.getBoard().getHeight() / 2);
             decentFacing = deployCoords.direction(center);
         }
 
@@ -549,7 +555,11 @@ public class Princess extends BotClient {
                 deployElevation = deployEntity.getAltitude();
             } else if (game.getBoard().inAtmosphere()) {
                 // try to keep the altitude set in the lobby, but stay above the terrain
-                var deploymentHelper = new AllowedDeploymentHelper(deployEntity, deployCoords, game.getBoard(), deployHex, game);
+                var deploymentHelper = new AllowedDeploymentHelper(deployEntity,
+                      deployCoords,
+                      game.getBoard(),
+                      deployHex,
+                      game);
                 List<ElevationOption> allowedDeployment = deploymentHelper.findAllowedElevations(DeploymentElevationType.ALTITUDE);
                 if (allowedDeployment.isEmpty()) {
                     // that's bad, cannot deploy at all
@@ -557,7 +567,8 @@ public class Princess extends BotClient {
                     sendDeleteEntity(entityNum);
                     return;
                 } else {
-                    deployElevation = Math.max(deployEntity.getAltitude(), Collections.min(allowedDeployment).elevation());
+                    deployElevation = Math.max(deployEntity.getAltitude(),
+                          Collections.min(allowedDeployment).elevation());
                 }
             }
         } else {
@@ -569,13 +580,13 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Calculate the deployment elevation for the given entity.
-     * Gun Emplacements should deploy on the rooftop of the building for maximum visibility.
+     * Calculate the deployment elevation for the given entity. Gun Emplacements should deploy on the rooftop of the
+     * building for maximum visibility.
      */
     private int getDeployElevation(Entity deployEntity, Hex deployHex) {
         // Entity.elevationOccupied performs a null check on Hex
         if (deployEntity instanceof GunEmplacement) {
-           return deployEntity.elevationOccupied(deployHex) + deployHex.terrainLevel(Terrains.BLDG_ELEV);
+            return deployEntity.elevationOccupied(deployHex) + deployHex.terrainLevel(Terrains.BLDG_ELEV);
         } else {
             return deployEntity.elevationOccupied(deployHex);
         }
@@ -586,11 +597,10 @@ public class Princess extends BotClient {
      * It's possible to return null, which indicates that there are no valid hexes for the given unit to deploy into.
      */
     @Override
-    protected @Nullable Coords getFirstValidCoords(final Entity deployedUnit,
-                                         final List<Coords> possibleDeployCoords) {
+    protected @Nullable Coords getFirstValidCoords(final Entity deployedUnit, final List<Coords> possibleDeployCoords) {
         if (Entity.ETYPE_GUN_EMPLACEMENT == (deployedUnit.getEntityType() & Entity.ETYPE_GUN_EMPLACEMENT)) {
-            final List<Coords> validCoords = calculateTurretDeploymentLocations(
-                    (GunEmplacement) deployedUnit, possibleDeployCoords);
+            final List<Coords> validCoords = calculateTurretDeploymentLocations((GunEmplacement) deployedUnit,
+                  possibleDeployCoords);
             if (!validCoords.isEmpty()) {
                 return validCoords.get(0);
             }
@@ -605,8 +615,10 @@ public class Princess extends BotClient {
 
     /**
      * Function that calculates deployment coordinates
-     * @param deployedUnit The unit being considered for deployment
+     *
+     * @param deployedUnit         The unit being considered for deployment
      * @param possibleDeployCoords The coordinates being considered for deployment
+     *
      * @return The first valid deployment coordinates.
      */
     private Coords calculateAdvancedAerospaceDeploymentCoords(final Entity deployedUnit,
@@ -628,7 +640,8 @@ public class Princess extends BotClient {
 
     /**
      * Helper function that calculates the possible locations where a given gun emplacement can be deployed
-     * @param deployedUnit The unit to check
+     *
+     * @param deployedUnit         The unit to check
      * @param possibleDeployCoords The list of possible deployment coordinates
      */
     private List<Coords> calculateTurretDeploymentLocations(final GunEmplacement deployedUnit,
@@ -647,8 +660,13 @@ public class Princess extends BotClient {
                 final int buildingHeight = hex.terrainLevel(Terrains.BLDG_ELEV);
 
                 // check stacking violation at the roof level
-                final Entity violation = Compute.stackingViolation(game, deployedUnit, coords, buildingHeight, coords,
-                        null, deployedUnit.climbMode());
+                final Entity violation = Compute.stackingViolation(game,
+                      deployedUnit,
+                      coords,
+                      buildingHeight,
+                      coords,
+                      null,
+                      deployedUnit.climbMode());
                 // Ignore coords that could cause a stacking violation
                 if (null == violation) {
                     turretDeploymentLocations.add(coords);
@@ -656,13 +674,16 @@ public class Princess extends BotClient {
             }
         }
 
-        turretDeploymentLocations.sort((arg0, arg1) -> calculateTurretDeploymentValue(arg1) - calculateTurretDeploymentValue(arg0));
+        turretDeploymentLocations.sort((arg0, arg1) -> calculateTurretDeploymentValue(arg1) -
+                                                             calculateTurretDeploymentValue(arg0));
         return turretDeploymentLocations;
     }
 
     /**
      * Helper function that calculates the "utility" of placing a turret at the given coords
+     *
      * @param coords The location of the building being considered.
+     *
      * @return An "arbitrary" utility number
      */
     private int calculateTurretDeploymentValue(final Coords coords) {
@@ -687,26 +708,25 @@ public class Princess extends BotClient {
 
         double rank;
         // allAtDistance uses a concept of radius that is 1 smaller.
-        ArrayList<Coords> kernel = start.getFinalCoords().allAtDistance(radius+1);
+        ArrayList<Coords> kernel = start.getFinalCoords().allAtDistance(radius + 1);
 
         // Get all paths from the start point to the outer hexes that use "radius" MP
         // Worse starting hexes have fewer, and shorter, paths
-        ShortestPathFinder pf = ShortestPathFinder.newInstanceOfOneToAll(
-                                        radius, MoveStepType.FORWARDS, game);
+        ShortestPathFinder pf = ShortestPathFinder.newInstanceOfOneToAll(radius, MoveStepType.FORWARDS, game);
         pf.run(start);
 
         // Lower rank is better; 0.0 is minimum at this point.
         rank = Math.max(kernel.size() - pf.getAllComputedPaths().size(), 0.0);
-        for (MovePath mp: pf.getAllComputedPaths().values()) {
+        for (MovePath mp : pf.getAllComputedPaths().values()) {
             rank -= mp.getHexesMoved();
             rank += ranker.checkPathForHazards(mp, deployedUnit, game);
         }
 
         if (sb != null) {
             sb.append("\n\tAll computed ")
-                    .append(radius)
-                    .append("-length paths: ")
-                    .append(pf.getAllComputedPaths().size());
+                  .append(radius)
+                  .append("-length paths: ")
+                  .append(pf.getAllComputedPaths().size());
             sb.append("\n\tFinal rank (including hazards): ").append(rank);
             logger.debug(sb.toString());
         }
@@ -715,16 +735,13 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Rank possible deployment coordinates by hazard, path freedom, concealment
-     * 1. Randomly select N coords from list
-     * 2. For selected coords:
-     *      1. Check if hex is invalid
-     *      2. Create a MovePath containing the starting coordinate
-     *      3. Get the hazard value
-     *      4. Save Coords to HashMap with hazard as key
+     * Rank possible deployment coordinates by hazard, path freedom, concealment 1. Randomly select N coords from list
+     * 2. For selected coords: 1. Check if hex is invalid 2. Create a MovePath containing the starting coordinate 3. Get
+     * the hazard value 4. Save Coords to HashMap with hazard as key
      *
      * @param deployedUnit
      * @param possibleDeployCoords
+     *
      * @return
      */
     protected Coords rankDeploymentCoords(Entity deployedUnit, List<Coords> possibleDeployCoords) {
@@ -734,9 +751,11 @@ public class Princess extends BotClient {
             sb.append("Ranking deployment hexes...");
         }
 
-        if ((deployedUnit.getTowing() != Entity.NONE && game.getEntity(deployedUnit.getTowing()) != null)
-                || (deployedUnit.getTowedBy() != Entity.NONE) && game.getEntity(deployedUnit.getTowedBy()) != null) {
-            List<Coords> filteredCoords = TowLinkWarning.findValidDeployCoordsForTractorTrailer(game, deployedUnit, getBoard());
+        if ((deployedUnit.getTowing() != Entity.NONE && game.getEntity(deployedUnit.getTowing()) != null) ||
+                  (deployedUnit.getTowedBy() != Entity.NONE) && game.getEntity(deployedUnit.getTowedBy()) != null) {
+            List<Coords> filteredCoords = TowLinkWarning.findValidDeployCoordsForTractorTrailer(game,
+                  deployedUnit,
+                  getBoard());
             if (filteredCoords != null && !filteredCoords.isEmpty()) {
                 possibleDeployCoords = possibleDeployCoords.stream().filter(filteredCoords::contains).toList();
             } else {
@@ -760,10 +779,9 @@ public class Princess extends BotClient {
         HashMap<Double, ArrayList<Coords>> rankedCoords = new HashMap<>();
 
         // Units that deploy airborne don't need to worry about all this
-        if (!(deployedUnit.isAero()
-                || ((deployedUnit.getMovementMode().isVTOL() || deployedUnit.getMovementMode().isWiGE())
-                    && deployedUnit.getElevation() > 0)
-        )) {
+        if (!(deployedUnit.isAero() ||
+                    ((deployedUnit.getMovementMode().isVTOL() || deployedUnit.getMovementMode().isWiGE()) &&
+                           deployedUnit.getElevation() > 0))) {
             double hazard;
             int longest = 0;
             int size = 0;
@@ -779,9 +797,10 @@ public class Princess extends BotClient {
                     longest = Math.max(size, longest);
 
                     if (sb != null) {
-                        sb.append("\n\tFound valid coordinates (").append(dest.toString())
-                                .append(") with initial hazard of: ")
-                                .append(hazard);
+                        sb.append("\n\tFound valid coordinates (")
+                              .append(dest.toString())
+                              .append(") with initial hazard of: ")
+                              .append(hazard);
                     }
                 }
 
@@ -796,12 +815,11 @@ public class Princess extends BotClient {
                 double scoreToBeat = -Double.MAX_VALUE;
                 double current;
                 ArrayList<Coords> candidates = rankedCoords.get(bestRank);
-                for (Coords c: candidates) {
+                for (Coords c : candidates) {
                     mp.clear();
-                    mp.addStep((deployedUnit.getAnyTypeMaxJumpMP() == 0) ? MoveStepType.NONE: MoveStepType.START_JUMP);
+                    mp.addStep((deployedUnit.getAnyTypeMaxJumpMP() == 0) ? MoveStepType.NONE : MoveStepType.START_JUMP);
                     mp.getLastStep().setPosition(c);
-                    current = bestRank - rankKernelAroundCoords(
-                            mp, deployedUnit, RADIUS, (BasicPathRanker) ranker);
+                    current = bestRank - rankKernelAroundCoords(mp, deployedUnit, RADIUS, (BasicPathRanker) ranker);
                     if (current > scoreToBeat) {
                         scoreToBeat = current;
                         bestCandidate = c;
@@ -809,11 +827,12 @@ public class Princess extends BotClient {
                 }
                 if (bestCandidate != null) {
                     if (sb != null) {
-                        sb.append("\n\tFound best candidate (").append(bestCandidate.toString())
-                                .append(") out of ")
-                                .append(candidates.size())
-                                .append(" with a score of ")
-                                .append(scoreToBeat);
+                        sb.append("\n\tFound best candidate (")
+                              .append(bestCandidate.toString())
+                              .append(") out of ")
+                              .append(candidates.size())
+                              .append(" with a score of ")
+                              .append(scoreToBeat);
                         logger.debug(sb.toString());
                     }
                     return bestCandidate;
@@ -862,8 +881,8 @@ public class Princess extends BotClient {
 
             // If my unit is forced to withdraw, don't fire unless I've been fired on.
             if (getForcedWithdrawal() && shooter.isCrippled()) {
-                final StringBuilder msg = new StringBuilder(shooter.getDisplayName())
-                        .append(" is crippled and withdrawing.");
+                final StringBuilder msg = new StringBuilder(shooter.getDisplayName()).append(
+                      " is crippled and withdrawing.");
                 try {
                     if (shooter.getSwarmTargetId() != Entity.NONE) {
                         msg.append("\n\tBut will need to stop swarming before fleeing.");
@@ -892,16 +911,18 @@ public class Princess extends BotClient {
 
                 // entity that can act this turn make sure weapons are loaded
                 final FiringPlan plan = getFireControl(shooter).getBestFiringPlan(shooter,
-                        getHonorUtil(), game, ammoConservation);
+                      getHonorUtil(),
+                      game,
+                      ammoConservation);
                 if ((null != plan) && (plan.getExpectedDamage() > 0)) {
                     getFireControl(shooter).loadAmmo(shooter, plan);
                     plan.sortPlan();
 
                     // Log info and debug at different levels
-                    logger.info(shooter.getDisplayName() + " - Best Firing Plan: " +
-                            plan.getDebugDescription(false));
-                    logger.debug(shooter.getDisplayName() + " - Detailed Best Firing Plan: " +
-                            plan.getDebugDescription(true));
+                    logger.info(shooter.getDisplayName() + " - Best Firing Plan: " + plan.getDebugDescription(false));
+                    logger.debug(shooter.getDisplayName() +
+                                       " - Detailed Best Firing Plan: " +
+                                       plan.getDebugDescription(true));
 
                     // Consider making an aimed shot if the target is shut down or the attacker has
                     // a targeting computer. Alternatively, consider using the called shots optional
@@ -922,15 +943,15 @@ public class Princess extends BotClient {
 
                     // TODO: gate this block on a game option or client option
                     if (targetID > Entity.NONE &&
-                            primaryFire.getTarget() != null &&
-                            plan.stream().allMatch(curFire -> primaryFire.getTarget().getId() == targetID) &&
-                            checkForEnhancedTargeting(shooter,
+                              primaryFire.getTarget() != null &&
+                              plan.stream().allMatch(curFire -> primaryFire.getTarget().getId() == targetID) &&
+                              checkForEnhancedTargeting(shooter,
                                     primaryFire.getTarget(),
                                     primaryFire.getToHit().getCover())) {
 
                         Entity aimTarget = (Mek) primaryFire.getTarget();
                         if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_CALLED_SHOTS) &&
-                                (!aimTarget.isImmobile() || useCalledShotsOnImmobileTarget)) {
+                                  (!aimTarget.isImmobile() || useCalledShotsOnImmobileTarget)) {
                             isCalledShot = true;
                         }
 
@@ -941,13 +962,16 @@ public class Princess extends BotClient {
                             // Get the Mek location to aim at. Infantry and BA will go for the head
                             // if the odds are good.
                             aimLocation = getAimedShotLocation(primaryFire.getTarget(),
-                                    plan, rearShot, shooter.isInfantry());
+                                  plan,
+                                  rearShot,
+                                  shooter.isInfantry());
 
                             // When aiming at a location, don't bother checking for called shots
                             if (aimLocation != Mek.LOC_NONE) {
                                 isCalledShot = false;
                                 // TODO: this should be adjusted to better handle multiple target types
-                                locationDestruction = aimTarget.getArmor(aimLocation, rearShot) + aimTarget.getInternal(aimLocation);
+                                locationDestruction = aimTarget.getArmor(aimLocation, rearShot) +
+                                                            aimTarget.getInternal(aimLocation);
                             }
 
                         }
@@ -955,8 +979,8 @@ public class Princess extends BotClient {
                         if (isCalledShot) {
 
                             calledShotDirection = getCalledShotDirection(primaryFire.getTarget(),
-                                    primaryFire.getToHit().getSideTable(),
-                                    plan);
+                                  primaryFire.getToHit().getSideTable(),
+                                  plan);
 
                         }
 
@@ -980,13 +1004,12 @@ public class Princess extends BotClient {
 
                         // Set attacks as aimed or called, as required
                         if (aimLocation != Mek.LOC_NONE || calledShotDirection != CalledShot.CALLED_NONE) {
-                            setAttackAsAimedOrCalled(shot,
-                                    aimLocation,
-                                    calledShotDirection,
-                                    locationDestruction);
+                            setAttackAsAimedOrCalled(shot, aimLocation, calledShotDirection, locationDestruction);
                         }
                         if (shot.getUpdatedFiringMode() != null) {
-                            super.sendModeChange(shooter.getId(), shooter.getEquipmentNum(shot.getWeapon()), shot.getUpdatedFiringMode());
+                            super.sendModeChange(shooter.getId(),
+                                  shooter.getEquipmentNum(shot.getWeapon()),
+                                  shot.getUpdatedFiringMode());
                         }
                     }
 
@@ -994,7 +1017,8 @@ public class Princess extends BotClient {
                     Vector<EntityAction> actions = new Vector<>();
 
                     // if using search light, it needs to go before the other actions so we can light up what we're shooting at
-                    SearchlightAttackAction searchLightAction = getFireControl(shooter).getSearchLightAction(shooter, plan);
+                    SearchlightAttackAction searchLightAction = getFireControl(shooter).getSearchLightAction(shooter,
+                          plan);
                     if (searchLightAction != null) {
                         actions.add(searchLightAction);
                     }
@@ -1020,16 +1044,19 @@ public class Princess extends BotClient {
             if (shooter.getSwarmTargetId() != Entity.NONE) {
                 // If we are skipping firing while swarming, it is because we are fleeing...
                 // so let's stop swarming if we are doing so
-                final Mounted<?> stopSwarmWeapon = shooter.getIndividualWeaponList().stream()
-                        .filter(weapon -> weapon.getType() instanceof StopSwarmAttack)
-                        .findFirst()
-                        .orElse(null);
+                final Mounted<?> stopSwarmWeapon = shooter.getIndividualWeaponList()
+                                                         .stream()
+                                                         .filter(weapon -> weapon.getType() instanceof StopSwarmAttack)
+                                                         .findFirst()
+                                                         .orElse(null);
                 if (stopSwarmWeapon == null) {
-                    logger.error("Failed to find a Stop Swarm Weapon while Swarming a unit, which should not be possible.");
+                    logger.error(
+                          "Failed to find a Stop Swarm Weapon while Swarming a unit, which should not be possible.");
                 } else {
                     miscPlan = new Vector<>();
-                    miscPlan.add(new WeaponAttackAction(shooter.getId(), shooter.getSwarmTargetId(),
-                            shooter.getEquipmentNum(stopSwarmWeapon)));
+                    miscPlan.add(new WeaponAttackAction(shooter.getId(),
+                          shooter.getSwarmTargetId(),
+                          shooter.getEquipmentNum(stopSwarmWeapon)));
                 }
             }
 
@@ -1070,15 +1097,16 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Calculates the targeting/ off board turn
-     * This includes firing TAG and non-direct-fire artillery
+     * Calculates the targeting/ off board turn This includes firing TAG and non-direct-fire artillery
      */
     @Override
     protected void calculateTargetingOffBoardTurn() {
         Entity entityToFire = getGame().getFirstEntity(getMyTurn());
 
         // if we're crippled, off-board and can do so, disengage
-        if (entityToFire.isOffBoard() && entityToFire.canFlee(entityToFire.getPosition()) && entityToFire.isCrippled(true)) {
+        if (entityToFire.isOffBoard() &&
+                  entityToFire.canFlee(entityToFire.getPosition()) &&
+                  entityToFire.isCrippled(true)) {
             Vector<EntityAction> disengageVector = new Vector<>();
             disengageVector.add(new DisengageAction(entityToFire.getId()));
             sendAttackData(entityToFire.getId(), disengageVector);
@@ -1086,12 +1114,13 @@ public class Princess extends BotClient {
             return;
         }
 
-        FiringPlan firingPlan = getArtilleryTargetingControl().calculateIndirectArtilleryPlan(entityToFire, getGame(), this);
+        FiringPlan firingPlan = getArtilleryTargetingControl().calculateIndirectArtilleryPlan(entityToFire,
+              getGame(),
+              this);
 
         if (!firingPlan.getEntityActionVector().isEmpty()) {
             sendAttackData(entityToFire.getId(), firingPlan.getEntityActionVector());
-        }
-        else {
+        } else {
             if (this.fireControls == null) {
                 initializeFireControls();
             }
@@ -1102,8 +1131,7 @@ public class Princess extends BotClient {
 
     protected Map<WeaponMounted, Double> calcAmmoConservation(final Entity shooter) {
         final double aggroFactor = getBehaviorSettings().getHyperAggressionIndex();
-        final StringBuilder msg = new StringBuilder("\nCalculating ammo conservation for ")
-                .append(shooter.getDisplayName());
+        final StringBuilder msg = new StringBuilder("\nCalculating ammo conservation for ").append(shooter.getDisplayName());
         msg.append("\nAggression Factor = ").append(aggroFactor);
 
         try {
@@ -1114,13 +1142,11 @@ public class Princess extends BotClient {
                 msg.append("\n\t").append(ammoType);
                 if (ammoCounts.containsKey(ammoType)) {
                     ammoCounts.put(ammoType, ammoCounts.get(ammoType) + ammo.getUsableShotsLeft());
-                    msg.append(" + ").append(ammo.getUsableShotsLeft())
-                       .append(" = ").append(ammoCounts.get(ammoType));
+                    msg.append(" + ").append(ammo.getUsableShotsLeft()).append(" = ").append(ammoCounts.get(ammoType));
                     continue;
                 }
                 ammoCounts.put(ammoType, ammo.getUsableShotsLeft());
-                msg.append(" + ").append(ammo.getUsableShotsLeft())
-                   .append(" = ").append(ammoCounts.get(ammoType));
+                msg.append(" + ").append(ammo.getUsableShotsLeft()).append(" = ").append(ammoCounts.get(ammoType));
             }
 
             final Map<WeaponMounted, Double> ammoConservation = new HashMap<>();
@@ -1152,10 +1178,9 @@ public class Princess extends BotClient {
                 // At min aggro (0 of 10), fire on TN 10, 9, 7
                 // At normal aggro (5 of 10), fire on 12, 11, 10
                 // At max aggro (10 of 10), fire on 12, 12, 10
-                final double toHitThreshold =
-                        Math.max(0.01,
-                                (0.6/((8*aggroFactor) + 4)
-                                + 4.0 / (4 * (ammoCount*ammoCount) * (aggroFactor + 2) + (4 / (aggroFactor + 1)))));
+                final double toHitThreshold = Math.max(0.01,
+                      (0.6 / ((8 * aggroFactor) + 4) +
+                             4.0 / (4 * (ammoCount * ammoCount) * (aggroFactor + 2) + (4 / (aggroFactor + 1)))));
                 msg.append("; To Hit Threshold = ").append(new DecimalFormat("0.000").format(toHitThreshold));
                 ammoConservation.put(weapon, toHitThreshold);
             }
@@ -1170,7 +1195,7 @@ public class Princess extends BotClient {
      * Worker method that calculates a point blank shot action vector given a firing entity ID and a target ID.
      *
      * @param firingEntityID the ID of the entity taking the point blank shot
-     * @param targetID the ID of the entity being shot at potentially
+     * @param targetID       the ID of the entity being shot at potentially
      */
     @Override
     protected Vector<EntityAction> calculatePointBlankShot(int firingEntityID, int targetID) {
@@ -1180,7 +1205,9 @@ public class Princess extends BotClient {
             return new Vector<>();
         }
 
-        final FiringPlanCalculationParameters firingPlanCalculationParameters = new Builder().buildExact(shooter, target, calcAmmoConservation(shooter));
+        final FiringPlanCalculationParameters firingPlanCalculationParameters = new Builder().buildExact(shooter,
+              target,
+              calcAmmoConservation(shooter));
         FiringPlan plan = getFireControl(shooter).determineBestFiringPlan(firingPlanCalculationParameters);
         getFireControl(shooter).loadAmmo(shooter, plan);
         plan.sortPlan();
@@ -1200,11 +1227,11 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Calculates the move index for the given unit.
-     * In general, faster units and units closer to the enemy should move before others.
-     * Additional modifiers for being prone, stealth-ed, unit type and so on are also factored in.
+     * Calculates the move index for the given unit. In general, faster units and units closer to the enemy should move
+     * before others. Additional modifiers for being prone, stealth-ed, unit type and so on are also factored in.
      *
      * @param entity The unit to be indexed.
+     *
      * @return The movement index of this unit. May be positive or negative. Higher index values should move first.
      */
     double calculateMoveIndex(final Entity entity, final StringBuilder msg) {
@@ -1281,8 +1308,7 @@ public class Princess extends BotClient {
             }
 
             // Move stealthy units later.
-            if (entity.isStealthActive() || entity.isStealthOn() ||
-                entity.isVoidSigActive() || entity.isVoidSigOn()) {
+            if (entity.isStealthActive() || entity.isStealthOn() || entity.isVoidSigActive() || entity.isVoidSigOn()) {
                 total *= PRIORITY_STEALTH;
                 modifiers.append("\tx1/3 (is Stealth-ed)");
             }
@@ -1295,39 +1321,35 @@ public class Princess extends BotClient {
     }
 
 
-
     // Enhanced targeting controls
 
-    public boolean getEnhancedTargetingControl () {
+    public boolean getEnhancedTargetingControl() {
         return enableEnhancedTargeting;
     }
 
-    public void setEnableEnhancedTargeting (boolean newSetting) {
+    public void setEnableEnhancedTargeting(boolean newSetting) {
         enableEnhancedTargeting = newSetting;
     }
 
     /**
      * Sets all enhanced targeting controls to default values and optionally enables its use
-     * @param enable  true to immediately enable enhanced targeting features after reset
+     *
+     * @param enable true to immediately enable enhanced targeting features after reset
      */
-    public void resetEnhancedTargeting (boolean enable) {
+    public void resetEnhancedTargeting(boolean enable) {
 
         // Toggle enhanced targeting
         enableEnhancedTargeting = enable;
 
         // Set default enhanced targeting target and attacker types
-        enhancedTargetingTargetTypes = new ArrayList<>(Arrays.asList(
-                UnitType.MEK
-        ));
-        enhancedTargetingAttackerTypes = new ArrayList<>(Arrays.asList(
-                UnitType.MEK,
-                UnitType.TANK,
-                UnitType.BATTLE_ARMOR,
-                UnitType.INFANTRY,
-                UnitType.PROTOMEK,
-                UnitType.VTOL,
-                UnitType.GUN_EMPLACEMENT
-        ));
+        enhancedTargetingTargetTypes = new ArrayList<>(Arrays.asList(UnitType.MEK));
+        enhancedTargetingAttackerTypes = new ArrayList<>(Arrays.asList(UnitType.MEK,
+              UnitType.TANK,
+              UnitType.BATTLE_ARMOR,
+              UnitType.INFANTRY,
+              UnitType.PROTOMEK,
+              UnitType.VTOL,
+              UnitType.GUN_EMPLACEMENT));
 
         // Set default as not using called shots against immobile targets
         useCalledShotsOnImmobileTarget = false;
@@ -1339,11 +1361,12 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Swap out current set of valid enhanced targeting target types for a new set. Automatically
-     * removes certain types that will never apply, such as infantry.
-     * @param newTargetTypes  List of {@link UnitType} constants, may be empty or null to clear
+     * Swap out current set of valid enhanced targeting target types for a new set. Automatically removes certain types
+     * that will never apply, such as infantry.
+     *
+     * @param newTargetTypes List of {@link UnitType} constants, may be empty or null to clear
      */
-    public void setEnhancedTargetingTargetTypes (List<Integer> newTargetTypes) {
+    public void setEnhancedTargetingTargetTypes(List<Integer> newTargetTypes) {
         enhancedTargetingTargetTypes = Objects.requireNonNullElseGet(newTargetTypes, ArrayList::new);
         if (enhancedTargetingTargetTypes.contains(UnitType.INFANTRY)) {
             enhancedTargetingTargetTypes.remove(UnitType.INFANTRY);
@@ -1355,34 +1378,39 @@ public class Princess extends BotClient {
 
     /**
      * Swap out current set of valid enhanced targeting attacker types for a new set
-     * @param newAttackerTypes  List of {@link UnitType} constants, may be empty or null to clear
+     *
+     * @param newAttackerTypes List of {@link UnitType} constants, may be empty or null to clear
      */
-    public void setEnhancedTargetingAttackerTypes (List<Integer> newAttackerTypes) {
+    public void setEnhancedTargetingAttackerTypes(List<Integer> newAttackerTypes) {
         enhancedTargetingAttackerTypes = Objects.requireNonNullElseGet(newAttackerTypes, ArrayList::new);
     }
 
     /**
      * Returns a copy of the list of valid enhanced targeting target types
-     * @return   list of {@link UnitType} constants, or empty list
+     *
+     * @return list of {@link UnitType} constants, or empty list
      */
-    public List<Integer> seeEnhancedTargetingTargetTypes () {
+    public List<Integer> seeEnhancedTargetingTargetTypes() {
         return new ArrayList<>(enhancedTargetingTargetTypes);
     }
 
     /**
      * Returns a copy of the list of valid enhanced targeting attacker types
-     * @return   list of {@link UnitType} constants, or empty list
+     *
+     * @return list of {@link UnitType} constants, or empty list
      */
-    public List<Integer> seeEnhancedTargetingAttackerTypes () {
+    public List<Integer> seeEnhancedTargetingAttackerTypes() {
         return new ArrayList<>(enhancedTargetingAttackerTypes);
     }
 
     /**
      * Checks if the supplied unit type is considered a valid target for enhanced targeting
-     * @param testType  {@link UnitType} constant
-     * @return          true, if unit is a valid target for enhanced targeting
+     *
+     * @param testType {@link UnitType} constant
+     *
+     * @return true, if unit is a valid target for enhanced targeting
      */
-    public boolean isValidEnhancedTargetingTarget (int testType) {
+    public boolean isValidEnhancedTargetingTarget(int testType) {
         if (enhancedTargetingTargetTypes != null) {
             return enhancedTargetingTargetTypes.contains(testType);
         } else {
@@ -1392,10 +1420,12 @@ public class Princess extends BotClient {
 
     /**
      * Checks if the supplied unit type is considered a valid attacker for enhanced targeting
-     * @param testType  {@link UnitType} constant
-     * @return          true, if unit is a valid attacker for enhanced targeting
+     *
+     * @param testType {@link UnitType} constant
+     *
+     * @return true, if unit is a valid attacker for enhanced targeting
      */
-    public boolean isValidEnhancedTargetingAttacker (int testType) {
+    public boolean isValidEnhancedTargetingAttacker(int testType) {
         if (enhancedTargetingAttackerTypes != null) {
             return enhancedTargetingAttackerTypes.contains(testType);
         } else {
@@ -1403,40 +1433,41 @@ public class Princess extends BotClient {
         }
     }
 
-    public boolean getAllowCalledShotsOnImmobile () {
+    public boolean getAllowCalledShotsOnImmobile() {
         return useCalledShotsOnImmobileTarget;
     }
 
-    public void setAllowCalledShotsOnImmobile (boolean newSetting) {
+    public void setAllowCalledShotsOnImmobile(boolean newSetting) {
         useCalledShotsOnImmobileTarget = newSetting;
     }
 
-    public boolean getPartialCoverEnhancedTargeting () {
+    public boolean getPartialCoverEnhancedTargeting() {
         return allowCoverEnhancedTargeting;
     }
 
     /**
-     * Controls whether enhanced targeting will be used against targets with partial cover from
-     * the shooter. Use with caution as this can result in situations like aiming for a location
-     * which is protected by intervening cover.
-     * @param newSetting  true, to allow aimed/called shots against targets with partial cover
+     * Controls whether enhanced targeting will be used against targets with partial cover from the shooter. Use with
+     * caution as this can result in situations like aiming for a location which is protected by intervening cover.
+     *
+     * @param newSetting true, to allow aimed/called shots against targets with partial cover
      */
-    public void setPartialCoverEnhancedTargeting (boolean newSetting) {
+    public void setPartialCoverEnhancedTargeting(boolean newSetting) {
         allowCoverEnhancedTargeting = newSetting;
     }
 
     /**
-     * Determine if a shooter should consider using enhanced targeting - aimed or called shots -
-     * against a given target. This includes some basic filtering for unit types and equipment such
-     * targeting computers.
-     * @param shooter           Entity doing the shooting
-     * @param targetable        Hex, Building, or Entity being shot at (Enhanced Targeting only works on the last one)
-     * @param cover            {@link LosEffects} constant for partial cover, derived from {@code ToHitData.getCover()}
-     * @return                 true, if aimed or called shots should be checked
+     * Determine if a shooter should consider using enhanced targeting - aimed or called shots - against a given target.
+     * This includes some basic filtering for unit types and equipment such targeting computers.
+     *
+     * @param shooter    Entity doing the shooting
+     * @param targetable Hex, Building, or Entity being shot at (Enhanced Targeting only works on the last one)
+     * @param cover      {@link LosEffects} constant for partial cover, derived from {@code ToHitData.getCover()}
+     *
+     * @return true, if aimed or called shots should be checked
      */
-    protected boolean checkForEnhancedTargeting (Entity shooter, Targetable targetable, int cover) {
+    protected boolean checkForEnhancedTargeting(Entity shooter, Targetable targetable, int cover) {
         // Only works on entities
-        if (!(targetable instanceof Entity)){
+        if (!(targetable instanceof Entity)) {
             return false;
         }
 
@@ -1451,8 +1482,7 @@ public class Princess extends BotClient {
 
         // Basic unit type filtering for shooter. Ejected crews are considered infantry, so need
         // to be specifically checked.
-        if (!isValidEnhancedTargetingAttacker(shooter.getUnitType()) ||
-                shooter instanceof EjectedCrew) {
+        if (!isValidEnhancedTargetingAttacker(shooter.getUnitType()) || shooter instanceof EjectedCrew) {
             return false;
         }
 
@@ -1465,13 +1495,11 @@ public class Princess extends BotClient {
         boolean useCalledShot = false;
 
         // Only certain unit types can be the target of aimed shots
-        List<Integer> validAimTypes = new ArrayList<>(Arrays.asList(
-                UnitType.MEK,
-                UnitType.TANK,
-                UnitType.VTOL,
-                UnitType.CONV_FIGHTER,
-                UnitType.AEROSPACEFIGHTER
-        ));
+        List<Integer> validAimTypes = new ArrayList<>(Arrays.asList(UnitType.MEK,
+              UnitType.TANK,
+              UnitType.VTOL,
+              UnitType.CONV_FIGHTER,
+              UnitType.AEROSPACEFIGHTER));
 
         if (validAimTypes.contains(target.getUnitType())) {
 
@@ -1494,20 +1522,18 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Determine which location to aim for on a general target. Returned location constant is
-     * relative to the provided target type.
-     * Currently only supports aimed shots against Meks.
-     * @param target        Entity being shot at
-     * @param planOfAttack  Proposed attacks against {@code target}
-     * @param rearAttack    true if attacking from rear arc
-     * @param includeHead   true if the head is a valid location, ignored for non-Mek targets
-     * @return              location constant to aim for, with the {@code LOC_NONE} constant
-     *                      indicating no suitable location
+     * Determine which location to aim for on a general target. Returned location constant is relative to the provided
+     * target type. Currently only supports aimed shots against Meks.
+     *
+     * @param target       Entity being shot at
+     * @param planOfAttack Proposed attacks against {@code target}
+     * @param rearAttack   true if attacking from rear arc
+     * @param includeHead  true if the head is a valid location, ignored for non-Mek targets
+     *
+     * @return location constant to aim for, with the {@code LOC_NONE} constant indicating no suitable location
      */
-    protected int getAimedShotLocation (Targetable target,
-                                        FiringPlan planOfAttack,
-                                        boolean rearAttack,
-                                        boolean includeHead) {
+    protected int getAimedShotLocation(Targetable target, FiringPlan planOfAttack, boolean rearAttack,
+                                       boolean includeHead) {
 
         int aimLocation = Entity.LOC_NONE;
         if (planOfAttack == null || target == null) {
@@ -1516,25 +1542,23 @@ public class Princess extends BotClient {
 
         // Only check attacks if the target has locations that can be aimed for, which can be
         // aimed, and are against the designated target
-        List<Integer> validAimTypes = new ArrayList<>(Arrays.asList(
-                UnitType.MEK,
-                UnitType.TANK,
-                UnitType.VTOL,
-                UnitType.CONV_FIGHTER,
-                UnitType.AEROSPACEFIGHTER
-        ));
+        List<Integer> validAimTypes = new ArrayList<>(Arrays.asList(UnitType.MEK,
+              UnitType.TANK,
+              UnitType.VTOL,
+              UnitType.CONV_FIGHTER,
+              UnitType.AEROSPACEFIGHTER));
 
         if (!validAimTypes.contains(((Entity) target).getUnitType())) {
             return aimLocation;
         }
 
-        List<WeaponFireInfo> workingShots = planOfAttack.
-                stream().
-                filter(curShot -> curShot.getTarget().getId() == target.getId()).
-                filter(curShot ->
-                Compute.allowAimedShotWith(curShot.getWeapon(),
-                        target.isImmobile() ? AimingMode.IMMOBILE : AimingMode.TARGETING_COMPUTER)).
-                collect(Collectors.toList());
+        List<WeaponFireInfo> workingShots = planOfAttack.stream()
+                                                  .filter(curShot -> curShot.getTarget().getId() == target.getId())
+                                                  .filter(curShot -> Compute.allowAimedShotWith(curShot.getWeapon(),
+                                                        target.isImmobile() ?
+                                                              AimingMode.IMMOBILE :
+                                                              AimingMode.TARGETING_COMPUTER))
+                                                  .collect(Collectors.toList());
 
         if (workingShots.isEmpty()) {
             return aimLocation;
@@ -1544,12 +1568,7 @@ public class Princess extends BotClient {
         // TODO: placeholders are used for non-Mek targets. Create appropriate methods for each.
         switch (((Entity) target).getUnitType()) {
             case UnitType.MEK:
-                aimLocation = calculateAimedShotLocation(
-                        (Mek) target,
-                        workingShots,
-                        rearAttack,
-                        includeHead
-                );
+                aimLocation = calculateAimedShotLocation((Mek) target, workingShots, rearAttack, includeHead);
                 break;
             case UnitType.TANK:
             case UnitType.VTOL:
@@ -1568,19 +1587,17 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Determine which direction to make a called shot - left, right, high, or low. Some target
-     * types only support calling shots left or right.
-     * Currently only supports called shots against Meks.
+     * Determine which direction to make a called shot - left, right, high, or low. Some target types only support
+     * calling shots left or right. Currently only supports called shots against Meks.
+     *
      * @param target       Entity being shot at
-     * @param attackSide   {@link ToHitData} SIDE_ constant, indicating attack direction relative
-     *                     to target
+     * @param attackSide   {@link ToHitData} SIDE_ constant, indicating attack direction relative to target
      * @param planOfAttack Proposed attacks against {@code target}
-     * @return             {@link CalledShot} constant indicating which direction to call, may
-     *                     return {@code CalledShot.CALLED_NONE}.
+     *
+     * @return {@link CalledShot} constant indicating which direction to call, may return
+     *       {@code CalledShot.CALLED_NONE}.
      */
-    protected int getCalledShotDirection (Targetable target,
-                                          int attackSide,
-                                          FiringPlan planOfAttack) {
+    protected int getCalledShotDirection(Targetable target, int attackSide, FiringPlan planOfAttack) {
         int calledShotDirection = CalledShot.CALLED_NONE;
         if (planOfAttack == null || target == null) {
             return calledShotDirection;
@@ -1594,11 +1611,11 @@ public class Princess extends BotClient {
         // Limit the weapons fire to those against the designated target and which have a
         // reasonable to-hit number
         int maximumToHit = calcEnhancedTargetingMaxTN(false);
-        List<WeaponFireInfo> workingShots = planOfAttack.
-                stream().
-                filter(curShot -> curShot.getTarget().getId() == target.getId()).
-                filter(curShot -> curShot.getToHit().getValue() + CALLED_SHOT_MODIFIER <= maximumToHit).
-                collect(Collectors.toList());
+        List<WeaponFireInfo> workingShots = planOfAttack.stream()
+                                                  .filter(curShot -> curShot.getTarget().getId() == target.getId())
+                                                  .filter(curShot -> curShot.getToHit().getValue() +
+                                                                           CALLED_SHOT_MODIFIER <= maximumToHit)
+                                                  .collect(Collectors.toList());
 
         if (workingShots.isEmpty()) {
             return calledShotDirection;
@@ -1615,20 +1632,18 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Determine which location to aim for on a Mek. Prioritizes torsos and legs, and ignores
-     * destroyed locations. Prefers right to left, given that most non-symmetrical Meks are
-     * 'right-handed'.
-     * @param target        Mek being shot at
-     * @param aimedShots    Proposed attacks against {@code target}
-     * @param rearAttack    true if attacking from the rear arc
-     * @param includeHead   true to include the head as a valid location
-     * @return              {@link Mek} constant for location to shoot, or {@code Mek.LOC_NONE}
-     *                      for none
+     * Determine which location to aim for on a Mek. Prioritizes torsos and legs, and ignores destroyed locations.
+     * Prefers right to left, given that most non-symmetrical Meks are 'right-handed'.
+     *
+     * @param target      Mek being shot at
+     * @param aimedShots  Proposed attacks against {@code target}
+     * @param rearAttack  true if attacking from the rear arc
+     * @param includeHead true to include the head as a valid location
+     *
+     * @return {@link Mek} constant for location to shoot, or {@code Mek.LOC_NONE} for none
      */
-    protected int calculateAimedShotLocation (Mek target,
-                                              List<WeaponFireInfo> aimedShots,
-                                              boolean rearAttack,
-                                              boolean includeHead) {
+    protected int calculateAimedShotLocation(Mek target, List<WeaponFireInfo> aimedShots, boolean rearAttack,
+                                             boolean includeHead) {
         int aimLocation = Mek.LOC_NONE;
 
         if (aimedShots == null || target == null) {
@@ -1642,14 +1657,15 @@ public class Princess extends BotClient {
         // Aiming for the head can only be done against an immobile Mek, and takes a penalty.
         // Don't aim for the head for anti-Mek attacks except after swarming.
         if (includeHead &&
-                target.isImmobile() &&
-                !primaryFire.getWeapon().getShortName().equalsIgnoreCase(Infantry.LEG_ATTACK) &&
-                !primaryFire.getWeapon().getShortName().equalsIgnoreCase(Infantry.SWARM_MEK) &&
-                !primaryFire.getWeapon().getShortName().equalsIgnoreCase(Infantry.STOP_SWARM)) {
+                  target.isImmobile() &&
+                  !primaryFire.getWeapon().getShortName().equalsIgnoreCase(Infantry.LEG_ATTACK) &&
+                  !primaryFire.getWeapon().getShortName().equalsIgnoreCase(Infantry.SWARM_MEK) &&
+                  !primaryFire.getWeapon().getShortName().equalsIgnoreCase(Infantry.STOP_SWARM)) {
             aimLocation = Mek.LOC_HEAD;
             int headShotMaxTN = calcEnhancedTargetingMaxTN(false);
-            if (aimedShots.stream().anyMatch(curFire -> curFire.getToHit().getValue() +
-                    IMMOBILE_HEAD_SHOT_MODIFIER > headShotMaxTN)) {
+            if (aimedShots.stream()
+                      .anyMatch(curFire -> curFire.getToHit().getValue() + IMMOBILE_HEAD_SHOT_MODIFIER >
+                                                 headShotMaxTN)) {
                 aimLocation = Mek.LOC_NONE;
             } else {
                 return aimLocation;
@@ -1660,18 +1676,18 @@ public class Princess extends BotClient {
         if (!primaryFire.getWeapon().getShortName().equalsIgnoreCase(Infantry.LEG_ATTACK)) {
 
             // Consider arm locations if they have a 'big' weapon
-            for (WeaponMounted curWeapon : target.getWeaponList().
-                    stream().
-                    filter(w -> w.isOperable() && isBigGun(w)).
-                    collect(Collectors.toSet())) {
+            for (WeaponMounted curWeapon : target.getWeaponList()
+                                                 .stream()
+                                                 .filter(w -> w.isOperable() && isBigGun(w))
+                                                 .collect(Collectors.toSet())) {
 
                 if (!rankedLocations.contains(Mek.LOC_RARM) &&
-                        curWeapon.getLocation() == Mek.LOC_RARM &&
-                        target.getInternal(Mek.LOC_RARM) > 0) {
+                          curWeapon.getLocation() == Mek.LOC_RARM &&
+                          target.getInternal(Mek.LOC_RARM) > 0) {
                     rankedLocations.add(Mek.LOC_RARM);
                 } else if (!rankedLocations.contains(Mek.LOC_LARM) &&
-                        curWeapon.getLocation() == Mek.LOC_LARM &&
-                        target.getInternal(Mek.LOC_LARM) > 0) {
+                                 curWeapon.getLocation() == Mek.LOC_LARM &&
+                                 target.getInternal(Mek.LOC_LARM) > 0) {
                     rankedLocations.add(Mek.LOC_LARM);
                 }
                 if (rankedLocations.contains(Mek.LOC_RARM) && rankedLocations.contains(Mek.LOC_LARM)) {
@@ -1717,12 +1733,12 @@ public class Princess extends BotClient {
         int locationDestruction = 0;
         for (int curLocation : rankedLocations) {
             int locationArmor = Math.max(target.hasRearArmor(curLocation) ?
-                    target.getArmor(curLocation, rearAttack) :
-                    target.getArmor(curLocation), 0);
+                                               target.getArmor(curLocation, rearAttack) :
+                                               target.getArmor(curLocation), 0);
 
             if (target.getInternal(curLocation) > 0 &&
-                    (lowestArmor > locationArmor ||
-                            locationDestruction > locationArmor + target.getInternal(curLocation))) {
+                      (lowestArmor > locationArmor ||
+                             locationDestruction > locationArmor + target.getInternal(curLocation))) {
 
                 aimLocation = curLocation;
                 lowestArmor = locationArmor;
@@ -1732,15 +1748,12 @@ public class Princess extends BotClient {
 
             // Doesn't get any better than a torso with no armor
             if (lowestArmor == 0 &&
-                    (aimLocation == Mek.LOC_RT ||
-                            aimLocation == Mek.LOC_LT ||
-                            aimLocation == Mek.LOC_CT)) {
+                      (aimLocation == Mek.LOC_RT || aimLocation == Mek.LOC_LT || aimLocation == Mek.LOC_CT)) {
                 break;
             }
         }
         // Evaluate whether all the weapons at the chosen location will be effective
-        if (aimLocation != Mek.LOC_NONE &&
-                (!target.isImmobile() || aimLocation == Mek.LOC_HEAD)) {
+        if (aimLocation != Mek.LOC_NONE && (!target.isImmobile() || aimLocation == Mek.LOC_HEAD)) {
 
             int offset = 0;
             if (locationDestruction <= LOCATION_DESTRUCTION_THREAT) {
@@ -1751,8 +1764,9 @@ public class Princess extends BotClient {
             double totalDamage = 0;
             int maximumToHit = calcEnhancedTargetingMaxTN(target.isImmobile() && aimLocation != Mek.LOC_HEAD);
             for (WeaponFireInfo curFire : aimedShots) {
-                if (curFire.getToHit().getValue() + (aimLocation == Mek.LOC_HEAD ?
-                        IMMOBILE_HEAD_SHOT_MODIFIER : AIMED_SHOT_MODIFIER) <= (maximumToHit + offset)) {
+                if (curFire.getToHit().getValue() +
+                          (aimLocation == Mek.LOC_HEAD ? IMMOBILE_HEAD_SHOT_MODIFIER : AIMED_SHOT_MODIFIER) <=
+                          (maximumToHit + offset)) {
 
                     totalDamage += curFire.getMaxDamage();
                     if (curFire.getMaxDamage() >= lowestArmor) {
@@ -1764,8 +1778,7 @@ public class Princess extends BotClient {
 
             // If none of the weapons have a low enough to-hit number, or if none of the weapons
             // can penetrate the armor individually or cumulatively, don't bother aiming
-            if (totalDamage == 0 ||
-                    (penetratorCount == 0 && 0.4 * totalDamage < lowestArmor)) {
+            if (totalDamage == 0 || (penetratorCount == 0 && 0.4 * totalDamage < lowestArmor)) {
                 aimLocation = Mek.LOC_NONE;
             }
 
@@ -1775,24 +1788,21 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Determine which direction to make a called shot against a Mek - left, right, high, or low.
-     * Shots into a side arc will be called to become rear shots. Shots to the front or rear will
-     * call high or low based on how many locations have minimal armor.
-     * @param target       Mek being shot at
-     * @param attackSide   {@link ToHitData} SIDE_ constant, indicating attack direction relative
-     *                     to target
-     * @param calledShots  Proposed attacks against {@code target} parameter
-     * @return             {@link CalledShot} constant indicating which direction to call, may
-     *                     return {@code CalledShot.CALLED_NONE}.
+     * Determine which direction to make a called shot against a Mek - left, right, high, or low. Shots into a side arc
+     * will be called to become rear shots. Shots to the front or rear will call high or low based on how many locations
+     * have minimal armor.
+     *
+     * @param target      Mek being shot at
+     * @param attackSide  {@link ToHitData} SIDE_ constant, indicating attack direction relative to target
+     * @param calledShots Proposed attacks against {@code target} parameter
+     *
+     * @return {@link CalledShot} constant indicating which direction to call, may return
+     *       {@code CalledShot.CALLED_NONE}.
      */
-    protected int calculateCalledShotDirection (Mek target,
-                                                int attackSide,
-                                                List<WeaponFireInfo> calledShots) {
+    protected int calculateCalledShotDirection(Mek target, int attackSide, List<WeaponFireInfo> calledShots) {
         int calledShotDirection = CalledShot.CALLED_NONE;
 
-        if (calledShots == null ||
-                calledShots.isEmpty() ||
-                calledShots.get(0) == null) {
+        if (calledShots == null || calledShots.isEmpty() || calledShots.get(0) == null) {
             return calledShotDirection;
         }
 
@@ -1807,23 +1817,21 @@ public class Princess extends BotClient {
 
         if (attackSide == ToHitData.SIDE_FRONT || attackSide == ToHitData.SIDE_REAR) {
 
-            List<Integer> upperLocations = new ArrayList<>(Arrays.asList(Mek.LOC_RT,
-                    Mek.LOC_LT,
-                    Mek.LOC_CT));
+            List<Integer> upperLocations = new ArrayList<>(Arrays.asList(Mek.LOC_RT, Mek.LOC_LT, Mek.LOC_CT));
 
             // Only consider the arms if they have 'big' weapons
-            for (WeaponMounted curWeapon : target.getWeaponList().
-                    stream().
-                    filter(w -> w.isOperable() && isBigGun(w)).
-                    collect(Collectors.toSet())) {
+            for (WeaponMounted curWeapon : target.getWeaponList()
+                                                 .stream()
+                                                 .filter(w -> w.isOperable() && isBigGun(w))
+                                                 .collect(Collectors.toSet())) {
 
                 if (!upperLocations.contains(Mek.LOC_RARM) &&
-                        curWeapon.getLocation() == Mek.LOC_RARM &&
-                        target.getInternal(Mek.LOC_RARM) > 0) {
+                          curWeapon.getLocation() == Mek.LOC_RARM &&
+                          target.getInternal(Mek.LOC_RARM) > 0) {
                     upperLocations.add(Mek.LOC_RARM);
                 } else if (!upperLocations.contains(Mek.LOC_LARM) &&
-                        curWeapon.getLocation() == Mek.LOC_LARM &&
-                        target.getInternal(Mek.LOC_LARM) > 0) {
+                                 curWeapon.getLocation() == Mek.LOC_LARM &&
+                                 target.getInternal(Mek.LOC_LARM) > 0) {
                     upperLocations.add(Mek.LOC_LARM);
                 }
                 if (upperLocations.contains(Mek.LOC_RARM) && upperLocations.contains(Mek.LOC_LARM)) {
@@ -1849,11 +1857,11 @@ public class Princess extends BotClient {
                 armorThreshold = CALLED_SHOT_DEFAULT_MAX_ARMOR;
             }
 
-            double upperTargets = upperLocations.
-                    stream().
-                    mapToInt(loc -> loc).
-                    filter(loc -> target.getArmor(loc, attackSide == ToHitData.SIDE_REAR) <= armorThreshold).
-                    count();
+            double upperTargets = upperLocations.stream()
+                                        .mapToInt(loc -> loc)
+                                        .filter(loc -> target.getArmor(loc, attackSide == ToHitData.SIDE_REAR) <=
+                                                             armorThreshold)
+                                        .count();
 
             // Only consider shooting low if both legs are intact
             double lowerTargets = 0;
@@ -1869,11 +1877,11 @@ public class Princess extends BotClient {
             // If the head armor is weak or there are proportionally more upper targets, call high.
             // If the leg armor is weak and this is a fast and/or jumping Mek, call low.
             if (target.getArmor(Mek.LOC_HEAD) + target.getInternal(Mek.LOC_HEAD) <= LOCATION_DESTRUCTION_THREAT ||
-                    (upperTargets / upperLocations.size() > lowerTargets / 2.0)) {
+                      (upperTargets / upperLocations.size() > lowerTargets / 2.0)) {
                 calledShotDirection = CalledShot.CALLED_HIGH;
             } else if (lowerTargets >= 1 ||
-                    target.getWalkMP() >= CALLED_SHOT_MIN_MOVE ||
-                    target.getAnyTypeMaxJumpMP() >= CALLED_SHOT_MIN_JUMP) {
+                             target.getWalkMP() >= CALLED_SHOT_MIN_MOVE ||
+                             target.getAnyTypeMaxJumpMP() >= CALLED_SHOT_MIN_JUMP) {
                 calledShotDirection = CalledShot.CALLED_LOW;
             }
 
@@ -1885,21 +1893,23 @@ public class Princess extends BotClient {
 
     /**
      * Checks if a weapon is considered a 'big gun' worth taking a shot at
-     * @param testWeapon  weapon to check
-     * @return            true if weapon damage exceeds {@code BIG_GUN_MIN_DAMAGE} at a
-     *                    typical range value
+     *
+     * @param testWeapon weapon to check
+     *
+     * @return true if weapon damage exceeds {@code BIG_GUN_MIN_DAMAGE} at a typical range value
      */
     private boolean isBigGun(WeaponMounted testWeapon) {
         return testWeapon.getType().getDamage(BIG_GUN_TYPICAL_RANGE) >= BIG_GUN_MIN_DAMAGE;
     }
 
     /**
-     * Figure out the highest practical to-hit number for enhanced aiming (aimed/called shots),
-     * using behavior settings
-     * @param isAimedImmobile   true if making aimed shot at immobile target
-     * @return  maximum to-hit number for a weapons attack with enhanced aiming
+     * Figure out the highest practical to-hit number for enhanced aiming (aimed/called shots), using behavior settings
+     *
+     * @param isAimedImmobile true if making aimed shot at immobile target
+     *
+     * @return maximum to-hit number for a weapons attack with enhanced aiming
      */
-    private int calcEnhancedTargetingMaxTN (boolean isAimedImmobile) {
+    private int calcEnhancedTargetingMaxTN(boolean isAimedImmobile) {
         if (isAimedImmobile) {
             return SHUTDOWN_MAX_TARGET_NUMBER;
         } else {
@@ -1909,47 +1919,49 @@ public class Princess extends BotClient {
 
 
     /**
-     * If a shot meets criteria, set it as aimed or called.  {@code aimLocation} and {@code
-     * calledShotDirection} are not mutually exclusive - if both are provided, weapons which
-     * cannot make an aimed shot will make a called shot instead
-     * @param shot   Single-weapon attack action
-     * @param aimLocation     {@link Mek} LOC_ constant with aiming location
+     * If a shot meets criteria, set it as aimed or called.  {@code aimLocation} and {@code calledShotDirection} are not
+     * mutually exclusive - if both are provided, weapons which cannot make an aimed shot will make a called shot
+     * instead
+     *
+     * @param shot                 Single-weapon attack action
+     * @param aimLocation          {@link Mek} LOC_ constant with aiming location
      * @param destructionThreshold how much damage to completely destroy the location
      */
-    protected void setAttackAsAimedOrCalled (WeaponFireInfo shot,
-                                             int aimLocation,
-                                             int calledShotDirection,
-                                             int destructionThreshold) {
+    protected void setAttackAsAimedOrCalled(WeaponFireInfo shot, int aimLocation, int calledShotDirection,
+                                            int destructionThreshold) {
         Entity shooter = shot.getShooter();
 
         int offset = 0;
 
         // If the target is a Mek and the attack is not artillery or non-damaging anti-Mek
         if (shot.getTarget().getTargetType() == UnitType.MEK &&
-                !shot.getWeapon().getType().hasFlag(WeaponType.F_ARTILLERY) &&
-                !shot.getWeapon().getShortName().equalsIgnoreCase(Infantry.SWARM_MEK) &&
-                !shot.getWeapon().getShortName().equalsIgnoreCase(Infantry.STOP_SWARM)) {
+                  !shot.getWeapon().getType().hasFlag(WeaponType.F_ARTILLERY) &&
+                  !shot.getWeapon().getShortName().equalsIgnoreCase(Infantry.SWARM_MEK) &&
+                  !shot.getWeapon().getShortName().equalsIgnoreCase(Infantry.STOP_SWARM)) {
 
             Mek target = (Mek) shot.getTarget();
             int maximumTN;
 
             // If set for aimed shots, and the weapon can make aimed shots
             if ((aimLocation != Mek.LOC_NONE) &&
-                    Compute.allowAimedShotWith(shot.getWeapon(), target.isImmobile() ? AimingMode.IMMOBILE : AimingMode.TARGETING_COMPUTER)) {
+                      Compute.allowAimedShotWith(shot.getWeapon(),
+                            target.isImmobile() ? AimingMode.IMMOBILE : AimingMode.TARGETING_COMPUTER)) {
 
                 maximumTN = calcEnhancedTargetingMaxTN(target.isImmobile() && aimLocation != Mek.LOC_HEAD);
 
                 // Increase the maximum target number for attacks that may destroy the location,
                 // as well as infantry weapons which may have multiple hits per shot
                 if ((!shooter.isInfantry() && shot.getMaxDamage() >= destructionThreshold) ||
-                        shot.getWeapon().getType().hasFlag(WeaponType.F_INFANTRY)) {
+                          shot.getWeapon().getType().hasFlag(WeaponType.F_INFANTRY)) {
                     offset = 1;
                 }
 
                 // If the target number is considered viable set attack as aimed
                 // at the provided location
-                if ((shot.getToHit().getValue() + (target.isImmobile() ? 0 : AIMED_SHOT_MODIFIER)) <= (maximumTN + offset)) {
-                    shot.getAction().setAimingMode(target.isImmobile() ? AimingMode.IMMOBILE : AimingMode.TARGETING_COMPUTER);
+                if ((shot.getToHit().getValue() + (target.isImmobile() ? 0 : AIMED_SHOT_MODIFIER)) <=
+                          (maximumTN + offset)) {
+                    shot.getAction()
+                          .setAimingMode(target.isImmobile() ? AimingMode.IMMOBILE : AimingMode.TARGETING_COMPUTER);
                     shot.getAction().setAimedLocation(aimLocation);
                 }
 
@@ -1959,9 +1971,9 @@ public class Princess extends BotClient {
 
                 // If the weapon uses the cluster table, increase the maximum target number
                 if (shot.getWeapon().getType().getDamage() == WeaponType.DAMAGE_BY_CLUSTERTABLE ||
-                        (shot.getAmmo() != null &&
-                                shot.getAmmo().getType().getMunitionType().contains(AmmoType.Munitions.M_CLUSTER)) ||
-                        shot.getWeapon().getType().hasFlag(WeaponType.F_INFANTRY)) {
+                          (shot.getAmmo() != null &&
+                                 shot.getAmmo().getType().getMunitionType().contains(AmmoType.Munitions.M_CLUSTER)) ||
+                          shot.getWeapon().getType().hasFlag(WeaponType.F_INFANTRY)) {
                     offset = 2;
                 }
 
@@ -1979,9 +1991,6 @@ public class Princess extends BotClient {
         }
 
     }
-
-
-
 
 
     /**
@@ -2004,8 +2013,8 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Sorts firing entities to ensure that entities that can do indirect fire go after
-     * entities that cannot, so that IDF units go after spotting units.
+     * Sorts firing entities to ensure that entities that can do indirect fire go after entities that cannot, so that
+     * IDF units go after spotting units.
      */
     private void initFiringEntities(FireControlState fireControlState) {
         List<Entity> myEntities = game.getPlayerEntities(this.getLocalPlayer(), true);
@@ -2026,13 +2035,10 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Loops through the list of entities controlled by this Princess instance
-     * and decides which should be moved first.
-     * Immobile units and ejected MekWarriors / crews will be moved first.
-     * After that, each unit is given an index// This unit should have already
-     * moved due to the isImmobilized check. via the
-     * {@link #calculateMoveIndex(Entity, StringBuilder)} method.  The highest
-     * index value is moved first.
+     * Loops through the list of entities controlled by this Princess instance and decides which should be moved first.
+     * Immobile units and ejected MekWarriors / crews will be moved first. After that, each unit is given an index//
+     * This unit should have already moved due to the isImmobilized check. via the
+     * {@link #calculateMoveIndex(Entity, StringBuilder)} method.  The highest index value is moved first.
      *
      * @return The entity that should be moved next.
      */
@@ -2051,10 +2057,11 @@ public class Princess extends BotClient {
                 continue;
             }
 
-            if (!getGame().getPhase().isSimultaneous(getGame()) && (entity.isOffBoard()
-                    || (null == entity.getPosition())
-                    || entity.isUnloadedThisTurn()
-                    || !getGame().getTurn().isValidEntity(entity, getGame()))) {
+            if (!getGame().getPhase().isSimultaneous(getGame()) &&
+                      (entity.isOffBoard() ||
+                             (null == entity.getPosition()) ||
+                             entity.isUnloadedThisTurn() ||
+                             !getGame().getTurn().isValidEntity(entity, getGame()))) {
                 msg.append("cannot be moved.");
                 continue;
             }
@@ -2088,8 +2095,7 @@ public class Princess extends BotClient {
 
             // We will move the entity with the highest index.
             final double moveIndex = calculateMoveIndex(entity, msg);
-            msg.append("\n\thas index ").append(moveIndex).append(" vs ")
-               .append(highestIndex);
+            msg.append("\n\thas index ").append(moveIndex).append(" vs ").append(highestIndex);
             if (moveIndex >= highestIndex) {
                 highestIndex = moveIndex;
                 movingEntity = entity;
@@ -2130,8 +2136,8 @@ public class Princess extends BotClient {
             // If my unit is forced to withdraw, don't attack unless I've been
             // attacked.
             if (getForcedWithdrawal() && attacker.isCrippled()) {
-                final StringBuilder msg = new StringBuilder(attacker.getDisplayName())
-                        .append(" is crippled and withdrawing.");
+                final StringBuilder msg = new StringBuilder(attacker.getDisplayName()).append(
+                      " is crippled and withdrawing.");
                 if (attackedWhileFleeing.contains(attacker.getId())) {
                     msg.append("\n\tBut I was fired on, so I will hit back.");
                 } else {
@@ -2158,17 +2164,21 @@ public class Princess extends BotClient {
 
     /**
      * Logic to determine if this entity is "falling back" for any reason
+     *
      * @param entity The entity to check.
+     *
      * @return Whether or not the entity is falling back.
      */
     boolean isFallingBack(final Entity entity) {
         return (getBehaviorSettings().shouldAutoFlee() ||
-                (getBehaviorSettings().isForcedWithdrawal() && entity.isCrippled(true)));
+                      (getBehaviorSettings().isForcedWithdrawal() && entity.isCrippled(true)));
     }
 
     /**
      * Logic to determine if this entity is in a state where it can shoot due to being attacked while fleeing.
+     *
      * @param entity Entity to check.
+     *
      * @return Whether or not this entity can shoot while falling back.
      */
     boolean canShootWhileFallingBack(Entity entity) {
@@ -2180,8 +2190,7 @@ public class Princess extends BotClient {
             return false;
         } else if (!entity.canFlee(entity.getPosition())) {
             return false;
-        } else if (0 < getPathRanker(entity).distanceToHomeEdge(entity.getPosition(),
-                getHomeEdge(entity), getGame())) {
+        } else if (0 < getPathRanker(entity).distanceToHomeEdge(entity.getPosition(), getHomeEdge(entity), getGame())) {
             return false;
         } else if (!getFleeBoard() && !(entity.isCrippled() && getForcedWithdrawal())) {
             return false;
@@ -2243,15 +2252,15 @@ public class Princess extends BotClient {
                 return true;
             }
 
-            final MoveStepType type = getBooleanOption(OptionsConstants.ADVGRNDMOV_TACOPS_CAREFUL_STAND)
-                    ? MoveStepType.CAREFUL_STAND : MoveStepType.GET_UP;
+            final MoveStepType type = getBooleanOption(OptionsConstants.ADVGRNDMOV_TACOPS_CAREFUL_STAND) ?
+                                            MoveStepType.CAREFUL_STAND :
+                                            MoveStepType.GET_UP;
             final MoveStep getUp = new MoveStep(movePath, type);
 
             // If our odds to get up are equal to or worse than the threshold,
             // consider ourselves immobile.
             final PilotingRollData target = mek.checkGetUp(getUp, movePath.getLastStepMovementType());
-            logger.info("Need to roll " + target.getValue() +
-                " to stand and our tolerance is " + threshold);
+            logger.info("Need to roll " + target.getValue() + " to stand and our tolerance is " + threshold);
             return (target.getValue() >= threshold);
         }
 
@@ -2259,8 +2268,13 @@ public class Princess extends BotClient {
         final MoveStepType type = MoveStepType.FORWARDS;
         final MoveStep walk = new MoveStep(movePath, type);
         final Hex hex = getHex(mek.getPosition());
-        final PilotingRollData target = mek.checkBogDown(walk, movePath.getLastStepMovementType(),
-                hex, mek.getPriorPosition(), mek.getPosition(), hex.getLevel(), false);
+        final PilotingRollData target = mek.checkBogDown(walk,
+              movePath.getLastStepMovementType(),
+              hex,
+              mek.getPriorPosition(),
+              mek.getPosition(),
+              hex.getLevel(),
+              false);
         logger.info("Need to roll " + target.getValue() + " to get unstuck and our tolerance is " + threshold);
         return (target.getValue() >= threshold);
     }
@@ -2326,10 +2340,12 @@ public class Princess extends BotClient {
                 if (0 != thisTimeEstimate) {
                     timeEstimate = (int) thisTimeEstimate + " seconds";
                 }
-                final String message = "Moving " + entity.getChassis() + ". "
-                        + Long.toString(paths.size())
-                        + " paths to consider.  Estimated time to completion: "
-                        + timeEstimate;
+                final String message = "Moving " +
+                                             entity.getChassis() +
+                                             ". " +
+                                             Long.toString(paths.size()) +
+                                             " paths to consider.  Estimated time to completion: " +
+                                             timeEstimate;
                 sendChat(message);
             }
 
@@ -2339,14 +2355,16 @@ public class Princess extends BotClient {
             final double fallTolerance = getBehaviorSettings().getFallShameIndex() / 20d + 0.50d;
 
             final TreeSet<RankedPath> rankedPaths = getPathRanker(entity).rankPaths(paths,
-                    getGame(), getMaxWeaponRange(entity), fallTolerance, getEnemyEntities(),
-                    getFriendEntities());
+                  getGame(),
+                  getMaxWeaponRange(entity),
+                  fallTolerance,
+                  getEnemyEntities(),
+                  getFriendEntities());
 
             final long stop_time = System.currentTimeMillis();
 
             // update path evaluation time estimate
-            final double updatedEstimate =
-                    ((double) (stop_time - startTime)) / ((double) paths.size());
+            final double updatedEstimate = ((double) (stop_time - startTime)) / ((double) paths.size());
             if (0 == moveEvaluationTimeEstimate) {
                 moveEvaluationTimeEstimate = updatedEstimate;
             }
@@ -2401,11 +2419,13 @@ public class Princess extends BotClient {
                         final BuildingTarget bt = new BuildingTarget(coords, game.getBoard(), false);
                         // Want to target buildings with hostile infantry / BA inside them, since
                         // there's no other way to attack them.
-                        if (isEnemyInfantry(entity, coords) && Compute.isInBuilding(game, entity)
-                                && !entity.isHidden()) {
+                        if (isEnemyInfantry(entity, coords) &&
+                                  Compute.isInBuilding(game, entity) &&
+                                  !entity.isHidden()) {
                             fireControlState.getAdditionalTargets().add(bt);
-                            sendChat("Building in Hex " + coords.toFriendlyString()
-                                    + " designated target due to infantry inside building.", Level.INFO);
+                            sendChat("Building in Hex " +
+                                           coords.toFriendlyString() +
+                                           " designated target due to infantry inside building.", Level.INFO);
                         }
                     }
                 }
@@ -2420,7 +2440,8 @@ public class Princess extends BotClient {
             damageMap.clear();
             // Now add an ID for each possible target.
             final List<Targetable> potentialTargets = FireControl.getAllTargetableEnemyEntities(getLocalPlayer(),
-                    getGame(), getFireControlState());
+                  getGame(),
+                  getFireControlState());
             for (final Targetable target : potentialTargets) {
                 damageMap.put(target.getId(), 0d);
             }
@@ -2432,8 +2453,8 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Function with side effects. Retrieves the move path collection we want
-     * the entity to consider. Sometimes it's the standard "circle", sometimes it's pruned long-range movement paths
+     * Function with side effects. Retrieves the move path collection we want the entity to consider. Sometimes it's the
+     * standard "circle", sometimes it's pruned long-range movement paths
      */
     public List<MovePath> getMovePathsAndSetNecessaryTargets(Entity mover, boolean forceMoveToContact) {
         // if the mover can't move, then there's nothing for us to do here, let's cut out.
@@ -2441,7 +2462,9 @@ public class Princess extends BotClient {
             return Collections.emptyList();
         }
 
-        BehaviorType behavior = forceMoveToContact ? BehaviorType.MoveToContact : unitBehaviorTracker.getBehaviorType(mover, this);
+        BehaviorType behavior = forceMoveToContact ?
+                                      BehaviorType.MoveToContact :
+                                      unitBehaviorTracker.getBehaviorType(mover, this);
         // during the movement phase, it is technically necessary to clear this data between each unit
         // as the state of the board may have changed due to crashes etc.
         // generating movable clusters is a relatively cheap operation, so it's not a big deal
@@ -2458,14 +2481,14 @@ public class Princess extends BotClient {
         //  - if we're unable to get where we're going, use standard set of move paths
         switch (behavior) {
             case Engaged:
-                return getPrecognition().getPathEnumerator()
-                        .getUnitPaths()
-                        .get(mover.getId());
+                return getPrecognition().getPathEnumerator().getUnitPaths().get(mover.getId());
             case MoveToDestination:
             case MoveToContact:
             case ForcedWithdrawal:
             default: {
-                List<BulldozerMovePath> bulldozerPaths = getPrecognition().getPathEnumerator().getLongRangePaths().get(mover.getId());
+                List<BulldozerMovePath> bulldozerPaths = getPrecognition().getPathEnumerator()
+                                                               .getLongRangePaths()
+                                                               .get(mover.getId());
 
                 // for whatever reason (most likely it's wheeled), there are no long-range paths for this unit,
                 // so just have it mill around in place as usual. Also set the behavior to "no path to destination"
@@ -2485,7 +2508,9 @@ public class Princess extends BotClient {
                 if (bulldozerPaths.get(0).needsLeveling()) {
                     levelingTarget = getAppropriateTarget(bulldozerPaths.get(0).getCoordsToLevel().get(0));
                     getFireControlState().getAdditionalTargets().add(levelingTarget);
-                    sendChat("Hex " + levelingTarget.getPosition().toFriendlyString() + " impedes route to destination, targeting for clearing.", Level.INFO);
+                    sendChat("Hex " +
+                                   levelingTarget.getPosition().toFriendlyString() +
+                                   " impedes route to destination, targeting for clearing.", Level.INFO);
                 }
 
                 // if any of the long range paths, pruned, are within LOS of leveling coordinates, then we're actually
@@ -2496,7 +2521,12 @@ public class Princess extends BotClient {
                     prunedPath.clipToPossible();
 
                     if (levelingTarget != null) {
-                        LosEffects los = LosEffects.calculateLOS(game, mover, levelingTarget, prunedPath.getFinalCoords(), levelingTarget.getPosition(), false);
+                        LosEffects los = LosEffects.calculateLOS(game,
+                              mover,
+                              levelingTarget,
+                              prunedPath.getFinalCoords(),
+                              levelingTarget.getPosition(),
+                              false);
 
                         // break out of this loop, we can get to the thing we're trying to level this turn, so let's
                         // use normal movement routines to move into optimal position to blow it up
@@ -2519,7 +2549,8 @@ public class Princess extends BotClient {
                     // in case the faster path would force an unwanted PSR or MASC check
                     prunedPaths.addAll(PathDecorator.decoratePath(prunedPath));
                     // Return some of the already-computed unit paths as well.
-                    prunedPaths.addAll(getPrecognition().getPathEnumerator().getSimilarUnitPaths(mover.getId(), prunedPath));
+                    prunedPaths.addAll(getPrecognition().getPathEnumerator()
+                                             .getSimilarUnitPaths(mover.getId(), prunedPath));
                 }
                 return prunedPaths;
             }
@@ -2554,13 +2585,13 @@ public class Princess extends BotClient {
                         continue;
                     }
 
-                    if (getHonorUtil().isEnemyBroken(entity.getId(), entity.getOwnerId(),
-                            getForcedWithdrawal()) || !entity.isMilitary()) {
+                    if (getHonorUtil().isEnemyBroken(entity.getId(), entity.getOwnerId(), getForcedWithdrawal()) ||
+                              !entity.isMilitary()) {
                         // If he'd just continued running, I would have let him
                         // go, but the bastard shot at me!
                         msg.append("\n\t")
-                           .append(entity.getDisplayName())
-                           .append("dishonored himself by attacking me even though he is ");
+                              .append(entity.getDisplayName())
+                              .append("dishonored himself by attacking me even though he is ");
                         if (!entity.isMilitary()) {
                             msg.append("a civilian.");
                         } else {
@@ -2573,10 +2604,10 @@ public class Princess extends BotClient {
                     // He shot me while I was running away!
                     if (fleeing) {
                         msg.append("\n\t")
-                           .append(entity.getDisplayName())
-                           .append("dishonored himself by attacking a fleeing unit (")
-                           .append(mine.getDisplayName())
-                           .append(").");
+                              .append(entity.getDisplayName())
+                              .append("dishonored himself by attacking a fleeing unit (")
+                              .append(mine.getDisplayName())
+                              .append(").");
                         getHonorUtil().setEnemyDishonored(entity.getOwnerId());
                         attackedWhileFleeing.add(mine.getId());
                     }
@@ -2600,8 +2631,7 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Update the various state trackers for a specific entity.
-     * Useful to call when receiving an entity update packet
+     * Update the various state trackers for a specific entity. Useful to call when receiving an entity update packet
      */
     public void updateEntityState(final @Nullable Entity entity) {
         if ((entity != null) && entity.getOwner().isEnemyOf(getLocalPlayer())) {
@@ -2622,17 +2652,14 @@ public class Princess extends BotClient {
             fireControlState.setAdditionalTargets(new ArrayList<>());
             for (final Coords strategicTarget : getStrategicBuildingTargets()) {
                 if (null == game.getBoard().getBuildingAt(strategicTarget)) {
-                    fireControlState.getAdditionalTargets().add(
-                            getAppropriateTarget(strategicTarget));
+                    fireControlState.getAdditionalTargets().add(getAppropriateTarget(strategicTarget));
                     sendChat("No building to target in Hex " +
-                             strategicTarget.toFriendlyString() +
-                             ", targeting for clearing.", Level.INFO);
+                                   strategicTarget.toFriendlyString() +
+                                   ", targeting for clearing.", Level.INFO);
                 } else {
-                    fireControlState.getAdditionalTargets().add(
-                            getAppropriateTarget(strategicTarget));
-                    sendChat("Building in Hex " +
-                             strategicTarget.toFriendlyString() +
-                             " designated strategic target.", Level.INFO);
+                    fireControlState.getAdditionalTargets().add(getAppropriateTarget(strategicTarget));
+                    sendChat("Building in Hex " + strategicTarget.toFriendlyString() + " designated strategic target.",
+                          Level.INFO);
                 }
             }
 
@@ -2648,8 +2675,9 @@ public class Princess extends BotClient {
 
                         if (isEnemyGunEmplacement(entity, coords)) {
                             fireControlState.getAdditionalTargets().add(bt);
-                            sendChat("Building in Hex " + coords.toFriendlyString()
-                                    + " designated target due to Gun Emplacement.", Level.INFO);
+                            sendChat("Building in Hex " +
+                                           coords.toFriendlyString() +
+                                           " designated target due to Gun Emplacement.", Level.INFO);
                         }
                     }
                 }
@@ -2665,8 +2693,9 @@ public class Princess extends BotClient {
             damageMap.clear();
 
             // Now add an ID for each possible target.
-            final List<Targetable> potentialTargets = FireControl.getAllTargetableEnemyEntities(
-                    getLocalPlayer(), getGame(), fireControlState);
+            final List<Targetable> potentialTargets = FireControl.getAllTargetableEnemyEntities(getLocalPlayer(),
+                  getGame(),
+                  fireControlState);
             for (final Targetable target : potentialTargets) {
                 damageMap.put(target.getId(), 0d);
             }
@@ -2708,8 +2737,9 @@ public class Princess extends BotClient {
                         if (isEnemyGunEmplacement(entity, coords)) {
                             getStrategicBuildingTargets().add(coords);
 
-                            sendChat("Building in Hex " + coords.toFriendlyString()
-                                    + " designated target due to Gun Emplacement.", Level.INFO);
+                            sendChat("Building in Hex " +
+                                           coords.toFriendlyString() +
+                                           " designated target due to Gun Emplacement.", Level.INFO);
                         }
                     }
                 }
@@ -2751,8 +2781,7 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Initialize the possible path rankers.
-     * Has a dependency on the fire controls being initialized.
+     * Initialize the possible path rankers. Has a dependency on the fire controls being initialized.
      */
     public void initializePathRankers() {
         initializeFireControls();
@@ -2777,10 +2806,12 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Reduce utility of TAGging something if we're already trying.  Update the utility if it's better,
-     * otherwise try to dissuade the next attacker.
+     * Reduce utility of TAGging something if we're already trying.  Update the utility if it's better, otherwise try to
+     * dissuade the next attacker.
+     *
      * @param te
      * @param damage
+     *
      * @return
      */
     public int computeTeamTagUtility(Targetable te, int damage) {
@@ -2796,20 +2827,18 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Because Aerospace units can either TAG _or_ attack with their weapons, we want every
-     * friendly TAG-equipped Aero (and possibly others) to know about all the possible
-     * incoming Homing or IF attacks that could take advantage of their TAGs, for later calculations.
-     *
-     * Steps are:
-     *  1. All relevant guidable attacks (within range of the target) are added to a list.
-     *  1a. All Homing Weapons landing this turn are added to the list.
-     *  1b. All IF-capable, Semi-Guided, and Homing weapons that have not yet fired but _could_ are added as well.
-     *  2. Each attacker-target location pair's expected homing/indirect fire damage is cached for later re-use.
-     *  3. During the Indirect phase, when TAG attacks are announced, relevant units can use this info to decide
-     *      whether they want to TAG or reserve their activation for actual attacks.
-     *  4. All info is cleared at the start of the next turn.
+     * Because Aerospace units can either TAG _or_ attack with their weapons, we want every friendly TAG-equipped Aero
+     * (and possibly others) to know about all the possible incoming Homing or IF attacks that could take advantage of
+     * their TAGs, for later calculations.
+     * <p>
+     * Steps are: 1. All relevant guidable attacks (within range of the target) are added to a list. 1a. All Homing
+     * Weapons landing this turn are added to the list. 1b. All IF-capable, Semi-Guided, and Homing weapons that have
+     * not yet fired but _could_ are added as well. 2. Each attacker-target location pair's expected homing/indirect
+     * fire damage is cached for later re-use. 3. During the Indirect phase, when TAG attacks are announced, relevant
+     * units can use this info to decide whether they want to TAG or reserve their activation for actual attacks. 4. All
+     * info is cleared at the start of the next turn.
      */
-    public List<WeaponMounted> computeGuidedWeapons(Entity entityToFire, Coords location){
+    public List<WeaponMounted> computeGuidedWeapons(Entity entityToFire, Coords location) {
         // Key cached entries to firing entity _and_ coordinates, as each shooter may have different targets and weapons
         // to support.
         Map.Entry<Integer, Coords> key = Map.entry(entityToFire.getId(), location);
@@ -2823,7 +2852,9 @@ public class Princess extends BotClient {
         // turns, but not from this turn.
         for (Enumeration<ArtilleryAttackAction> attacks = game.getArtilleryAttacks(); attacks.hasMoreElements(); ) {
             ArtilleryAttackAction a = attacks.nextElement();
-            if (a.getTurnsTilHit() == 0 && a.getAmmoMunitionType().contains(AmmoType.Munitions.M_HOMING) && (!a.getEntity(game).isEnemyOf(entityToFire))) {
+            if (a.getTurnsTilHit() == 0 &&
+                      a.getAmmoMunitionType().contains(AmmoType.Munitions.M_HOMING) &&
+                      (!a.getEntity(game).isEnemyOf(entityToFire))) {
                 // Must be a shot that should land within 8 hexes of the target hex
                 if (a.getCoords().distance(location) <= Compute.HOMING_RADIUS) {
                     friendlyGuidedWeapons.add((WeaponMounted) a.getEntity(game).getEquipment(a.getWeaponId()));
@@ -2851,7 +2882,9 @@ public class Princess extends BotClient {
                     candidateWeapons.add(m);
                 } else if (m.isGroundBomb()) {
                     // Only care about Laser-Guided bombs here; Homing Arrow IV handled separately.
-                    if (((IBomber) f).getBombs().stream().anyMatch(b -> ((BombType) b.getType()).getBombType() == BombType.B_LG)) {
+                    if (((IBomber) f).getBombs()
+                              .stream()
+                              .anyMatch(b -> ((BombType) b.getType()).getBombType() == BombType.B_LG)) {
                         candidateWeapons.add(m);
                     }
                 }
@@ -2866,8 +2899,8 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Load the list of units considered crippled at the time the bot was loaded or the beginning of the turn,
-     * whichever is the more recent.
+     * Load the list of units considered crippled at the time the bot was loaded or the beginning of the turn, whichever
+     * is the more recent.
      */
     public void refreshCrippledUnits() {
         // if we're not following 'forced withdrawal' rules, there's no need for this
@@ -2887,19 +2920,20 @@ public class Princess extends BotClient {
     }
 
     private boolean isEnemyGunEmplacement(final Entity entity, final Coords coords) {
-        return entity.hasETypeFlag(Entity.ETYPE_GUN_EMPLACEMENT)
-               && !getBehaviorSettings().getIgnoredUnitTargets().contains(entity.getId())
-               && entity.getOwner().isEnemyOf(getLocalPlayer())
-               && !getStrategicBuildingTargets().contains(coords)
-               && !entity.isCrippled();
+        return entity.hasETypeFlag(Entity.ETYPE_GUN_EMPLACEMENT) &&
+                     !getBehaviorSettings().getIgnoredUnitTargets().contains(entity.getId()) &&
+                     entity.getOwner().isEnemyOf(getLocalPlayer()) &&
+                     !getStrategicBuildingTargets().contains(coords) &&
+                     !entity.isCrippled();
     }
 
     private boolean isEnemyInfantry(final Entity entity, final Coords coords) {
-        return entity.hasETypeFlag(Entity.ETYPE_INFANTRY) && !entity.hasETypeFlag(Entity.ETYPE_MEKWARRIOR)
-                && !getBehaviorSettings().getIgnoredUnitTargets().contains(entity.getId())
-                && entity.getOwner().isEnemyOf(getLocalPlayer())
-                && !getStrategicBuildingTargets().contains(coords)
-                && !entity.isCrippled();
+        return entity.hasETypeFlag(Entity.ETYPE_INFANTRY) &&
+                     !entity.hasETypeFlag(Entity.ETYPE_MEKWARRIOR) &&
+                     !getBehaviorSettings().getIgnoredUnitTargets().contains(entity.getId()) &&
+                     entity.getOwner().isEnemyOf(getLocalPlayer()) &&
+                     !getStrategicBuildingTargets().contains(coords) &&
+                     !entity.isCrippled();
     }
 
     @Override
@@ -2917,8 +2951,8 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Given an entity and the current behavior settings, get the "home" edge to which the entity should attempt to retreat
-     * Guaranteed to return a cardinal edge or NONE.
+     * Given an entity and the current behavior settings, get the "home" edge to which the entity should attempt to
+     * retreat Guaranteed to return a cardinal edge or NONE.
      */
     CardinalEdge getHomeEdge(Entity entity) {
         // if I am crippled and using forced withdrawal rules, my home edge is the "retreat" edge
@@ -2962,10 +2996,10 @@ public class Princess extends BotClient {
     @Override
     protected void checkMorale() {
         moraleUtil.checkMorale(behaviorSettings.isForcedWithdrawal(),
-                             behaviorSettings.getBraveryIndex(),
-                             behaviorSettings.getSelfPreservationIndex(),
-                             getLocalPlayer(),
-                             game);
+              behaviorSettings.getBraveryIndex(),
+              behaviorSettings.getSelfPreservationIndex(),
+              getLocalPlayer(),
+              game);
     }
 
     public IHonorUtil getHonorUtil() {
@@ -2973,13 +3007,12 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Lazy-loaded calculation of the "to-hit target number" threshold for
-     * spinning up a rapid fire autocannon.
+     * Lazy-loaded calculation of the "to-hit target number" threshold for spinning up a rapid fire autocannon.
      */
     public int getSpinUpThreshold() {
         if (spinUpThreshold == null) {
-        // we start spinning up the cannon at 11+ TN at highest aggression levels
-        // dropping it down to 6+ TN at the lower aggression levels
+            // we start spinning up the cannon at 11+ TN at highest aggression levels
+            // dropping it down to 6+ TN at the lower aggression levels
             spinUpThreshold = Math.min(11, Math.max(getBehaviorSettings().getHyperAggressionIndex() + 2, 6));
         }
 
@@ -3028,12 +3061,11 @@ public class Princess extends BotClient {
 
     @Override
     protected void handlePacket(final Packet c) {
-        final StringBuilder msg = new StringBuilder("Received packet, cmd: " + c.getCommand());
+        final StringBuilder msg = new StringBuilder("Received packet, cmd: " + c.command());
         try {
             super.handlePacket(c);
             getPrecognition().handlePacket(c);
-        }
-        finally {
+        } finally {
             logger.trace(msg.toString());
         }
     }
@@ -3074,9 +3106,10 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Helper function to perform some modifications to a given path.
-     * Intended to happen after we pick the best path.
+     * Helper function to perform some modifications to a given path. Intended to happen after we pick the best path.
+     *
      * @param path The ranked path to process
+     *
      * @return Altered move path
      */
     private MovePath performPathPostProcessing(final RankedPath path) {
@@ -3085,8 +3118,10 @@ public class Princess extends BotClient {
 
     /**
      * Helper function to perform some modifications to a given path.
-     * @param path The move path to process
+     *
+     * @param path           The move path to process
      * @param expectedDamage The damage expected to be done by the unit as a result of the path
+     *
      * @return Altered move path
      */
     private MovePath performPathPostProcessing(MovePath path, double expectedDamage) {
@@ -3096,7 +3131,7 @@ public class Princess extends BotClient {
         unloadTransportedInfantry(retVal);
         launchFighters(retVal);
         abandonShip(retVal);
-        unjamRAC(retVal, expectedDamage >= 5 );
+        unjamRAC(retVal, expectedDamage >= 5);
 
         // if we are using vector movement, there's a whole bunch of post-processing that happens to
         // aircraft flight paths when a player does it, so we apply it here.
@@ -3105,10 +3140,10 @@ public class Princess extends BotClient {
         }
 
         // allow fleeing at end of movement if is falling back and can flee from position
-        if ((isFallingBack(path.getEntity()))
-            && (path.getLastStep() != null)
-            && (getGame().canFleeFrom(path.getEntity(), path.getLastStep().getPosition()))
-            && (path.getMpUsed() < path.getMaxMP())) {
+        if ((isFallingBack(path.getEntity())) &&
+                  (path.getLastStep() != null) &&
+                  (getGame().canFleeFrom(path.getEntity(), path.getLastStep().getPosition())) &&
+                  (path.getMpUsed() < path.getMaxMP())) {
             path.addStep(MoveStepType.FLEE);
         }
 
@@ -3117,18 +3152,21 @@ public class Princess extends BotClient {
 
     /**
      * Helper function that appends an unjam RAC command to the end of a qualifying path.
+     *
      * @param path The path to process.
      */
     private void unjamRAC(MovePath path, boolean expectFiveOrMore) {
         if (path.getEntity().canUnjamRAC() &&
-                (path.getMpUsed() <= path.getEntity().getWalkMP()) &&
-                !path.isJumping() && !expectFiveOrMore) {
+                  (path.getMpUsed() <= path.getEntity().getWalkMP()) &&
+                  !path.isJumping() &&
+                  !expectFiveOrMore) {
             path.addStep(MoveStepType.UNJAM_RAC);
         }
     }
 
     /**
      * Helper function that insinuates an "evade" step for aircraft that will not be shooting.
+     *
      * @param path The path to process
      */
     private void evadeIfNotFiring(MovePath path, boolean possibleToInflictDamage) {
@@ -3144,33 +3182,35 @@ public class Princess extends BotClient {
         // and we can do so without causing a PSR
         // then evade
         if (pathEntity.isAirborne() &&
-           !possibleToInflictDamage &&
-           (path.getMpUsed() <= AeroPathUtil.calculateMaxSafeThrust((IAero) path.getEntity()) - 2)) {
+                  !possibleToInflictDamage &&
+                  (path.getMpUsed() <= AeroPathUtil.calculateMaxSafeThrust((IAero) path.getEntity()) - 2)) {
             path.addStep(MoveStepType.EVADE);
         }
     }
 
     /**
      * Turn on the searchlight if we expect to be shooting at something and it's dark out
-     * @param path Path being considered
+     *
+     * @param path                    Path being considered
      * @param possibleToInflictDamage Whether we expect to be shooting at something.
      */
     private void turnOnSearchLight(MovePath path, boolean possibleToInflictDamage) {
         Entity pathEntity = path.getEntity();
-        if (possibleToInflictDamage
-                && pathEntity.hasSearchlight()
-                && !pathEntity.isUsingSearchlight()
-                && path.getGame().getPlanetaryConditions().getLight().isDuskOrFullMoonOrMoonlessOrPitchBack()) {
+        if (possibleToInflictDamage &&
+                  pathEntity.hasSearchlight() &&
+                  !pathEntity.isUsingSearchlight() &&
+                  path.getGame().getPlanetaryConditions().getLight().isDuskOrFullMoonOrMoonlessOrPitchBack()) {
             path.addStep(MoveStepType.SEARCHLIGHT);
         }
     }
 
     /**
-     * Helper function that adds an "unload" step for units that are transporting infantry
-     * if the conditions for unloading are favorable.
+     * Helper function that adds an "unload" step for units that are transporting infantry if the conditions for
+     * unloading are favorable.
+     * <p>
+     * Infantry unloading logic is different from, for example, hot-dropping Meks or launching aerospace fighters, so we
+     * handle it separately.
      *
-     * Infantry unloading logic is different from, for example, hot-dropping Meks or launching aerospace fighters,
-     * so we handle it separately.
      * @param path The path to modify
      */
     private void unloadTransportedInfantry(MovePath path) {
@@ -3182,7 +3222,10 @@ public class Princess extends BotClient {
 
         final Entity movingEntity = path.getEntity();
         final Coords pathEndpoint = path.getFinalCoords();
-        Targetable closestEnemy = getPathRanker(movingEntity).findClosestEnemy(movingEntity, pathEndpoint, getGame(), false);
+        Targetable closestEnemy = getPathRanker(movingEntity).findClosestEnemy(movingEntity,
+              pathEndpoint,
+              getGame(),
+              false);
 
         // if there are no enemies on the board, then we're not unloading anything.
         // infantry can't clear hexes, so let's not unload them for that purpose
@@ -3213,17 +3256,21 @@ public class Princess extends BotClient {
 
                 // this condition is a simple check that we're not unloading infantry into deep space
                 // or into lava or some other such nonsense
-                boolean unloadFatal = loadedEntity.isBoardProhibited(getGame().getBoard().getType())
-                        || loadedEntity.isLocationProhibited(pathEndpoint)
-                        || loadedEntity.isLocationDeadly(pathEndpoint);
+                boolean unloadFatal = loadedEntity.isBoardProhibited(getGame().getBoard().getType()) ||
+                                            loadedEntity.isLocationProhibited(pathEndpoint) ||
+                                            loadedEntity.isLocationDeadly(pathEndpoint);
 
                 // Unloading a unit may sometimes cause a stacking violation, take that into account when planning
-                boolean unloadIllegal = Compute.stackingViolation(getGame(), loadedEntity, pathEndpoint, movingEntity,
-                        loadedEntity.climbMode()) != null;
+                boolean unloadIllegal = Compute.stackingViolation(getGame(),
+                      loadedEntity,
+                      pathEndpoint,
+                      movingEntity,
+                      loadedEntity.climbMode()) != null;
 
                 // this is a primitive condition that checks whether we're within "engagement range" of an enemy
                 // where "engagement range" is defined as the maximum range of our weapons plus our walking movement
-                boolean inEngagementRange = loadedEntity.getWalkMP() + getMaxWeaponRange(loadedEntity) >= distanceToClosestEnemy;
+                boolean inEngagementRange = loadedEntity.getWalkMP() + getMaxWeaponRange(loadedEntity) >=
+                                                  distanceToClosestEnemy;
 
                 if (!unloadFatal && !unloadIllegal && inEngagementRange) {
                     path.addStep(MoveStepType.UNLOAD, loadedEntity, pathEndpoint);
@@ -3234,8 +3281,8 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Helper function that adds an "launch" step for units that are transporting
-     * launch-able units in some kind of bay.
+     * Helper function that adds an "launch" step for units that are transporting launch-able units in some kind of
+     * bay.
      */
     private void launchFighters(MovePath path) {
         // if my objective is to cross the board, even though it's tempting, I won't be leaving the aerospace
@@ -3246,14 +3293,17 @@ public class Princess extends BotClient {
 
         Entity movingEntity = path.getEntity();
         Coords pathEndpoint = path.getFinalCoords();
-        Targetable closestEnemy = getPathRanker(movingEntity).findClosestEnemy(movingEntity, pathEndpoint, getGame(), false);
+        Targetable closestEnemy = getPathRanker(movingEntity).findClosestEnemy(movingEntity,
+              pathEndpoint,
+              getGame(),
+              false);
 
         // Don't launch at high velocity in atmosphere or the fighters will be destroyed!
         if (path.getFinalVelocity() > 2 && !game.getBoard().inSpace()) {
             return;
         }
 
-            // if there are no enemies on the board, then we're not launching anything.
+        // if there are no enemies on the board, then we're not launching anything.
         if ((null == closestEnemy) || (closestEnemy.getTargetType() != Targetable.TYPE_ENTITY)) {
             return;
         }
@@ -3290,12 +3340,10 @@ public class Princess extends BotClient {
     protected boolean shouldAbandon(Entity entity) {
         boolean shouldAbandon = false;
         // Nonfunctional entity?  Abandon!
-        if ((
-            entity.isPermanentlyImmobilized(true)
-                || entity.isCrippled()
-                || entity.isShutDown()
-                || entity.isDoomed()
-        ) && (entity.getAltitude() < 1)){
+        if ((entity.isPermanentlyImmobilized(true) ||
+                   entity.isCrippled() ||
+                   entity.isShutDown() ||
+                   entity.isDoomed()) && (entity.getAltitude() < 1)) {
             shouldAbandon = true;
         } else if (entity instanceof Tank tank) {
             // Immobile tank?  Abandon!
@@ -3303,7 +3351,7 @@ public class Princess extends BotClient {
             if (tank.isImmobile()) {
                 shouldAbandon = true;
             }
-        } else if ((entity instanceof Aero aero && aero.getAltitude() < 1 && !aero.isAirborne())){
+        } else if ((entity instanceof Aero aero && aero.getAltitude() < 1 && !aero.isAirborne())) {
             // Aero and unable to take off?  Abandon!
             if (!aero.canTakeOffHorizontally() && !aero.canTakeOffVertically()) {
                 shouldAbandon = true;
@@ -3324,15 +3372,15 @@ public class Princess extends BotClient {
 
         // Set dismount locations: this hex / adjacent hexes / outer-ring adjacent hexes
         List<Coords> dismountLocations = List.of(movingEntity.getPosition());
-        if (
-            movingEntity.isDropShip()
-            || movingEntity.isSmallCraft()
-            || (movingEntity.isSupportVehicle() && movingEntity.isSuperHeavy())
-        ) {
+        if (movingEntity.isDropShip() ||
+                  movingEntity.isSmallCraft() ||
+                  (movingEntity.isSupportVehicle() && movingEntity.isSuperHeavy())) {
             int distance = (movingEntity.isDropShip()) ? 2 : 1;
             dismountLocations = movingEntity.getPosition()
-                .allAtDistance(distance).stream()
-                .filter(c -> game.getBoard().contains(c)).toList();
+                                      .allAtDistance(distance)
+                                      .stream()
+                                      .filter(c -> game.getBoard().contains(c))
+                                      .toList();
         }
 
         int dismountIndex = 0;
@@ -3371,16 +3419,16 @@ public class Princess extends BotClient {
                 if (unitsUnloaded < maxDismountsPerBay) {
                     while (dismountIndex < dismountLocations.size()) {
                         // this condition is a simple check that we're not unloading units into fatal conditions
-                        boolean unloadFatal = loadedEntity.isBoardProhibited(getGame().getBoard().getType())
-                            || loadedEntity.isLocationProhibited(dismountLocation)
-                            || loadedEntity.isLocationDeadly(dismountLocation);
+                        boolean unloadFatal = loadedEntity.isBoardProhibited(getGame().getBoard().getType()) ||
+                                                    loadedEntity.isLocationProhibited(dismountLocation) ||
+                                                    loadedEntity.isLocationDeadly(dismountLocation);
 
                         // Unloading a unit may sometimes cause a stacking violation, take that into account when planning
-                        boolean unloadIllegal = Compute.stackingViolation(
-                            getGame(), loadedEntity, dismountLocation,
-                            (dismountLocations.size() == 1) ? movingEntity : null,
-                            loadedEntity.climbMode()
-                        ) != null;
+                        boolean unloadIllegal = Compute.stackingViolation(getGame(),
+                              loadedEntity,
+                              dismountLocation,
+                              (dismountLocations.size() == 1) ? movingEntity : null,
+                              loadedEntity.climbMode()) != null;
 
                         if (unloadIllegal) {
                             // Try the next hex
@@ -3405,11 +3453,10 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Helper function that starts unloading a transport if it is crippled, doomed, unable to move,
-     * or otherwise no longer functional as a transport.
-     * We don't care if there are enemies on the board here; get the units out as soon as possible.
-     * Returns after one unload b/c MovePathHandler will give us another Turn if we still have
-     * more to unload (up to standard limits).
+     * Helper function that starts unloading a transport if it is crippled, doomed, unable to move, or otherwise no
+     * longer functional as a transport. We don't care if there are enemies on the board here; get the units out as soon
+     * as possible. Returns after one unload b/c MovePathHandler will give us another Turn if we still have more to
+     * unload (up to standard limits).
      *
      * @param path MovePath that brought us here.
      */
@@ -3434,19 +3481,20 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Sets the mode for AMS on each unit this bot controls. This may be on or off, and possibly
-     * manual fire if the game options allow it, with any change taking effect next round.
-     * Normal setting is to have the AMS active/automatic. It may be turned off to conserve
-     * ammo on relatively undamaged units, and laser AMS may be turned off to help reduce
-     * overheating. Manual use is reserved as an emergency anti-infantry measure.
-     *
+     * Sets the mode for AMS on each unit this bot controls. This may be on or off, and possibly manual fire if the game
+     * options allow it, with any change taking effect next round. Normal setting is to have the AMS active/automatic.
+     * It may be turned off to conserve ammo on relatively undamaged units, and laser AMS may be turned off to help
+     * reduce overheating. Manual use is reserved as an emergency anti-infantry measure.
      */
     private void setAMSModes() {
 
         // Get conventional infantry if manual mode is available
         List<Entity> enemyInfantry = new ArrayList<>();
         if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_MANUAL_AMS)) {
-            for (Entity curEnemy : this.getEnemyEntities().stream().filter(Entity::isDeployed).collect(Collectors.toSet())) {
+            for (Entity curEnemy : this.getEnemyEntities()
+                                         .stream()
+                                         .filter(Entity::isDeployed)
+                                         .collect(Collectors.toSet())) {
                 if (curEnemy.getPosition() != null && curEnemy.isVisibleToEnemy()) {
 
                     if (curEnemy instanceof Infantry && !(curEnemy instanceof EjectedCrew)) {
@@ -3462,11 +3510,10 @@ public class Princess extends BotClient {
                 continue;
             }
 
-            List<WeaponMounted> activeAMS = curEntity.
-                    getWeaponList().
-                    stream().
-                    filter(w -> w.getType().hasFlag(AmmoWeapon.F_AMS) && w.hasModes()).
-                    collect(Collectors.toList());
+            List<WeaponMounted> activeAMS = curEntity.getWeaponList()
+                                                  .stream()
+                                                  .filter(w -> w.getType().hasFlag(AmmoWeapon.F_AMS) && w.hasModes())
+                                                  .collect(Collectors.toList());
 
             if (!activeAMS.isEmpty()) {
 
@@ -3478,7 +3525,10 @@ public class Princess extends BotClient {
                 // If there are enough nearby enemy infantry (only counted if the game option is
                 // set), choose manual fire
                 if (!enemyInfantry.isEmpty() && !curEntity.isAirborne()) {
-                    int infantryRange = enemyInfantry.stream().mapToInt(e -> Compute.effectiveDistance(game, curEntity, e)).min().getAsInt();
+                    int infantryRange = enemyInfantry.stream()
+                                              .mapToInt(e -> Compute.effectiveDistance(game, curEntity, e))
+                                              .min()
+                                              .getAsInt();
                     if (infantryRange <= 3) {
                         newAMSMode = EquipmentMode.getMode(Weapon.MODE_AMS_MANUAL);
                     }
@@ -3501,8 +3551,10 @@ public class Princess extends BotClient {
                     } else {
 
                         // Determine if ammo needs to be conserved
-                        boolean conserveAmmo = curAMS.getLinkedAmmo().getUsableShotsLeft() <= (int) Math.floor(curAMS.getOriginalShots() *
-                                behaviorSettings.getSelfPreservationValue() / 100.0);
+                        boolean conserveAmmo = curAMS.getLinkedAmmo().getUsableShotsLeft() <=
+                                                     (int) Math.floor(curAMS.getOriginalShots() *
+                                                                            behaviorSettings.getSelfPreservationValue() /
+                                                                            100.0);
 
                         // Consider turning off AMS to conserve ammo unless it's needed for infantry
                         if (conserveAmmo && !newAMSMode.equals(Weapon.MODE_AMS_MANUAL)) {
@@ -3570,9 +3622,10 @@ public class Princess extends BotClient {
 
     /**
      * Flag an entity as having used manual AMS this round
+     *
      * @param id
      */
-    public void flagManualAMSUse (int id) {
+    public void flagManualAMSUse(int id) {
         if (manualAMSIds == null) {
             manualAMSIds = new ArrayList<>();
         }
@@ -3581,7 +3634,7 @@ public class Princess extends BotClient {
         }
     }
 
-    public boolean usedManualAMS (int id) {
+    public boolean usedManualAMS(int id) {
         if (manualAMSIds == null) {
             manualAMSIds = new ArrayList<>();
             return false;
@@ -3592,7 +3645,7 @@ public class Princess extends BotClient {
     /**
      * Clear the manual AMS tracking list
      */
-    public void clearManualAMSIds () {
+    public void clearManualAMSIds() {
         if (manualAMSIds == null) {
             manualAMSIds = new ArrayList<>();
         }
@@ -3601,9 +3654,10 @@ public class Princess extends BotClient {
 
     /**
      * Get a list of all hot spots (positions of high activity) for opposing units
+     *
      * @return
      */
-    public List<Coords> getEnemyHotSpots () {
+    public List<Coords> getEnemyHotSpots() {
         List<Coords> accumulatedHotSpots = new ArrayList<>();
         for (HeatMap curMap : enemyHeatMaps) {
             List<Coords> mapHotSpots = curMap.getHotSpots();
@@ -3621,25 +3675,28 @@ public class Princess extends BotClient {
 
     /**
      * Get the best hot spot (positions of high activity) for friendly units
-     * @return  {@code Coords} with high friendly activity; may return null
+     *
+     * @return {@code Coords} with high friendly activity; may return null
      */
-    public Coords getFriendlyHotSpot () {
+    public Coords getFriendlyHotSpot() {
         return friendlyHeatMap.getHotSpot();
     }
 
     /**
      * Get the nearest top-rated hot spot for friendly units
+     *
      * @param testPosition
+     *
      * @return
      */
-    public Coords getFriendlyHotSpot (Coords testPosition) {
+    public Coords getFriendlyHotSpot(Coords testPosition) {
         return friendlyHeatMap == null ? null : friendlyHeatMap.getHotSpot(testPosition, true);
     }
 
     /**
      * Set up heat maps to track enemy unit positions over time
      */
-    protected void initEnemyHeatMaps () {
+    protected void initEnemyHeatMaps() {
         enemyHeatMaps = new ArrayList<>();
         int princessTeamId = getGame().getTeamForPlayer(this.getLocalPlayer()).getId();
         for (Team curTeam : getGame().getTeams()) {
@@ -3655,7 +3712,7 @@ public class Princess extends BotClient {
     /**
      * Set up heat map to track friendly units over time
      */
-    protected void initFriendlyHeatMap () {
+    protected void initFriendlyHeatMap() {
         friendlyHeatMap = new HeatMap(getGame().getTeamForPlayer(this.getLocalPlayer()).getId());
         friendlyHeatMap.setMovementWeightValue(5);
         friendlyHeatMap.setMapTrimThreshold(0.6);
@@ -3668,11 +3725,10 @@ public class Princess extends BotClient {
      */
     protected void updateEnemyHeatMaps() {
 
-        List<Entity> trackedEntities = getGame().
-                inGameTWEntities().
-                stream().
-                filter(HeatMap::validateForTracking).
-                collect(Collectors.toList());
+        List<Entity> trackedEntities = getGame().inGameTWEntities()
+                                             .stream()
+                                             .filter(HeatMap::validateForTracking)
+                                             .collect(Collectors.toList());
 
         // Process entities into each heat map, then age it
         for (HeatMap curMap : enemyHeatMaps) {
@@ -3684,17 +3740,16 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Update the heat map with allied unit positions (entities controlled by this bot have
-     * already been processed as they move), then apply decay
+     * Update the heat map with allied unit positions (entities controlled by this bot have already been processed as
+     * they move), then apply decay
      */
-    protected void updateFriendlyHeatMap () {
+    protected void updateFriendlyHeatMap() {
 
-        List<Entity> trackedEntities = getGame().
-                inGameTWEntities().
-                stream().
-                filter(e -> e.getOwner().getId() != this.getLocalPlayer().getId() &&
-                    HeatMap.validateForTracking(e)).
-                collect(Collectors.toList());
+        List<Entity> trackedEntities = getGame().inGameTWEntities()
+                                             .stream()
+                                             .filter(e -> e.getOwner().getId() != this.getLocalPlayer().getId() &&
+                                                                HeatMap.validateForTracking(e))
+                                             .collect(Collectors.toList());
 
         if (!trackedEntities.isEmpty()) {
             friendlyHeatMap.updateTrackers(trackedEntities);
@@ -3712,13 +3767,12 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Override for the 'receive entity update' handler
-     * Updates internal state in addition to base client functionality
+     * Override for the 'receive entity update' handler Updates internal state in addition to base client functionality
      */
     @Override
     public void receiveEntityUpdate(final Packet packet) {
         super.receiveEntityUpdate(packet);
-        updateEntityState((Entity) packet.getObject(1));
+        updateEntityState(packet.getEntityValue(1));
     }
 
     public SwarmContext getSwarmContext() {
@@ -3738,7 +3792,7 @@ public class Princess extends BotClient {
     }
 
     @Override
-    protected void postMovementProcessing(){
+    protected void postMovementProcessing() {
         for (var entity : getEntitiesOwned()) {
             if (entity.getPosition() == null) {
                 continue;

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -481,7 +481,8 @@ public class AmmoType extends EquipmentType {
         if (flag instanceof AmmoTypeFlag) {
             return super.hasFlag(flag);
         } else {
-            LOGGER.warn("Incorrect flag check: make sure to test only AmmoTypeFlags on an AmmoType.");
+            LOGGER.warn("Incorrect flag check: make sure to test only AmmoTypeFlags on an AmmoType. Checked flag: {}",
+                  flag);
             return false;
         }
     }
@@ -15440,7 +15441,8 @@ public class AmmoType extends EquipmentType {
 
         private final TechAdvancement techAdvancement;
 
-        public MunitionMutator(String munitionName, int weightRatio, Munitions munitionType, TechAdvancement techAdvancement, String rulesRefs) {
+        public MunitionMutator(String munitionName, int weightRatio, Munitions munitionType,
+                               TechAdvancement techAdvancement, String rulesRefs) {
             name = munitionName;
             weight = weightRatio;
             type = EnumSet.of(munitionType);

--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -74,8 +74,7 @@ import megamek.logging.MMLogger;
 // TODO add XML support back in.
 
 /**
- * A type of mek or vehicle weapon. There is only one instance of this weapon
- * for all weapons of this type.
+ * A type of mek or vehicle weapon. There is only one instance of this weapon for all weapons of this type.
  */
 public class WeaponType extends EquipmentType {
 
@@ -214,8 +213,7 @@ public class WeaponType extends EquipmentType {
     public static final WeaponTypeFlag F_ARTEMIS_COMPATIBLE = WeaponTypeFlag.F_ARTEMIS_COMPATIBLE;
 
     /**
-     * This flag is used by mortar-type weapons that allow indirect fire without a
-     * spotter and/or with LOS.
+     * This flag is used by mortar-type weapons that allow indirect fire without a spotter and/or with LOS.
      */
     public static final WeaponTypeFlag F_MORTARTYPE_INDIRECT = WeaponTypeFlag.F_MORTARTYPE_INDIRECT;
 
@@ -282,31 +280,11 @@ public class WeaponType extends EquipmentType {
     // Used for BA vs BA damage for BA Plasma Rifle
     public static final int WEAPON_PLASMA = 15;
 
-    public static String[] classNames = {
-            "Unknown",
-            "Laser",
-            "Point Defense",
-            "PPC",
-            "Pulse Laser",
-            "Artillery",
-            "Plasma",
-            "AC",
-            "LBX",
-            "LRM",
-            "SRM",
-            "MRM",
-            "ATM",
-            "Rocket Launcher",
-            "Capital Laser",
-            "Capital PPC",
-            "Capital AC",
-            "Capital Gauss",
-            "Capital Missile",
-            "AR10", "Screen",
-            "Sub Capital Cannon",
-            "Capital Mass Driver",
-            "AMS"
-    };
+    public static String[] classNames = { "Unknown", "Laser", "Point Defense", "PPC", "Pulse Laser", "Artillery",
+                                          "Plasma", "AC", "LBX", "LRM", "SRM", "MRM", "ATM", "Rocket Launcher",
+                                          "Capital Laser", "Capital PPC", "Capital AC", "Capital Gauss",
+                                          "Capital Missile", "AR10", "Screen", "Sub Capital Cannon",
+                                          "Capital Mass Driver", "AMS" };
 
     public static final int BFCLASS_STANDARD = 0;
     public static final int BFCLASS_LRM = 1;
@@ -346,9 +324,8 @@ public class WeaponType extends EquipmentType {
     public int infDamageClass = WEAPON_DIRECT_FIRE;
 
     /**
-     * Used for the BA vs BA damage rules on TO pg 109. Determines how much
-     * damage a weapon will inflict on BA, where the default WEAPON_DIRECT_FIRE
-     * indicates normal weapon damage.
+     * Used for the BA vs BA damage rules on TO pg 109. Determines how much damage a weapon will inflict on BA, where
+     * the default WEAPON_DIRECT_FIRE indicates normal weapon damage.
      */
     protected int baDamageClass = WEAPON_DIRECT_FIRE;
 
@@ -419,7 +396,8 @@ public class WeaponType extends EquipmentType {
         if (flag instanceof WeaponTypeFlag) {
             return super.hasFlag(flag);
         } else {
-            LOGGER.warn("Incorrect flag check: make sure to test only WeaponTypeFlags on a WeaponType.");
+            LOGGER.warn("Incorrect flag check: make sure to test only WeaponTypeFlags on a WeaponType. Tested: {}",
+                  flag);
             return false;
         }
     }
@@ -475,15 +453,15 @@ public class WeaponType extends EquipmentType {
         boolean hasLoadedAmmo = (ammo != null);
         if ((getAmmoType() == AmmoType.T_ATM) && hasLoadedAmmo) {
             AmmoType ammoType = (AmmoType) ammo.getType();
-            if ((ammoType.getAmmoType() == AmmoType.T_ATM)
-                    && (ammoType.getMunitionType().contains(AmmoType.Munitions.M_EXTENDED_RANGE))) {
+            if ((ammoType.getAmmoType() == AmmoType.T_ATM) &&
+                      (ammoType.getMunitionType().contains(AmmoType.Munitions.M_EXTENDED_RANGE))) {
                 minRange = 4;
                 sRange = 9;
                 mRange = 18;
                 lRange = 27;
                 eRange = 36;
-            } else if ((ammoType.getAmmoType() == AmmoType.T_ATM)
-                    && (ammoType.getMunitionType().contains(AmmoType.Munitions.M_HIGH_EXPLOSIVE))) {
+            } else if ((ammoType.getAmmoType() == AmmoType.T_ATM) &&
+                             (ammoType.getMunitionType().contains(AmmoType.Munitions.M_HIGH_EXPLOSIVE))) {
                 minRange = 0;
                 sRange = 3;
                 mRange = 6;
@@ -493,16 +471,16 @@ public class WeaponType extends EquipmentType {
         }
         if ((getAmmoType() == AmmoType.T_IATM) && hasLoadedAmmo) {
             AmmoType ammoType = (AmmoType) ammo.getType();
-            if ((ammoType.getAmmoType() == AmmoType.T_IATM)
-                    && (ammoType.getMunitionType().contains(AmmoType.Munitions.M_EXTENDED_RANGE))) {
+            if ((ammoType.getAmmoType() == AmmoType.T_IATM) &&
+                      (ammoType.getMunitionType().contains(AmmoType.Munitions.M_EXTENDED_RANGE))) {
                 minRange = 4;
                 sRange = 9;
                 mRange = 18;
                 lRange = 27;
                 eRange = 36;
-            } else if ((ammoType.getAmmoType() == AmmoType.T_IATM)
-                    && ((ammoType.getMunitionType().contains(AmmoType.Munitions.M_HIGH_EXPLOSIVE))
-                            || (ammoType.getMunitionType().contains(AmmoType.Munitions.M_IATM_IMP)))) {
+            } else if ((ammoType.getAmmoType() == AmmoType.T_IATM) &&
+                             ((ammoType.getMunitionType().contains(AmmoType.Munitions.M_HIGH_EXPLOSIVE)) ||
+                                    (ammoType.getMunitionType().contains(AmmoType.Munitions.M_IATM_IMP)))) {
                 minRange = 0;
                 sRange = 3;
                 mRange = 6;
@@ -543,8 +521,8 @@ public class WeaponType extends EquipmentType {
         }
         if ((getAmmoType() == AmmoType.T_LRM) && hasLoadedAmmo) {
             AmmoType ammoType = (AmmoType) ammo.getType();
-            if ((ammoType.getAmmoType() == AmmoType.T_LRM)
-                    && (ammoType.getMunitionType().contains(AmmoType.Munitions.M_DEAD_FIRE))) {
+            if ((ammoType.getAmmoType() == AmmoType.T_LRM) &&
+                      (ammoType.getMunitionType().contains(AmmoType.Munitions.M_DEAD_FIRE))) {
                 minRange = 4;
                 sRange = 5;
                 mRange = 10;
@@ -554,8 +532,8 @@ public class WeaponType extends EquipmentType {
         }
         if ((getAmmoType() == AmmoType.T_SRM) && hasLoadedAmmo) {
             AmmoType ammoType = (AmmoType) ammo.getType();
-            if ((ammoType.getAmmoType() == AmmoType.T_SRM)
-                    && (ammoType.getMunitionType().contains(AmmoType.Munitions.M_DEAD_FIRE))) {
+            if ((ammoType.getAmmoType() == AmmoType.T_SRM) &&
+                      (ammoType.getMunitionType().contains(AmmoType.Munitions.M_DEAD_FIRE))) {
                 minRange = 0;
                 sRange = 2;
                 mRange = 4;
@@ -598,13 +576,7 @@ public class WeaponType extends EquipmentType {
     }
 
     public int[] getWRanges() {
-        return new int[] {
-                minimumRange,
-                waterShortRange,
-                waterMediumRange,
-                waterLongRange,
-                waterExtremeRange
-        };
+        return new int[] { minimumRange, waterShortRange, waterMediumRange, waterLongRange, waterExtremeRange };
     }
 
     public int getWShortRange() {
@@ -727,76 +699,55 @@ public class WeaponType extends EquipmentType {
     }
 
     // Probably not the best place for this
+
     /**
-     * @param capitalOnly If true, this will return the equivalent capital bay for
-     *                    subcapital weapons.
+     * @param capitalOnly If true, this will return the equivalent capital bay for subcapital weapons.
+     *
      * @return The type of weapon bay this weapon goes in
      */
     public EquipmentType getBayType(boolean capitalOnly) {
         // Return the correct weapons bay for the given type of weapon
-        switch (getAtClass()) {
-            case CLASS_LASER:
-                return EquipmentType.get(EquipmentTypeLookup.LASER_BAY);
-            case CLASS_AMS:
-                return EquipmentType.get(EquipmentTypeLookup.AMS_BAY);
-            case CLASS_POINT_DEFENSE:
-                return EquipmentType.get(EquipmentTypeLookup.POINT_DEFENSE_BAY);
-            case CLASS_PPC:
-                return EquipmentType.get(EquipmentTypeLookup.PPC_BAY);
-            case CLASS_PULSE_LASER:
-                return EquipmentType.get(EquipmentTypeLookup.PULSE_LASER_BAY);
-            case CLASS_ARTILLERY:
-                return EquipmentType.get(EquipmentTypeLookup.ARTILLERY_BAY);
-            case CLASS_PLASMA:
-                return EquipmentType.get(EquipmentTypeLookup.PLASMA_BAY);
-            case CLASS_AC:
-                return EquipmentType.get(EquipmentTypeLookup.AC_BAY);
-            case CLASS_LBX_AC:
-                return EquipmentType.get(EquipmentTypeLookup.LBX_AC_BAY);
-            case CLASS_LRM:
-                return EquipmentType.get(EquipmentTypeLookup.LRM_BAY);
-            case CLASS_SRM:
-                return EquipmentType.get(EquipmentTypeLookup.SRM_BAY);
-            case CLASS_MRM:
-                return EquipmentType.get(EquipmentTypeLookup.MRM_BAY);
-            case CLASS_MML:
-                return EquipmentType.get(EquipmentTypeLookup.MML_BAY);
-            case CLASS_THUNDERBOLT:
-                return EquipmentType.get(EquipmentTypeLookup.THUNDERBOLT_BAY);
-            case CLASS_ATM:
-                return EquipmentType.get(EquipmentTypeLookup.ATM_BAY);
-            case CLASS_ROCKET_LAUNCHER:
-                return EquipmentType.get(EquipmentTypeLookup.ROCKET_LAUNCHER_BAY);
-            case CLASS_CAPITAL_LASER:
-                return (isSubCapital() && !capitalOnly) ? EquipmentType.get(EquipmentTypeLookup.SCL_BAY)
-                        : EquipmentType.get(EquipmentTypeLookup.CAPITAL_LASER_BAY);
-            case CLASS_CAPITAL_PPC:
-                return EquipmentType.get(EquipmentTypeLookup.CAPITAL_PPC_BAY);
-            case CLASS_CAPITAL_AC:
-                return (isSubCapital() && !capitalOnly) ? EquipmentType.get(EquipmentTypeLookup.SCC_BAY)
-                        : EquipmentType.get(EquipmentTypeLookup.CAPITAL_AC_BAY);
-            case CLASS_CAPITAL_GAUSS:
-                return EquipmentType.get(EquipmentTypeLookup.CAPITAL_GAUSS_BAY);
-            case CLASS_CAPITAL_MD:
-                return EquipmentType.get(EquipmentTypeLookup.CAPITAL_MASS_DRIVER_BAY);
-            case CLASS_CAPITAL_MISSILE:
-                return (isSubCapital() && !capitalOnly) ? EquipmentType.get(EquipmentTypeLookup.SC_MISSILE_BAY)
-                        : EquipmentType.get(EquipmentTypeLookup.CAPITAL_MISSILE_BAY);
-            case CLASS_TELE_MISSILE:
-                return EquipmentType.get(EquipmentTypeLookup.TELE_CAPITAL_MISSILE_BAY);
-            case CLASS_AR10:
-                return EquipmentType.get(EquipmentTypeLookup.AR10_BAY);
-            case CLASS_SCREEN:
-                return EquipmentType.get(EquipmentTypeLookup.SCREEN_LAUNCHER_BAY);
-            default:
-                return EquipmentType.get(EquipmentTypeLookup.MISC_BAY);
-        }
+        return switch (getAtClass()) {
+            case CLASS_LASER -> EquipmentType.get(EquipmentTypeLookup.LASER_BAY);
+            case CLASS_AMS -> EquipmentType.get(EquipmentTypeLookup.AMS_BAY);
+            case CLASS_POINT_DEFENSE -> EquipmentType.get(EquipmentTypeLookup.POINT_DEFENSE_BAY);
+            case CLASS_PPC -> EquipmentType.get(EquipmentTypeLookup.PPC_BAY);
+            case CLASS_PULSE_LASER -> EquipmentType.get(EquipmentTypeLookup.PULSE_LASER_BAY);
+            case CLASS_ARTILLERY -> EquipmentType.get(EquipmentTypeLookup.ARTILLERY_BAY);
+            case CLASS_PLASMA -> EquipmentType.get(EquipmentTypeLookup.PLASMA_BAY);
+            case CLASS_AC -> EquipmentType.get(EquipmentTypeLookup.AC_BAY);
+            case CLASS_LBX_AC -> EquipmentType.get(EquipmentTypeLookup.LBX_AC_BAY);
+            case CLASS_LRM -> EquipmentType.get(EquipmentTypeLookup.LRM_BAY);
+            case CLASS_SRM -> EquipmentType.get(EquipmentTypeLookup.SRM_BAY);
+            case CLASS_MRM -> EquipmentType.get(EquipmentTypeLookup.MRM_BAY);
+            case CLASS_MML -> EquipmentType.get(EquipmentTypeLookup.MML_BAY);
+            case CLASS_THUNDERBOLT -> EquipmentType.get(EquipmentTypeLookup.THUNDERBOLT_BAY);
+            case CLASS_ATM -> EquipmentType.get(EquipmentTypeLookup.ATM_BAY);
+            case CLASS_ROCKET_LAUNCHER -> EquipmentType.get(EquipmentTypeLookup.ROCKET_LAUNCHER_BAY);
+            case CLASS_CAPITAL_LASER -> (isSubCapital() && !capitalOnly) ?
+                                              EquipmentType.get(EquipmentTypeLookup.SCL_BAY) :
+                                              EquipmentType.get(EquipmentTypeLookup.CAPITAL_LASER_BAY);
+            case CLASS_CAPITAL_PPC -> EquipmentType.get(EquipmentTypeLookup.CAPITAL_PPC_BAY);
+            case CLASS_CAPITAL_AC -> (isSubCapital() && !capitalOnly) ?
+                                           EquipmentType.get(EquipmentTypeLookup.SCC_BAY) :
+                                           EquipmentType.get(EquipmentTypeLookup.CAPITAL_AC_BAY);
+            case CLASS_CAPITAL_GAUSS -> EquipmentType.get(EquipmentTypeLookup.CAPITAL_GAUSS_BAY);
+            case CLASS_CAPITAL_MD -> EquipmentType.get(EquipmentTypeLookup.CAPITAL_MASS_DRIVER_BAY);
+            case CLASS_CAPITAL_MISSILE -> (isSubCapital() && !capitalOnly) ?
+                                                EquipmentType.get(EquipmentTypeLookup.SC_MISSILE_BAY) :
+                                                EquipmentType.get(EquipmentTypeLookup.CAPITAL_MISSILE_BAY);
+            case CLASS_TELE_MISSILE -> EquipmentType.get(EquipmentTypeLookup.TELE_CAPITAL_MISSILE_BAY);
+            case CLASS_AR10 -> EquipmentType.get(EquipmentTypeLookup.AR10_BAY);
+            case CLASS_SCREEN -> EquipmentType.get(EquipmentTypeLookup.SCREEN_LAUNCHER_BAY);
+            default -> EquipmentType.get(EquipmentTypeLookup.MISC_BAY);
+        };
     }
 
     /**
      * Damage calculation for BattleForce and AlphaStrike
      *
      * @param range The range in hexes
+     *
      * @return Damage in BattleForce scale
      */
     // TODO : the calculations are superseded by the ASC table but correct most of
@@ -806,9 +757,9 @@ public class WeaponType extends EquipmentType {
         if (range <= getLongRange()) {
             // Variable damage weapons that cannot reach into the BF long range band use LR
             // damage for the MR band
-            if (getDamage() == DAMAGE_VARIABLE
-                    && range == AlphaStrikeElement.MEDIUM_RANGE
-                    && getLongRange() < AlphaStrikeElement.LONG_RANGE) {
+            if (getDamage() == DAMAGE_VARIABLE &&
+                      range == AlphaStrikeElement.MEDIUM_RANGE &&
+                      getLongRange() < AlphaStrikeElement.LONG_RANGE) {
                 damage = getDamage(AlphaStrikeElement.LONG_RANGE);
             } else {
                 damage = getDamage(range);
@@ -827,11 +778,11 @@ public class WeaponType extends EquipmentType {
     }
 
     /**
-     * Damage calculation for BattleForce and AlphaStrike for missile weapons that
-     * may have advanced fire control
+     * Damage calculation for BattleForce and AlphaStrike for missile weapons that may have advanced fire control
      *
      * @param range - the range in hexes
      * @param fcs   - linked Artemis or Apollo FCS (null for none)
+     *
      * @return - damage in BattleForce scale
      */
     public double getBattleForceDamage(int range, Mounted<?> fcs) {
@@ -843,12 +794,12 @@ public class WeaponType extends EquipmentType {
     }
 
     /**
-     * BattleForce-scale damage for BattleArmor, using cluster hits table based on
-     * squad size.
-     * AlphaStrike uses a different method.
+     * BattleForce-scale damage for BattleArmor, using cluster hits table based on squad size. AlphaStrike uses a
+     * different method.
      *
      * @param range       - the range in hexes
      * @param baSquadSize - the number of suits in the squad/point/level i
+     *
      * @return - damage in BattleForce scale
      */
     public double getBattleForceDamage(int range, int baSquadSize) {
@@ -856,49 +807,44 @@ public class WeaponType extends EquipmentType {
     }
 
     /**
-     * @return The class of weapons for those that are tracked separately from
-     *         standard damage (AlphaStrike)
+     * @return The class of weapons for those that are tracked separately from standard damage (AlphaStrike)
      */
     public int getBattleForceClass() {
         return BFCLASS_STANDARD;
     }
 
     /**
-     * Returns the weapon's heat for AlphaStrike conversion. Overridden where it
-     * differs from TW heat.
+     * Returns the weapon's heat for AlphaStrike conversion. Overridden where it differs from TW heat.
      */
     public int getAlphaStrikeHeat() {
         return getHeat();
     }
 
     /**
-     * Returns the weapon's AlphaStrike heat damage for AlphaStrike conversion. ASC
-     * p.124.
+     * Returns the weapon's AlphaStrike heat damage for AlphaStrike conversion. ASC p.124.
      */
     public int getAlphaStrikeHeatDamage(int rangeBand) {
         return 0;
     }
 
     /**
-     * Returns true if this weapon type can be used for Total War LRM-type indirect
-     * fire.
+     * Returns true if this weapon type can be used for Total War LRM-type indirect fire.
      */
     public boolean hasIndirectFire() {
         return false;
     }
 
     /**
-     * Returns true if this weapon type contributes to the AlphaStrike IF ability.
-     * This is identical to TW indirect fire for most but not all weapons (see e.g.
-     * IATMs)
+     * Returns true if this weapon type contributes to the AlphaStrike IF ability. This is identical to TW indirect fire
+     * for most but not all weapons (see e.g. IATMs)
      */
     public boolean isAlphaStrikeIndirectFire() {
         return hasIndirectFire();
     }
 
     /**
-     * Returns true if this weapon type contributes to the AlphaStrike PNT ability.
-     * This is not identical to TW point defense, therefore implemented separately.
+     * Returns true if this weapon type contributes to the AlphaStrike PNT ability. This is not identical to TW point
+     * defense, therefore implemented separately.
      */
     public boolean isAlphaStrikePointDefense() {
         return false;
@@ -906,10 +852,9 @@ public class WeaponType extends EquipmentType {
 
     /**
      * Add all the types of weapons we can create to the list
-     *
-     * When a weapon class extends another, the subclass must be listed first to
-     * avoid clobbering the name lookup when calling the constructor of the
-     * superclass.
+     * <p>
+     * When a weapon class extends another, the subclass must be listed first to avoid clobbering the name lookup when
+     * calling the constructor of the superclass.
      */
     public static void initializeTypes() {
         // Laser types

--- a/megamek/src/megamek/common/net/connections/SendPacket.java
+++ b/megamek/src/megamek/common/net/connections/SendPacket.java
@@ -35,12 +35,12 @@ class SendPacket implements INetworkPacket {
     private final AbstractConnection connection;
 
     public SendPacket(Packet packet, AbstractConnection connection) {
-        command = packet.getCommand();
+        command = packet.command();
         this.connection = connection;
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         OutputStream out;
         try {
-            if (connection.isCompressed() && (packet.getData() != null)) {
+            if (connection.isCompressed() && (packet.data() != null)) {
                 out = new GZIPOutputStream(bos);
                 zipped = true;
             } else {

--- a/megamek/src/megamek/common/net/marshalling/NativeSerializationMarshaller.java
+++ b/megamek/src/megamek/common/net/marshalling/NativeSerializationMarshaller.java
@@ -31,8 +31,8 @@ class NativeSerializationMarshaller extends PacketMarshaller {
     @Override
     public void marshall(final Packet packet, final OutputStream stream) throws Exception {
         ObjectOutputStream out = new ObjectOutputStream(stream);
-        out.writeInt(packet.getCommand().ordinal());
-        out.writeObject(packet.getData());
+        out.writeInt(packet.command().ordinal());
+        out.writeObject(packet.data());
         out.flush();
     }
 

--- a/megamek/src/megamek/common/net/packets/InvalidPacketObjectException.java
+++ b/megamek/src/megamek/common/net/packets/InvalidPacketObjectException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ */
+
+package megamek.common.net.packets;
+
+public class InvalidPacketObjectException extends RuntimeException {
+    public InvalidPacketObjectException(String message) {
+        super(message);
+    }
+}

--- a/megamek/src/megamek/common/net/packets/Packet.java
+++ b/megamek/src/megamek/common/net/packets/Packet.java
@@ -14,34 +14,45 @@
 package megamek.common.net.packets;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
 
+import megamek.Version;
+import megamek.client.ui.Base64Image;
+import megamek.common.Board;
+import megamek.common.Entity;
+import megamek.common.GameTurn;
+import megamek.common.InGameObject;
+import megamek.common.Player;
+import megamek.common.UnitLocation;
 import megamek.common.annotations.Nullable;
+import megamek.common.enums.GamePhase;
+import megamek.common.force.Force;
+import megamek.common.force.Forces;
 import megamek.common.net.enums.PacketCommand;
 
 /**
  * Application layer data packet used to exchange information between client and server.
  */
-public class Packet implements Serializable {
-    private final PacketCommand command;
-    private final Object[] data;
-
+public record Packet(PacketCommand command, Object... data) implements Serializable {
     /**
      * Creates a <code>Packet</code> with a command and an array of objects
      *
-     * @param command
-     * @param data
+     * @param command a {@link PacketCommand} describing the kind of data.
+     * @param data    an Object Array of data.
      */
-    public Packet(PacketCommand command, Object... data) {
-        this.command = command;
-        this.data = data;
+    public Packet {
     }
 
     /**
      * @return the command associated.
      */
     public PacketCommand getCommand() {
-        return command;
+        return command();
     }
 
     /**
@@ -55,7 +66,10 @@ public class Packet implements Serializable {
      * @param index the index of the desired object
      *
      * @return the object at the specified index
+     *
+     * @deprecated Use/create methods to handle conversion and enforce types and convert this to a private method
      */
+    @Deprecated(since = "0.50.05")
     public @Nullable Object getObject(final int index) {
         return (index >= 0 && index < data.length) ? data[index] : null;
     }
@@ -78,6 +92,27 @@ public class Packet implements Serializable {
     /**
      * @param index the index of the desired object
      *
+     * @return the List of <code>int</code> value of the object at the specified index
+     */
+    public List<Integer> getIntListValue(int index) {
+        Object o = getObject(index);
+
+        List<Integer> integers = new ArrayList<>();
+
+        if (o instanceof List<?> list) {
+            for (Object o1 : list) {
+                if (o1 instanceof Integer integer) {
+                    integers.add(integer);
+                }
+            }
+        }
+
+        return integers;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
      * @return the <code>boolean</code> value of the object at the specified index
      */
     public boolean getBooleanValue(int index) {
@@ -88,6 +123,27 @@ public class Packet implements Serializable {
         }
 
         return false;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return List of <code>boolean</code> value of the object at the specified index
+     */
+    public List<Boolean> getBooleanListValue(int index) {
+        Object o = getObject(index);
+
+        List<Boolean> booleans = new ArrayList<>();
+
+        if (o instanceof List<?> list) {
+            for (Object o1 : list) {
+                if (o1 instanceof Boolean bool) {
+                    booleans.add(bool);
+                }
+            }
+        }
+
+        return booleans;
     }
 
     /**
@@ -105,6 +161,337 @@ public class Packet implements Serializable {
         return "";
     }
 
+    /**
+     * @param index the index of the desired object
+     *
+     * @return List of <code>String</code> value of the object at the specified index
+     */
+    public List<String> getStringListValue(int index) {
+        Object o = getObject(index);
+
+        List<String> strings = new ArrayList<>();
+
+        if (o instanceof List<?> objects) {
+            for (Object o1 : objects) {
+                if (o1 instanceof String string) {
+                    strings.add(string);
+                }
+            }
+        }
+
+        return strings;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return the {@link Player} value of the object at the specified index
+     */
+    public @Nullable Player getPlayerValue(int index) {
+        Object o = getObject(index);
+
+        if (o instanceof Player player) {
+            return player;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return List of <code>String</code> value of the object at the specified index
+     */
+    public Vector<Player> getPlayerVectorValue(int index) {
+        Object o = getObject(index);
+
+        Vector<Player> players = new Vector<>();
+
+        if (o instanceof List<?> objects) {
+            for (Object o1 : objects) {
+                if (o1 instanceof Player player) {
+                    players.add(player);
+                }
+            }
+        }
+
+        return players;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return A List of {@link Force} value of the object at the specified index
+     */
+    public List<Force> getForceListValue(int index) {
+        Object o = getObject(index);
+
+        List<Force> verifiedForces = new ArrayList<>();
+
+        if (o instanceof List<?> forces) {
+            for (Object force : forces) {
+                if (force instanceof Force verifiedForce) {
+                    verifiedForces.add(verifiedForce);
+                }
+            }
+        }
+
+        return verifiedForces;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return A List of {@link Force} value of the object at the specified index
+     */
+    public List<InGameObject> getInGameObjectListValue(int index) {
+        Object o = getObject(index);
+
+        List<InGameObject> verifiedInGameObjects = new ArrayList<>();
+
+        if (o instanceof List<?> inGameObjects) {
+            for (Object force : inGameObjects) {
+                if (force instanceof InGameObject verifiedInGameObject) {
+                    verifiedInGameObjects.add(verifiedInGameObject);
+                }
+            }
+        }
+
+        return verifiedInGameObjects;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return A List of {@link Packet} value of the object at the specified index
+     */
+    public List<Packet> getPackteListValue(int index) {
+        Object o = getObject(index);
+
+        List<Packet> verifiedPackets = new ArrayList<>();
+
+        if (o instanceof List<?> packets) {
+            for (Object force : packets) {
+                if (force instanceof Packet verifiedPacket) {
+                    verifiedPackets.add(verifiedPacket);
+                }
+            }
+        }
+
+        return verifiedPackets;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return The {@link Version} value of the object at the specified index
+     */
+    public @Nullable Version getVersionValue(int index) {
+        Object o = getObject(index);
+
+        if (o instanceof Version version) {
+            return version;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return A Map of {@link Board} keyed to Integers value of the object at the specified index
+     */
+    public Map<Integer, Board> getMapOfIntegerAndBoard(int index) {
+        Object o = getObject(index);
+
+        Map<Integer, Board> mapOfIntegerAndBoard = new HashMap<>();
+
+        if (o instanceof Map<?, ?> mapOfInteger) {
+            for (Object key : mapOfInteger.keySet()) {
+                Object value = mapOfInteger.get(key);
+
+                if (key instanceof Integer integer && value instanceof Board board) {
+                    mapOfIntegerAndBoard.put(integer, board);
+                }
+            }
+        }
+
+        return mapOfIntegerAndBoard;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return The {@link megamek.client.ui.Base64Image} value of the object at the specified index
+     */
+    public @Nullable Base64Image getBase64ImageValue(int index) {
+        Object o = getObject(index);
+
+        if (o instanceof Base64Image image) {
+            return image;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return The {@link GamePhase} value of the object at the specified index
+     */
+    public @Nullable GamePhase getGamePhaseValue(int index) {
+        Object o = getObject(index);
+
+        if (o instanceof GamePhase gamePhase) {
+            return gamePhase;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return the <code>String</code> value of the object at the specified index
+     */
+    public @Nullable GameTurn getGameTurnValue(int index) {
+        Object o = getObject(index);
+
+        if (o instanceof GameTurn gameTurn) {
+            return gameTurn;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return List of <code>String</code> value of the object at the specified index
+     */
+    public List<GameTurn> getGameTurnListValue(int index) {
+        Object o = getObject(index);
+
+        List<GameTurn> gameTurns = new ArrayList<>();
+
+        if (o instanceof List<?> objects) {
+            for (Object o1 : objects) {
+                if (o1 instanceof GameTurn gameTurn) {
+                    gameTurns.add(gameTurn);
+                }
+            }
+        }
+
+        return gameTurns;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return the <code>String</code> value of the object at the specified index
+     */
+    public @Nullable Entity getEntityValue(int index) {
+        Object o = getObject(index);
+
+        if (o instanceof Entity entity) {
+            return entity;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return List of <code>String</code> value of the object at the specified index
+     */
+    public List<Entity> getEntityListValue(int index) {
+        Object o = getObject(index);
+
+        List<Entity> entityList = new ArrayList<>();
+
+        if (o instanceof List<?> objects) {
+            for (Object o1 : objects) {
+                if (o1 instanceof Entity entity) {
+                    entityList.add(entity);
+                }
+            }
+        }
+
+        return entityList;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return the <code>String</code> value of the object at the specified index
+     */
+    public @Nullable Forces getForcesValue(int index) {
+        Object o = getObject(index);
+
+        if (o instanceof Forces forces) {
+            return forces;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return List of <code>String</code> value of the object at the specified index
+     */
+    public List<Forces> getForcesListValue(int index) {
+        Object o = getObject(index);
+
+        List<Forces> forcesList = new ArrayList<>();
+
+        if (o instanceof List<?> objects) {
+            for (Object o1 : objects) {
+                if (o1 instanceof Forces forces) {
+                    forcesList.add(forces);
+                }
+            }
+        }
+
+        return forcesList;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return the <code>String</code> value of the object at the specified index
+     */
+    public @Nullable UnitLocation getUnitLocationValue(int index) {
+        Object o = getObject(index);
+
+        if (o instanceof UnitLocation unitLocation) {
+            return unitLocation;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return List of <code>String</code> value of the object at the specified index
+     */
+    public Vector<UnitLocation> getUnitLocationVectorValue(int index) {
+        Object o = getObject(index);
+
+        Vector<UnitLocation> unitLocations = new Vector<>();
+
+        if (o instanceof List<?> objects) {
+            for (Object o1 : objects) {
+                if (o1 instanceof UnitLocation unitLocation) {
+                    unitLocations.add(unitLocation);
+                }
+            }
+        }
+
+        return unitLocations;
+    }
 
     @Override
     public String toString() {

--- a/megamek/src/megamek/server/AbstractGameManager.java
+++ b/megamek/src/megamek/server/AbstractGameManager.java
@@ -57,7 +57,7 @@ public abstract class AbstractGameManager implements IGameManager {
 
     @Override
     public void handlePacket(int connId, Packet packet) {
-        if (packet.getCommand() == PacketCommand.PLAYER_READY) {
+        if (packet.command() == PacketCommand.PLAYER_READY) {
             receivePlayerDone(packet, connId);
             send(packetHelper.createPlayerDonePacket(connId));
             checkReady();
@@ -70,21 +70,18 @@ public abstract class AbstractGameManager implements IGameManager {
     protected abstract void endCurrentPhase();
 
     /**
-     * Do anything we need to work through the current phase, such as give a turn to
-     * the first player to play.
+     * Do anything we need to work through the current phase, such as give a turn to the first player to play.
      */
     protected abstract void executeCurrentPhase();
 
     /**
-     * Prepares for the game's current phase. This typically involves resetting the
-     * states of units in the game and making sure the clients have the information
-     * they need for the new phase.
+     * Prepares for the game's current phase. This typically involves resetting the states of units in the game and
+     * making sure the clients have the information they need for the new phase.
      */
     protected abstract void prepareForCurrentPhase();
 
     /**
-     * Switches to the given new Phase and preforms preparation, checks if it should
-     * be skipped and executes it.
+     * Switches to the given new Phase and preforms preparation, checks if it should be skipped and executes it.
      */
     public final void changePhase(GamePhase newPhase) {
         if (getGame().getPhase().isExchange() || getGame().getPhase().isStartingScenario()) {
@@ -122,8 +119,7 @@ public abstract class AbstractGameManager implements IGameManager {
     }
 
     /**
-     * Called when a player declares that they are "done". By default, this method
-     * advances to the next phase, if
+     * Called when a player declares that they are "done". By default, this method advances to the next phase, if
      * <BR>
      * - all non-ghost, non-observer players are done,
      * <BR>
@@ -131,9 +127,9 @@ public abstract class AbstractGameManager implements IGameManager {
      * <BR>
      * - we are not in an empty lobby (= no units at all).
      * <BR>
-     * In other circumstances, ending the current phase is triggered elsewhere. Note
-     * that specifically, ghost players are not checked for their status here so the
-     * game can advance through non-turn (report) phases even with ghost players.
+     * In other circumstances, ending the current phase is triggered elsewhere. Note that specifically, ghost players
+     * are not checked for their status here so the game can advance through non-turn (report) phases even with ghost
+     * players.
      */
     protected void checkReady() {
         for (Player player : getGame().getPlayersList()) {
@@ -155,16 +151,14 @@ public abstract class AbstractGameManager implements IGameManager {
     }
 
     /**
-     * @return True when the game is in the lobby phase and is empty (no units
-     *         present).
+     * @return True when the game is in the lobby phase and is empty (no units present).
      */
     protected boolean isEmptyLobby() {
         return getGame().getPhase().isLounge() && getGame().getInGameObjects().isEmpty();
     }
 
     /**
-     * Sets a player's ready status as received from the Client. This method does
-     * not perform any follow-up actions.
+     * Sets a player's ready status as received from the Client. This method does not perform any follow-up actions.
      */
     private void receivePlayerDone(Packet packet, int connIndex) {
         boolean ready = packet.getBooleanValue(0);
@@ -177,10 +171,11 @@ public abstract class AbstractGameManager implements IGameManager {
     }
 
     /**
-     * Sends out the player object to all players. Private info of the given player
-     * is redacted before being sent to other players.
+     * Sends out the player object to all players. Private info of the given player is redacted before being sent to
+     * other players.
      *
      * @param player The player whose information is to be shared
+     *
      * @see #transmitAllPlayerUpdates()
      */
     protected void transmitPlayerUpdate(Player player) {
@@ -188,8 +183,7 @@ public abstract class AbstractGameManager implements IGameManager {
     }
 
     /**
-     * Shares all player objects with all players. Private info is redacted before
-     * being sent to other players.
+     * Shares all player objects with all players. Private info is redacted before being sent to other players.
      *
      * @see #transmitPlayerUpdate(Player)
      */
@@ -198,10 +192,9 @@ public abstract class AbstractGameManager implements IGameManager {
     }
 
     /**
-     * Performs an automatic save (does not check the autosave settings - the
-     * autosave will simply be done). Depending on the settings, the "autosave"
-     * filename is appended with a timestamp and/or a chat message is sent
-     * announcing the autosave.
+     * Performs an automatic save (does not check the autosave settings - the autosave will simply be done). Depending
+     * on the settings, the "autosave" filename is appended with a timestamp and/or a chat message is sent announcing
+     * the autosave.
      */
     public void autoSave() {
         String fileName = "autosave";
@@ -240,8 +233,7 @@ public abstract class AbstractGameManager implements IGameManager {
     }
 
     /**
-     * Sends the current list of player turns as stored in the game's turn list to
-     * the Clients.
+     * Sends the current list of player turns as stored in the game's turn list to the Clients.
      *
      * @see IGame#getTurnsList()
      */
@@ -266,15 +258,14 @@ public abstract class AbstractGameManager implements IGameManager {
     }
 
     /**
-     * Sends out a notification message indicating that a ghost player's turn may be
-     * skipped with the /skip command.
+     * Sends out a notification message indicating that a ghost player's turn may be skipped with the /skip command.
      *
      * @param ghost the Player who is ghosted. This value must not be null.
      */
     protected void sendGhostSkipMessage(Player ghost) {
         String message = String.format(
-                "Player '%s' is disconnected. You may skip their current turn with the /skip command.",
-                ghost.getName());
+              "Player '%s' is disconnected. You may skip their current turn with the /skip command.",
+              ghost.getName());
         sendServerChat(message);
     }
 }

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -246,7 +246,7 @@ public class Server implements Runnable {
         @Override
         public void packetReceived(PacketReceivedEvent e) {
             ReceivedPacket rp = new ReceivedPacket(e.getConnection().getId(), e.getPacket());
-            switch (e.getPacket().getCommand()) {
+            switch (e.getPacket().command()) {
                 case CLIENT_FEEDBACK_REQUEST:
                     // Handled CFR packets specially
                     gameManager.handleCfrPacket(rp);
@@ -583,7 +583,7 @@ public class Server implements Runnable {
      * Allow the player to set whatever parameters he is able to
      */
     private void receivePlayerInfo(Packet packet, int connId) {
-        Player player = (Player) packet.getObject(0);
+        Player player = packet.getPlayerValue(0);
         Player gamePlayer = getGame().getPlayer(connId);
         if (null != gamePlayer) {
             gamePlayer.setColour(player.getColour());
@@ -645,7 +645,7 @@ public class Server implements Runnable {
     }
 
     private boolean receivePlayerVersion(Packet packet, int connId) {
-        final Version version = (Version) packet.getObject(0);
+        final Version version = packet.getVersionValue(0);
 
         if (!SuiteConstants.VERSION.is(version)) {
             final String message = String.format("Client/Server Version Mismatch -- Client: %s, Server: %s",
@@ -661,7 +661,7 @@ public class Server implements Runnable {
             return false;
         }
 
-        final String clientChecksum = (String) packet.getObject(1);
+        final String clientChecksum = packet.getStringValue(1);
         final String serverChecksum = MegaMek.getMegaMekSHA256();
         String message = "";
 
@@ -1297,7 +1297,7 @@ public class Server implements Runnable {
             return;
         }
         // act on it
-        switch (packet.getCommand()) {
+        switch (packet.command()) {
             case CLIENT_VERSIONS:
                 final boolean valid = receivePlayerVersion(packet, connId);
                 if (valid) {
@@ -1323,11 +1323,11 @@ public class Server implements Runnable {
                 transmitPlayerUpdate(getPlayer(connId));
                 break;
             case CHAT:
-                String chat = (String) packet.getObject(0);
+                String chat = packet.getStringValue(0);
                 if (chat.startsWith("/")) {
                     processCommand(connId, chat);
-                } else if (packet.getData().length > 1) {
-                    connId = (int) packet.getObject(1);
+                } else if (packet.data().length > 1) {
+                    connId = packet.getIntValue(1);
                     if (connId == Player.PLAYER_NONE) {
                         sendServerChat(chat);
                     } else {

--- a/megamek/src/megamek/server/ServerLobbyHelper.java
+++ b/megamek/src/megamek/server/ServerLobbyHelper.java
@@ -18,6 +18,14 @@
  */
 package megamek.server;
 
+import static java.util.stream.Collectors.toList;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import megamek.common.Entity;
 import megamek.common.ForceAssignable;
 import megamek.common.Game;
@@ -30,29 +38,20 @@ import megamek.common.options.OptionsConstants;
 import megamek.logging.MMLogger;
 import megamek.server.totalwarfare.TWGameManager;
 
-import java.util.*;
-
-import static java.util.stream.Collectors.toList;
-
 public class ServerLobbyHelper {
     private static final MMLogger logger = MMLogger.create(ServerLobbyHelper.class);
 
     /**
-     * Returns true when the given new force (that is not part of the given game's
-     * forces)
-     * can be integrated into game's forces without error; i.e.:
-     * if the force's parent exists or it is top-level,
-     * if it has no entities and no subforces,
-     * if the client sending it is the owner
+     * Returns true when the given new force (that is not part of the given game's forces) can be integrated into game's
+     * forces without error; i.e.: if the force's parent exists or it is top-level, if it has no entities and no
+     * subforces, if the client sending it is the owner
      */
     static boolean isNewForceValid(Game game, Force force) {
-        return (force.isTopLevel() || game.getForces().contains(force.getParentId()))
-            && (force.getChildCount() == 0);
+        return (force.isTopLevel() || game.getForces().contains(force.getParentId())) && (force.getChildCount() == 0);
     }
 
     /**
-     * Writes a "Unit XX has been customized" message to the chat. The message
-     * is adapted to blind drop conditions.
+     * Writes a "Unit XX has been customized" message to the chat. The message is adapted to blind drop conditions.
      */
     public static String entityUpdateMessage(Entity entity, Game game) {
         StringBuilder result = new StringBuilder();
@@ -79,11 +78,9 @@ public class ServerLobbyHelper {
     }
 
     /**
-     * Disembarks and offloads the given entities (removing it from transports
-     * and removing transported units from it).
-     * Returns a set of entities that received changes. The set may be empty, but
-     * not null.
-     * <P>
+     * Disembarks and offloads the given entities (removing it from transports and removing transported units from it).
+     * Returns a set of entities that received changes. The set may be empty, but not null.
+     * <p>
      * NOTE: This is a simplified unload that is only valid in the lobby!
      */
     public static HashSet<Entity> lobbyUnload(Game game, Collection<Entity> entities) {
@@ -98,12 +95,10 @@ public class ServerLobbyHelper {
     }
 
     /**
-     * Disembarks and offloads the given entity (removing it from transports
-     * and removing transported units from it) unless the transport or carried unit
-     * is also part of the given entities.
-     * Returns a set of entities that received changes. The set may be empty, but
-     * not null.
-     * <P>
+     * Disembarks and offloads the given entity (removing it from transports and removing transported units from it)
+     * unless the transport or carried unit is also part of the given entities. Returns a set of entities that received
+     * changes. The set may be empty, but not null.
+     * <p>
      * NOTE: This is a simplified unload that is only valid in the lobby!
      */
     static HashSet<Entity> lobbyUnloadOthers(Game game, Collection<Entity> entities) {
@@ -118,10 +113,9 @@ public class ServerLobbyHelper {
     }
 
     /**
-     * Have the given entity disembark if it is carried by another unit.
-     * Returns a set of entities that were modified. The set is empty if
-     * the entity was not loaded to a carrier.
-     * <P>
+     * Have the given entity disembark if it is carried by another unit. Returns a set of entities that were modified.
+     * The set is empty if the entity was not loaded to a carrier.
+     * <p>
      * NOTE: This is a simplified disembark that is only valid in the lobby!
      */
     private static HashSet<Entity> lobbyDisembark(Game game, Entity entity) {
@@ -129,10 +123,9 @@ public class ServerLobbyHelper {
     }
 
     /**
-     * Have the given entity disembark if it is carried by another unit.
-     * Returns a set of entities that were modified. The set is empty if
-     * the entity was not loaded to a carrier.
-     * <P>
+     * Have the given entity disembark if it is carried by another unit. Returns a set of entities that were modified.
+     * The set is empty if the entity was not loaded to a carrier.
+     * <p>
      * NOTE: This is a simplified disembark that is only valid in the lobby!
      */
     private static HashSet<Entity> lobbyDisembarkOthers(Game game, Entity entity, Collection<Entity> entities) {
@@ -152,7 +145,7 @@ public class ServerLobbyHelper {
 
     /**
      * Have the given entity disembark if it is carried by an enemy unit.
-     * <P>
+     * <p>
      * NOTE: This is a simplified disembark that is only valid in the lobby!
      */
     private static void lobbyDisembarkEnemy(Game game, Entity entity) {
@@ -168,9 +161,8 @@ public class ServerLobbyHelper {
     }
 
     /**
-     * Performs a disconnect from C3 networks for the given entities.
-     * This is a simplified version that is only valid in the lobby.
-     * Returns a set of entities that received changes.
+     * Performs a disconnect from C3 networks for the given entities. This is a simplified version that is only valid in
+     * the lobby. Returns a set of entities that received changes.
      */
     public static HashSet<Entity> performC3Disconnect(Game game, Collection<Entity> entities) {
         HashSet<Entity> result = new HashSet<>();
@@ -195,30 +187,26 @@ public class ServerLobbyHelper {
     }
 
     /**
-     * Creates a packet for an update for the given entities.
-     * Only valid in the lobby.
+     * Creates a packet for an update for the given entities. Only valid in the lobby.
      */
     public static Packet createMultiEntityPacket(Collection<Entity> entities) {
         return new Packet(PacketCommand.ENTITY_MULTIUPDATE, entities);
     }
 
     /**
-     * Creates a packet detailing a force delete.
-     * Only valid in the lobby.
+     * Creates a packet detailing a force delete. Only valid in the lobby.
      */
     public static Packet createForcesDeletePacket(Collection<Integer> forces) {
         return new Packet(PacketCommand.FORCE_DELETE, forces);
     }
 
     /**
-     * Handles a force parent packet, attaching the sent forces to a new parent or
-     * making the sent forces top-level.
+     * Handles a force parent packet, attaching the sent forces to a new parent or making the sent forces top-level.
      * This method is intended for use in the lobby!
      */
     public static void receiveForceParent(Packet c, int connId, Game game, TWGameManager gameManager) {
-        @SuppressWarnings("unchecked")
-        var forceList = (Collection<Force>) c.getObject(0);
-        int newParentId = (int) c.getObject(1);
+        @SuppressWarnings("unchecked") var forceList = (Collection<Force>) c.getObject(0);
+        int newParentId = c.getIntValue(1);
 
         var forces = game.getForces();
         var changedForces = new HashSet<Force>();
@@ -240,14 +228,12 @@ public class ServerLobbyHelper {
     }
 
     /**
-     * Handles a force assign full packet, changing the owner of forces and
-     * everything in them.
-     * This method is intended for use in the lobby!
+     * Handles a force assign full packet, changing the owner of forces and everything in them. This method is intended
+     * for use in the lobby!
      */
-    public static void receiveEntitiesAssign(Packet c, int connId, Game game, TWGameManager gameManager) {
-        @SuppressWarnings("unchecked")
-        var entityList = (Collection<Entity>) c.getObject(0);
-        int newOwnerId = (int) c.getObject(1);
+    public static void receiveEntitiesAssign(Packet packet, int connId, Game game, TWGameManager gameManager) {
+        List<Entity> entityList = (List<Entity>) packet.getEntityListValue(0);
+        int newOwnerId = packet.getIntValue(1);
         Player newOwner = game.getPlayer(newOwnerId);
 
         if (entityList.isEmpty() || newOwner == null) {
@@ -267,14 +253,12 @@ public class ServerLobbyHelper {
     }
 
     /**
-     * Handles a force assign full packet, changing the owner of forces and
-     * everything in them.
-     * This method is intended for use in the lobby!
+     * Handles a force assign full packet, changing the owner of forces and everything in them. This method is intended
+     * for use in the lobby!
      */
-    public static void receiveForceAssignFull(Packet c, int connId, Game game, TWGameManager gameManager) {
-        @SuppressWarnings("unchecked")
-        var forceList = (Collection<Force>) c.getObject(0);
-        int newOwnerId = (int) c.getObject(1);
+    public static void receiveForceAssignFull(Packet packet, int connId, Game game, TWGameManager gameManager) {
+        @SuppressWarnings("unchecked") var forceList = (Collection<Force>) packet.getObject(0);
+        int newOwnerId = packet.getIntValue(1);
         Player newOwner = game.getPlayer(newOwnerId);
 
         if (forceList.isEmpty() || newOwner == null) {
@@ -304,17 +288,12 @@ public class ServerLobbyHelper {
     }
 
     /**
-     * Handles a force update packet, forwarding a client-side change that
-     * only affects forces, not entities:
-     * - rename
-     * - move subforce/entity up/down (this does not change the entity, only the
-     * force)
-     * - owner change of only the force (not the entities, only within a team)
-     * This method is intended for use in the lobby!
+     * Handles a force update packet, forwarding a client-side change that only affects forces, not entities: - rename -
+     * move subforce/entity up/down (this does not change the entity, only the force) - owner change of only the force
+     * (not the entities, only within a team) This method is intended for use in the lobby!
      */
     public static void receiveForceUpdate(Packet c, int connId, Game game, TWGameManager gameManager) {
-        @SuppressWarnings("unchecked")
-        var forceList = (Collection<Force>) c.getObject(0);
+        @SuppressWarnings("unchecked") var forceList = (Collection<Force>) c.getObject(0);
 
         // Check if the updated Forces are valid
         Forces forcesClone = game.getForces().clone();
@@ -331,13 +310,11 @@ public class ServerLobbyHelper {
     }
 
     /**
-     * Handles a team change, updating units and forces as necessary.
-     * This method is intended for use in the lobby!
+     * Handles a team change, updating units and forces as necessary. This method is intended for use in the lobby!
      */
     public static void receiveLobbyTeamChange(Packet c, int connId, Game game, TWGameManager gameManager) {
-        @SuppressWarnings("unchecked")
-        var players = (Collection<Player>) c.getObject(0);
-        var newTeam = (int) c.getObject(1);
+        var players = (Collection<Player>) c.getPlayerVectorValue(0);
+        var newTeam = c.getIntValue(1);
 
         // Collect server-side player objects
         Set<Player> serverPlayers = new HashSet<>();
@@ -365,9 +342,8 @@ public class ServerLobbyHelper {
     }
 
     /**
-     * For all game units, disembarks from carriers and offloads carried units
-     * if they are enemies.
-     * <P>
+     * For all game units, disembarks from carriers and offloads carried units if they are enemies.
+     * <p>
      * NOTE: This is a simplified unload that is only valid in the lobby!
      */
     public static void correctLoading(Game game) {
@@ -381,7 +357,7 @@ public class ServerLobbyHelper {
 
     /**
      * For all game units, disconnects from enemy C3 masters / networks
-     * <P>
+     * <p>
      * NOTE: This is intended for use in the lobby phase!
      */
     public static void correctC3Connections(Game game) {
@@ -397,8 +373,7 @@ public class ServerLobbyHelper {
                 } catch (Exception ignored) {
                 }
             } else if (entity.hasAnyC3System()) {
-                if ((entity.getC3Master() != null)
-                        && entity.getC3Master().getOwner().isEnemyOf(entity.getOwner())) {
+                if ((entity.getC3Master() != null) && entity.getC3Master().getOwner().isEnemyOf(entity.getOwner())) {
                     entity.setC3Master(null, true);
                 }
             }
@@ -406,14 +381,12 @@ public class ServerLobbyHelper {
     }
 
     /**
-     * Handles an add entity to force / remove from force packet, attaching the
-     * sent entities to a force or removing them from any force.
-     * This method is intended for use in the lobby!
+     * Handles an add entity to force / remove from force packet, attaching the sent entities to a force or removing
+     * them from any force. This method is intended for use in the lobby!
      */
-    public static void receiveAddEntititesToForce(Packet c, int connId, Game game, TWGameManager gameManager) {
-        @SuppressWarnings("unchecked")
-        var entityList = (Collection<Entity>) c.getObject(0);
-        var forceId = (int) c.getObject(1);
+    public static void receiveAddEntititesToForce(Packet packet, int connId, Game game, TWGameManager gameManager) {
+        var entityList = (Collection<Entity>) packet.getEntityListValue(0);
+        var forceId = packet.getIntValue(1);
         // Get the local (server) entities
         List<Entity> entities = entityList.stream().map(e -> game.getEntity(e.getId())).collect(toList());
         var forces = game.getForces();
@@ -443,13 +416,11 @@ public class ServerLobbyHelper {
     }
 
     /**
-     * Adds a force with the info from the client. Only valid during the lobby
-     * phase.
+     * Adds a force with the info from the client. Only valid during the lobby phase.
      */
     public static void receiveForceAdd(Packet c, int connId, Game game, TWGameManager gameManager) {
         var force = (Force) c.getObject(0);
-        @SuppressWarnings("unchecked")
-        var entities = (Collection<Entity>) c.getObject(1);
+        var entities = (Collection<Entity>) c.getEntityListValue(1);
 
         int newId;
         if (force.isTopLevel()) {
@@ -465,28 +436,24 @@ public class ServerLobbyHelper {
     }
 
     /**
-     * Creates a packet detailing a force update. Force updates must contain all
-     * affected forces and all affected entities.
+     * Creates a packet detailing a force update. Force updates must contain all affected forces and all affected
+     * entities.
      */
     static Packet createForceUpdatePacket(Collection<Force> changedForces) {
         return createForceUpdatePacket(changedForces, new ArrayList<>());
     }
 
     /**
-     * Creates a packet detailing a force update. Force updates must contain all
-     * affected forces and all affected entities. Entities are only affected if
-     * their
-     * forceId changed.
+     * Creates a packet detailing a force update. Force updates must contain all affected forces and all affected
+     * entities. Entities are only affected if their forceId changed.
      */
     static Packet createForceUpdatePacket(Collection<Force> changedForces, Collection<Entity> entities) {
         return new Packet(PacketCommand.FORCE_UPDATE, changedForces, entities);
     }
 
     /**
-     * A force is editable to the sender of a command if any forces in its force
-     * chain
-     * (this includes the force itself) is owned by the sender. This allows editing
-     * forces of other players if they are a subforce of one's own force.
+     * A force is editable to the sender of a command if any forces in its force chain (this includes the force itself)
+     * is owned by the sender. This allows editing forces of other players if they are a subforce of one's own force.
      * See also LobbyActions.isEditable(Force)
      */
     static boolean isEditable(Force force, Game game, Player sender) {

--- a/megamek/src/megamek/server/sbf/SBFGameManager.java
+++ b/megamek/src/megamek/server/sbf/SBFGameManager.java
@@ -45,8 +45,7 @@ import megamek.server.Server;
 import megamek.server.commands.ServerCommand;
 
 /**
- * This class manages an SBF game on the server side. As of 2024, this is under
- * construction.
+ * This class manages an SBF game on the server side. As of 2024, this is under construction.
  */
 public final class SBFGameManager extends AbstractGameManager implements SBFRuleOptionsUser {
     private static final MMLogger logger = MMLogger.create(SBFGameManager.class);
@@ -73,7 +72,7 @@ public final class SBFGameManager extends AbstractGameManager implements SBFRule
     public void handlePacket(int connId, Packet packet) {
         super.handlePacket(connId, packet);
 
-        switch (packet.getCommand()) {
+        switch (packet.command()) {
             case ENTITY_MOVE:
                 receiveMovement(packet, connId);
                 break;
@@ -84,14 +83,13 @@ public final class SBFGameManager extends AbstractGameManager implements SBFRule
                 break;
         }
 
-        logger.info("Leaving handle packet: {}", packet.getCommand());
+        logger.info("Leaving handle packet: {}", packet.command());
         logger.info(pendingPackets);
         sendPendingPackets();
     }
 
     /**
-     * Sends all pending packets to eligible players and clears out the pending
-     * packets.
+     * Sends all pending packets to eligible players and clears out the pending packets.
      */
     private void sendPendingPackets() {
         // packets must be sorted/filtered according to recipient for double blind games
@@ -103,10 +101,11 @@ public final class SBFGameManager extends AbstractGameManager implements SBFRule
             // Send each player what they should receive ...
             for (int playerId : game.getPlayersList().stream().map(Player::getId).toList()) {
                 List<Packet> packets = pendingPackets.stream()
-                        // ... including packets to PLAYER_NONE; these go to every player
-                        .filter(p -> (p.recipient == Player.PLAYER_NONE) || (p.recipient == playerId))
-                        .map(PendingPacket::packet)
-                        .toList();
+                                             // ... including packets to PLAYER_NONE; these go to every player
+                                             .filter(p -> (p.recipient == Player.PLAYER_NONE) ||
+                                                                (p.recipient == playerId))
+                                             .map(PendingPacket::packet)
+                                             .toList();
                 // the redundant new ArrayList is necessary to prevent an xstream error
                 super.send(playerId, new Packet(PacketCommand.MULTI_PACKET, new ArrayList<>(packets)));
             }
@@ -183,15 +182,14 @@ public final class SBFGameManager extends AbstractGameManager implements SBFRule
     }
 
     /**
-     * Creates a packet containing all entities, including wrecks, visible to
-     * the player in a blind game
+     * Creates a packet containing all entities, including wrecks, visible to the player in a blind game
      */
     Packet createGameStartUnitPacket(Player recipient) {
         return new Packet(PacketCommand.SENDING_ENTITIES,
-                new ArrayList<>(getVisibleUnits(recipient)),
-                getGame().getGraveyard(),
-                // TODO: must add Sensor blips of all kinds as a separate list of stuff
-                getGame().getForces());
+              new ArrayList<>(getVisibleUnits(recipient)),
+              getGame().getGraveyard(),
+              // TODO: must add Sensor blips of all kinds as a separate list of stuff
+              getGame().getForces());
     }
 
     @Override
@@ -224,8 +222,10 @@ public final class SBFGameManager extends AbstractGameManager implements SBFRule
 
             send(connId, packetHelper.createPlanetaryConditionsPacket());
             //
-            if (game.getPhase().isFiring() || game.getPhase().isTargeting()
-                    || game.getPhase().isOffboard() || game.getPhase().isPhysical()) {
+            if (game.getPhase().isFiring() ||
+                      game.getPhase().isTargeting() ||
+                      game.getPhase().isOffboard() ||
+                      game.getPhase().isPhysical()) {
                 // can't go above, need board to have been sent
                 // send(connId, packetHelper.createAttackPacket(getGame().getActionsVector(),
                 // false));
@@ -332,9 +332,9 @@ public final class SBFGameManager extends AbstractGameManager implements SBFRule
 
     private void setPlayerDone(Player player, boolean normalDone) {
         // FIXME This is highly specialized and very arcane!!
-        if (getGame().getPhase().isReport()
-                && getGame().getOptions().booleanOption(OptionsConstants.BASE_GM_CONTROLS_DONE_REPORT_PHASE)
-                && getGame().getPlayersList().stream().filter(p -> p.isGameMaster()).count() > 0) {
+        if (getGame().getPhase().isReport() &&
+                  getGame().getOptions().booleanOption(OptionsConstants.BASE_GM_CONTROLS_DONE_REPORT_PHASE) &&
+                  getGame().getPlayersList().stream().filter(p -> p.isGameMaster()).count() > 0) {
             if (player.isGameMaster()) {
                 player.setDone(false);
             } else {
@@ -346,8 +346,7 @@ public final class SBFGameManager extends AbstractGameManager implements SBFRule
     }
 
     /**
-     * Called at the beginning of certain phases to make every active player not
-     * ready.
+     * Called at the beginning of certain phases to make every active player not ready.
      */
     void resetActivePlayersDone() {
         for (Player player : game.getPlayersList()) {
@@ -386,9 +385,8 @@ public final class SBFGameManager extends AbstractGameManager implements SBFRule
     }
 
     /**
-     * Tries to change to the next turn. If there are no more turns, ends the
-     * current phase. If the player whose turn it is next is not connected, we
-     * allow the other players to skip that player.
+     * Tries to change to the next turn. If there are no more turns, ends the current phase. If the player whose turn it
+     * is next is not connected, we allow the other players to skip that player.
      */
     private void changeToNextTurn(int prevPlayerId) {
         if (!game.hasMoreTurns()) {
@@ -411,8 +409,8 @@ public final class SBFGameManager extends AbstractGameManager implements SBFRule
                 // send(packetHelper.createTurnIndexPacket(prevPlayerId));
                 addPendingPacket(packetHelper.createTurnIndexPacket(prevPlayerId));
             } else {
-                addPendingPacket(
-                        packetHelper.createTurnIndexPacket(player.map(Player::getId).orElse(Player.PLAYER_NONE)));
+                addPendingPacket(packetHelper.createTurnIndexPacket(player.map(Player::getId)
+                                                                          .orElse(Player.PLAYER_NONE)));
                 // send(packetHelper.createTurnIndexPacket(player.map(Player::getId).orElse(Player.PLAYER_NONE)));
             }
 
@@ -454,8 +452,7 @@ public final class SBFGameManager extends AbstractGameManager implements SBFRule
     }
 
     /**
-     * Receives an entity movement packet, and if valid, executes it and ends
-     * the current turn.
+     * Receives an entity movement packet, and if valid, executes it and ends the current turn.
      */
     private void receiveMovement(Packet packet, int connId) {
         var movePath = (SBFMovePath) packet.getObject(0);
@@ -475,8 +472,7 @@ public final class SBFGameManager extends AbstractGameManager implements SBFRule
     }
 
     /**
-     * Called when the current player has done his current turn and the turn
-     * counter needs to be advanced.
+     * Called when the current player has done his current turn and the turn counter needs to be advanced.
      */
     void endCurrentTurn(SBFFormation entityUsed) {
         final int playerId = (null == entityUsed) ? Player.PLAYER_NONE : entityUsed.getOwnerId();
@@ -485,8 +481,8 @@ public final class SBFGameManager extends AbstractGameManager implements SBFRule
 
     @Override
     protected void transmitAllPlayerDones() {
-        getGame().getPlayersList().forEach(
-                player -> addPendingPacket(player.getId(), packetHelper.createPlayerDonePacket(player.getId())));
+        getGame().getPlayersList()
+              .forEach(player -> addPendingPacket(player.getId(), packetHelper.createPlayerDonePacket(player.getId())));
         // getGame().getPlayersList().forEach(player ->
         // send(packetHelper.createPlayerDonePacket(player.getId())));
     }
@@ -505,14 +501,13 @@ public final class SBFGameManager extends AbstractGameManager implements SBFRule
     }
 
     /**
-     * Sends out the player object to all players. Private info of the given player
-     * is redacted before being sent to other players.
+     * Sends out the player object to all players. Private info of the given player is redacted before being sent to
+     * other players.
      *
      * @param player The player whose information is to be shared
-     * @see #transmitAllPlayerUpdates()
-     *      //TODO: wonder if pending packets can be extended to TW
-     *      //TODO: might work easily by overriding send; must send CFR packets
-     *      immediately
+     *
+     * @see #transmitAllPlayerUpdates() //TODO: wonder if pending packets can be extended to TW //TODO: might work
+     *       easily by overriding send; must send CFR packets immediately
      */
     protected void transmitPlayerUpdate(Player player) {
         int playerId = player.getId();
@@ -555,11 +550,11 @@ public final class SBFGameManager extends AbstractGameManager implements SBFRule
     @SuppressWarnings("unchecked")
     void receiveAttack(Packet packet, int connId) {
         var attacks = (List<EntityAction>) packet.getObject(1);
-        int formationId = (int) packet.getObject(0);
+        int formationId = packet.getIntValue(0);
         Optional<SBFFormation> formationInfo = game.getFormation(formationId);
 
-        if (formationInfo.isEmpty()
-                || !attacks.stream().map(EntityAction::getEntityId).allMatch(id -> id == formationId)) {
+        if (formationInfo.isEmpty() ||
+                  !attacks.stream().map(EntityAction::getEntityId).allMatch(id -> id == formationId)) {
             logger.error("Invalid formation ID or diverging attacker IDs");
             repeatTurn(connId); // TODO: This is untested; questionable if this can save a game after an error
             return;
@@ -573,8 +568,10 @@ public final class SBFGameManager extends AbstractGameManager implements SBFRule
         }
 
         // is this the right phase?
-        if (!getGame().getPhase().isFiring() && !getGame().getPhase().isPhysical()
-                && !getGame().getPhase().isTargeting() && !getGame().getPhase().isOffboard()) {
+        if (!getGame().getPhase().isFiring() &&
+                  !getGame().getPhase().isPhysical() &&
+                  !getGame().getPhase().isTargeting() &&
+                  !getGame().getPhase().isOffboard()) {
             logger.error("Server got attack packet in wrong phase");
             return;
         }
@@ -600,8 +597,7 @@ public final class SBFGameManager extends AbstractGameManager implements SBFRule
     }
 
     /**
-     * Sends the game's pending actions to all Clients for them to replace any
-     * previous actions
+     * Sends the game's pending actions to all Clients for them to replace any previous actions
      */
     void sendPendingActions() {
         send(new Packet(PacketCommand.ACTIONS, new ArrayList<>(game.getActionsVector())));

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -50,12 +50,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 
-import megamek.common.planetaryconditions.Atmosphere;
-import megamek.common.planetaryconditions.PlanetaryConditions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import megamek.client.bot.princess.PathRanker.PathRankerType;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.*;
@@ -64,10 +58,15 @@ import megamek.common.equipment.WeaponMounted;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
+import megamek.common.planetaryconditions.Atmosphere;
+import megamek.common.planetaryconditions.PlanetaryConditions;
 import megamek.common.weapons.StopSwarmAttack;
 import megamek.common.weapons.missiles.ATMWeapon;
 import megamek.common.weapons.missiles.MMLWeapon;
 import megamek.server.SmokeCloud;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * @author Deric "Netzilla" Page (deric dot page at usa dot net)
@@ -226,8 +225,7 @@ class FireControlTest {
         // weapon type is AMS
         // since it's more of a pain to set up all the weapon types, we simply pretend
         // the feature is turned on
-        when(mockGameOptions.booleanOption(eq(OptionsConstants.ADVCOMBAT_TACOPS_MANUAL_AMS)))
-                .thenReturn(true);
+        when(mockGameOptions.booleanOption(eq(OptionsConstants.ADVCOMBAT_TACOPS_MANUAL_AMS))).thenReturn(true);
 
         mockHex = mock(Hex.class);
 
@@ -255,13 +253,10 @@ class FireControlTest {
         when(mockTarget.getMovementMode()).thenReturn(EntityMovementMode.BIPED);
 
         testFireControl = spy(new FireControl(mockPrincess));
-        doReturn(mockShooterMoveMod)
-                .when(testFireControl)
-                .getAttackerMovementModifier(any(Game.class), anyInt(),
-                        nullable(EntityMovementType.class));
-        doReturn(mockTargetMoveMod)
-                .when(testFireControl)
-                .getTargetMovementModifier(anyInt(), anyBoolean(), anyBoolean(), any(Game.class));
+        doReturn(mockShooterMoveMod).when(testFireControl)
+              .getAttackerMovementModifier(any(Game.class), anyInt(), nullable(EntityMovementType.class));
+        doReturn(mockTargetMoveMod).when(testFireControl)
+              .getTargetMovementModifier(anyInt(), anyBoolean(), anyBoolean(), any(Game.class));
 
         doReturn(false).when(testFireControl).isCommander(any(Entity.class));
         doReturn(false).when(testFireControl).isSubCommander(any(Entity.class));
@@ -284,8 +279,7 @@ class FireControlTest {
         when(mockAmmoAC5Flak.getType()).thenReturn(mockAmmoTypeAC5Flak);
         when(mockAmmoAC5Flak.isAmmoUsable()).thenReturn(true);
         mockAmmoTypeAC5Incendiary = mock(AmmoType.class);
-        when(mockAmmoTypeAC5Incendiary.getMunitionType())
-                .thenReturn(EnumSet.of(AmmoType.Munitions.M_INCENDIARY_AC));
+        when(mockAmmoTypeAC5Incendiary.getMunitionType()).thenReturn(EnumSet.of(AmmoType.Munitions.M_INCENDIARY_AC));
         when(mockAmmoTypeAC5Incendiary.getAmmoType()).thenReturn(AmmoType.T_AC);
         mockAmmoAc5Incendiary = mock(AmmoMounted.class);
         when(mockAmmoAc5Incendiary.getType()).thenReturn(mockAmmoTypeAC5Incendiary);
@@ -325,41 +319,86 @@ class FireControlTest {
         when(mockAC5FlakFireInfo.getProbabilityToHit()).thenReturn(0.8333);
         when(mockAC5FlakFireInfo.getExpectedDamage()).thenReturn(0.8333 * 3);
         // Std AC5
-        doReturn(mockAC5StdFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(EntityState.class), any(Targetable.class), any(EntityState.class),
-                eq(mockWeaponAC5), any(AmmoMounted.class),
-                any(Game.class), anyBoolean());
-        doReturn(mockAC5StdFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponAC5),
-                any(AmmoMounted.class),
-                any(Game.class), anyBoolean(), anyBoolean());
-        doReturn(mockAC5StdFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(Targetable.class), eq(mockWeaponAC5), any(AmmoMounted.class), any(Game.class),
-                anyBoolean());
+        doReturn(mockAC5StdFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(EntityState.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockWeaponAC5),
+                    any(AmmoMounted.class),
+                    any(Game.class),
+                    anyBoolean());
+        doReturn(mockAC5StdFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(MovePath.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockWeaponAC5),
+                    any(AmmoMounted.class),
+                    any(Game.class),
+                    anyBoolean(),
+                    anyBoolean());
+        doReturn(mockAC5StdFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(Targetable.class),
+                    eq(mockWeaponAC5),
+                    any(AmmoMounted.class),
+                    any(Game.class),
+                    anyBoolean());
         // Incendiary AC5
-        doReturn(mockAC5IncendiaryFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(EntityState.class), any(Targetable.class), any(EntityState.class),
-                eq(mockWeaponAC5), any(AmmoMounted.class),
-                any(Game.class), anyBoolean());
-        doReturn(mockAC5IncendiaryFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponAC5),
-                any(AmmoMounted.class),
-                any(Game.class), anyBoolean(), anyBoolean());
-        doReturn(mockAC5IncendiaryFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(Targetable.class), eq(mockWeaponAC5), any(AmmoMounted.class), any(Game.class),
-                anyBoolean());
+        doReturn(mockAC5IncendiaryFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(EntityState.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockWeaponAC5),
+                    any(AmmoMounted.class),
+                    any(Game.class),
+                    anyBoolean());
+        doReturn(mockAC5IncendiaryFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(MovePath.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockWeaponAC5),
+                    any(AmmoMounted.class),
+                    any(Game.class),
+                    anyBoolean(),
+                    anyBoolean());
+        doReturn(mockAC5IncendiaryFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(Targetable.class),
+                    eq(mockWeaponAC5),
+                    any(AmmoMounted.class),
+                    any(Game.class),
+                    anyBoolean());
         // Flak AC5
-        doReturn(mockAC5FlakFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(EntityState.class), any(Targetable.class), any(EntityState.class),
-                eq(mockWeaponAC5), any(AmmoMounted.class),
-                any(Game.class), anyBoolean());
-        doReturn(mockAC5FlakFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponAC5),
-                any(AmmoMounted.class),
-                any(Game.class), anyBoolean(), anyBoolean());
-        doReturn(mockAC5FlakFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(Targetable.class), eq(mockWeaponAC5), any(AmmoMounted.class), any(Game.class),
-                anyBoolean());
+        doReturn(mockAC5FlakFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(EntityState.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockWeaponAC5),
+                    any(AmmoMounted.class),
+                    any(Game.class),
+                    anyBoolean());
+        doReturn(mockAC5FlakFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(MovePath.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockWeaponAC5),
+                    any(AmmoMounted.class),
+                    any(Game.class),
+                    anyBoolean(),
+                    anyBoolean());
+        doReturn(mockAC5FlakFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(Targetable.class),
+                    eq(mockWeaponAC5),
+                    any(AmmoMounted.class),
+                    any(Game.class),
+                    anyBoolean());
 
         // LB10X
         mockLB10X = mock(WeaponType.class);
@@ -394,30 +433,60 @@ class FireControlTest {
         when(mockLB10XClusterFireInfo.getExpectedDamage()).thenReturn(0.8333 * 6);
 
         // Firing Cluster ammo
-        doReturn(mockLB10XClusterFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(EntityState.class), any(Targetable.class), any(EntityState.class),
-                eq(mockWeaponLB10X), any(AmmoMounted.class),
-                any(Game.class), anyBoolean());
-        doReturn(mockLB10XClusterFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponLB10X),
-                any(AmmoMounted.class),
-                any(Game.class), anyBoolean(), anyBoolean());
-        doReturn(mockLB10XClusterFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(Targetable.class), eq(mockWeaponLB10X), any(AmmoMounted.class), any(Game.class),
-                anyBoolean());
+        doReturn(mockLB10XClusterFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(EntityState.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockWeaponLB10X),
+                    any(AmmoMounted.class),
+                    any(Game.class),
+                    anyBoolean());
+        doReturn(mockLB10XClusterFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(MovePath.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockWeaponLB10X),
+                    any(AmmoMounted.class),
+                    any(Game.class),
+                    anyBoolean(),
+                    anyBoolean());
+        doReturn(mockLB10XClusterFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(Targetable.class),
+                    eq(mockWeaponLB10X),
+                    any(AmmoMounted.class),
+                    any(Game.class),
+                    anyBoolean());
 
         // Firing Slug ammo
-        doReturn(mockLB10XSlugFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(EntityState.class), any(Targetable.class), any(EntityState.class),
-                eq(mockWeaponLB10X), eq(mockAmmoLB10XSlug),
-                any(Game.class), anyBoolean());
-        doReturn(mockLB10XSlugFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponLB10X),
-                eq(mockAmmoLB10XSlug),
-                any(Game.class), anyBoolean(), anyBoolean());
-        doReturn(mockLB10XSlugFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(Targetable.class), eq(mockWeaponLB10X), eq(mockAmmoLB10XSlug), any(Game.class),
-                anyBoolean());
+        doReturn(mockLB10XSlugFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(EntityState.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockWeaponLB10X),
+                    eq(mockAmmoLB10XSlug),
+                    any(Game.class),
+                    anyBoolean());
+        doReturn(mockLB10XSlugFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(MovePath.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockWeaponLB10X),
+                    eq(mockAmmoLB10XSlug),
+                    any(Game.class),
+                    anyBoolean(),
+                    anyBoolean());
+        doReturn(mockLB10XSlugFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(Targetable.class),
+                    eq(mockWeaponLB10X),
+                    eq(mockAmmoLB10XSlug),
+                    any(Game.class),
+                    anyBoolean());
 
         // MML
         mockMML5 = mock(MMLWeapon.class);
@@ -537,34 +606,71 @@ class FireControlTest {
         mockPPCFireInfo = mock(WeaponFireInfo.class);
         when(mockPPCFireInfo.getProbabilityToHit()).thenReturn(0.5);
         when(mockPPCFireInfo.getExpectedDamage()).thenReturn(5.0);
-        doReturn(mockPPCFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockPPC),
-                isNull(),
-                any(Game.class), anyBoolean());
-        doReturn(mockPPCFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockPPC),
-                isNull(),
-                any(Game.class), anyBoolean(), anyBoolean());
-        doReturn(mockPPCFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(Targetable.class), eq(mockPPC), isNull(), any(Game.class), anyBoolean());
-        doReturn(mockPPCFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(Targetable.class), eq(mockPPC), isNull(), any(Game.class), anyBoolean());
+        doReturn(mockPPCFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(EntityState.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockPPC),
+                    isNull(),
+                    any(Game.class),
+                    anyBoolean());
+        doReturn(mockPPCFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(MovePath.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockPPC),
+                    isNull(),
+                    any(Game.class),
+                    anyBoolean(),
+                    anyBoolean());
+        doReturn(mockPPCFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(Targetable.class),
+                    eq(mockPPC),
+                    isNull(),
+                    any(Game.class),
+                    anyBoolean());
+        doReturn(mockPPCFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(Targetable.class),
+                    eq(mockPPC),
+                    isNull(),
+                    any(Game.class),
+                    anyBoolean());
 
         mockML = mock(WeaponMounted.class);
         shooterWeapons.add(mockML);
         when(mockML.getType()).thenReturn(mockEnergyWeaponType);
         mockMLFireInfo = mock(WeaponFireInfo.class);
         when(mockMLFireInfo.getProbabilityToHit()).thenReturn(0.0);
-        doReturn(mockMLFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockML),
-                isNull(),
-                any(Game.class), anyBoolean());
-        doReturn(mockMLFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockML),
-                isNull(),
-                any(Game.class), anyBoolean(), anyBoolean());
-        doReturn(mockMLFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(Targetable.class), eq(mockML), isNull(), any(Game.class), anyBoolean());
+        doReturn(mockMLFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(EntityState.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockML),
+                    isNull(),
+                    any(Game.class),
+                    anyBoolean());
+        doReturn(mockMLFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(MovePath.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockML),
+                    isNull(),
+                    any(Game.class),
+                    anyBoolean(),
+                    anyBoolean());
+        doReturn(mockMLFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(Targetable.class),
+                    eq(mockML),
+                    isNull(),
+                    any(Game.class),
+                    anyBoolean());
 
         mockLRM5 = mock(WeaponMounted.class);
         when(mockLRM5.getType()).thenReturn(mockWeaponType);
@@ -573,17 +679,32 @@ class FireControlTest {
         mockLRMFireInfo = mock(WeaponFireInfo.class);
         when(mockLRMFireInfo.getProbabilityToHit()).thenReturn(0.6);
         when(mockLRMFireInfo.getExpectedDamage()).thenReturn(2.0);
-        doReturn(mockLRMFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(EntityState.class), any(Targetable.class), any(EntityState.class), eq(mockLRM5),
-                any(AmmoMounted.class),
-                any(Game.class), anyBoolean());
-        doReturn(mockLRMFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockLRM5),
-                any(AmmoMounted.class),
-                any(Game.class), anyBoolean(), anyBoolean());
-        doReturn(mockLRMFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(Targetable.class), eq(mockLRM5), any(AmmoMounted.class), any(Game.class),
-                anyBoolean());
+        doReturn(mockLRMFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(EntityState.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockLRM5),
+                    any(AmmoMounted.class),
+                    any(Game.class),
+                    anyBoolean());
+        doReturn(mockLRMFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(MovePath.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockLRM5),
+                    any(AmmoMounted.class),
+                    any(Game.class),
+                    anyBoolean(),
+                    anyBoolean());
+        doReturn(mockLRMFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(Targetable.class),
+                    eq(mockLRM5),
+                    any(AmmoMounted.class),
+                    any(Game.class),
+                    anyBoolean());
 
         when(mockWeaponMML5.getType()).thenReturn(mockWeaponType);
         mockMMLFireInfo = mock(WeaponFireInfo.class);
@@ -596,43 +717,88 @@ class FireControlTest {
         when(mockMMLSRM5FireInfo.getExpectedDamage()).thenReturn(0.0 * 10);
 
         // General
-        doReturn(mockMMLFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(EntityState.class), any(Targetable.class), any(EntityState.class),
-                eq(mockWeaponMML5), any(AmmoMounted.class),
-                any(Game.class), anyBoolean());
-        doReturn(mockMMLFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponMML5),
-                any(AmmoMounted.class),
-                any(Game.class), anyBoolean(), anyBoolean());
-        doReturn(mockMMLFireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(Targetable.class), eq(mockWeaponMML5), any(AmmoMounted.class), any(Game.class),
-                anyBoolean());
+        doReturn(mockMMLFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(EntityState.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockWeaponMML5),
+                    any(AmmoMounted.class),
+                    any(Game.class),
+                    anyBoolean());
+        doReturn(mockMMLFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(MovePath.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockWeaponMML5),
+                    any(AmmoMounted.class),
+                    any(Game.class),
+                    anyBoolean(),
+                    anyBoolean());
+        doReturn(mockMMLFireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(Targetable.class),
+                    eq(mockWeaponMML5),
+                    any(AmmoMounted.class),
+                    any(Game.class),
+                    anyBoolean());
 
         // Firing LRM5 ammo
-        doReturn(mockMMLLRM5FireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(EntityState.class), any(Targetable.class), any(EntityState.class),
-                eq(mockWeaponMML5), eq(mockAmmoLRM5),
-                any(Game.class), anyBoolean());
-        doReturn(mockMMLLRM5FireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponMML5),
-                eq(mockAmmoLRM5),
-                any(Game.class), anyBoolean(), anyBoolean());
-        doReturn(mockMMLLRM5FireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(Targetable.class), eq(mockWeaponMML5), eq(mockAmmoLRM5), any(Game.class),
-                anyBoolean());
+        doReturn(mockMMLLRM5FireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(EntityState.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockWeaponMML5),
+                    eq(mockAmmoLRM5),
+                    any(Game.class),
+                    anyBoolean());
+        doReturn(mockMMLLRM5FireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(MovePath.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockWeaponMML5),
+                    eq(mockAmmoLRM5),
+                    any(Game.class),
+                    anyBoolean(),
+                    anyBoolean());
+        doReturn(mockMMLLRM5FireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(Targetable.class),
+                    eq(mockWeaponMML5),
+                    eq(mockAmmoLRM5),
+                    any(Game.class),
+                    anyBoolean());
 
         // Firing SRM5 ammo
-        doReturn(mockMMLSRM5FireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(EntityState.class), any(Targetable.class), any(EntityState.class),
-                eq(mockWeaponMML5), eq(mockAmmoSRM5),
-                any(Game.class), anyBoolean());
-        doReturn(mockMMLSRM5FireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(MovePath.class), any(Targetable.class), any(EntityState.class), eq(mockWeaponMML5),
-                eq(mockAmmoSRM5),
-                any(Game.class), anyBoolean(), anyBoolean());
-        doReturn(mockMMLSRM5FireInfo).when(testFireControl).buildWeaponFireInfo(any(Entity.class),
-                any(Targetable.class), eq(mockWeaponMML5), eq(mockAmmoSRM5), any(Game.class),
-                anyBoolean());
+        doReturn(mockMMLSRM5FireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(EntityState.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockWeaponMML5),
+                    eq(mockAmmoSRM5),
+                    any(Game.class),
+                    anyBoolean());
+        doReturn(mockMMLSRM5FireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(MovePath.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    eq(mockWeaponMML5),
+                    eq(mockAmmoSRM5),
+                    any(Game.class),
+                    anyBoolean(),
+                    anyBoolean());
+        doReturn(mockMMLSRM5FireInfo).when(testFireControl)
+              .buildWeaponFireInfo(any(Entity.class),
+                    any(Targetable.class),
+                    eq(mockWeaponMML5),
+                    eq(mockAmmoSRM5),
+                    any(Game.class),
+                    anyBoolean());
 
         // Mock the getAmmo(Mounted) call return value
         List<AmmoMounted> mockAmmoList = new ArrayList<>();
@@ -749,8 +915,7 @@ class FireControlTest {
         List<AmmoMounted> testAmmoList = new ArrayList<>(1);
         testAmmoList.add(mockAmmoAc5Incendiary);
         final FireControl testFireControl = new FireControl(mockPrincess);
-        assertEquals(mockAmmoAc5Incendiary, testFireControl.getIncendiaryAmmo(testAmmoList, mockWeaponTypeAC5,
-                5));
+        assertEquals(mockAmmoAc5Incendiary, testFireControl.getIncendiaryAmmo(testAmmoList, mockWeaponTypeAC5, 5));
 
         // Test an ammo list with only 1 bin of standard ammo.
         testAmmoList = new ArrayList<>(1);
@@ -762,8 +927,7 @@ class FireControlTest {
         testAmmoList.add(mockAmmoAC5Std);
         testAmmoList.add(mockAmmoAc5Incendiary);
         testAmmoList.add(mockAmmoAC5Flak);
-        assertEquals(mockAmmoAc5Incendiary,
-                testFireControl.getIncendiaryAmmo(testAmmoList, mockWeaponTypeAC5, 5));
+        assertEquals(mockAmmoAc5Incendiary, testFireControl.getIncendiaryAmmo(testAmmoList, mockWeaponTypeAC5, 5));
 
         // Test LBX
         testAmmoList = new ArrayList<>(2);
@@ -787,8 +951,7 @@ class FireControlTest {
         List<AmmoMounted> testAmmoList = new ArrayList<>(1);
         testAmmoList.add(mockAmmoAc5Flechette);
         final FireControl testFireControl = new FireControl(mockPrincess);
-        assertEquals(mockAmmoAc5Flechette, testFireControl.getAntiInfantryAmmo(testAmmoList,
-                mockWeaponTypeAC5, 5));
+        assertEquals(mockAmmoAc5Flechette, testFireControl.getAntiInfantryAmmo(testAmmoList, mockWeaponTypeAC5, 5));
 
         // Test an ammo list with only 1 bin of standard ammo.
         testAmmoList = new ArrayList<>(1);
@@ -800,8 +963,7 @@ class FireControlTest {
         testAmmoList.add(mockAmmoAC5Std);
         testAmmoList.add(mockAmmoAC5Flak);
         testAmmoList.add(mockAmmoAc5Flechette);
-        assertEquals(mockAmmoAc5Flechette, testFireControl.getAntiInfantryAmmo(testAmmoList,
-                mockWeaponTypeAC5, 5));
+        assertEquals(mockAmmoAc5Flechette, testFireControl.getAntiInfantryAmmo(testAmmoList, mockWeaponTypeAC5, 5));
 
         // Test LBX
         testAmmoList = new ArrayList<>(2);
@@ -1004,8 +1166,7 @@ class FireControlTest {
         mockTarget = mock(BuildingTarget.class);
         when(mockTarget.getPosition()).thenReturn(new Coords(10, 15));
         when(mockWeaponAC5.getLinkedAmmo()).thenReturn(mockAmmoAc5Incendiary);
-        assertEquals(mockAmmoAc5Incendiary,
-                testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockWeaponAC5));
+        assertEquals(mockAmmoAc5Incendiary, testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockWeaponAC5));
 
         // Test shooting an LBX at an airborne target.
         mockTarget = mock(VTOL.class);
@@ -1013,28 +1174,26 @@ class FireControlTest {
         when(mockTarget.getPosition()).thenReturn(new Coords(10, 15));
         when(mockTarget.isAirborne()).thenReturn(true);
         when(mockWeaponLB10X.getLinkedAmmo()).thenReturn(mockAmmoLB10XCluster);
-        assertEquals(mockAmmoLB10XCluster,
-                testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockWeaponLB10X));
+        assertEquals(mockAmmoLB10XCluster, testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockWeaponLB10X));
 
         // Test shooting an LBX at a tank.
         mockTarget = mock(Tank.class);
         when(((Entity) mockTarget).getArmorType(anyInt())).thenReturn(EquipmentType.T_ARMOR_STANDARD);
         when(mockTarget.getPosition()).thenReturn(new Coords(10, 15));
         when(mockWeaponLB10X.getLinkedAmmo()).thenReturn(mockAmmoLB10XCluster);
-        assertEquals(mockAmmoLB10XCluster,
-                testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockWeaponLB10X));
+        assertEquals(mockAmmoLB10XCluster, testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockWeaponLB10X));
 
         // Test shooting an AC at infantry.
         mockTarget = mock(Infantry.class);
         when(((Entity) mockTarget).getArmorType(anyInt())).thenReturn(EquipmentType.T_ARMOR_STANDARD);
         when(mockTarget.getPosition()).thenReturn(new Coords(10, 15));
         when(mockWeaponAC5.getLinkedAmmo()).thenReturn(mockAmmoAc5Flechette);
-        assertTrue(
-                mockAmmoAc5Flechette.equals(testFireControl.getPreferredAmmo(mockShooter, mockTarget,
-                        mockWeaponAC5))
-                        || mockAmmoAc5Incendiary.equals(testFireControl.getPreferredAmmo(
-                                mockShooter, mockTarget,
-                                mockWeaponAC5)));
+        assertTrue(mockAmmoAc5Flechette.equals(testFireControl.getPreferredAmmo(mockShooter,
+              mockTarget,
+              mockWeaponAC5)) ||
+                         mockAmmoAc5Incendiary.equals(testFireControl.getPreferredAmmo(mockShooter,
+                               mockTarget,
+                               mockWeaponAC5)));
 
         // Test a LBX at a heavily damaged target.
         mockTarget = mock(BipedMek.class);
@@ -1042,16 +1201,14 @@ class FireControlTest {
         when(mockTarget.getPosition()).thenReturn(new Coords(10, 15));
         when(((Entity) mockTarget).getDamageLevel()).thenReturn(Entity.DMG_HEAVY);
         when(mockWeaponLB10X.getLinkedAmmo()).thenReturn(mockAmmoLB10XCluster);
-        assertEquals(mockAmmoLB10XCluster,
-                testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockWeaponLB10X));
+        assertEquals(mockAmmoLB10XCluster, testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockWeaponLB10X));
 
         // Test a hot target.
         when(((Entity) mockTarget).getDamageLevel()).thenReturn(Entity.DMG_LIGHT);
         when(((Entity) mockTarget).getHeat()).thenReturn(12);
 
         when(mockWeaponMML5.getLinkedAmmo()).thenReturn(mockAmmoInferno5);
-        assertEquals(mockAmmoInferno5,
-                testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockWeaponMML5));
+        assertEquals(mockAmmoInferno5, testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockWeaponMML5));
         when(((Entity) mockTarget).getArmorType(anyInt())).thenReturn(EquipmentType.T_ARMOR_HEAT_DISSIPATING);
         when(mockWeaponMML5.getLinkedAmmo()).thenReturn(mockAmmoSRM5);
         assertEquals(mockAmmoSRM5, testFireControl.getPreferredAmmo(mockShooter, mockTarget, mockWeaponMML5));
@@ -1077,15 +1234,19 @@ class FireControlTest {
         when(mockTargetState.isProne()).thenReturn(false);
         when(mockTarget.isAirborne()).thenReturn(false);
         when(mockTarget.isAirborneVTOLorWIGE()).thenReturn(false);
-        when(mockGameOptions.booleanOption(eq(OptionsConstants.ADVGRNDMOV_TACOPS_STANDING_STILL)))
-                .thenReturn(false);
+        when(mockGameOptions.booleanOption(eq(OptionsConstants.ADVGRNDMOV_TACOPS_STANDING_STILL))).thenReturn(false);
         when(mockHex.terrainLevel(Terrains.WOODS)).thenReturn(Terrain.LEVEL_NONE);
         when(mockHex.terrainLevel(Terrains.JUNGLE)).thenReturn(Terrain.LEVEL_NONE);
         when(mockHex.terrainLevel(Terrains.SMOKE)).thenReturn(Terrain.LEVEL_NONE);
         when(mockPrincess.getMaxWeaponRange(any(Entity.class), anyBoolean())).thenReturn(21);
         ToHitData expected = new ToHitData();
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(
-                mockShooter, mockShooterState, mockTarget, mockTargetState, 10, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
 
         // Test ground units firing on airborne aero's.
         final ConvFighter mockFighter = mock(ConvFighter.class);
@@ -1096,30 +1257,50 @@ class FireControlTest {
         when(mockFighterState.getMovementType()).thenReturn(EntityMovementType.MOVE_SAFE_THRUST);
         when(mockFighterState.getPosition()).thenReturn(new Coords(10, 0));
         when(mockFighterState.isProne()).thenReturn(false);
-        doReturn(new Coords(0, 2)).when(testFireControl).getNearestPointInFlightPath(
-                any(Coords.class), any(Aero.class));
+        doReturn(new Coords(0, 2)).when(testFireControl)
+              .getNearestPointInFlightPath(any(Coords.class), any(Aero.class));
         expected = new ToHitData();
         expected.addModifier(FireControl.TH_TAR_AERO_NOE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(
-                mockShooter, mockShooterState, mockFighter, mockFighterState, 10, mockGame));
-        doReturn(new Coords(0, 1)).when(testFireControl).getNearestPointInFlightPath(
-                any(Coords.class), any(Aero.class));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockFighter,
+                    mockFighterState,
+                    10,
+                    mockGame));
+        doReturn(new Coords(0, 1)).when(testFireControl)
+              .getNearestPointInFlightPath(any(Coords.class), any(Aero.class));
         expected = new ToHitData();
         expected.addModifier(FireControl.TH_TAR_AERO_NOE_ADJ);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(
-                mockShooter, mockShooterState, mockFighter, mockFighterState, 10, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockFighter,
+                    mockFighterState,
+                    10,
+                    mockGame));
 
         // Test industrial meks.
         when(((Mek) mockShooter).hasAdvancedFireControl()).thenReturn(false);
         expected = new ToHitData();
         expected.addModifier(FireControl.TH_INDUSTRIAL);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(
-                mockShooter, mockShooterState, mockTarget, mockTargetState, 10, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
         when(((Mek) mockShooter).getCockpitType()).thenReturn(Mek.COCKPIT_PRIMITIVE_INDUSTRIAL);
         expected = new ToHitData();
         expected.addModifier(FireControl.TH_PRIMITIVE_INDUSTRIAL);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(
-                mockShooter, mockShooterState, mockTarget, mockTargetState, 10, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
         when(((Mek) mockShooter).getCockpitType()).thenReturn(Mek.COCKPIT_STANDARD);
         when(((Mek) mockShooter).hasAdvancedFireControl()).thenReturn(true);
 
@@ -1127,8 +1308,13 @@ class FireControlTest {
         when(((Mek) mockTarget).getCockpitType()).thenReturn(Mek.COCKPIT_SUPERHEAVY);
         expected = new ToHitData();
         expected.addModifier(FireControl.TH_TAR_SUPER);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(
-                mockShooter, mockShooterState, mockTarget, mockTargetState, 10, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
         when(((Mek) mockTarget).getCockpitType()).thenReturn(Mek.COCKPIT_STANDARD);
 
         // Test attacking a grounded dropship.
@@ -1137,45 +1323,62 @@ class FireControlTest {
         when(mockDropship.isAirborneVTOLorWIGE()).thenReturn(false);
         expected = new ToHitData();
         expected.addModifier(FireControl.TH_TAR_GROUND_DS);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(
-                mockShooter, mockShooterState, mockDropship, mockTargetState, 10, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockDropship,
+                    mockTargetState,
+                    10,
+                    mockGame));
 
         // Test the shooter having a null position.
         when(mockShooterState.getPosition()).thenReturn(null);
         expected = new ToHitData(FireControl.TH_NULL_POSITION);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(
-                mockShooter, mockShooterState, mockTarget, mockTargetState, 10, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
         when(mockShooterState.getPosition()).thenReturn(new Coords(0, 0));
 
         // Test the target having a null position.
         when(mockTargetState.getPosition()).thenReturn(null);
         expected = new ToHitData(FireControl.TH_NULL_POSITION);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(
-                mockShooter, mockShooterState, mockTarget, mockTargetState, 10, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
         when(mockTargetState.getPosition()).thenReturn(new Coords(10, 0));
 
         // Make the shooter prone.
         when(mockShooterState.isProne()).thenReturn(true);
         expected = new ToHitData();
         expected.addModifier(FireControl.TH_ATT_PRONE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-                mockShooterState,
-                mockTarget,
-                mockTargetState,
-                10,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
         when(mockShooterState.isProne()).thenReturn(false);
 
         // Make the target immobile.
         when(mockTargetState.isImmobile()).thenReturn(true);
         expected = new ToHitData();
         expected.addModifier(FireControl.TH_TAR_IMMOBILE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-                mockShooterState,
-                mockTarget,
-                mockTargetState,
-                10,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
         when(mockTargetState.isImmobile()).thenReturn(false);
 
         // Have the target fall prone adjacent.
@@ -1183,66 +1386,70 @@ class FireControlTest {
         when(mockTargetState.getPosition()).thenReturn(new Coords(0, 1));
         expected = new ToHitData();
         expected.addModifier(FireControl.TH_TAR_PRONE_ADJ);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-                mockShooterState,
-                mockTarget,
-                mockTargetState,
-                1,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    1,
+                    mockGame));
         when(mockTargetState.getPosition()).thenReturn(new Coords(10, 0)); // Move the target away.
         expected = new ToHitData();
         expected.addModifier(FireControl.TH_TAR_PRONE_RANGE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-                mockShooterState,
-                mockTarget,
-                mockTargetState,
-                10,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
         when(mockTargetState.getMovementType()).thenReturn(EntityMovementType.MOVE_SKID); // Have the target
         // skid.
         expected.addModifier(FireControl.TH_TAR_SKID);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-                mockShooterState,
-                mockTarget,
-                mockTargetState,
-                10,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
         when(mockTargetState.isProne()).thenReturn(false);
         when(mockTargetState.getMovementType()).thenReturn(EntityMovementType.MOVE_NONE);
 
         // Turn on Tac-Ops Standing Still rules.
-        when(mockGameOptions.booleanOption(eq(OptionsConstants.ADVGRNDMOV_TACOPS_STANDING_STILL)))
-                .thenReturn(true);
+        when(mockGameOptions.booleanOption(eq(OptionsConstants.ADVGRNDMOV_TACOPS_STANDING_STILL))).thenReturn(true);
         expected = new ToHitData();
         expected.addModifier(FireControl.TH_TAR_NO_MOVE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-                mockShooterState,
-                mockTarget,
-                mockTargetState,
-                10,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
         when(mockTargetState.getMovementType()).thenReturn(EntityMovementType.MOVE_WALK); // Walking target.
         expected = new ToHitData();
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-                mockShooterState,
-                mockTarget,
-                mockTargetState,
-                10,
-                mockGame));
-        when(mockGameOptions.booleanOption(eq(OptionsConstants.ADVGRNDMOV_TACOPS_STANDING_STILL)))
-                .thenReturn(false);
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
+        when(mockGameOptions.booleanOption(eq(OptionsConstants.ADVGRNDMOV_TACOPS_STANDING_STILL))).thenReturn(false);
         when(mockTargetState.getMovementType()).thenReturn(EntityMovementType.MOVE_NONE);
 
         // Have the target sprint.
         when(mockTargetState.getMovementType()).thenReturn(EntityMovementType.MOVE_SPRINT);
         expected = new ToHitData();
         expected.addModifier(FireControl.TH_TAR_SPRINT);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-                mockShooterState,
-                mockTarget,
-                mockTargetState,
-                10,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
         when(mockTargetState.getMovementType()).thenReturn(EntityMovementType.MOVE_NONE);
 
         // Stand the target in light woods.
@@ -1258,12 +1465,13 @@ class FireControlTest {
 
         expected = new ToHitData();
         expected.addModifier(1, FireControl.TH_WOODS);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-                mockShooterState,
-                mockTarget,
-                mockTargetState,
-                1,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    1,
+                    mockGame));
 
         // Stand the target farther away in light woods
         mockShooterCoords = new Coords(0, 0);
@@ -1273,12 +1481,13 @@ class FireControlTest {
 
         expected = new ToHitData();
         expected.addModifier(2, FireControl.TH_WOODS);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-            mockShooterState,
-            mockTarget,
-            mockTargetState,
-            2,
-            mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    2,
+                    mockGame));
         when(mockHex.terrainLevel(Terrains.WOODS)).thenReturn(Terrain.LEVEL_NONE);
 
         // Revert positions and foliage
@@ -1291,12 +1500,13 @@ class FireControlTest {
         when(mockHex.terrainLevel(Terrains.WOODS)).thenReturn(2);
         expected = new ToHitData();
         expected.addModifier(2, FireControl.TH_WOODS);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-                mockShooterState,
-                mockTarget,
-                mockTargetState,
-                1,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    1,
+                    mockGame));
         when(mockHex.terrainLevel(Terrains.WOODS)).thenReturn(Terrain.LEVEL_NONE);
 
         // Stand the target in super heavy woods.
@@ -1304,12 +1514,13 @@ class FireControlTest {
         when(mockHex.terrainLevel(Terrains.FOLIAGE_ELEV)).thenReturn(3);
         expected = new ToHitData();
         expected.addModifier(3, FireControl.TH_WOODS);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-                mockShooterState,
-                mockTarget,
-                mockTargetState,
-                1,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    1,
+                    mockGame));
         when(mockHex.terrainLevel(Terrains.WOODS)).thenReturn(Terrain.LEVEL_NONE);
 
         // Stand the target in jungle.
@@ -1317,12 +1528,13 @@ class FireControlTest {
         when(mockHex.terrainLevel(Terrains.FOLIAGE_ELEV)).thenReturn(2);
         expected = new ToHitData();
         expected.addModifier(2, FireControl.TH_WOODS);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-                mockShooterState,
-                mockTarget,
-                mockTargetState,
-                1,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    1,
+                    mockGame));
 
         // 3. reset coords and terrain
         mockShooterCoords = new Coords(0, 0);
@@ -1338,12 +1550,13 @@ class FireControlTest {
         // Give the shooter the anti-air quirk but fire on a ground target.
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_ANTI_AIR))).thenReturn(true);
         expected = new ToHitData();
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-                mockShooterState,
-                mockTarget,
-                mockTargetState,
-                10,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_ANTI_AIR))).thenReturn(false);
 
         // Give the shooter the anti-air quirk, and fire on an airborne target.
@@ -1353,12 +1566,13 @@ class FireControlTest {
         when(mockTarget.isAirborneVTOLorWIGE()).thenReturn(false);
         expected = new ToHitData();
         expected.addModifier(FireControl.TH_ANTI_AIR);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-                mockShooterState,
-                mockTarget,
-                mockTargetState,
-                10,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_ANTI_AIR))).thenReturn(false);
         mockTarget = mock(BipedMek.class);
         when(mockTarget.isAirborne()).thenReturn(false);
@@ -1368,80 +1582,78 @@ class FireControlTest {
         mockTarget = mock(BattleArmor.class);
         expected = new ToHitData();
         expected.addModifier(FireControl.TH_TAR_BA);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-                mockShooterState,
-                mockTarget,
-                mockTargetState,
-                10,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
         mockTarget = mock(BipedMek.class);
 
         // Firing at an ejected mekwarrior.
         mockTarget = mock(MekWarrior.class);
         expected = new ToHitData();
         expected.addModifier(FireControl.TH_TAR_MW);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-                mockShooterState,
-                mockTarget,
-                mockTargetState,
-                10,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
         mockTarget = mock(BipedMek.class);
 
         // Firing at infantry
         mockTarget = mock(Infantry.class);
         expected = new ToHitData();
         expected.addModifier(FireControl.TH_TAR_INF);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-                mockShooterState,
-                mockTarget,
-                mockTargetState,
-                10,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
         mockTarget = mock(BipedMek.class);
 
         // Target is out of range.
         when(mockPrincess.getMaxWeaponRange(any(Entity.class), anyBoolean())).thenReturn(5);
         expected = new ToHitData(FireControl.TH_RNG_TOO_FAR);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
-                mockShooterState,
-                mockTarget,
-                mockTargetState,
-                10,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
         when(mockShooter.getMaxWeaponRange()).thenReturn(21);
 
         // Target is in smoke.
         // Light smoke
-        when(mockHex.terrainLevel(Terrains.SMOKE)).thenReturn(
-                SmokeCloud.SMOKE_LIGHT);
+        when(mockHex.terrainLevel(Terrains.SMOKE)).thenReturn(SmokeCloud.SMOKE_LIGHT);
         expected = new ToHitData();
         expected.addModifier(1, FireControl.TH_SMOKE);
 
         // Heavy Smoke
-        when(mockHex.terrainLevel(Terrains.SMOKE)).thenReturn(
-                SmokeCloud.SMOKE_HEAVY);
+        when(mockHex.terrainLevel(Terrains.SMOKE)).thenReturn(SmokeCloud.SMOKE_HEAVY);
         expected = new ToHitData();
         expected.addModifier(2, FireControl.TH_SMOKE);
 
         // Light LI smoke
-        when(mockHex.terrainLevel(Terrains.SMOKE)).thenReturn(
-                SmokeCloud.SMOKE_LI_LIGHT);
+        when(mockHex.terrainLevel(Terrains.SMOKE)).thenReturn(SmokeCloud.SMOKE_LI_LIGHT);
         expected = new ToHitData();
         expected.addModifier(1, FireControl.TH_SMOKE);
 
         // Chaff Smoke
-        when(mockHex.terrainLevel(Terrains.SMOKE)).thenReturn(
-                SmokeCloud.SMOKE_CHAFF_LIGHT);
+        when(mockHex.terrainLevel(Terrains.SMOKE)).thenReturn(SmokeCloud.SMOKE_CHAFF_LIGHT);
         expected = new ToHitData();
         expected.addModifier(1, FireControl.TH_SMOKE);
 
-        when(mockHex.terrainLevel(Terrains.SMOKE)).thenReturn(
-                SmokeCloud.SMOKE_NONE);
+        when(mockHex.terrainLevel(Terrains.SMOKE)).thenReturn(SmokeCloud.SMOKE_NONE);
     }
 
-    private void assertToHitDataEquals(final ToHitData expected,
-            final Object actual) {
+    private void assertToHitDataEquals(final ToHitData expected, final Object actual) {
         assertNotNull(actual);
         assertTrue(actual instanceof ToHitData, "actual: " + actual.getClass().getName());
         final ToHitData actualTHD = (ToHitData) actual;
@@ -1465,15 +1677,16 @@ class FireControlTest {
     void testGuessToHitModifierPhysical() {
 
         // guessToHitModifierHelperForAnyAttack being tested elsewhere.
-        doReturn(new ToHitData())
-                .when(testFireControl)
-                .guessToHitModifierHelperForAnyAttack(any(Entity.class), any(EntityState.class),
-                        any(Targetable.class), any(EntityState.class),
-                        anyInt(), any(Game.class));
+        doReturn(new ToHitData()).when(testFireControl)
+              .guessToHitModifierHelperForAnyAttack(any(Entity.class),
+                    any(EntityState.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    anyInt(),
+                    any(Game.class));
         mockTargetCoords = new Coords(0, 1);
         when(mockTargetState.getPosition()).thenReturn(mockTargetCoords);
-        doReturn(true).when(testFireControl).isInArc(any(Coords.class), anyInt(),
-                any(Coords.class), anyInt());
+        doReturn(true).when(testFireControl).isInArc(any(Coords.class), anyInt(), any(Coords.class), anyInt());
         final Hex mockShooterHex = mock(Hex.class);
         when(mockShooterHex.getLevel()).thenReturn(0);
         when(mockBoard.getHex(eq(mockShooterState.getPosition()))).thenReturn(mockShooterHex);
@@ -1498,39 +1711,62 @@ class FireControlTest {
         // Test a regular kick.
         ToHitData expected = new ToHitData();
         expected.addModifier(mockCrew.getPiloting() - 2, FireControl.TH_PHY_BASE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierPhysical(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, PhysicalAttackType.LEFT_KICK, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_KICK,
+                    mockGame));
 
         // Test a superheavy mek attempting a kick.
         when(((Mek) mockShooter).getCockpitType()).thenReturn(Mek.COCKPIT_SUPERHEAVY);
         expected = new ToHitData();
         expected.addModifier(mockCrew.getPiloting() - 2, FireControl.TH_PHY_BASE);
         expected.addModifier(FireControl.TH_PHY_SUPER);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierPhysical(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, PhysicalAttackType.LEFT_KICK, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_KICK,
+                    mockGame));
         when(((Mek) mockShooter).getCockpitType()).thenReturn(Mek.COCKPIT_STANDARD);
 
         // Test turning on the TacOps Attacker Weight modifier.
-        when(mockGameOptions.booleanOption(OptionsConstants.ADVGRNDMOV_TACOPS_PHYSICAL_ATTACK_PSR))
-                .thenReturn(true);
+        when(mockGameOptions.booleanOption(OptionsConstants.ADVGRNDMOV_TACOPS_PHYSICAL_ATTACK_PSR)).thenReturn(true);
         expected = new ToHitData();
         expected.addModifier(mockCrew.getPiloting() - 2, FireControl.TH_PHY_BASE);
         expected.addModifier(FireControl.TH_PHY_LIGHT);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierPhysical(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, PhysicalAttackType.LEFT_KICK, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_KICK,
+                    mockGame));
         when(mockShooter.getWeightClass()).thenReturn(EntityWeightClass.WEIGHT_MEDIUM);
         expected = new ToHitData();
         expected.addModifier(mockCrew.getPiloting() - 2, FireControl.TH_PHY_BASE);
         expected.addModifier(FireControl.TH_PHY_MEDIUM);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierPhysical(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, PhysicalAttackType.LEFT_KICK, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_KICK,
+                    mockGame));
         when(mockShooter.getWeightClass()).thenReturn(EntityWeightClass.WEIGHT_HEAVY);
         expected = new ToHitData();
         expected.addModifier(mockCrew.getPiloting() - 2, FireControl.TH_PHY_BASE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierPhysical(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, PhysicalAttackType.LEFT_KICK, mockGame));
-        when(mockGameOptions.booleanOption(OptionsConstants.ADVGRNDMOV_TACOPS_PHYSICAL_ATTACK_PSR))
-                .thenReturn(false);
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_KICK,
+                    mockGame));
+        when(mockGameOptions.booleanOption(OptionsConstants.ADVGRNDMOV_TACOPS_PHYSICAL_ATTACK_PSR)).thenReturn(false);
         when(mockShooter.getWeightClass()).thenReturn(EntityWeightClass.WEIGHT_LIGHT);
 
         // Test trying to kick infantry in a different hex.
@@ -1538,16 +1774,24 @@ class FireControlTest {
         when(infantryTarget.getElevation()).thenReturn(0);
         when(infantryTarget.getHeight()).thenReturn(1);
         expected = new ToHitData(FireControl.TH_PHY_K_INF_RNG);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierPhysical(mockShooter,
-                mockShooterState, infantryTarget, mockTargetState, PhysicalAttackType.LEFT_KICK,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    infantryTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_KICK,
+                    mockGame));
         when(mockTargetState.getPosition()).thenReturn(new Coords(0, 0)); // Move them into my hex.
         expected = new ToHitData();
         expected.addModifier(mockCrew.getPiloting() - 2, FireControl.TH_PHY_BASE);
         expected.addModifier(FireControl.TH_PHY_K_INF);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierPhysical(mockShooter,
-                mockShooterState, infantryTarget, mockTargetState, PhysicalAttackType.LEFT_KICK,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    infantryTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_KICK,
+                    mockGame));
         when(mockTargetState.getPosition()).thenReturn(new Coords(0, 1));
 
         // Test kicking with a busted foot.
@@ -1555,8 +1799,13 @@ class FireControlTest {
         expected = new ToHitData();
         expected.addModifier(mockCrew.getPiloting() - 2, FireControl.TH_PHY_BASE);
         expected.addModifier(FireControl.TH_PHY_K_FOOT);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierPhysical(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, PhysicalAttackType.LEFT_KICK, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_KICK,
+                    mockGame));
         when(mockShooter.hasWorkingSystem(Mek.ACTUATOR_FOOT, Mek.LOC_LLEG)).thenReturn(true);
 
         // Test kicking with a bad lower leg actuator.
@@ -1564,8 +1813,13 @@ class FireControlTest {
         expected = new ToHitData();
         expected.addModifier(mockCrew.getPiloting() - 2, FireControl.TH_PHY_BASE);
         expected.addModifier(FireControl.TH_PHY_K_LOWER_LEG);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierPhysical(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, PhysicalAttackType.LEFT_KICK, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_KICK,
+                    mockGame));
         when(mockShooter.hasWorkingSystem(Mek.ACTUATOR_LOWER_LEG, Mek.LOC_LLEG)).thenReturn(true);
 
         // Test kicking with a bad upper leg actuator.
@@ -1573,45 +1827,72 @@ class FireControlTest {
         expected = new ToHitData();
         expected.addModifier(mockCrew.getPiloting() - 2, FireControl.TH_PHY_BASE);
         expected.addModifier(FireControl.TH_PHY_K_UPPER_LEG);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierPhysical(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, PhysicalAttackType.LEFT_KICK, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_KICK,
+                    mockGame));
         when(mockShooter.hasWorkingSystem(Mek.ACTUATOR_UPPER_LEG, Mek.LOC_RLEG)).thenReturn(true);
 
         // Test kicking with a busted hip.
         when(mockShooter.hasHipCrit()).thenReturn(true);
         expected = new ToHitData(FireControl.TH_PHY_K_HIP);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierPhysical(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, PhysicalAttackType.LEFT_KICK, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_KICK,
+                    mockGame));
         when(mockShooter.hasHipCrit()).thenReturn(false);
 
         // Test trying to kick while prone.
         expected = new ToHitData(FireControl.TH_PHY_K_PRONE);
         when(mockShooterState.isProne()).thenReturn(true);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierPhysical(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, PhysicalAttackType.LEFT_KICK, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_KICK,
+                    mockGame));
         when(mockShooterState.isProne()).thenReturn(false);
 
         // Test a regular punch.
         expected = new ToHitData();
         expected.addModifier(mockCrew.getPiloting(), FireControl.TH_PHY_BASE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierPhysical(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, PhysicalAttackType.LEFT_PUNCH,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_PUNCH,
+                    mockGame));
 
         // Test having the 'easy to pilot' quirk.
         when(mockShooter.hasQuirk(OptionsConstants.QUIRK_POS_EASY_PILOT)).thenReturn(true);
         expected = new ToHitData();
         expected.addModifier(mockCrew.getPiloting(), FireControl.TH_PHY_BASE);
         expected.addModifier(FireControl.TH_PHY_EASY_PILOT);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierPhysical(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, PhysicalAttackType.LEFT_PUNCH,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_PUNCH,
+                    mockGame));
         when(mockCrew.getPiloting()).thenReturn(2); // Pilot to good to use the quirk.
         expected = new ToHitData();
         expected.addModifier(mockCrew.getPiloting(), FireControl.TH_PHY_BASE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierPhysical(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, PhysicalAttackType.LEFT_PUNCH,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_PUNCH,
+                    mockGame));
         when(mockShooter.hasQuirk(OptionsConstants.QUIRK_POS_EASY_PILOT)).thenReturn(false);
         when(mockCrew.getPiloting()).thenReturn(5);
 
@@ -1621,10 +1902,12 @@ class FireControlTest {
         expected.addModifier(mockCrew.getPiloting(), FireControl.TH_PHY_BASE);
         expected.addModifier(FireControl.TH_PHY_P_HAND);
         assertToHitDataEquals(expected,
-                testFireControl.guessToHitModifierPhysical(mockShooter, mockShooterState,
-                        mockTarget, mockTargetState,
-                        PhysicalAttackType.LEFT_PUNCH,
-                        mockGame));
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_PUNCH,
+                    mockGame));
         when(mockShooter.hasWorkingSystem(Mek.ACTUATOR_HAND, Mek.LOC_LARM)).thenReturn(true);
 
         /// Test having a damaged/missing upper arm.
@@ -1633,10 +1916,12 @@ class FireControlTest {
         expected.addModifier(mockCrew.getPiloting(), FireControl.TH_PHY_BASE);
         expected.addModifier(FireControl.TH_PHY_P_UPPER_ARM);
         assertToHitDataEquals(expected,
-                testFireControl.guessToHitModifierPhysical(mockShooter, mockShooterState,
-                        mockTarget, mockTargetState,
-                        PhysicalAttackType.LEFT_PUNCH,
-                        mockGame));
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_PUNCH,
+                    mockGame));
         when(mockShooter.hasWorkingSystem(Mek.ACTUATOR_UPPER_ARM, Mek.LOC_LARM)).thenReturn(true);
 
         /// Test having a damaged/missing lower arm.
@@ -1645,29 +1930,35 @@ class FireControlTest {
         expected.addModifier(mockCrew.getPiloting(), FireControl.TH_PHY_BASE);
         expected.addModifier(FireControl.TH_PHY_P_LOWER_ARM);
         assertToHitDataEquals(expected,
-                testFireControl.guessToHitModifierPhysical(mockShooter, mockShooterState,
-                        mockTarget, mockTargetState,
-                        PhysicalAttackType.LEFT_PUNCH,
-                        mockGame));
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_PUNCH,
+                    mockGame));
         when(mockShooter.hasWorkingSystem(Mek.ACTUATOR_LOWER_ARM, Mek.LOC_LARM)).thenReturn(true);
 
         // Test trying to punch with a bad shoulder.
         when(mockShooter.hasWorkingSystem(Mek.ACTUATOR_SHOULDER, Mek.LOC_RARM)).thenReturn(false);
         expected = new ToHitData(FireControl.TH_PHY_P_NO_SHOULDER);
         assertToHitDataEquals(expected,
-                testFireControl.guessToHitModifierPhysical(mockShooter, mockShooterState,
-                        mockTarget, mockTargetState,
-                        PhysicalAttackType.RIGHT_PUNCH,
-                        mockGame));
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.RIGHT_PUNCH,
+                    mockGame));
 
         // Test trying to punch with a destroyed arm.
         when(mockShooter.isLocationBad(Mek.LOC_RARM)).thenReturn(true);
         expected = new ToHitData(FireControl.TH_PHY_P_NO_ARM);
         assertToHitDataEquals(expected,
-                testFireControl.guessToHitModifierPhysical(mockShooter, mockShooterState,
-                        mockTarget, mockTargetState,
-                        PhysicalAttackType.RIGHT_PUNCH,
-                        mockGame));
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.RIGHT_PUNCH,
+                    mockGame));
 
         // Test trying to punch an infantry target.
         infantryTarget = mock(Infantry.class);
@@ -1675,64 +1966,78 @@ class FireControlTest {
         when(infantryTarget.getHeight()).thenReturn(1);
         expected = new ToHitData(FireControl.TH_PHY_P_TAR_INF);
         assertToHitDataEquals(expected,
-                testFireControl.guessToHitModifierPhysical(mockShooter, mockShooterState,
-                        infantryTarget, mockTargetState,
-                        PhysicalAttackType.LEFT_PUNCH,
-                        mockGame));
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    infantryTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_PUNCH,
+                    mockGame));
 
         // Test trying to punch while prone.
         when(mockShooterState.isProne()).thenReturn(true);
         expected = new ToHitData(FireControl.TH_PHY_P_TAR_PRONE);
         assertToHitDataEquals(expected,
-                testFireControl.guessToHitModifierPhysical(mockShooter, mockShooterState,
-                        mockTarget, mockTargetState,
-                        PhysicalAttackType.LEFT_PUNCH,
-                        mockGame));
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_PUNCH,
+                    mockGame));
 
         // Test the target being at the wrong elevation for a punch.
         when(mockShooterHex.getLevel()).thenReturn(1);
         expected = new ToHitData(FireControl.TH_PHY_TOO_MUCH_ELEVATION);
         assertToHitDataEquals(expected,
-                testFireControl.guessToHitModifierPhysical(mockShooter, mockShooterState,
-                        mockTarget, mockTargetState,
-                        PhysicalAttackType.LEFT_PUNCH,
-                        mockGame));
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_PUNCH,
+                    mockGame));
 
         // Test an attacker with the 'no arms' quirk trying to punch.
         when(mockShooter.hasQuirk(OptionsConstants.QUIRK_NEG_NO_ARMS)).thenReturn(true);
         expected = new ToHitData(FireControl.TH_PHY_P_NO_ARMS_QUIRK);
         assertToHitDataEquals(expected,
-                testFireControl.guessToHitModifierPhysical(mockShooter, mockShooterState,
-                        mockTarget, mockTargetState,
-                        PhysicalAttackType.LEFT_PUNCH,
-                        mockGame));
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_PUNCH,
+                    mockGame));
 
         // Test the target not being in the attack arc.
-        doReturn(false).when(testFireControl).isInArc(any(Coords.class), anyInt(),
-                any(Coords.class), anyInt());
+        doReturn(false).when(testFireControl).isInArc(any(Coords.class), anyInt(), any(Coords.class), anyInt());
         expected = new ToHitData(FireControl.TH_PHY_NOT_IN_ARC);
         assertToHitDataEquals(expected,
-                testFireControl.guessToHitModifierPhysical(mockShooter, mockShooterState,
-                        mockTarget, mockTargetState,
-                        PhysicalAttackType.LEFT_PUNCH,
-                        mockGame));
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_PUNCH,
+                    mockGame));
 
         // Test the target being more than 1 hex away.
         when(mockTargetState.getPosition()).thenReturn(new Coords(10, 10));
         expected = new ToHitData(FireControl.TH_PHY_TOO_FAR);
         assertToHitDataEquals(expected,
-                testFireControl.guessToHitModifierPhysical(mockShooter, mockShooterState,
-                        mockTarget, mockTargetState,
-                        PhysicalAttackType.LEFT_PUNCH,
-                        mockGame));
+              testFireControl.guessToHitModifierPhysical(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.LEFT_PUNCH,
+                    mockGame));
 
         // Test an attacker that is not a mek.
         final Entity mockVee = mock(Tank.class);
         expected = new ToHitData(FireControl.TH_PHY_NOT_MEK);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierPhysical(mockVee, null, mockTarget,
-                mockTargetState,
-                PhysicalAttackType.CHARGE,
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierPhysical(mockVee,
+                    null,
+                    mockTarget,
+                    mockTargetState,
+                    PhysicalAttackType.CHARGE,
+                    mockGame));
     }
 
     @Test
@@ -1740,18 +2045,22 @@ class FireControlTest {
         when(mockGameOptions.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RANGE)).thenReturn(false);
         when(mockTarget.hasQuirk(eq(OptionsConstants.QUIRK_POS_LOW_PROFILE))).thenReturn(false);
         when(mockShooterState.getFacing()).thenReturn(1);
-        doReturn(true).when(testFireControl).isInArc(any(Coords.class), anyInt(),
-                any(Coords.class), anyInt());
-        doReturn(new ToHitData())
-                .when(testFireControl)
-                .guessToHitModifierHelperForAnyAttack(any(Entity.class), any(EntityState.class),
-                        any(Targetable.class), any(EntityState.class), anyInt(),
-                        any(Game.class));
+        doReturn(true).when(testFireControl).isInArc(any(Coords.class), anyInt(), any(Coords.class), anyInt());
+        doReturn(new ToHitData()).when(testFireControl)
+              .guessToHitModifierHelperForAnyAttack(any(Entity.class),
+                    any(EntityState.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    anyInt(),
+                    any(Game.class));
         final LosEffects spyLosEffects = spy(new LosEffects());
-        doReturn(spyLosEffects)
-                .when(testFireControl)
-                .getLosEffects(any(Game.class), any(Entity.class), any(Targetable.class),
-                        any(Coords.class), any(Coords.class), anyBoolean());
+        doReturn(spyLosEffects).when(testFireControl)
+              .getLosEffects(any(Game.class),
+                    any(Entity.class),
+                    any(Targetable.class),
+                    any(Coords.class),
+                    any(Coords.class),
+                    anyBoolean());
         doReturn(new ToHitData()).when(spyLosEffects).losModifiers(eq(mockGame));
 
         final Hex mockTargetHex = mock(Hex.class);
@@ -1768,8 +2077,7 @@ class FireControlTest {
         final WeaponType mockWeaponType = mock(WeaponType.class);
         when(mockWeapon.getType()).thenReturn(mockWeaponType);
         when(mockWeaponType.getAmmoType()).thenReturn(AmmoType.T_AC);
-        when(mockWeaponType.getRanges(eq(mockWeapon), any(Mounted.class)))
-                .thenReturn(new int[] { 3, 6, 12, 18, 24 });
+        when(mockWeaponType.getRanges(eq(mockWeapon), any(Mounted.class))).thenReturn(new int[] { 3, 6, 12, 18, 24 });
         when(mockWeaponType.getMinimumRange()).thenReturn(3);
         when(mockWeaponType.hasFlag(eq(WeaponType.F_DIRECT_FIRE))).thenReturn(true);
 
@@ -1780,23 +2088,41 @@ class FireControlTest {
         // Test the vanilla case.
         ToHitData expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
 
         // Test weapon quirks.
         when(mockWeapon.hasQuirk(eq(OptionsConstants.QUIRK_WEAP_POS_ACCURATE))).thenReturn(true);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(FireControl.TH_ACCURATE_WEAPON);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockWeapon.hasQuirk(eq(OptionsConstants.QUIRK_WEAP_POS_ACCURATE))).thenReturn(false);
         when(mockWeapon.hasQuirk(eq(OptionsConstants.QUIRK_WEAP_NEG_INACCURATE))).thenReturn(true);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(FireControl.TH_INACCURATE_WEAPON);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockWeapon.hasQuirk(eq(OptionsConstants.QUIRK_WEAP_NEG_INACCURATE))).thenReturn(false);
 
         // Test long range shooter quirks.
@@ -1805,29 +2131,53 @@ class FireControlTest {
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_LONG_RANGE);
         expected.addModifier(FireControl.TH_IMP_TARGETING_LONG);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_IMP_TARG_L))).thenReturn(false);
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_VAR_RNG_TARG_S))).thenReturn(true);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_LONG_RANGE);
         expected.addModifier(FireControl.TH_VAR_RNG_TARGETING_SHORT_AT_LONG);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_VAR_RNG_TARG_S))).thenReturn(false);
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_VAR_RNG_TARG_L))).thenReturn(true);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_LONG_RANGE);
         expected.addModifier(FireControl.TH_VAR_RNG_TARGETING_LONG_AT_LONG);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_VAR_RNG_TARG_L))).thenReturn(false);
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_NEG_POOR_TARG_L))).thenReturn(true);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_LONG_RANGE);
         expected.addModifier(FireControl.TH_POOR_TARGETING_LONG);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_NEG_POOR_TARG_L))).thenReturn(false);
         when(mockTargetState.getPosition()).thenReturn(mockTargetCoords);
 
@@ -1836,15 +2186,27 @@ class FireControlTest {
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(FireControl.TH_IMP_TARGETING_MEDIUM);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_IMP_TARG_M))).thenReturn(false);
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_NEG_POOR_TARG_M))).thenReturn(true);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(FireControl.TH_POOR_TARGETING_MEDIUM);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_NEG_POOR_TARG_M))).thenReturn(false);
 
         // Test short range shooter quirks.
@@ -1853,29 +2215,53 @@ class FireControlTest {
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_SHORT_RANGE);
         expected.addModifier(FireControl.TH_IMP_TARGETING_SHORT);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_IMP_TARG_S))).thenReturn(false);
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_VAR_RNG_TARG_S))).thenReturn(true);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_SHORT_RANGE);
         expected.addModifier(FireControl.TH_VAR_RNG_TARGETING_SHORT_AT_SHORT);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_VAR_RNG_TARG_S))).thenReturn(false);
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_VAR_RNG_TARG_L))).thenReturn(true);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_SHORT_RANGE);
         expected.addModifier(FireControl.TH_VAR_RNG_TARGETING_LONG_AT_SHORT);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_VAR_RNG_TARG_L))).thenReturn(false);
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_NEG_POOR_TARG_S))).thenReturn(true);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_SHORT_RANGE);
         expected.addModifier(FireControl.TH_POOR_TARGETING_SHORT);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_NEG_POOR_TARG_S))).thenReturn(false);
         when(mockTargetState.getPosition()).thenReturn(mockTargetCoords);
 
@@ -1884,13 +2270,25 @@ class FireControlTest {
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(FireControl.TH_TARGETING_COMP);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockWeaponType.hasFlag(eq(WeaponType.F_DIRECT_FIRE))).thenReturn(false);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockWeaponType.hasFlag(eq(WeaponType.F_DIRECT_FIRE))).thenReturn(false);
         when(mockShooter.hasTargComp()).thenReturn(false);
 
@@ -1902,8 +2300,14 @@ class FireControlTest {
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(1, FireControl.TH_AMMO_MOD);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockAmmoType.getToHitModifier()).thenReturn(0);
 
         // Test target size mods.
@@ -1911,14 +2315,26 @@ class FireControlTest {
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(FireControl.TH_RNG_LARGE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockLargeTank, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockLargeTank,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(((Mek) mockTarget).getCockpitType()).thenReturn(Mek.COCKPIT_SUPERHEAVY);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(FireControl.TH_RNG_LARGE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(((Mek) mockTarget).getCockpitType()).thenReturn(Mek.COCKPIT_STANDARD);
 
         // Test weapon mods.
@@ -1926,8 +2342,14 @@ class FireControlTest {
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(-2, FireControl.TH_WEAPON_MOD);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockWeaponType.getToHitModifier(mockWeapon)).thenReturn(0);
 
         // Test heat mods.
@@ -1935,8 +2357,14 @@ class FireControlTest {
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         expected.addModifier(1, FireControl.TH_HEAT);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockShooter.getHeatFiringModifier()).thenReturn(0);
 
         // Test fighter's at altitude
@@ -1950,31 +2378,61 @@ class FireControlTest {
         when(mockFighterState.getPosition()).thenReturn(mockTargetCoords);
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_LONG_RANGE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockFighter, mockFighterState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockFighter,
+                    mockFighterState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockFighter.getId()).thenReturn(1); // Target aero is also firing on shooter.
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_SHORT_RANGE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockFighter, mockFighterState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockFighter,
+                    mockFighterState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
 
         // Test changing the range.
         when(mockTargetState.getPosition()).thenReturn(new Coords(5, 0));
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_SHORT_RANGE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockTargetState.getPosition()).thenReturn(new Coords(1, 0));
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(3, FireControl.TH_MINIMUM_RANGE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockGameOptions.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RANGE)).thenReturn(true);
         when(mockTargetState.getPosition()).thenReturn(new Coords(20, 0));
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_EXTREME_RANGE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         // todo Test infantry range mods.
         when(mockTargetState.getPosition()).thenReturn(mockTargetCoords);
         when(mockGameOptions.booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_RANGE)).thenReturn(false);
@@ -1984,114 +2442,189 @@ class FireControlTest {
         // Test sensor damage.
         expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
-        when(mockShooter.getBadCriticals(eq(CriticalSlot.TYPE_SYSTEM), eq(Mek.SYSTEM_SENSORS),
-                eq(Mek.LOC_HEAD))).thenReturn(2);
+        when(mockShooter.getBadCriticals(eq(CriticalSlot.TYPE_SYSTEM),
+              eq(Mek.SYSTEM_SENSORS),
+              eq(Mek.LOC_HEAD))).thenReturn(2);
         expected.addModifier(2, FireControl.TH_SENSORS);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         final Tank mockTank = mock(Tank.class); // Tank sensor damage is a little different.
         when(mockTank.getCrew()).thenReturn(mockCrew);
         expected = new ToHitData(mockTank.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_MEDIUM_RANGE);
         when(mockTank.getSensorHits()).thenReturn(1);
         expected.addModifier(1, FireControl.TH_SENSORS);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockTank,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
-        when(mockShooter.getBadCriticals(eq(CriticalSlot.TYPE_SYSTEM), eq(Mek.SYSTEM_SENSORS),
-                eq(Mek.LOC_HEAD))).thenReturn(0);
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockTank,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
+        when(mockShooter.getBadCriticals(eq(CriticalSlot.TYPE_SYSTEM),
+              eq(Mek.SYSTEM_SENSORS),
+              eq(Mek.LOC_HEAD))).thenReturn(0);
 
         // Test stopping swarm attacks.
         final WeaponType mockSwarmStop = mock(StopSwarmAttack.class);
-        when(mockSwarmStop.getRanges(eq(mockWeapon), any(Mounted.class)))
-                .thenReturn(new int[] { 0, 0, 0, 0, 0 });
+        when(mockSwarmStop.getRanges(eq(mockWeapon), any(Mounted.class))).thenReturn(new int[] { 0, 0, 0, 0, 0 });
         when(mockTargetState.getPosition()).thenReturn(new Coords(0, 0));
         when(mockWeapon.getType()).thenReturn(mockSwarmStop);
         when(mockShooter.getSwarmTargetId()).thenReturn(Entity.NONE); // Invalid attack.
         expected = new ToHitData(FireControl.TH_STOP_SWARM_INVALID);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockShooter.getSwarmTargetId()).thenReturn(10); // Valid attack.
         expected = new ToHitData(FireControl.TH_SWARM_STOPPED);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockWeapon.getType()).thenReturn(mockWeaponType);
         when(mockTargetState.getPosition()).thenReturn(mockTargetCoords);
 
         // Test shooting infantry at 0 range.
         when(mockTargetState.getPosition()).thenReturn(new Coords(0, 0));
         expected = new ToHitData(FireControl.TH_INF_ZERO_RNG);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         // TODO : Infantry on Infantry violence.
         when(mockTargetState.getPosition()).thenReturn(mockTargetCoords);
 
         // Test being out of range.
         when(mockTargetState.getPosition()).thenReturn(new Coords(0, 100));
         expected = new ToHitData(FireControl.TH_OUT_OF_RANGE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockTargetState.getPosition()).thenReturn(mockTargetCoords);
 
         // Test the target being out of arc.
-        doReturn(false).when(testFireControl).isInArc(any(Coords.class), anyInt(),
-                any(Coords.class), anyInt());
+        doReturn(false).when(testFireControl).isInArc(any(Coords.class), anyInt(), any(Coords.class), anyInt());
         expected = new ToHitData(FireControl.TH_WEAPON_NO_ARC);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
 
         // Test a prone mek w/ no arms.
         when(mockShooterState.isProne()).thenReturn(true);
         when(mockShooter.isLocationBad(Mek.LOC_RARM)).thenReturn(true);
         when(mockShooter.isLocationBad(Mek.LOC_LARM)).thenReturn(true);
         expected = new ToHitData(FireControl.TH_WEAPON_PRONE_ARMLESS);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         // Propping self up on firing arm.
         when(mockShooter.isLocationBad(Mek.LOC_LARM)).thenReturn(false);
         expected = new ToHitData(FireControl.TH_WEAPON_ARM_PROP);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         // Trying to fire a leg weapon.
         when(mockWeapon.getLocation()).thenReturn(Mek.LOC_LLEG);
         expected = new ToHitData(FireControl.TH_WEAPON_PRONE_LEG);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockAmmo, mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
         when(mockShooterState.isProne()).thenReturn(false);
 
         // Test a weapon that is out of ammo.
         when(mockAmmo.getUsableShotsLeft()).thenReturn(0);
         expected = new ToHitData(FireControl.TH_WEAPON_NO_AMMO);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockWeapon.getLinkedAmmo(),
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockWeapon.getLinkedAmmo(),
+                    mockGame));
         when(mockAmmo.getUsableShotsLeft()).thenReturn(10);
         when(mockWeapon.getLinkedAmmo()).thenReturn(null);
         expected = new ToHitData(FireControl.TH_WEAPON_NO_AMMO);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockWeapon.getLinkedAmmo(),
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockWeapon.getLinkedAmmo(),
+                    mockGame));
 
         // Test a weapon that cannot fire.
         when(mockWeapon.canFire()).thenReturn(false);
         expected = new ToHitData(FireControl.TH_WEAPON_CANNOT_FIRE);
-        assertToHitDataEquals(expected, testFireControl.guessToHitModifierForWeapon(mockShooter,
-                mockShooterState, mockTarget, mockTargetState, mockWeapon, mockWeapon.getLinkedAmmo(),
-                mockGame));
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockWeapon.getLinkedAmmo(),
+                    mockGame));
     }
 
     @Test
     void testGuessAirToGroundStrikeToHitModifier() {
         final MovePath mockFlightPathGood = mock(MovePath.class);
         final MovePath mockFlightPathBad = mock(MovePath.class);
-        doReturn(new ToHitData())
-                .when(testFireControl)
-                .guessToHitModifierHelperForAnyAttack(any(Entity.class), any(EntityState.class),
-                        any(Targetable.class), any(EntityState.class), anyInt(),
-                        any(Game.class));
-        doReturn(true).when(testFireControl).isTargetUnderFlightPath(any(MovePath.class),
-                any(EntityState.class));
-        doReturn(false).when(testFireControl).isTargetUnderFlightPath(eq(mockFlightPathBad),
-                any(EntityState.class));
+        doReturn(new ToHitData()).when(testFireControl)
+              .guessToHitModifierHelperForAnyAttack(any(Entity.class),
+                    any(EntityState.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    anyInt(),
+                    any(Game.class));
+        doReturn(true).when(testFireControl).isTargetUnderFlightPath(any(MovePath.class), any(EntityState.class));
+        doReturn(false).when(testFireControl).isTargetUnderFlightPath(eq(mockFlightPathBad), any(EntityState.class));
 
         final WeaponMounted mockWeapon = mock(WeaponMounted.class);
         when(mockWeapon.canFire()).thenReturn(true);
@@ -2110,39 +2643,81 @@ class FireControlTest {
         // Test the vanilla case.
         ToHitData expected = new ToHitData(mockCrew.getGunnery(), FireControl.TH_GUNNERY);
         expected.addModifier(FireControl.TH_AIR_STRIKE);
-        assertToHitDataEquals(expected, testFireControl.guessAirToGroundStrikeToHitModifier(
-                mockFighter, mockShooterState, mockTarget, mockTargetState, mockFlightPathGood,
-                mockWeapon, null, mockGame, true));
-        assertToHitDataEquals(expected, testFireControl.guessAirToGroundStrikeToHitModifier(
-                mockFighter, mockShooterState, mockTarget, mockTargetState, mockFlightPathGood,
-                mockWeapon, null, mockGame, false));
+        assertToHitDataEquals(expected,
+              testFireControl.guessAirToGroundStrikeToHitModifier(mockFighter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockFlightPathGood,
+                    mockWeapon,
+                    null,
+                    mockGame,
+                    true));
+        assertToHitDataEquals(expected,
+              testFireControl.guessAirToGroundStrikeToHitModifier(mockFighter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockFlightPathGood,
+                    mockWeapon,
+                    null,
+                    mockGame,
+                    false));
 
         // Test the target not being under our flight path.
         expected = new ToHitData(FireControl.TH_AIR_STRIKE_PATH);
-        assertToHitDataEquals(expected, testFireControl.guessAirToGroundStrikeToHitModifier(
-                mockFighter, mockShooterState, mockTarget, mockTargetState, mockFlightPathBad,
-                mockWeapon, null, mockGame, false));
+        assertToHitDataEquals(expected,
+              testFireControl.guessAirToGroundStrikeToHitModifier(mockFighter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockFlightPathBad,
+                    mockWeapon,
+                    null,
+                    mockGame,
+                    false));
 
         // Test a weapon that is out of ammo.
         when(mockAmmo.getUsableShotsLeft()).thenReturn(0);
         expected = new ToHitData(FireControl.TH_WEAPON_NO_AMMO);
-        assertToHitDataEquals(expected, testFireControl.guessAirToGroundStrikeToHitModifier(
-                mockFighter, mockShooterState, mockTarget, mockTargetState, mockFlightPathGood,
-                mockWeapon, null, mockGame, true));
+        assertToHitDataEquals(expected,
+              testFireControl.guessAirToGroundStrikeToHitModifier(mockFighter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockFlightPathGood,
+                    mockWeapon,
+                    null,
+                    mockGame,
+                    true));
 
         // Test a weapon who's ammo has been destroyed.
         when(mockWeapon.getLinked()).thenReturn(null);
         expected = new ToHitData(FireControl.TH_WEAPON_NO_AMMO);
-        assertToHitDataEquals(expected, testFireControl.guessAirToGroundStrikeToHitModifier(
-                mockFighter, mockShooterState, mockTarget, mockTargetState, mockFlightPathGood,
-                mockWeapon, null, mockGame, true));
+        assertToHitDataEquals(expected,
+              testFireControl.guessAirToGroundStrikeToHitModifier(mockFighter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockFlightPathGood,
+                    mockWeapon,
+                    null,
+                    mockGame,
+                    true));
 
         // Test a weapon unable to fire.
         when(mockWeapon.canFire()).thenReturn(false);
         expected = new ToHitData(FireControl.TH_WEAPON_CANNOT_FIRE);
-        assertToHitDataEquals(expected, testFireControl.guessAirToGroundStrikeToHitModifier(
-                mockFighter, mockShooterState, mockTarget, mockTargetState, mockFlightPathGood,
-                mockWeapon, null, mockGame, true));
+        assertToHitDataEquals(expected,
+              testFireControl.guessAirToGroundStrikeToHitModifier(mockFighter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockFlightPathGood,
+                    mockWeapon,
+                    null,
+                    mockGame,
+                    true));
     }
 
     @Test
@@ -2182,21 +2757,32 @@ class FireControlTest {
         FiringPlan expected = new FiringPlan(mockTarget);
         expected.add(mockPPCFireInfo);
         expected.add(mockLRMFireInfo);
-        final FiringPlan actual = testFireControl.guessFullFiringPlan(mockShooter, mockShooterState,
-                mockTarget, mockTargetState, mockGame);
+        final FiringPlan actual = testFireControl.guessFullFiringPlan(mockShooter,
+              mockShooterState,
+              mockTarget,
+              mockTargetState,
+              mockGame);
         assertEquals(new HashSet<>(expected), new HashSet<>(actual));
 
         // Test the target not being on the board.
         when(mockTarget.getPosition()).thenReturn(null);
         expected = new FiringPlan(mockTarget);
-        assertEquals(expected, testFireControl.guessFullFiringPlan(mockShooter, mockShooterState,
-                mockTarget, mockTargetState, mockGame));
+        assertEquals(expected,
+              testFireControl.guessFullFiringPlan(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockGame));
 
         // Test the shooter not being on the board.
         when(mockShooter.getPosition()).thenReturn(null);
         expected = new FiringPlan(mockTarget);
-        assertEquals(expected, testFireControl.guessFullFiringPlan(mockShooter, mockShooterState,
-                mockTarget, mockTargetState, mockGame));
+        assertEquals(expected,
+              testFireControl.guessFullFiringPlan(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockGame));
     }
 
     @Test
@@ -2220,22 +2806,35 @@ class FireControlTest {
         expected = new FiringPlan(mockTarget);
         expected.add(mockPPCFireInfo);
         expected.add(mockLRMFireInfo);
-        final FiringPlan actual = testFireControl.guessFullAirToGroundPlan(mockShooter, mockTarget,
-                mockTargetState,
-                mockFlightPath, mockGame, true);
+        final FiringPlan actual = testFireControl.guessFullAirToGroundPlan(mockShooter,
+              mockTarget,
+              mockTargetState,
+              mockFlightPath,
+              mockGame,
+              true);
         assertEquals(new HashSet<>(expected), new HashSet<>(actual));
 
         // test the target not being on the board.
         when(mockTarget.getPosition()).thenReturn(null);
         expected = new FiringPlan(mockTarget);
-        assertEquals(expected, testFireControl.guessFullAirToGroundPlan(mockShooter, mockTarget,
-                mockTargetState, mockFlightPath, mockGame, true));
+        assertEquals(expected,
+              testFireControl.guessFullAirToGroundPlan(mockShooter,
+                    mockTarget,
+                    mockTargetState,
+                    mockFlightPath,
+                    mockGame,
+                    true));
 
         // Test the shooter not being on the board.
         when(mockShooter.getPosition()).thenReturn(null);
         expected = new FiringPlan(mockTarget);
-        assertEquals(expected, testFireControl.guessFullAirToGroundPlan(mockShooter, mockTarget,
-                mockTargetState, mockFlightPath, mockGame, true));
+        assertEquals(expected,
+              testFireControl.guessFullAirToGroundPlan(mockShooter,
+                    mockTarget,
+                    mockTargetState,
+                    mockFlightPath,
+                    mockGame,
+                    true));
     }
 
     private void prepForFullFiringPlan(List<WeaponMounted> wepList, List<AmmoMounted> ammoList) {
@@ -2271,30 +2870,32 @@ class FireControlTest {
         FiringPlan expected = new FiringPlan(mockTarget);
         expected.add(mockPPCFireInfo);
         expected.add(mockLRMFireInfo);
-        final FiringPlan actual = testFireControl.getFullFiringPlan(mockShooter, mockTarget,
-                testToHitThreshold, mockGame);
+        final FiringPlan actual = testFireControl.getFullFiringPlan(mockShooter,
+              mockTarget,
+              testToHitThreshold,
+              mockGame);
         assertEquals(new HashSet<>(expected), new HashSet<>(actual));
 
         // test the target not being on the board.
         when(mockTarget.getPosition()).thenReturn(null);
         expected = new FiringPlan(mockTarget);
-        assertEquals(expected, testFireControl.getFullFiringPlan(mockShooter, mockTarget,
-                testToHitThreshold, mockGame));
+        assertEquals(expected,
+              testFireControl.getFullFiringPlan(mockShooter, mockTarget, testToHitThreshold, mockGame));
         when(mockTarget.getPosition()).thenReturn(mockTargetCoords);
 
         // Test the shooter not being on the board.
         when(mockShooter.getPosition()).thenReturn(null);
         expected = new FiringPlan(mockTarget);
-        assertEquals(expected, testFireControl.getFullFiringPlan(mockShooter, mockTarget,
-                testToHitThreshold, mockGame));
+        assertEquals(expected,
+              testFireControl.getFullFiringPlan(mockShooter, mockTarget, testToHitThreshold, mockGame));
         when(mockShooter.getPosition()).thenReturn(mockShooterCoords);
 
         // Test the LRMs not having a good enough chance to hit.
         testToHitThreshold.put(mockLRM5, 1.0);
         expected = new FiringPlan(mockTarget);
         expected.add(mockPPCFireInfo);
-        assertEquals(expected, testFireControl.getFullFiringPlan(mockShooter, mockTarget,
-                testToHitThreshold, mockGame));
+        assertEquals(expected,
+              testFireControl.getFullFiringPlan(mockShooter, mockTarget, testToHitThreshold, mockGame));
         testToHitThreshold.put(mockLRM5, 0.0);
     }
 
@@ -2308,8 +2909,10 @@ class FireControlTest {
         // Should get the plan back with an LRM5 shot
         FiringPlan expected = new FiringPlan(mockTarget);
         expected.add(mockMMLLRM5FireInfo);
-        final FiringPlan actual = testFireControl.getFullFiringPlan(mockShooter, mockTarget,
-                testToHitThreshold, mockGame);
+        final FiringPlan actual = testFireControl.getFullFiringPlan(mockShooter,
+              mockTarget,
+              testToHitThreshold,
+              mockGame);
         assertEquals(new HashSet<>(expected), new HashSet<>(actual));
     }
 
@@ -2326,38 +2929,44 @@ class FireControlTest {
         // Should get the plan back with an SRM5 shot
         FiringPlan expected = new FiringPlan(mockTarget);
         expected.add(mockMMLSRM5FireInfo);
-        final FiringPlan actual = testFireControl.getFullFiringPlan(mockShooter, mockTarget,
-                testToHitThreshold, mockGame);
+        final FiringPlan actual = testFireControl.getFullFiringPlan(mockShooter,
+              mockTarget,
+              testToHitThreshold,
+              mockGame);
         assertEquals(new HashSet<>(expected), new HashSet<>(actual));
     }
 
     @Test
     void testChooseLBXAmmoForEngagingFlyer() {
         ArrayList<WeaponMounted> wepList = new ArrayList<>(Arrays.asList(mockWeaponLB10X));
-        ArrayList<AmmoMounted> ammoList = new ArrayList<>(
-                Arrays.asList(mockAmmoLB10XSlug, mockAmmoLB10XCluster));
+        ArrayList<AmmoMounted> ammoList = new ArrayList<>(Arrays.asList(mockAmmoLB10XSlug, mockAmmoLB10XCluster));
         prepForFullFiringPlan(wepList, ammoList);
 
         // Should get the plan back with a Cluster shot
         FiringPlan expected = new FiringPlan(mockTarget);
         expected.add(mockLB10XClusterFireInfo);
-        final FiringPlan actual = testFireControl.getFullFiringPlan(mockShooter, mockTarget,
-                testToHitThreshold, mockGame);
+        final FiringPlan actual = testFireControl.getFullFiringPlan(mockShooter,
+              mockTarget,
+              testToHitThreshold,
+              mockGame);
         assertEquals(new HashSet<>(expected), new HashSet<>(actual));
     }
 
     @Test
     void testChooseACAmmoForEngagingFlyer() {
         ArrayList<WeaponMounted> wepList = new ArrayList<>(Arrays.asList(mockWeaponAC5));
-        ArrayList<AmmoMounted> ammoList = new ArrayList<>(Arrays.asList(
-                mockAmmoAC5Std, mockAmmoAc5Incendiary, mockAmmoAC5Flak));
+        ArrayList<AmmoMounted> ammoList = new ArrayList<>(Arrays.asList(mockAmmoAC5Std,
+              mockAmmoAc5Incendiary,
+              mockAmmoAC5Flak));
         prepForFullFiringPlan(wepList, ammoList);
 
         // Should get the plan back with a Cluster shot
         FiringPlan expected = new FiringPlan(mockTarget);
         expected.add(mockAC5FlakFireInfo);
-        final FiringPlan actual = testFireControl.getFullFiringPlan(mockShooter, mockTarget,
-                testToHitThreshold, mockGame);
+        final FiringPlan actual = testFireControl.getFullFiringPlan(mockShooter,
+              mockTarget,
+              testToHitThreshold,
+              mockGame);
         assertEquals(new HashSet<>(expected), new HashSet<>(actual));
     }
 
@@ -2498,18 +3107,18 @@ class FireControlTest {
         for (int i = 0; i < expected.length; i++) {
             if ((null == expected[i]) && (null != actualArray[i])) {
                 failure.append("\nExpected[").append(i).append("]: null");
-                failure.append("\nActual[").append(i).append("]:   ")
-                        .append(actualArray[i].getDebugDescription(true));
+                failure.append("\nActual[").append(i).append("]:   ").append(actualArray[i].getDebugDescription(true));
                 continue;
             }
             if (!expected[i].equals(actualArray[i])) {
-                failure.append("\nExpected[").append(i).append("]: ")
-                        .append(expected[i].getDebugDescription(true));
+                failure.append("\nExpected[").append(i).append("]: ").append(expected[i].getDebugDescription(true));
                 if (null == actualArray[i]) {
                     failure.append("\nActual[").append(i).append("]:   null");
                 } else {
-                    failure.append("\nActual[").append(i).append("]:   ")
-                            .append(actualArray[i].getDebugDescription(true));
+                    failure.append("\nActual[")
+                          .append(i)
+                          .append("]:   ")
+                          .append(actualArray[i].getDebugDescription(true));
                 }
             }
         }
@@ -2520,8 +3129,8 @@ class FireControlTest {
     }
 
     /**
-     * Test to make sure that Princess will choose a FiringPlan that shoots at
-     * a MekWarrior, instead of choosing to do nothing.
+     * Test to make sure that Princess will choose a FiringPlan that shoots at a MekWarrior, instead of choosing to do
+     * nothing.
      */
     @Test
     void testCalcFiringPlansAtMekWarrior() {
@@ -2543,8 +3152,10 @@ class FireControlTest {
         when(mockShooter.getPosition()).thenReturn(mockShooterCoords);
         when(mockTarget.getPosition()).thenReturn(mockTargetCoords);
         when(mockShooter.getWeaponList()).thenReturn(shooterWeapons);
-        final FiringPlan plan = testFireControl.getBestFiringPlan(mockShooter, mockTarget, mockGame,
-                testToHitThreshold);
+        final FiringPlan plan = testFireControl.getBestFiringPlan(mockShooter,
+              mockTarget,
+              mockGame,
+              testToHitThreshold);
         assertFalse(0.00001 > Math.abs(0 - plan.getUtility()), "Expected not 0.0.  Got " + plan.getUtility());
     }
 }

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -19,6 +19,22 @@
  */
 package megamek.client.bot.princess;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import megamek.client.bot.princess.PathRanker.PathRankerType;
 import megamek.common.*;
 import megamek.common.enums.GamePhase;
@@ -29,14 +45,6 @@ import megamek.common.planetaryconditions.PlanetaryConditions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
 
 /**
  * @author Deric "Netzilla" Page (deric dot page at usa dot net)
@@ -104,7 +112,9 @@ class PrincessTest {
         when(mockPrincess.calculateMoveIndex(any(Entity.class), any(StringBuilder.class))).thenCallRealMethod();
         when(mockPrincess.isFallingBack(any(Entity.class))).thenReturn(false);
 
-        when(mockPathRanker.distanceToClosestEnemy(any(Entity.class), nullable(Coords.class), nullable(Game.class))).thenReturn(10.0);
+        when(mockPathRanker.distanceToClosestEnemy(any(Entity.class),
+              nullable(Coords.class),
+              nullable(Game.class))).thenReturn(10.0);
 
         // Test a 6/9/6 regular mek.
         Entity mockMek = mock(BipedMek.class);
@@ -492,7 +502,13 @@ class PrincessTest {
         when(mockMek.checkGetUp(any(MoveStep.class), any(EntityMovementType.class))).thenReturn(mockPilotingRollData);
         when(mockMek.getPosition()).thenReturn(mockPosition);
         when(mockMek.getPriorPosition()).thenReturn(mockPriorPosition);
-        when(mockMek.checkBogDown(any(MoveStep.class), any(EntityMovementType.class), eq(mockHex), eq(mockPriorPosition), eq(mockPosition), anyInt(), anyBoolean())).thenReturn(mockPilotingRollData);
+        when(mockMek.checkBogDown(any(MoveStep.class),
+              any(EntityMovementType.class),
+              eq(mockHex),
+              eq(mockPriorPosition),
+              eq(mockPosition),
+              anyInt(),
+              anyBoolean())).thenReturn(mockPilotingRollData);
         assertFalse(mockPrincess.isImmobilized(mockMek));
 
         // Test a shutdown mek.


### PR DESCRIPTION
This PR updated the Packet Class with type specific getters in both single (nullable) form and collection form. The old `getObject` method has been deprecated for purposes of facilitating this with the intention of making it private only.

`getObject` was adjusted to include out of bounds checking on the internal data array.

All other new methods include `instanceof` checking before either returning the value or creating an internal collection and returning it.