### PR TITLE
Updated Logging, Clone Handling, and Added `toString` Methods

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/Parameters.java
+++ b/megamek/src/megamek/client/ratgenerator/Parameters.java
@@ -32,12 +32,16 @@ import java.util.Collection;
 import java.util.EnumSet;
 
 import megamek.common.EntityMovementMode;
+import megamek.common.annotations.Nullable;
+import megamek.logging.MMLogger;
 
 /*
  * A class that holds all the parameters used to generate a table and is used as the key for the cache.
  *
  */
 public final class Parameters implements Cloneable {
+    private static final MMLogger logger = MMLogger.create(Parameters.class);
+
     private FactionRecord faction;
     private FactionRecord deployingFaction;
 
@@ -100,7 +104,7 @@ public final class Parameters implements Cloneable {
     }
 
     @Override
-    public Parameters clone() {
+    public @Nullable Parameters clone() {
         try {
 
             Parameters parameters = (Parameters) super.clone();
@@ -120,6 +124,7 @@ public final class Parameters implements Cloneable {
             parameters.rolesExcluded = this.rolesExcluded;
             return parameters;
         } catch (CloneNotSupportedException e) {
+            logger.error("Failed to clone Parameters. State of the object: {}", this, e);
             return null;
         }
     }
@@ -349,4 +354,31 @@ public final class Parameters implements Cloneable {
               deployingFaction);
     }
 
+    @Override
+    public String toString() {
+        return "Parameters{" +
+                     "faction=" +
+                     (faction != null ? faction : "null") +
+                     ", deployingFaction=" +
+                     (deployingFaction != null ? deployingFaction : "null") +
+                     ", unitType=" +
+                     unitType +
+                     ", year=" +
+                     year +
+                     ", rating=" +
+                     (rating != null ? rating : "null") +
+                     ", weightClasses=" +
+                     (weightClasses != null ? weightClasses : "[]") +
+                     ", networkMask=" +
+                     networkMask +
+                     ", movementModes=" +
+                     (movementModes != null ? movementModes : "[]") +
+                     ", roles=" +
+                     (roles != null ? roles : "[]") +
+                     ", rolesExcluded=" +
+                     (rolesExcluded != null ? rolesExcluded : "[]") +
+                     ", roleStrictness=" +
+                     roleStrictness +
+                     '}';
+    }
 }

--- a/megamek/src/megamek/client/ui/swing/CancelAction.java
+++ b/megamek/src/megamek/client/ui/swing/CancelAction.java
@@ -1,17 +1,30 @@
 /*
- * MegaMek - Copyright (C) 2020 - The MegaMek Team
+ * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
  *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
+ * This file is part of MegaMek.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
- * details.
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
  */
-
 package megamek.client.ui.swing;
 
 import java.awt.Window;
@@ -20,6 +33,8 @@ import java.io.Serial;
 import javax.swing.AbstractAction;
 
 import megamek.client.ui.Messages;
+import megamek.common.annotations.Nullable;
+import megamek.logging.MMLogger;
 
 /**
  * An {@link javax.swing.AbstractAction Action} for canceling a dialog (closing without action) using setVisible(false).
@@ -28,6 +43,7 @@ import megamek.client.ui.Messages;
  * @author SJuliez
  */
 public class CancelAction extends AbstractAction {
+    private static final MMLogger logger = MMLogger.create(CancelAction.class);
 
     @Serial
     private static final long serialVersionUID = 1680850851585381148L;
@@ -44,13 +60,14 @@ public class CancelAction extends AbstractAction {
     }
 
     @Override
-    public CancelAction clone() {
+    public @Nullable CancelAction clone() {
         try {
 
             CancelAction cancelAction = (CancelAction) super.clone();
             cancelAction.owner = this.owner;
             return cancelAction;
         } catch (CloneNotSupportedException e) {
+            logger.error("Failed to clone CancelAction. State of the object: {}", this, e);
             return null;
         }
     }
@@ -60,4 +77,13 @@ public class CancelAction extends AbstractAction {
         owner.setVisible(false);
     }
 
+    @Override
+    public String toString() {
+        return "CancelAction{" +
+                     "owner=" +
+                     (owner != null ? owner.getClass().getSimpleName() : "null") +
+                     ", name=" +
+                     getValue(NAME) +
+                     '}';
+    }
 }

--- a/megamek/src/megamek/client/ui/swing/CloseAction.java
+++ b/megamek/src/megamek/client/ui/swing/CloseAction.java
@@ -1,17 +1,30 @@
 /*
- * MegaMek - Copyright (C) 2020 - The MegaMek Team
+ * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
  *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
+ * This file is part of MegaMek.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
- * details.
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
  */
-
 package megamek.client.ui.swing;
 
 import java.awt.Window;
@@ -20,6 +33,8 @@ import java.io.Serial;
 import javax.swing.AbstractAction;
 
 import megamek.client.ui.Messages;
+import megamek.common.annotations.Nullable;
+import megamek.logging.MMLogger;
 
 /**
  * An {@link javax.swing.AbstractAction Action} for closing a dialog using setVisible(false). Will assign the
@@ -28,6 +43,7 @@ import megamek.client.ui.Messages;
  * @author SJuliez
  */
 public class CloseAction extends AbstractAction {
+    private static final MMLogger logger = MMLogger.create(CloseAction.class);
 
     @Serial
     private static final long serialVersionUID = 1680850851585381148L;
@@ -44,12 +60,13 @@ public class CloseAction extends AbstractAction {
     }
 
     @Override
-    public CloseAction clone() {
+    public @Nullable CloseAction clone() {
         try {
             CloseAction closeAction = (CloseAction) super.clone();
             closeAction.owner = this.owner;
             return closeAction;
         } catch (CloneNotSupportedException e) {
+            logger.error("Failed to clone CloseAction. State of the object: {}", this, e);
             return null;
         }
     }
@@ -59,4 +76,13 @@ public class CloseAction extends AbstractAction {
         owner.setVisible(false);
     }
 
+    @Override
+    public String toString() {
+        return "CloseAction{" +
+                     "owner=" +
+                     (owner != null ? owner.getClass().getSimpleName() : "null") +
+                     ", name=" +
+                     getValue(NAME) +
+                     '}';
+    }
 }

--- a/megamek/src/megamek/client/ui/swing/OkayAction.java
+++ b/megamek/src/megamek/client/ui/swing/OkayAction.java
@@ -1,17 +1,30 @@
 /*
- * MegaMek - Copyright (C) 2020 - The MegaMek Team
+ * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
  *
- * This program is free software; you can redistribute it and/or modify it under
- * the terms of the GNU General Public License as published by the Free Software
- * Foundation; either version 2 of the License, or (at your option) any later
- * version.
+ * This file is part of MegaMek.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
- * details.
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
  */
-
 package megamek.client.ui.swing;
 
 import java.awt.event.ActionEvent;
@@ -20,6 +33,8 @@ import java.io.Serial;
 import javax.swing.AbstractAction;
 
 import megamek.client.ui.Messages;
+import megamek.common.annotations.Nullable;
+import megamek.logging.MMLogger;
 
 /**
  * An {@link javax.swing.AbstractAction Action} for getting an Okay/Done response from a button in a dialog Assigns the
@@ -28,6 +43,7 @@ import megamek.client.ui.Messages;
  * @author SJuliez
  */
 public class OkayAction extends AbstractAction {
+    private static final MMLogger logger = MMLogger.create(OkayAction.class);
 
     @Serial
     private static final long serialVersionUID = 1680850851585381148L;
@@ -46,12 +62,13 @@ public class OkayAction extends AbstractAction {
     }
 
     @Override
-    public OkayAction clone() {
+    public @Nullable OkayAction clone() {
         try {
             OkayAction okayAction = (OkayAction) super.clone();
             okayAction.owner = this.owner;
             return okayAction;
         } catch (CloneNotSupportedException e) {
+            logger.error("Failed to clone OkayAction. State of the object: {}", this, e);
             return null;
         }
     }
@@ -62,4 +79,15 @@ public class OkayAction extends AbstractAction {
         owner.actionPerformed(f);
     }
 
+    @Override
+    public String toString() {
+        return "OkayAction{" +
+                     "owner=" +
+                     (owner != null ? owner.getClass().getSimpleName() : "null") +
+                     ", name=" +
+                     getValue(NAME) +
+                     ", actionCommand=" +
+                     OKAY +
+                     '}';
+    }
 }


### PR DESCRIPTION
- Introduced logging with `MMLogger` across `CancelAction`, `CloseAction`, `OkayAction`, and `Parameters` classes to log errors during cloning.
- Enhanced `clone` method by marking it with `@Nullable` and adding detailed error logs for failed cloning operations.
- Implemented `toString` methods in the aforementioned classes for better state representation during debugging.

### Dev Notes
During the investigation of an unrelated mhq issue I spotted that these methods could silently throw up a `null` return. In mhq this was causing problems, so rather than just fixing the logging in mhq I decided to go through the other instances in MegaMek to ensure any cloning failure is logged so we can spot it in the logs.

I would have gone through and added null protection for any instances where `clone` was going to be called from these classes, but IDEA couldn't find any and neither did a good ol' fashioned project search. So I'm assuming these are just utility methods, or required when extending the parent class.

Either way, we're logging now so in the event these do mysteriously start breaking after 5 years we'll know about it.