### PR TITLE
Deprecate Aero#initializeSI

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -724,7 +724,7 @@ public abstract class Aero extends Entity implements IAero, IBomber {
     /**
      * @deprecated use {@link Aero#setOSI(int)} instead
      */
-    @Deprecated
+    @Deprecated(since = "0.50.05")
     public void initializeSI(int val) {
         setOSI(val);
     }

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -686,7 +686,12 @@ public abstract class Aero extends Entity implements IAero, IBomber {
         currentDamage = i;
     }
 
-    public void set0SI(int si) {
+    /**
+     * Set the starting Structural Integrity of this unit.
+     * Also sets the current SI as if by {@link #setSI(int)}.
+     * @param si The new value for SI
+     */
+    public void setOSI(int si) {
         orig_structIntegrity = si;
         structIntegrity = si;
     }
@@ -716,9 +721,12 @@ public abstract class Aero extends Entity implements IAero, IBomber {
         fatalThresh = Math.max(baseThresh, (int) Math.ceil(capitalArmor / 4.0));
     }
 
+    /**
+     * @deprecated use {@link Aero#setOSI(int)} instead
+     */
+    @Deprecated
     public void initializeSI(int val) {
-        orig_structIntegrity = val;
-        setSI(val);
+        setOSI(val);
     }
 
     @Override

--- a/megamek/src/megamek/common/AeroSpaceFighter.java
+++ b/megamek/src/megamek/common/AeroSpaceFighter.java
@@ -105,4 +105,17 @@ public class AeroSpaceFighter extends Aero {
         return (int) Math.round(Math.exp(3.729 + 0.898 * Math.log(getWeight())));
     }
 
+    @Override
+    public void setOriginalWalkMP(int walkMP) {
+        super.setOriginalWalkMP(walkMP);
+        autoSetSI();
+    }
+
+    @Override
+    public void setWeight(double weight) {
+        super.setWeight(weight);
+        autoSetMaxBombPoints();
+    }
+
+
 }

--- a/megamek/src/megamek/common/MULParser.java
+++ b/megamek/src/megamek/common/MULParser.java
@@ -2524,7 +2524,7 @@ public class MULParser {
         String value = OsiTag.getAttribute(ATTR_NUMBER);
         try {
             int newSI = Integer.parseInt(value);
-            ((Aero) entity).set0SI(newSI);
+            ((Aero) entity).setOSI(newSI);
         } catch (Exception ignored) {
             warning.append("Invalid SI value in original structural integrity tag.\n");
         }

--- a/megamek/src/megamek/common/loaders/BLKAeroSpaceFighterFile.java
+++ b/megamek/src/megamek/common/loaders/BLKAeroSpaceFighterFile.java
@@ -158,7 +158,6 @@ public class BLKAeroSpaceFighterFile extends BLKFile implements IMekLoader {
 
         a.autoSetInternal();
         a.recalculateTechAdvancement();
-        a.autoSetSI();
         // This is not working right for arrays for some reason
         a.autoSetThresh();
 
@@ -175,10 +174,6 @@ public class BLKAeroSpaceFighterFile extends BLKFile implements IMekLoader {
         if (dataFile.exists("omni")) {
             a.setOmni(true);
         }
-
-        // how many bombs can it carry; dependent on transport bays as well as total
-        // mass.
-        a.autoSetMaxBombPoints();
 
         a.setArmorTonnage(a.getArmorWeight());
         loadQuirks(a);

--- a/megamek/src/megamek/common/loaders/BLKDropshipFile.java
+++ b/megamek/src/megamek/common/loaders/BLKDropshipFile.java
@@ -101,7 +101,7 @@ public class BLKDropshipFile extends BLKFile implements IMekLoader {
             throw new EntityLoadingException(
                     "Could not find structural integrity block.");
         }
-        a.set0SI(dataFile.getDataAsInt("structural_integrity")[0]);
+        a.setOSI(dataFile.getDataAsInt("structural_integrity")[0]);
 
         if (dataFile.exists("collartype")) {
             a.setCollarType(dataFile.getDataAsInt("collartype")[0]);

--- a/megamek/src/megamek/common/loaders/BLKJumpshipFile.java
+++ b/megamek/src/megamek/common/loaders/BLKJumpshipFile.java
@@ -98,7 +98,7 @@ public class BLKJumpshipFile extends BLKFile implements IMekLoader {
         if (!dataFile.exists("structural_integrity")) {
             throw new EntityLoadingException("Could not find structual integrity block.");
         }
-        a.set0SI(dataFile.getDataAsInt("structural_integrity")[0]);
+        a.setOSI(dataFile.getDataAsInt("structural_integrity")[0]);
 
         // figure out heat
         if (!dataFile.exists("heatsinks")) {

--- a/megamek/src/megamek/common/loaders/BLKSmallCraftFile.java
+++ b/megamek/src/megamek/common/loaders/BLKSmallCraftFile.java
@@ -93,7 +93,7 @@ public class BLKSmallCraftFile extends BLKFile implements IMekLoader {
         if (!dataFile.exists("structural_integrity")) {
             throw new EntityLoadingException("Could not find structual_integrity block.");
         }
-        a.set0SI(dataFile.getDataAsInt("structural_integrity")[0]);
+        a.setOSI(dataFile.getDataAsInt("structural_integrity")[0]);
 
         // figure out heat
         if (!dataFile.exists("heatsinks")) {

--- a/megamek/src/megamek/common/loaders/BLKSpaceStationFile.java
+++ b/megamek/src/megamek/common/loaders/BLKSpaceStationFile.java
@@ -94,7 +94,7 @@ public class BLKSpaceStationFile extends BLKFile implements IMekLoader {
         if (!dataFile.exists("structural_integrity")) {
             throw new EntityLoadingException("Could not find structual integrity block.");
         }
-        a.set0SI(dataFile.getDataAsInt("structural_integrity")[0]);
+        a.setOSI(dataFile.getDataAsInt("structural_integrity")[0]);
 
         // figure out heat
         if (!dataFile.exists("heatsinks")) {

--- a/megamek/src/megamek/common/loaders/BLKWarshipFile.java
+++ b/megamek/src/megamek/common/loaders/BLKWarshipFile.java
@@ -100,7 +100,7 @@ public class BLKWarshipFile extends BLKFile implements IMekLoader {
         if (!dataFile.exists("structural_integrity")) {
             throw new EntityLoadingException("Could not find structual integrity block.");
         }
-        a.set0SI(dataFile.getDataAsInt("structural_integrity")[0]);
+        a.setOSI(dataFile.getDataAsInt("structural_integrity")[0]);
 
         // figure out heat
         if (!dataFile.exists("heatsinks")) {

--- a/megamek/src/megamek/server/totalwarfare/TWPhasePreparationManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWPhasePreparationManager.java
@@ -259,7 +259,7 @@ public class TWPhasePreparationManager {
                         }
                         Aero a = (Aero) entity;
                         int currentSI = a.getSI() / (2 * scale);
-                        a.set0SI(a.get0SI() / (2 * scale));
+                        a.setOSI(a.get0SI() / (2 * scale));
                         if (currentSI > 0) {
                             a.setSI(currentSI);
                         }

--- a/megamek/unittests/megamek/common/JumpshipTest.java
+++ b/megamek/unittests/megamek/common/JumpshipTest.java
@@ -28,7 +28,7 @@ class JumpshipTest {
     void calculateArmorWeightISWithClanArmor() {
         final Jumpship ship = new Jumpship();
         ship.setWeight(100000); // 1.0 for Clan, 0.8 for IS
-        ship.set0SI(0); // ignore the extra armor from SI
+        ship.setOSI(0); // ignore the extra armor from SI
         ship.setTechLevel(TechConstants.T_IS_ADVANCED);
         ship.setMixedTech(true);
         ship.setArmorType(EquipmentType.getArmorTypeName(EquipmentType.T_ARMOR_AEROSPACE, true));
@@ -44,7 +44,7 @@ class JumpshipTest {
     void calculateArmorWeightClanWithISArmor() {
         final Jumpship ship = new Jumpship();
         ship.setWeight(100000); // 1.0 for Clan, 0.8 for IS
-        ship.set0SI(0); // ignore the extra armor from SI
+        ship.setOSI(0); // ignore the extra armor from SI
         ship.setTechLevel(TechConstants.T_CLAN_ADVANCED);
         ship.setMixedTech(true);
         ship.setArmorType(EquipmentType.getArmorTypeName(EquipmentType.T_ARMOR_AEROSPACE, false));


### PR DESCRIPTION
- Aero#initializeSI is identical to Aero#setOSI, so deprecate the former in favor of the latter.
- Rename `Aero#set0SI` to `Aero#setOSI`. Why was there a zero there.
- Call autoSetSI when weight or engine rating changes.