### PR TITLE
Fixes for various Artillery and Artillery Flak issues

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -4148,6 +4148,7 @@ WeaponAttackAction.LegBlockedByTerrain=Nearby terrain blocks leg weapons.
 WeaponAttackAction.MinimumAlt1=attacker must be at least at elevation 1
 WeaponAttackAction.NoAeroDirectArty=Airborne aerospace units cannot make direct-fire artillery attacks.
 WeaponAttackAction.FlakOnGroundedAero=Grounded aerospace/vtol units are not valid Flak targets.
+WeaponAttackAction.FlakIndirect=Flak Artillery attacks must be Direct Attacks
 WeaponAttackAction.ADARangeBracket=ADA range brackets (+0/+2/+4)
 WeaponAttackAction.NoAttacker=Invalid Attacker!
 WeaponAttackAction.NoBombInMekMode=Cannot launch bomb in mek mode.

--- a/megamek/i18n/megamek/common/report-messages.properties
+++ b/megamek/i18n/megamek/common/report-messages.properties
@@ -432,6 +432,7 @@
 3383=Terrain burns for <data> damage.
 3384=Hex <data>: terrain takes <data> damage.
 3385=Terrain takes <data> damage.
+3386=Hex <data>: terrain takes <data> damage at level <data>.
 3390=<span class='success'><B>hits</B></span>.
 3395=However, <data> (<data>) has fire protection gear so no damage is done.
 3400=Target gains <data> <msg:3401,3402> heat during heat phase.
@@ -449,6 +450,7 @@
 3426=The remaining <data> missile(s) find no new target due to hostile ECM interference.
 3430=Needs <data> [<data>] to ignite, rolls <data>
 3433=-2 bonus for laser-guided bomb against tagged target!
+3434=<data><data><data> points of damage at level <data>.
 3435=<data><data><data> points of damage.
 3436=<newline><data> points absorbed by armor. <data> armor remaining.
 3437=<newline>Damage changed to <data> due to building scale.

