### PR TITLE
Don't fail loading unit with MASS in wrong location

### DIFF
--- a/megamek/src/megamek/common/MekFileParser.java
+++ b/megamek/src/megamek/common/MekFileParser.java
@@ -518,15 +518,6 @@ public class MekFileParser {
                 throw new EntityLoadingException("Unable to load harjel in head for " + ent.getShortName());
             }
 
-            if (m.getType().hasFlag(MiscType.F_MASS) &&
-                      ((m.getLocation() != Mek.LOC_HEAD) ||
-                             ((ent instanceof Mek && ((Mek) ent).getCockpitType() == Mek.COCKPIT_TORSO_MOUNTED) &&
-                                    (m.getLocation() != Mek.LOC_CT)))) {
-                throw new EntityLoadingException("Unable to load MASS for " +
-                                                       ent.getShortName() +
-                                                       "!  Must be located in the same location as the cockpit.");
-            }
-
             if (m.getType().hasFlag(MiscType.F_MODULAR_ARMOR) &&
                       (((ent instanceof Mek) && (m.getLocation() == Mek.LOC_HEAD)) ||
                              ((ent instanceof VTOL) && (m.getLocation() == VTOL.LOC_ROTOR)))) {


### PR DESCRIPTION
Fixes MegaMek/megameklab#1809.

If the MASS is in the wrong location, the unit will be marked as Invalid, so there's no reason to also throw an exception on load, so this just removes that exception. 

Also, the check to throw the exception (but not the check for validation) was wrong anyway.