### PR TITLE
Added `escapeWithSlashes` Method for Better String Escaping

### DIFF
--- a/megamek/src/megamek/utilities/xml/MMXMLUtility.java
+++ b/megamek/src/megamek/utilities/xml/MMXMLUtility.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2018-2025 - The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -18,17 +18,6 @@
  */
 package megamek.utilities.xml;
 
-import megamek.common.annotations.Nullable;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.text.StringEscapeUtils;
-import org.xml.sax.*;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.parsers.SAXParserFactory;
-import javax.xml.transform.Source;
-import javax.xml.transform.sax.SAXSource;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.time.LocalDate;
@@ -38,26 +27,33 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.StringJoiner;
 import java.util.UUID;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.Source;
+import javax.xml.transform.sax.SAXSource;
+
+import megamek.common.annotations.Nullable;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+import org.xml.sax.XMLReader;
 
 public class MMXMLUtility {
     // region Variable Declarations
     private static DocumentBuilderFactory DOCUMENT_BUILDER_FACTORY;
     private static SAXParserFactory SAX_PARSER_FACTORY;
 
-    private static final String[] INDENTS = new String[] {
-            "",
-            "\t",
-            "\t\t",
-            "\t\t\t",
-            "\t\t\t\t",
-            "\t\t\t\t\t",
-            "\t\t\t\t\t\t"
-    };
+    private static final String[] INDENTS = new String[] { "", "\t", "\t\t", "\t\t\t", "\t\t\t\t", "\t\t\t\t\t",
+                                                           "\t\t\t\t\t\t" };
     // endregion Variable Declarations
 
     /**
-     * Creates a DocumentBuilder safe from XML external entities
-     * attacks, and XML entity expansion attacks.
+     * Creates a DocumentBuilder safe from XML external entities attacks, and XML entity expansion attacks.
      *
      * @return A DocumentBuilder safe to use to read untrusted XML.
      */
@@ -98,8 +94,7 @@ public class MMXMLUtility {
     }
 
     /**
-     * @return a SAX {@linkplain XMLReader} that is safe from external entities and
-     *         entity expansion attacks.
+     * @return a SAX {@linkplain XMLReader} that is safe from external entities and entity expansion attacks.
      *
      * @see "https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#JAXB_Unmarshaller"
      */
@@ -112,7 +107,8 @@ public class MMXMLUtility {
                 spf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
             } catch (SAXNotRecognizedException | SAXNotSupportedException ex) {
                 throw new AssertionError(
-                        "SAX implementation does not recognize or support the features we want to disable", ex);
+                      "SAX implementation does not recognize or support the features we want to disable",
+                      ex);
             } catch (ParserConfigurationException ex) {
                 throw new AssertionError(ex); // Only if we messed up the CFG above
             }
@@ -128,8 +124,8 @@ public class MMXMLUtility {
     }
 
     /**
-     * @return a {@linkplain Source} for the provided input stream that is safe
-     *         from external entities and entity expansion attacks.
+     * @return a {@linkplain Source} for the provided input stream that is safe from external entities and entity
+     *       expansion attacks.
      *
      * @see "https://www.owasp.org/index.php/XML_External_Entity_(XXE)_Prevention_Cheat_Sheet#JAXB_Unmarshaller"
      */
