### PR TITLE
Issue Megameklab#1818: Correct "armor_tech" to "armor_tech_level" when applicable

### DIFF
--- a/megamek/src/megamek/common/loaders/BLKAeroSpaceFighterFile.java
+++ b/megamek/src/megamek/common/loaders/BLKAeroSpaceFighterFile.java
@@ -120,8 +120,8 @@ public class BLKAeroSpaceFighterFile extends BLKFile implements IMekLoader {
         } else {
             a.setArmorType(EquipmentType.T_ARMOR_STANDARD);
         }
-        if (!patchworkArmor && dataFile.exists("armor_tech")) {
-            a.setArmorTechLevel(dataFile.getDataAsInt("armor_tech")[0]);
+        if (!patchworkArmor) {
+            setArmorTechLevelFromDataFile(a);
         }
         if (patchworkArmor) {
             for (int i = 0; i < (a.locations() - 1); i++) {
@@ -160,9 +160,6 @@ public class BLKAeroSpaceFighterFile extends BLKFile implements IMekLoader {
         a.recalculateTechAdvancement();
         // This is not working right for arrays for some reason
         a.autoSetThresh();
-
-        // add Transporters prior to equipment to simplify F_CARGO bay assignment
-        addTransports(a);
 
         for (int loc = 0; loc < a.locations(); loc++) {
             loadEquipment(a, a.getLocationName(loc), loc);

--- a/megamek/src/megamek/common/loaders/BLKConvFighterFile.java
+++ b/megamek/src/megamek/common/loaders/BLKConvFighterFile.java
@@ -94,9 +94,7 @@ public class BLKConvFighterFile extends BLKFile implements IMekLoader {
         } else {
             a.setArmorType(EquipmentType.T_ARMOR_STANDARD);
         }
-        if (dataFile.exists("armor_tech")) {
-            a.setArmorTechLevel(dataFile.getDataAsInt("armor_tech")[0]);
-        }
+        setArmorTechLevelFromDataFile(a);
         if (dataFile.exists("internal_type")) {
             a.setStructureType(dataFile.getDataAsInt("internal_type")[0]);
         } else {

--- a/megamek/src/megamek/common/loaders/BLKDropshipFile.java
+++ b/megamek/src/megamek/common/loaders/BLKDropshipFile.java
@@ -142,9 +142,7 @@ public class BLKDropshipFile extends BLKFile implements IMekLoader {
             }
         }
         a.setArmorType(at);
-        if (dataFile.exists("armor_tech")) {
-            a.setArmorTechLevel(dataFile.getDataAsInt("armor_tech")[0]);
-        }
+        setArmorTechLevelFromDataFile(a);
         if (dataFile.exists("internal_type")) {
             a.setStructureType(dataFile.getDataAsInt("internal_type")[0]);
         } else {

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -1624,6 +1624,14 @@ public class BLKFile {
         }
     }
 
+    /**
+     * Sets the armor tech level for the entity based on the data file.
+     * The file should have "armor_tech_level", but it was changed from
+     * "armor_tech". And if this isn't found for some reason, it'll fall
+     * back and use the entity's tech base to determine this.
+     *
+     * @param entity entity that should have its armor tech level set based on the data file
+     */
     protected void setArmorTechLevelFromDataFile(Entity entity) {
         if (dataFile.exists("armor_tech_level")) {
             entity.setArmorTechLevel(dataFile.getDataAsInt("armor_tech_level")[0]);

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -14,6 +14,16 @@
  */
 package megamek.common.loaders;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.Vector;
+import java.util.stream.Collectors;
+
 import megamek.common.*;
 import megamek.common.InfantryTransporter.PlatoonType;
 import megamek.common.equipment.AmmoMounted;
@@ -27,10 +37,6 @@ import megamek.common.weapons.InfantryAttack;
 import megamek.common.weapons.bayweapons.BayWeapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
 import megamek.logging.MMLogger;
-
-import java.io.File;
-import java.util.*;
-import java.util.stream.Collectors;
 
 public class BLKFile {
     private static final MMLogger logger = MMLogger.create(BLKFile.class);
@@ -1615,6 +1621,16 @@ public class BLKFile {
             } else {
                 throw new BLKDecodingException(String.format("Cannot determine platoon type from '%s'", typeString));
             }
+        }
+    }
+
+    protected void setArmorTechLevelFromDataFile(Entity entity) {
+        if (dataFile.exists("armor_tech_level")) {
+            entity.setArmorTechLevel(dataFile.getDataAsInt("armor_tech_level")[0]);
+        } else if (dataFile.exists("armor_tech")) {
+            entity.setArmorTechLevel(dataFile.getDataAsInt("armor_tech")[0]);
+        } else {
+            entity.setArmorTechLevel(entity.getStaticTechLevel().getCompoundTechLevel(entity.isClan()));
         }
     }
 }

--- a/megamek/src/megamek/common/loaders/BLKJumpshipFile.java
+++ b/megamek/src/megamek/common/loaders/BLKJumpshipFile.java
@@ -169,9 +169,7 @@ public class BLKJumpshipFile extends BLKFile implements IMekLoader {
             }
         }
         a.setArmorType(at);
-        if (dataFile.exists("armor_tech")) {
-            a.setArmorTechLevel(dataFile.getDataAsInt("armor_tech")[0]);
-        }
+        setArmorTechLevelFromDataFile(a);
         if (dataFile.exists("internal_type")) {
             a.setStructureType(dataFile.getDataAsInt("internal_type")[0]);
         } else {

--- a/megamek/src/megamek/common/loaders/BLKMekFile.java
+++ b/megamek/src/megamek/common/loaders/BLKMekFile.java
@@ -116,8 +116,8 @@ public class BLKMekFile extends BLKFile implements IMekLoader {
         } else {
             mek.setArmorType(EquipmentType.T_ARMOR_STANDARD);
         }
-        if (!patchworkArmor && dataFile.exists("armor_tech")) {
-            mek.setArmorTechLevel(dataFile.getDataAsInt("armor_tech")[0]);
+        if (!patchworkArmor) {
+            setArmorTechLevelFromDataFile(mek);
         }
         if (patchworkArmor) {
             for (int i = 0; i < mek.locations(); i++) {

--- a/megamek/src/megamek/common/loaders/BLKProtoMekFile.java
+++ b/megamek/src/megamek/common/loaders/BLKProtoMekFile.java
@@ -110,11 +110,7 @@ public class BLKProtoMekFile extends BLKFile implements IMekLoader {
             t.setArmorType(EquipmentType.T_ARMOR_STANDARD_PROTOMEK);
         }
 
-        if (dataFile.exists("armor_tech")) {
-            t.setArmorTechLevel(dataFile.getDataAsInt("armor_tech")[0]);
-        } else {
-            t.setArmorTechLevel(TechConstants.T_ALL_CLAN);
-        }
+        setArmorTechLevelFromDataFile(t);
 
         // add the body to the armor array
         for (int x = 0; x < armor.length; x++) {

--- a/megamek/src/megamek/common/loaders/BLKSmallCraftFile.java
+++ b/megamek/src/megamek/common/loaders/BLKSmallCraftFile.java
@@ -130,9 +130,7 @@ public class BLKSmallCraftFile extends BLKFile implements IMekLoader {
             }
         }
         a.setArmorType(at);
-        if (dataFile.exists("armor_tech")) {
-            a.setArmorTechLevel(dataFile.getDataAsInt("armor_tech")[0]);
-        }
+        setArmorTechLevelFromDataFile(a);
         if (dataFile.exists("internal_type")) {
             a.setStructureType(dataFile.getDataAsInt("internal_type")[0]);
         } else {

--- a/megamek/src/megamek/common/loaders/BLKSpaceStationFile.java
+++ b/megamek/src/megamek/common/loaders/BLKSpaceStationFile.java
@@ -165,9 +165,7 @@ public class BLKSpaceStationFile extends BLKFile implements IMekLoader {
             }
         }
         a.setArmorType(at);
-        if (dataFile.exists("armor_tech")) {
-            a.setArmorTechLevel(dataFile.getDataAsInt("armor_tech")[0]);
-        }
+        setArmorTechLevelFromDataFile(a);
         if (dataFile.exists("internal_type")) {
             a.setStructureType(dataFile.getDataAsInt("internal_type")[0]);
         } else {

--- a/megamek/src/megamek/common/loaders/BLKTankFile.java
+++ b/megamek/src/megamek/common/loaders/BLKTankFile.java
@@ -290,9 +290,7 @@ public class BLKTankFile extends BLKFile implements IMekLoader {
         } else {
             t.setArmorType(EquipmentType.T_ARMOR_STANDARD);
         }
-        if (!patchworkArmor && dataFile.exists("armor_tech")) {
-            t.setArmorTechLevel(dataFile.getDataAsInt("armor_tech")[0]);
-        }
+        setArmorTechLevelFromDataFile(t);
         if (patchworkArmor) {
             for (int i = 1; i < t.locations(); i++) {
                 var armorTypeId = dataFile.getDataAsInt(t.getLocationName(i) + "_armor_type")[0];

--- a/megamek/src/megamek/common/loaders/BLKVTOLFile.java
+++ b/megamek/src/megamek/common/loaders/BLKVTOLFile.java
@@ -131,8 +131,10 @@ public class BLKVTOLFile extends BLKFile implements IMekLoader {
         } else {
             t.setArmorType(EquipmentType.T_ARMOR_STANDARD);
         }
-        if (!patchworkArmor && dataFile.exists("armor_tech")) {
-            t.setArmorTechLevel(dataFile.getDataAsInt("armor_tech")[0]);
+        if (!patchworkArmor && dataFile.exists("armor_tech_level")) {
+            t.setArmorTechLevel(dataFile.getDataAsInt("armor_tech_level")[0]);
+        } else if (!patchworkArmor) {
+            t.setArmorTechLevel(t.getStaticTechLevel().getCompoundTechLevel(t.isClan()));
         }
         if (patchworkArmor) {
             for (int i = 1; i < t.locations(); i++) {

--- a/megamek/src/megamek/common/loaders/BLKVTOLFile.java
+++ b/megamek/src/megamek/common/loaders/BLKVTOLFile.java
@@ -131,10 +131,8 @@ public class BLKVTOLFile extends BLKFile implements IMekLoader {
         } else {
             t.setArmorType(EquipmentType.T_ARMOR_STANDARD);
         }
-        if (!patchworkArmor && dataFile.exists("armor_tech_level")) {
-            t.setArmorTechLevel(dataFile.getDataAsInt("armor_tech_level")[0]);
-        } else if (!patchworkArmor) {
-            t.setArmorTechLevel(t.getStaticTechLevel().getCompoundTechLevel(t.isClan()));
+        if (!patchworkArmor) {
+            setArmorTechLevelFromDataFile(t);
         }
         if (patchworkArmor) {
             for (int i = 1; i < t.locations(); i++) {

--- a/megamek/src/megamek/common/loaders/BLKWarshipFile.java
+++ b/megamek/src/megamek/common/loaders/BLKWarshipFile.java
@@ -185,11 +185,7 @@ public class BLKWarshipFile extends BLKFile implements IMekLoader {
             }
         }
         a.setArmorType(at);
-        if (dataFile.exists("armor_tech_level")) {
-            a.setArmorTechLevel(dataFile.getDataAsInt("armor_tech_level")[0]);
-        } else {
-            a.setArmorTechLevel(a.getStaticTechLevel().getCompoundTechLevel(a.isClan()));
-        }
+        setArmorTechLevelFromDataFile(a);
         if (dataFile.exists("internal_type")) {
             a.setStructureType(dataFile.getDataAsInt("internal_type")[0]);
         } else {

--- a/megamek/src/megamek/common/loaders/BLKWarshipFile.java
+++ b/megamek/src/megamek/common/loaders/BLKWarshipFile.java
@@ -185,8 +185,10 @@ public class BLKWarshipFile extends BLKFile implements IMekLoader {
             }
         }
         a.setArmorType(at);
-        if (dataFile.exists("armor_tech")) {
-            a.setArmorTechLevel(dataFile.getDataAsInt("armor_tech")[0]);
+        if (dataFile.exists("armor_tech_level")) {
+            a.setArmorTechLevel(dataFile.getDataAsInt("armor_tech_level")[0]);
+        } else {
+            a.setArmorTechLevel(a.getStaticTechLevel().getCompoundTechLevel(a.isClan()));
         }
         if (dataFile.exists("internal_type")) {
             a.setStructureType(dataFile.getDataAsInt("internal_type")[0]);


### PR DESCRIPTION
Fixes MegaMek/megameklab#1818
Fixes #6858 

Recently, `armor_tech` was updated to `armor_tech_level` in some places. Notably, it was updated in the method used for saving. This was breaking units that were re-saved in the current version. This completes the change and updates the correct occurrences of `armor_tech` to `armor_tech_level`. Battle Armor still uses `armor_tech`, it's handled separately for some reason. IDK, that's not what I'm here for. 

@Scoppio made this real nifty test that's disabled by default, `BulkUnitFileTest`. I was able to use this to verify how many units had issues loading, saving, and loading again both before my changes and after. 346 units were failing this test before these changes. 157 are failing after these changes. There are no new units failing, the 157 failing now were also failing before these changes.

We should update the existing files so they have `armor_tech_level` instead of `armor_tech`, but this is able to handle a file that has `armor_tech` so this won't break master before the units are updated.