### PR TITLE
Revert "null check in Aero setEngineHits"

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -792,7 +792,7 @@ public abstract class Aero extends Entity implements IAero, IBomber {
 
     public void setEngineHits(int hits) {
         engineHits = hits;
-        if ((engineHits >= getMaxEngineHits()) && getEnginesLostRound() == Integer.MAX_VALUE && game != null) {
+        if ((engineHits >= getMaxEngineHits()) && getEnginesLostRound() == Integer.MAX_VALUE) {
             setEnginesLostRound(game.getCurrentRound());
         }
     }


### PR DESCRIPTION
Reverts MegaMek/megamek#6849

Merge #6846 instead, which still sets the engineLostRound