### PR TITLE
Fix NPE when loading ASF with engine damage from MUL

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -793,7 +793,7 @@ public abstract class Aero extends Entity implements IAero, IBomber {
     public void setEngineHits(int hits) {
         engineHits = hits;
         if ((engineHits >= getMaxEngineHits()) && getEnginesLostRound() == Integer.MAX_VALUE) {
-            setEnginesLostRound(game.getCurrentRound());
+            setEnginesLostRound(game != null ? game.getCurrentRound() : -1);
         }
     }
 


### PR DESCRIPTION
Units in the process of being loaded don't have a Game assigned to them yet.