@@ -139,6 +135,7 @@ public class MMXMLUtility {
 
     // region XML Writing
     // region Open Tag
+
     /**
      * This writes an open XML tag
      *
@@ -146,14 +143,12 @@ public class MMXMLUtility {
      * @param indent the indent to write at
      * @param name   the name of the XML tag
      */
-    public static void writeSimpleXMLOpenTag(final PrintWriter pw, final int indent,
-            final String name) {
+    public static void writeSimpleXMLOpenTag(final PrintWriter pw, final int indent, final String name) {
         writeSimpleXMLOpenTag(pw, indent, name, null, null, null, null);
     }
 
     /**
-     * This writes an open XML tag, with the possible addition of an attribute and
-     * its value
+     * This writes an open XML tag, with the possible addition of an attribute and its value
      *
      * @param pw             the PrintWriter to use
      * @param indent         the indent to write at
@@ -161,15 +156,13 @@ public class MMXMLUtility {
      * @param attributeName  the attribute to write as part of the XML tag
      * @param attributeValue the value of the attribute
      */
-    public static <T> void writeSimpleXMLOpenTag(final PrintWriter pw, final int indent,
-            final String name, final String attributeName,
-            final T attributeValue) {
+    public static <T> void writeSimpleXMLOpenTag(final PrintWriter pw, final int indent, final String name,
+          final String attributeName, final T attributeValue) {
         writeSimpleXMLOpenTag(pw, indent, name, attributeName, attributeValue, null, null);
     }
 
     /**
-     * This writes an open XML tag, with the possible addition of a class attribute
-     * and its class
+     * This writes an open XML tag, with the possible addition of a class attribute and its class
      *
      * @param pw             the PrintWriter to use
      * @param indent         the indent to write at
@@ -177,16 +170,14 @@ public class MMXMLUtility {
      * @param classAttribute the class attribute to write as part of the tag
      * @param c              the class to write as part of the tag
      */
-    public static void writeSimpleXMLOpenTag(final PrintWriter pw, final int indent,
-            final String name, final String classAttribute,
-            final Class<?> c) {
+    public static void writeSimpleXMLOpenTag(final PrintWriter pw, final int indent, final String name,
+          final String classAttribute, final Class<?> c) {
         writeSimpleXMLOpenTag(pw, indent, name, null, null, classAttribute, c);
     }
 
     /**
-     * This writes an open XML tag, with the possible addition of an attribute and
-     * its value
-     * and/or the possible addition of a class attribute and its class
+     * This writes an open XML tag, with the possible addition of an attribute and its value and/or the possible
+     * addition of a class attribute and its class
      *
      * @param pw             the PrintWriter to use
      * @param indent         the indent to write at
@@ -196,12 +187,9 @@ public class MMXMLUtility {
      * @param classAttribute the class attribute to write as part of the tag
      * @param c              the class to write as part of the tag
      */
-    public static <T> void writeSimpleXMLOpenTag(final PrintWriter pw, final int indent,
-            final String name,
-            final @Nullable String attributeName,
-            @Nullable T attributeValue,
-            final @Nullable String classAttribute,
-            final @Nullable Class<?> c) {
+    public static <T> void writeSimpleXMLOpenTag(final PrintWriter pw, final int indent, final String name,
+          final @Nullable String attributeName, @Nullable T attributeValue, final @Nullable String classAttribute,
+          final @Nullable Class<?> c) {
         final boolean hasValue = attributeValue != null;
         final boolean hasClass = c != null;
         pw.print(indentStr(indent) + '<' + name);
@@ -217,6 +205,7 @@ public class MMXMLUtility {
     // endregion Open Tag
 
     // region Simple XML Tag
+
     /**
      * This writes a UUID or an array of UUIDs to file
      *
@@ -226,7 +215,7 @@ public class MMXMLUtility {
      * @param values the UUID or UUID[] to write to XML
      */
     public static void writeSimpleXMLTag(final PrintWriter pw, final int indent, final String name,
-            final UUID... values) {
+          final UUID... values) {
         if (values.length > 0) {
             final StringJoiner stringJoiner = new StringJoiner(",");
             for (final UUID value : values) {
@@ -250,7 +239,7 @@ public class MMXMLUtility {
      * @param values the LocalDate or LocalDate[] to write to XML
      */
     public static void writeSimpleXMLTag(final PrintWriter pw, final int indent, final String name,
-            final LocalDate... values) {
+          final LocalDate... values) {
         if (values.length > 0) {
             final StringJoiner stringJoiner = new StringJoiner(",");
             for (final LocalDate value : values) {
@@ -266,9 +255,8 @@ public class MMXMLUtility {
     }
 
     /**
-     * This writes a collection of objects that are saved based on their toString
-     * value.
-     * Examples are UUID and LocalDate
+     * This writes a collection of objects that are saved based on their toString value. Examples are UUID and
+     * LocalDate
      *
      * @param pw     the PrintWriter to use
      * @param indent the indent to write at
@@ -276,7 +264,7 @@ public class MMXMLUtility {
      * @param values the collection to write to XML
      */
     public static void writeSimpleXMLTag(final PrintWriter pw, final int indent, final String name,
-            final Collection<?> values) {
+          final Collection<?> values) {
         if (!values.isEmpty()) {
             final StringJoiner stringJoiner = new StringJoiner(",");
             values.forEach(v -> stringJoiner.add(v.toString()));
@@ -293,14 +281,12 @@ public class MMXMLUtility {
      * @param values the String or String[] to write to XML
      */
     public static void writeSimpleXMLTag(final PrintWriter pw, final int indent, final String name,
-            final String... values) {
+          final String... values) {
         writeSimpleXMLAttributedTag(pw, indent, name, null, null, values);
     }
 
     /**
-     * This writes a String or an array of Strings to file, with an the possible
-     * addition of an
-     * attribute and its value
+     * This writes a String or an array of Strings to file, with an the possible addition of an attribute and its value
      *
      * @param pw             the PrintWriter to use
      * @param indent         the indent to write at
@@ -309,11 +295,8 @@ public class MMXMLUtility {
      * @param attributeValue the value of the attribute
      * @param values         the String or String[] to write to XML
      */
-    public static <T> void writeSimpleXMLAttributedTag(final PrintWriter pw, final int indent,
-            final String name,
-            final @Nullable String attributeName,
-            final @Nullable T attributeValue,
-            final String... values) {
+    public static <T> void writeSimpleXMLAttributedTag(final PrintWriter pw, final int indent, final String name,
+          final @Nullable String attributeName, final @Nullable T attributeValue, final String... values) {
         if (values.length > 0) {
             final boolean hasAttribute = attributeValue != null;
             pw.print(indentStr(indent) + '<' + name);
@@ -333,7 +316,7 @@ public class MMXMLUtility {
      * @param values the int or int[] to write to XML
      */
     public static void writeSimpleXMLTag(final PrintWriter pw, final int indent, final String name,
-            final int... values) {
+          final int... values) {
         if (values.length > 0) {
             pw.println(indentStr(indent) + '<' + name + '>' + StringUtils.join(values, ',') + "</" + name + '>');
         }
@@ -348,7 +331,7 @@ public class MMXMLUtility {
      * @param values the boolean or boolean[] to write to XML
      */
     public static void writeSimpleXMLTag(final PrintWriter pw, final int indent, final String name,
-            final boolean... values) {
+          final boolean... values) {
         if (values.length > 0) {
             final StringJoiner stringJoiner = new StringJoiner(",");
             for (final boolean value : values) {
@@ -367,7 +350,7 @@ public class MMXMLUtility {
      * @param values the long or long[] to write to XML
      */
     public static void writeSimpleXMLTag(final PrintWriter pw, final int indent, final String name,
-            final long... values) {
+          final long... values) {
         if (values.length > 0) {
             pw.println(indentStr(indent) + '<' + name + '>' + StringUtils.join(values, ',') + "</" + name + '>');
         }
@@ -382,7 +365,7 @@ public class MMXMLUtility {
      * @param values the double or double[] to write to XML
      */
     public static void writeSimpleXMLTag(final PrintWriter pw, final int indent, final String name,
-            final double... values) {
+          final double... values) {
         if (values.length > 0) {
             pw.println(indentStr(indent) + '<' + name + '>' + StringUtils.join(values, ',') + "</" + name + '>');
         }
@@ -390,6 +373,7 @@ public class MMXMLUtility {
     // endregion Simple XML Tag
 
     // region Close Tag
+
     /**
      * This writes a XML close tag to file
      *
@@ -397,14 +381,14 @@ public class MMXMLUtility {
      * @param indent the indent to write at
      * @param name   the name of the XML tag
      */
-    public static void writeSimpleXMLCloseTag(final PrintWriter pw, final int indent,
-            final String name) {
+    public static void writeSimpleXMLCloseTag(final PrintWriter pw, final int indent, final String name) {
         pw.println(indentStr(indent) + "</" + name + '>');
     }
     // endregion Close Tag
 
     /**
      * @param level the level to indent up to
+     *
      * @return a string containing level tab indents
      */
     public static String indentStr(final int level) {
@@ -415,6 +399,7 @@ public class MMXMLUtility {
      * Formats a Date suitable for writing to an XML node.
      *
      * @param date The date to format for XML.
+     *
      * @return A String suitable for writing a date to an XML node.
      *
      * @deprecated Use {@link LocalDate#toString()} instead.
@@ -428,19 +413,36 @@ public class MMXMLUtility {
      * Escapes a string to store in an XML element.
      *
      * @param string The string to be encoded
+     *
      * @return An encoded copy of the string
      */
     public static String escape(final String string) {
         return StringEscapeUtils.escapeXml10(string);
     }
+
+    /**
+     * Escapes a given string for use in XML and replaces all occurrences of forward slashes ("/") and backslashes ("\")
+     * with an underscore ("_").
+     *
+     * @param string the input string to be escaped and modified.
+     *
+     * @return the escaped string with slashes replaced by underscores.
+     *
+     * @throws NullPointerException if the input string is {@code null}.
+     * @author Illiani
+     * @since 0.50.05
+     */
+    public static String escapeWithSlashes(String string) {
+        return StringEscapeUtils.escapeXml10(string).replace("/", "_").replace("\\", "_");
+    }
     // endregion XML Writing
 
     // region XML Parsing
+
     /**
      * This parses an collection of UUIDs
      *
-     * @param values the XML text to parse containing a comma separated UUID
-     *               collection
+     * @param values the XML text to parse containing a comma separated UUID collection
      * @param ids    the collection to load the UUIDs into
      */
     public static void parseUUIDCollection(final String values, final Collection<UUID> ids) {
@@ -453,6 +455,7 @@ public class MMXMLUtility {
      * Parse a date from an XML node's content.
      *
      * @param value The date from an XML node's content.
+     *
      * @return The Date retrieved from the XML node content.
      */
     public static LocalDate parseDate(final String value) throws DateTimeParseException {
@@ -488,8 +491,7 @@ public class MMXMLUtility {
     /**
      * This parses an collection of LocalDates
      *
-     * @param values the XML text to parse containing a comma separated LocalDate
-     *               collection
+     * @param values the XML text to parse containing a comma separated LocalDate collection
      * @param dates  the collection to load the LocalDates into
      */
     public static void parseDateCollection(final String values, final Collection<LocalDate> dates) {
@@ -500,6 +502,7 @@ public class MMXMLUtility {
 
     /**
      * @param value the XML text to parse containing a single String
+     *
      * @return the parsed String
      */
     public static String parseString(final String value) {
@@ -508,6 +511,7 @@ public class MMXMLUtility {
 
     /**
      * @param value the XML text to parse containing a comma spaced String array
+     *
      * @return the parsed String Array
      */
     public static String[] parseStringArray(final String value) {
@@ -516,6 +520,7 @@ public class MMXMLUtility {
 
     /**
      * @param value the XML text to parse containing a comma spaced int array
+     *
      * @return the parsed int Array
      */
     public static int[] parseIntArray(final String value) {
@@ -524,6 +529,7 @@ public class MMXMLUtility {
 
     /**
      * @param value the XML text to parse containing a comma spaced boolean array
+     *
      * @return the parsed boolean Array
      */
     public static boolean[] parseBooleanArray(final String value) {
@@ -537,6 +543,7 @@ public class MMXMLUtility {
 
     /**
      * @param value the XML text to parse containing a comma spaced long array
+     *
      * @return the parsed long Array
      */
     public static long[] parseLongArray(final String value) {
@@ -545,6 +552,7 @@ public class MMXMLUtility {
 
     /**
      * @param value the XML text to parse containing a comma spaced double array
+     *
      * @return the parsed double Array
      */
     public static double[] parseDoubleArray(final String value) {


### PR DESCRIPTION
- Introduced `escapeWithSlashes` method to escape XML strings and replace forward/backslashes with underscores.

### Dev Notes
This PR is required by https://github.com/MegaMek/mekhq/issues/6341 - we had an issue where we were unable to save units that contained `/` or `\` in their name, as these were not caught by the stock escaping we had already implemented.

I opted to add a new method, rather than updating the original, as I didn't want to run the risk of breaking the cases where the original escaping was in-use.