### PR TITLE
Issue 6751: Princess will now deploy mines on her turn instead of at the start of the phase.

### DIFF
--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -275,6 +275,10 @@ public abstract class BotClient extends Client {
      */
     protected abstract MovePath continueMovementFor(Entity entity);
 
+    /**
+     * Deprecated, consider {@link BotClient#deployMinefields()}
+     */
+    @Deprecated (since = "0.50.05")
     protected abstract Vector<Minefield> calculateMinefieldDeployment();
 
     protected abstract Vector<Coords> calculateArtyAutoHitHexes();

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -25,7 +25,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStreamReader;
 import java.util.*;
-
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
@@ -396,9 +395,6 @@ public abstract class BotClient extends Client {
                 case LOUNGE:
                     sendChat(Messages.getString("BotClient.Hi"));
                     break;
-                case DEPLOY_MINEFIELDS:
-                    deployMinefields();
-                    break;
                 case DEPLOYMENT:
                     initialize();
                     break;
@@ -596,12 +592,7 @@ public abstract class BotClient extends Client {
             } else if (game.getPhase().isDeployment()) {
                 calculateDeployment();
             } else if (game.getPhase().isDeployMinefields()) {
-                Vector<Minefield> mines = calculateMinefieldDeployment();
-                for (Minefield mine : mines) {
-                    game.addMinefield(mine);
-                }
-                sendDeployMinefields(mines);
-                sendPlayerInfo();
+                deployMinefields();
             } else if (game.getPhase().isSetArtilleryAutohitHexes()) {
                 // For now, declare no auto hit hexes.
                 Vector<Coords> autoHitHexes = calculateArtyAutoHitHexes();

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -276,7 +276,7 @@ public abstract class BotClient extends Client {
     protected abstract MovePath continueMovementFor(Entity entity);
 
     /**
-     * Deprecated, consider {@link BotClient#deployMinefields()}
+     * @deprecated, consider {@link BotClient#deployMinefields()}
      */
     @Deprecated (since = "0.50.05")
     protected abstract Vector<Minefield> calculateMinefieldDeployment();

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -26,9 +26,6 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import megamek.client.ui.swing.TowLinkWarning;
-import org.apache.logging.log4j.Level;
-
 import megamek.client.bot.BotClient;
 import megamek.client.bot.ChatProcessor;
 import megamek.client.bot.PhysicalCalculator;
@@ -38,6 +35,7 @@ import megamek.client.bot.princess.FiringPlanCalculationParameters.Builder;
 import megamek.client.bot.princess.PathRanker.PathRankerType;
 import megamek.client.bot.princess.UnitBehavior.BehaviorType;
 import megamek.client.ui.SharedUtility;
+import megamek.client.ui.swing.TowLinkWarning;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.*;
 import megamek.common.BulldozerMovePath.MPCostComparator;
@@ -66,6 +64,7 @@ import megamek.common.weapons.AmmoWeapon;
 import megamek.common.weapons.StopSwarmAttack;
 import megamek.common.weapons.Weapon;
 import megamek.logging.MMLogger;
+import org.apache.logging.log4j.Level;
 
 public class Princess extends BotClient {
     private static final MMLogger logger = MMLogger.create(Princess.class);
@@ -1188,7 +1187,11 @@ public class Princess extends BotClient {
         return plan.getEntityActionVector();
     }
 
+    /**
+     * Deprecated, consider {@link BotClient#deployMinefields()}
+     */
     @Override
+    @Deprecated (since = "0.50.05", forRemoval = true)
     protected Vector<Minefield> calculateMinefieldDeployment() {
         try {
             // currently returns no minefields

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1188,7 +1188,7 @@ public class Princess extends BotClient {
     }
 
     /**
-     * Deprecated, consider {@link BotClient#deployMinefields()}
+     * @deprecated, consider {@link BotClient#deployMinefields()}
      */
     @Override
     @Deprecated (since = "0.50.05", forRemoval = true)


### PR DESCRIPTION
Fixes #6751 

I found there was another attempted implementation of Princess deploying minefields. It looks like it was abandoned and didn't do anything, I've marked it as `@Deprecated`. Note that the method deprecated in `BotClient` is not marked as for removal, IntelliJ throws an error (not warning) if I have a method overriding a deprecated for-removal method, like what would happen if `BotClient::calculateMinefieldDeployment` was marked as for-removal.