### PR TITLE
Seraph quirk fix for bug #6508

### DIFF
--- a/megamek/data/mekfiles/meks/3075/Seraph C-SRP-O Invictus.mtf
+++ b/megamek/data/mekfiles/meks/3075/Seraph C-SRP-O Invictus.mtf
@@ -14,7 +14,6 @@ role:Juggernaut
 
 quirk:imp_com
 quirk:imp_sensors
-quirk:low_profile
 quirk:bad_rep_clan
 quirk:bad_rep_is
 

--- a/megamek/data/mekfiles/meks/3075/Seraph C-SRP-OA Dominus.mtf
+++ b/megamek/data/mekfiles/meks/3075/Seraph C-SRP-OA Dominus.mtf
@@ -13,7 +13,6 @@ role:Skirmisher
 
 quirk:imp_com
 quirk:imp_sensors
-quirk:low_profile
 quirk:bad_rep_clan
 quirk:bad_rep_is
 

--- a/megamek/data/mekfiles/meks/3075/Seraph C-SRP-OB Infernus.mtf
+++ b/megamek/data/mekfiles/meks/3075/Seraph C-SRP-OB Infernus.mtf
@@ -13,7 +13,6 @@ role:Juggernaut
 
 quirk:imp_com
 quirk:imp_sensors
-quirk:low_profile
 quirk:bad_rep_clan
 quirk:bad_rep_is
 

--- a/megamek/data/mekfiles/meks/3075/Seraph C-SRP-OC Comminus.mtf
+++ b/megamek/data/mekfiles/meks/3075/Seraph C-SRP-OC Comminus.mtf
@@ -13,7 +13,6 @@ role:Juggernaut
 
 quirk:imp_com
 quirk:imp_sensors
-quirk:low_profile
 quirk:bad_rep_clan
 quirk:bad_rep_is
 

--- a/megamek/data/mekfiles/meks/3075/Seraph C-SRP-OD Luminos.mtf
+++ b/megamek/data/mekfiles/meks/3075/Seraph C-SRP-OD Luminos.mtf
@@ -13,7 +13,6 @@ role:Sniper
 
 quirk:imp_com
 quirk:imp_sensors
-quirk:low_profile
 quirk:bad_rep_clan
 quirk:bad_rep_is
 

--- a/megamek/data/mekfiles/meks/3075/Seraph C-SRP-OE Eminus.mtf
+++ b/megamek/data/mekfiles/meks/3075/Seraph C-SRP-OE Eminus.mtf
@@ -13,7 +13,6 @@ role:Missile Boat
 
 quirk:imp_com
 quirk:imp_sensors
-quirk:low_profile
 quirk:bad_rep_clan
 quirk:bad_rep_is
 

--- a/megamek/data/mekfiles/meks/Jihad Secrets/Seraph C-SRP-O Caelestis.mtf
+++ b/megamek/data/mekfiles/meks/Jihad Secrets/Seraph C-SRP-O Caelestis.mtf
@@ -13,7 +13,6 @@ role:Sniper
 
 quirk:imp_com
 quirk:imp_sensors
-quirk:low_profile
 quirk:bad_rep_clan
 quirk:bad_rep_is
 

--- a/megamek/data/mekfiles/meks/Turning Points/JTP Sian/Seraph C-SRP-O Ravana.mtf
+++ b/megamek/data/mekfiles/meks/Turning Points/JTP Sian/Seraph C-SRP-O Ravana.mtf
@@ -13,7 +13,6 @@ Source:Jihad Turning Points: Sian
 
 quirk:imp_com
 quirk:imp_sensors
-quirk:low_profile
 quirk:bad_rep_clan
 quirk:bad_rep_is
 

--- a/megamek/data/mekfiles/meks/Wolf and Blake/Seraph C-SRP-O Havalah.mtf
+++ b/megamek/data/mekfiles/meks/Wolf and Blake/Seraph C-SRP-O Havalah.mtf
@@ -13,7 +13,6 @@ role:Juggernaut
 
 quirk:imp_com
 quirk:imp_sensors
-quirk:low_profile
 quirk:bad_rep_clan
 quirk:bad_rep_is
 


### PR DESCRIPTION
This removes the "low profile" quirk from the Seraph omnimech configurations as mentioned in bug #6508 .  I confirmed with the BattleMech Manual that the Seraph in fact does not have the "low profile" quirk:

![image](https://github.com/user-attachments/assets/61c351a2-8772-44cf-afe3-b074b001b8eb)

Corrected sixth printing - PDF