### PR TITLE
Fixed Port Validation (Sentry)

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -4226,6 +4226,7 @@ MegaMek.LoadGameIncorrectVersion.message=Error: MegaMek does not support version
 MegaMek.HostGameAlert.title=Host a Game
 MegaMek.HostDialog.title=Start Game
 MegaMek.PlayerNameError=Error: enter a player name.
+MegaMek.PortError=Error: enter a valid port. Port must be between {0} and {1}.
 MegaMek.StartServerError=Error: could not start server at localhost:%s \n(%s)
 MegaMek.ServerConnectionError=Error: could not connect to server at %s:%s
 MegaMek.ConnectDialog.title=Connect To Game

--- a/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/AbstractGameConnectionDialog.java
+++ b/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/AbstractGameConnectionDialog.java
@@ -267,14 +267,10 @@ public abstract class AbstractGameConnectionDialog extends ClientDialog implemen
     public void actionPerformed(ActionEvent e) {
         // reached from the Okay button or pressing Enter in the text fields
         setPlayerName(getPlayerNameFromUI());
-        try {
-            int port = MathUtility.parseInt(getPortField().getText(), MMConstants.DEFAULT_PORT);
-            setPort(clamp(port, MMConstants.MIN_PORT, MMConstants.MAX_PORT));
-            setConfirmed(true);
-            getClientPreferences().setLastPlayerName(getPlayerName());
-            getClientPreferences().setLastConnectPort(getPort());
-        } catch (NumberFormatException ex) {
-            logger.error(ex, "");
-        }
+        int port = MathUtility.parseInt(getPortField().getText(), MMConstants.DEFAULT_PORT);
+        setPort(clamp(port, MMConstants.MIN_PORT, MMConstants.MAX_PORT));
+        setConfirmed(true);
+        getClientPreferences().setLastPlayerName(getPlayerName());
+        getClientPreferences().setLastConnectPort(getPort());
     }
 }

--- a/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/AbstractGameConnectionDialog.java
+++ b/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/AbstractGameConnectionDialog.java
@@ -18,6 +18,8 @@
  */
 package megamek.client.ui.swing.gameConnectionDialogs;
 
+import static megamek.codeUtilities.MathUtility.clamp;
+
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -266,7 +268,8 @@ public abstract class AbstractGameConnectionDialog extends ClientDialog implemen
         // reached from the Okay button or pressing Enter in the text fields
         setPlayerName(getPlayerNameFromUI());
         try {
-            setPort(MathUtility.parseInt(getPortField().getText(), MMConstants.DEFAULT_PORT));
+            int port = MathUtility.parseInt(getPortField().getText(), MMConstants.DEFAULT_PORT);
+            setPort(clamp(port, MMConstants.MIN_PORT, MMConstants.MAX_PORT));
             setConfirmed(true);
             getClientPreferences().setLastPlayerName(getPlayerName());
             getClientPreferences().setLastConnectPort(getPort());

--- a/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/AbstractGameConnectionDialog.java
+++ b/megamek/src/megamek/client/ui/swing/gameConnectionDialogs/AbstractGameConnectionDialog.java
@@ -26,7 +26,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyEvent;
 import java.util.Vector;
-
 import javax.swing.*;
 
 import megamek.MMConstants;
@@ -37,6 +36,7 @@ import megamek.client.ui.swing.CloseAction;
 import megamek.client.ui.swing.OkayAction;
 import megamek.client.ui.swing.dialog.DialogButton;
 import megamek.client.ui.swing.util.UIUtil;
+import megamek.codeUtilities.MathUtility;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.preference.ClientPreferences;
 import megamek.common.preference.PreferenceManager;
@@ -47,8 +47,8 @@ public abstract class AbstractGameConnectionDialog extends ClientDialog implemen
     private static final MMLogger logger = MMLogger.create(AbstractGameConnectionDialog.class);
 
     /**
-     * We need a way to access the action map for a JComboBox editor, so that we can
-     * have it fire an action when wenter is pressed. This simple class allows this.
+     * We need a way to access the action map for a JComboBox editor, so that we can have it fire an action when wenter
+     * is pressed. This simple class allows this.
      */
     public static class SimpleComboBoxEditor extends JTextField implements ComboBoxEditor {
 
@@ -94,7 +94,7 @@ public abstract class AbstractGameConnectionDialog extends ClientDialog implemen
     }
 
     protected AbstractGameConnectionDialog(JFrame owner, String title, boolean modal, String playerName,
-            Vector<String> playerNames) {
+          Vector<String> playerNames) {
         super(owner, title, modal);
 
         this.playerNames = playerNames;
@@ -240,16 +240,20 @@ public abstract class AbstractGameConnectionDialog extends ClientDialog implemen
         try {
             setPlayerName(Server.validatePlayerName(playerName));
         } catch (Exception ex) {
-            JOptionPane.showMessageDialog(getOwner(), Messages.getString("MegaMek.PlayerNameError"),
-                    Messages.getString(errorTitleKey), JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(getOwner(),
+                  Messages.getString("MegaMek.PlayerNameError"),
+                  Messages.getString(errorTitleKey),
+                  JOptionPane.ERROR_MESSAGE);
             return false;
         }
 
         try {
             setPort(Server.validatePort(port));
         } catch (Exception ex) {
-            JOptionPane.showMessageDialog(getOwner(), Messages.getString("MegaMek.PortError"),
-                    Messages.getString(errorTitleKey), JOptionPane.ERROR_MESSAGE);
+            JOptionPane.showMessageDialog(getOwner(),
+                  Messages.getFormattedString("MegaMek.PortError", MMConstants.MIN_PORT, MMConstants.MAX_PORT),
+                  Messages.getString(errorTitleKey),
+                  JOptionPane.ERROR_MESSAGE);
             return false;
         }
 
@@ -262,13 +266,12 @@ public abstract class AbstractGameConnectionDialog extends ClientDialog implemen
         // reached from the Okay button or pressing Enter in the text fields
         setPlayerName(getPlayerNameFromUI());
         try {
-            setPort(Integer.parseInt(getPortField().getText()));
+            setPort(MathUtility.parseInt(getPortField().getText(), MMConstants.DEFAULT_PORT));
+            setConfirmed(true);
+            getClientPreferences().setLastPlayerName(getPlayerName());
+            getClientPreferences().setLastConnectPort(getPort());
         } catch (NumberFormatException ex) {
             logger.error(ex, "");
         }
-
-        setConfirmed(true);
-        getClientPreferences().setLastPlayerName(getPlayerName());
-        getClientPreferences().setLastConnectPort(getPort());
     }
 }


### PR DESCRIPTION
- Fixed port parsing to use `MathUtility` and return the Default Port in the event a malformed port is entered by user
- Ensured the port value is clamped to valid bounds using the `clamp` utility method. This prevents invalid ports outside the range of `MMConstants.MIN_PORT` and `MMConstants.MAX_PORT`.  
- Added missing error string for port validation

Fix [Sentry Report](https://sentry.tapenvy.us/organizations/tapenvyus/issues/4238/?alert_rule_id=11&alert_type=issue&notification_uuid=9c2b5a9d-65cf-4f86-ae58-b6fb735bb46b&project=8&referrer=discord)