--- a/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
+++ b/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
@@ -429,10 +429,7 @@ public class ArtilleryTargetingControl {
         // coordinates, which indicates there's nothing worth shooting at
         // or we have a 1+ top valued coordinates.
         // Track ADA and Flak WFIs separately.
-        EnumSet<AmmoType.Munitions> aaMunitions = EnumSet.of(
-              AmmoType.Munitions.M_CLUSTER,
-              AmmoType.Munitions.M_FLAK);
-        List<WeaponFireInfo> topValuedADAInfos = new ArrayList<>();
+        EnumSet<AmmoType.Munitions> aaMunitions = EnumSet.of(AmmoType.Munitions.M_CLUSTER, AmmoType.Munitions.M_FLAK);
         List<WeaponFireInfo> topValuedFlakInfos = new ArrayList<>();
         for (WeaponMounted currentWeapon : shooter.getWeaponList()) {
             List<WeaponFireInfo> topValuedFireInfos = new ArrayList<>();
@@ -501,11 +498,7 @@ public class ArtilleryTargetingControl {
                                 } else {
                                     wfi.getAmmo().setSwitchedReason(1503);
                                 }
-                                if (isADA) {
-                                    topValuedADAInfos.clear();
-                                    maxDamage = damage; // Actual expected damage will be higher
-                                    topValuedADAInfos.add(wfi);
-                                } else if (wfi.getAmmo().getType().getMunitionType().stream().anyMatch(aaMunitions::contains)
+                                if (isADA || wfi.getAmmo().getType().getMunitionType().stream().anyMatch(aaMunitions::contains)
                                               || wfi.getAmmo().getType().countsAsFlak()) {
                                     // Handle Flak attacks during Direct Fire
                                     topValuedFlakInfos.clear();
@@ -518,8 +511,9 @@ public class ArtilleryTargetingControl {
                                 }
                             } else if ((damageValue == maxDamage) && (damageValue > 0)) {
                                 if (wfi.getAmmo().getType().getMunitionType()
-                                        .contains(Munitions.M_ADA)) {
-                                    topValuedADAInfos.add(wfi);
+                                        .contains(Munitions.M_ADA) || wfi.getAmmo().getType().getMunitionType().stream().anyMatch(aaMunitions::contains)
+                                          || wfi.getAmmo().getType().countsAsFlak()) {
+                                    topValuedFlakInfos.add(wfi);
                                 } else {
                                     topValuedFireInfos.add(wfi);
                                 }
@@ -581,9 +575,8 @@ public class ArtilleryTargetingControl {
 
         // Clear all artillery attacks if we have valid ADA or Flak attacks that do damage, but
         // keep any TAG attacks.
-        if (!topValuedADAInfos.isEmpty()) {
-            if ((topValuedADAInfos.get(0).getExpectedDamage() > 0)
-                || (topValuedFlakInfos.get(0).getExpectedDamage() > 0)) {
+        if (!topValuedFlakInfos.isEmpty()) {
+            if (topValuedFlakInfos.get(0).getExpectedDamage() > 0) {
                 returnValue = TAGPlan;
             }
         } else {

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -297,8 +297,7 @@ public class FireControl {
             targetState = new EntityState(target);
         }
 
-        // Can't shoot if one of us is not on the board.
-        // todo exception for off-board artillery.
+        // Can't shoot if one of us has not got a position (n.b.: off-board units have positions, but not hexes).
         if ((null == shooterState.getPosition()) || (null == targetState.getPosition())) {
             return new ToHitData(TH_NULL_POSITION);
         }

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -1207,6 +1207,11 @@ public class Compute {
             te = (Entity) target;
         }
 
+        // No _standard_ range mods for Artillery Flak or ADA vs airborne Aerospace or VTOL/WiGE
+        if (wtype.hasFlag(WeaponType.F_ARTILLERY) && (target.isAirborne() || target.isAirborneVTOLorWIGE())) {
+            return mods;
+        }
+
         // We need to adjust the ranges for Centurion Weapon Systems: it's
         // default range is 6/12/18 but that's only for units that are
         // susceptible to CWS, for those that aren't the ranges are 1/2/3

--- a/megamek/src/megamek/common/actions/ArtilleryAttackAction.java
+++ b/megamek/src/megamek/common/actions/ArtilleryAttackAction.java
@@ -41,15 +41,18 @@ public class ArtilleryAttackAction extends WeaponAttackAction implements Seriali
         this.playerId = game.getEntity(entityId).getOwnerId();
         this.firingCoords = game.getEntity(entityId).getPosition();
         int distance;
+        Targetable target = getTarget(game);
         EquipmentType eType = getEntity(game).getEquipment(weaponId).getType();
         WeaponType wType = (WeaponType) eType;
         WeaponMounted mounted = (WeaponMounted) getEntity(game).getEquipment(weaponId);
         // Remove altitude from Artillery Flak and ADA distance calcs
-        if (mounted.getLinkedAmmo() != null && mounted.getLinkedAmmo().getType().countsAsFlak()) {
+        if ((target != null) && target.isAirborne() && (mounted.getLinkedAmmo() != null)
+                  && mounted.getLinkedAmmo().getType().countsAsFlak())
+        {
             turnsTilHit = 0;
             return;
         } else {
-            distance = Compute.effectiveDistance(game, getEntity(game), getTarget(game));
+            distance = Compute.effectiveDistance(game, getEntity(game), target);
         }
 
         if (getEntity(game).usesWeaponBays() && wType.getAtClass() == WeaponType.CLASS_ARTILLERY) {

--- a/megamek/src/megamek/common/actions/ArtilleryAttackAction.java
+++ b/megamek/src/megamek/common/actions/ArtilleryAttackAction.java
@@ -40,13 +40,18 @@ public class ArtilleryAttackAction extends WeaponAttackAction implements Seriali
         super(entityId, targetType, targetId, weaponId);
         this.playerId = game.getEntity(entityId).getOwnerId();
         this.firingCoords = game.getEntity(entityId).getPosition();
-        int distance = Compute.effectiveDistance(game, getEntity(game), getTarget(game));
-        // TODO: replace this as it is completely wrong; see TO:AR pg 155
-        // Should be leaving distance alone as gravity only applies to _artillery range bands_, not actual distance
-        // distance = (int) Math.floor((double) distance / game.getPlanetaryConditions().getGravity());
+        int distance;
         EquipmentType eType = getEntity(game).getEquipment(weaponId).getType();
         WeaponType wType = (WeaponType) eType;
         WeaponMounted mounted = (WeaponMounted) getEntity(game).getEquipment(weaponId);
+        // Remove altitude from Artillery Flak and ADA distance calcs
+        if (mounted.getLinkedAmmo() != null && mounted.getLinkedAmmo().getType().countsAsFlak()) {
+            turnsTilHit = 0;
+            return;
+        } else {
+            distance = Compute.effectiveDistance(game, getEntity(game), getTarget(game));
+        }
+
         if (getEntity(game).usesWeaponBays() && wType.getAtClass() == WeaponType.CLASS_ARTILLERY) {
             for (WeaponMounted bayW : mounted.getBayWeapons()) {
                 WeaponType bayWType = bayW.getType();

--- a/megamek/src/megamek/common/actions/ArtilleryAttackAction.java
+++ b/megamek/src/megamek/common/actions/ArtilleryAttackAction.java
@@ -41,8 +41,9 @@ public class ArtilleryAttackAction extends WeaponAttackAction implements Seriali
         this.playerId = game.getEntity(entityId).getOwnerId();
         this.firingCoords = game.getEntity(entityId).getPosition();
         int distance = Compute.effectiveDistance(game, getEntity(game), getTarget(game));
-        // adjust distance for gravity
-        distance = (int) Math.floor((double) distance / game.getPlanetaryConditions().getGravity());
+        // TODO: replace this as it is completely wrong; see TO:AR pg 155
+        // Should be leaving distance alone as gravity only applies to _artillery range bands_, not actual distance
+        // distance = (int) Math.floor((double) distance / game.getPlanetaryConditions().getGravity());
         EquipmentType eType = getEntity(game).getEquipment(weaponId).getType();
         WeaponType wType = (WeaponType) eType;
         WeaponMounted mounted = (WeaponMounted) getEntity(game).getEquipment(weaponId);

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -2308,7 +2308,11 @@ public class WeaponAttackAction extends AbstractAttackAction {
                         return Messages.getString("WeaponAttackAction.TooShortForDirectArty");
                     }
                     // ...or more than 17 hexes
-                    if (distance > Board.DEFAULT_BOARD_HEIGHT) {
+                    if (!(target.isAirborne()) && distance > Board.DEFAULT_BOARD_HEIGHT) {
+                        return Messages.getString("WeaponAttackAction.TooLongForDirectArty");
+                    }
+                    // Artillery Flak targeting Aerospace ignores altitude when computing range
+                    if (target.isAirborne() && ae.getPosition().distance(target.getPosition()) > Board.DEFAULT_BOARD_HEIGHT) {
                         return Messages.getString("WeaponAttackAction.TooLongForDirectArty");
                     }
                 }
@@ -5510,7 +5514,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
             // Per TW pg 114, all other mods _should_ be included.
 
             // Special range calc
-            int distance = Compute.effectiveDistance(game, ae, target);
+            int distance = ae.getPosition().distance(target.getPosition());
             toHit.addModifier(Compute.getADARangeModifier(distance),
                   Messages.getString("WeaponAttackAction.ADARangeBracket"));
 

--- a/megamek/src/megamek/common/weapons/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/AreaEffectHelper.java
@@ -370,6 +370,8 @@ public class AreaEffectHelper {
             toHit.setHitTable(ToHitData.HIT_SPECIAL_PROTO);
         }
         int cluster = 5;
+        int effectiveLevel = (hex != null) ? hex.getLevel() : 0;
+        int entityLevel = (entity.isAirborne()) ? entity.getAltitude() : entity.getElevation() + effectiveLevel;
 
         // Check: is entity inside building?
         if ((bldg != null) && (bldgAbsorbs > 0) && hex != null
@@ -402,6 +404,7 @@ public class AreaEffectHelper {
         }
 
         // Flak should only hit VTOLs or similar craft.
+        // Correct elevation/altitude checks should happen elsewhere
         if (flak) {
             // Check: is entity not a VTOL in flight or an ASF
             if (!((entity instanceof VTOL)
@@ -409,11 +412,11 @@ public class AreaEffectHelper {
                 || entity.isAero())) {
                 return;
             }
-            // Check: is entity at correct elevation?
-            if (entity.getElevation() != altitude) {
+            // "Altitude" here is either true Altitude (Aerospace) or objective levels from 0;
+            // entityLevel will then either be Altitude or hex level + elevation
+            if (entityLevel != altitude) {
                 return;
             }
-            // But VTOLs can also be hit by AE blasts while flying!
         }
 
         // Work out hit table to use

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
@@ -321,6 +321,9 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
 
         // In the case of misses, we'll need to hit multiple hexes
         List<Coords> targets = new ArrayList<>();
+        List<Integer> altitudes = new ArrayList<>();
+        Hex targetHex = null;
+
         if (!bMissed) {
             r = new Report(3199);
             r.subject = subjectId;
@@ -331,6 +334,8 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
             if (!mineClear) {
                 vPhaseReport.addElement(r);
             }
+            targetHex = game.getBoard().getHex(targetPos);
+            altitudes.add((targetHex != null) ? game.getBoard().getHex(targetPos).getLevel() : 0);
             artyMsg = "Artillery hit here on round " + game.getRoundCount()
                     + ", fired by " + game.getPlayer(aaa.getPlayerId()).getName()
                     + " (this hex is now an auto-hit)";
@@ -362,6 +367,16 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
                 targetPos = Compute.scatterDirectArty(origPos, moF);
                 if (game.getBoard().contains(targetPos)) {
                     targets.add(targetPos);
+                    targetHex = game.getBoard().getHex(targetPos);
+                    if (targetHex != null) {
+                        altitudes.add(
+                              (isFlak) ? (
+                                    (asfFlak) ? target.getAltitude() : targetHex.getLevel() + target.getElevation()
+                              ) : targetHex.getLevel()
+                        );
+                    } else {
+                        altitudes.add(0);
+                    }
                     // misses and scatters to another hex
                     if (!isFlak) {
                         r = new Report(3202);
@@ -502,10 +517,6 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
             }
             return false;
         }
-        int altitude = 0;
-        if (isFlak) {
-            altitude = target.getElevation();
-        }
 
         // check to see if this is a mine clearing attack
         // According to the RAW you have to hit the right hex to hit even if the
@@ -549,13 +560,17 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
             // Here we're doing damage for each hit with more standard artillery shells
             while (nweaponsHit > 0) {
                 gameManager.artilleryDamageArea(targetPos, aaa.getCoords(), atype,
-                        subjectId, ae, isFlak, altitude, mineClear, vPhaseReport,
+                        subjectId, ae, isFlak, altitudes.get(0), mineClear, vPhaseReport,
                         asfFlak);
                 nweaponsHit--;
             }
         } else {
             // Now if we missed, resolve a strike on each scatter hex
-            for (Coords c : targets) {
+            Coords c;
+            int altitude;
+            for (int index=0;index<targets.size();index++) {
+                c = targets.get(index);
+                altitude = altitudes.get(index);
                 // Accidental mine clearance...
                 if (!mineClear && game.containsMinefield(c)) {
                     Enumeration<Minefield> minefields = game.getMinefields(c).elements();

--- a/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryBayWeaponIndirectFireHandler.java
@@ -321,7 +321,7 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
 
         // In the case of misses, we'll need to hit multiple hexes
         List<Coords> targets = new ArrayList<>();
-        List<Integer> altitudes = new ArrayList<>();
+        List<Integer> heights = new ArrayList<>();
         Hex targetHex = null;
 
         if (!bMissed) {
@@ -335,7 +335,7 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
                 vPhaseReport.addElement(r);
             }
             targetHex = game.getBoard().getHex(targetPos);
-            altitudes.add((targetHex != null) ? game.getBoard().getHex(targetPos).getLevel() : 0);
+            heights.add((targetHex != null) ? game.getBoard().getHex(targetPos).getLevel() : 0);
             artyMsg = "Artillery hit here on round " + game.getRoundCount()
                     + ", fired by " + game.getPlayer(aaa.getPlayerId()).getName()
                     + " (this hex is now an auto-hit)";
@@ -369,13 +369,13 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
                     targets.add(targetPos);
                     targetHex = game.getBoard().getHex(targetPos);
                     if (targetHex != null) {
-                        altitudes.add(
+                        heights.add(
                               (isFlak) ? (
                                     (asfFlak) ? target.getAltitude() : targetHex.getLevel() + target.getElevation()
                               ) : targetHex.getLevel()
                         );
                     } else {
-                        altitudes.add(0);
+                        heights.add(0);
                     }
                     // misses and scatters to another hex
                     if (!isFlak) {
@@ -560,17 +560,17 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
             // Here we're doing damage for each hit with more standard artillery shells
             while (nweaponsHit > 0) {
                 gameManager.artilleryDamageArea(targetPos, aaa.getCoords(), atype,
-                        subjectId, ae, isFlak, altitudes.get(0), mineClear, vPhaseReport,
+                        subjectId, ae, isFlak, heights.get(0), mineClear, vPhaseReport,
                         asfFlak);
                 nweaponsHit--;
             }
         } else {
             // Now if we missed, resolve a strike on each scatter hex
             Coords c;
-            int altitude;
+            int height;
             for (int index=0;index<targets.size();index++) {
                 c = targets.get(index);
-                altitude = altitudes.get(index);
+                height = heights.get(index);
                 // Accidental mine clearance...
                 if (!mineClear && game.containsMinefield(c)) {
                     Enumeration<Minefield> minefields = game.getMinefields(c).elements();
@@ -587,7 +587,7 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
                 }
                 handleArtilleryDriftMarker(origPos, c, aaa,
                         gameManager.artilleryDamageArea(c, aaa.getCoords(), atype, subjectId, ae, isFlak,
-                                altitude, mineClear, vPhaseReport, asfFlak));
+                                height, mineClear, vPhaseReport, asfFlak));
             }
 
         }

--- a/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
@@ -48,6 +48,7 @@ public class ArtilleryCannonWeaponHandler extends AmmoWeaponHandler {
         }
 
         Coords targetPos = target.getPosition();
+        Hex targetHex = game.getBoard().getHex(targetPos);
         boolean targetIsEntity = target.getTargetType() == Targetable.TYPE_ENTITY;
         boolean isFlak = targetIsEntity && Compute.isFlakAttack(ae, (Entity) target);
         boolean asfFlak = isFlak && target.isAirborne();
@@ -154,6 +155,13 @@ public class ArtilleryCannonWeaponHandler extends AmmoWeaponHandler {
             }
         }
 
+        int altitude = ((targetHex != null) ? targetHex.getLevel() : 0);
+        if (asfFlak) {
+            altitude = target.getAltitude();
+        } else if (isFlak) {
+            altitude += target.getElevation();
+        }
+
         // According to TacOps eratta, artillery cannons can only fire standard
         // rounds and fuel-air cannon shells (Interstellar Ops p165).
         // But, they're still in as unofficial tech, because they're fun. :)
@@ -188,31 +196,18 @@ public class ArtilleryCannonWeaponHandler extends AmmoWeaponHandler {
                 // Currently Artillery Cannons _can_ make Flak attacks using FAE munitions
                 // If this is an ASF Flak attack we know we hit an entity by itself in the air,
                 // so just hit it for full damage.
-                int height = target.getElevation();
-                if (target instanceof HexTarget) {
-                    Board board = game.getBoard();
-                    if (board.contains(targetPos)) {
-                        height = board.getHex(targetPos).getLevel();
-                    }
-                }
-
                 if (asfFlak) {
                     AreaEffectHelper.artilleryDamageEntity((Entity) target, ammoType.getRackSize(), null,
-                            0, false, asfFlak, isFlak, height,
+                            0, false, asfFlak, isFlak, altitude,
                             targetPos, atype, targetPos, false, ae, null, getAttackerId(),
                             vPhaseReport, gameManager);
                 } else {
-                    AreaEffectHelper.processFuelAirDamage(targetPos, height,
+                    AreaEffectHelper.processFuelAirDamage(targetPos, altitude,
                             ammoType, ae, vPhaseReport, gameManager);
                 }
 
                 return false;
             }
-        }
-
-        int altitude = 0;
-        if (isFlak) {
-            altitude = target.getElevation();
         }
 
         // check to see if this is a mine clearing attack

--- a/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryCannonWeaponHandler.java
@@ -155,11 +155,11 @@ public class ArtilleryCannonWeaponHandler extends AmmoWeaponHandler {
             }
         }
 
-        int altitude = ((targetHex != null) ? targetHex.getLevel() : 0);
+        int height = ((targetHex != null) ? targetHex.getLevel() : 0);
         if (asfFlak) {
-            altitude = target.getAltitude();
+            height = target.getAltitude();
         } else if (isFlak) {
-            altitude += target.getElevation();
+            height += target.getElevation();
         }
 
         // According to TacOps eratta, artillery cannons can only fire standard
@@ -198,11 +198,11 @@ public class ArtilleryCannonWeaponHandler extends AmmoWeaponHandler {
                 // so just hit it for full damage.
                 if (asfFlak) {
                     AreaEffectHelper.artilleryDamageEntity((Entity) target, ammoType.getRackSize(), null,
-                            0, false, asfFlak, isFlak, altitude,
+                            0, false, asfFlak, isFlak, height,
                             targetPos, atype, targetPos, false, ae, null, getAttackerId(),
                             vPhaseReport, gameManager);
                 } else {
-                    AreaEffectHelper.processFuelAirDamage(targetPos, altitude,
+                    AreaEffectHelper.processFuelAirDamage(targetPos, height,
                             ammoType, ae, vPhaseReport, gameManager);
                 }
 
@@ -226,7 +226,7 @@ public class ArtilleryCannonWeaponHandler extends AmmoWeaponHandler {
         }
 
         gameManager.artilleryDamageArea(targetPos, ae.getPosition(), ammoType,
-                subjectId, ae, isFlak, altitude, mineClear, vPhaseReport,
+                subjectId, ae, isFlak, height, mineClear, vPhaseReport,
                 asfFlak);
 
         // artillery may unintentionally clear minefields, but only if it wasn't trying

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -307,9 +307,9 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
         if (finalHex != null) {
             if (targetIsEntity) {
                 if (!isFlak && !bMissed) {
-                    altitude = target.getElevation();
+                    altitude = finalHex.getLevel() + target.getElevation();
                 } else if (isFlak) {
-                    altitude = (asfFlak) ? target.getAltitude() : target.getElevation();
+                    altitude = (asfFlak) ? target.getAltitude() : finalHex.getLevel() + target.getElevation();
                 }
             } else {
                 altitude = finalHex.getLevel();

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -303,8 +303,17 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
         }
 
         int altitude = 0;
-        if (isFlak) {
-            altitude = target.getElevation();
+        Hex finalHex = game.getBoard().getHex(finalPos);
+        if (finalHex != null) {
+            if (targetIsEntity) {
+                if (!isFlak && !bMissed) {
+                    altitude = target.getElevation();
+                } else if (isFlak) {
+                    altitude = (asfFlak) ? target.getAltitude() : target.getElevation();
+                }
+            } else {
+                altitude = finalHex.getLevel();
+            }
         }
 
         // if attacker is an off-board artillery piece, check to see if we need to set
@@ -322,8 +331,6 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
         }
 
         if (atype.getMunitionType().contains(Munitions.M_FAE)) {
-            Hex finalHex = game.getBoard().getHex(finalPos);
-            altitude = (finalHex != null) ? finalHex.getLevel() : altitude;
             handleArtilleryDriftMarker(targetPos, finalPos, aaa,
                     AreaEffectHelper.processFuelAirDamage(
                             finalPos, altitude, atype, aaa.getEntity(game), vPhaseReport, gameManager));

--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -302,17 +302,18 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
             return false;
         }
 
-        int altitude = 0;
+        // Absolute level / altitude, for blast calculations
+        int height = 0;
         Hex finalHex = game.getBoard().getHex(finalPos);
         if (finalHex != null) {
             if (targetIsEntity) {
                 if (!isFlak && !bMissed) {
-                    altitude = finalHex.getLevel() + target.getElevation();
+                    height = finalHex.getLevel() + target.getElevation();
                 } else if (isFlak) {
-                    altitude = (asfFlak) ? target.getAltitude() : finalHex.getLevel() + target.getElevation();
+                    height = (asfFlak) ? target.getAltitude() : finalHex.getLevel() + target.getElevation();
                 }
             } else {
-                altitude = finalHex.getLevel();
+                height = finalHex.getLevel();
             }
         }
 
@@ -333,7 +334,7 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
         if (atype.getMunitionType().contains(Munitions.M_FAE)) {
             handleArtilleryDriftMarker(targetPos, finalPos, aaa,
                     AreaEffectHelper.processFuelAirDamage(
-                            finalPos, altitude, atype, aaa.getEntity(game), vPhaseReport, gameManager));
+                            finalPos, height, atype, aaa.getEntity(game), vPhaseReport, gameManager));
             return false;
         }
 
@@ -411,10 +412,9 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
 
         Targetable updatedTarget = aaa.getTarget(game);
 
-        // the attack's target may have been destroyed or fled since the attack was
-        // generated
-        // so we need to carry out offboard/null checks against the "current" version of
-        // the target.
+        // the attack's target may have been destroyed or fled since the attack was generated
+        // so we need to carry out offboard/null checks against the "current" version of the target.
+        // Note: currently this only damages the target and does not deal blast damage to "nearby" off-board units.
         if ((updatedTarget != null) && updatedTarget.isOffBoard()) {
             // Calculate blast damage falloff and shape
             DamageFalloff df = AreaEffectHelper.calculateDamageFallOff(atype, shootingBA, mineClear);
@@ -434,7 +434,7 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
         } else {
             handleArtilleryDriftMarker(targetPos, finalPos, aaa,
                     gameManager.artilleryDamageArea(finalPos, aaa.getCoords(), atype,
-                            subjectId, ae, isFlak, altitude, mineClear, vPhaseReport,
+                            subjectId, ae, isFlak, height, mineClear, vPhaseReport,
                             asfFlak));
         }
 


### PR DESCRIPTION
Includes fixes for:
- #6772: Blast level was being set to 0, so blast would go under target hexes/units
- #6788: Artillery Flak incorrectly included target Altitude in range calculations, although not in to-hit mods
- Blast damage not showing level: added level to blast damage messages in phase report
- Princess firing "homing" indirect Artillery Flak shots: treat Artillery Flak like ADA and remove Indirect Flak shots from Fire Control.
- Gravity mod to Artillery range applied in reverse: use gravity to reduce Artillery max range, per TW: AR pg 155
- Indirect Flak Attack option in Attack UI: Add UI message to prevent user from illegally firing Artillery as Indirect Flak attacks.
- Flak AE attacks hitting, or not hitting, correct units: normalized passing of absolute "height" from various methods that call `artilleryDamageArea()`, `artilleryDamageHex()`, and `artilleryDamageEntity()`.

Testing:
- Ran all 3 projects' existing unit tests
- Confirmed correct AE and Flak damage dealt in various repro saves from issues above.

Note:
This PR adds a lot of gnarly height / level computation that will all be ripped out when I eventually add:
- Passing target level in attack packets
- User selection of bomb target level (for targeting buildings)
So please bear with it for right now; it will become much cleaner in the future.