### PR TITLE
Issue MekHQ#6619: Move `RestoreUnitAction::copyC3Networks` from MekHQ to MegaMek's `C3Utils`

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -5942,7 +5942,7 @@ public abstract class Entity extends TurnOrdered
         return hasC3() || hasNhC3();
     }
 
-    public String getC3NetId() {
+    public @Nullable String getC3NetId() {
         if (c3NetIdString == null) {
             if (hasC3()) {
                 c3NetIdString = "C3." + getId();
@@ -6010,6 +6010,16 @@ public abstract class Entity extends TurnOrdered
         } else {
             c3NetIdString = "C3i." + getId();
         }
+    }
+
+    /**
+     * Explicitly set the C3 Net ID using a string.
+     * @see megamek.common.util.C3Util
+     * @see #setC3NetId(Entity)
+     * @param c3NetId string value the id should be set to
+     */
+    public void setC3NetId(@Nullable String c3NetId) {
+        c3NetIdString = c3NetId;
     }
 
     /**

--- a/megamek/src/megamek/common/util/C3Util.java
+++ b/megamek/src/megamek/common/util/C3Util.java
@@ -99,4 +99,24 @@ public class C3Util {
 
         return affectedUnits;
     }
+
+    /**
+     * Copies the C3 network setup from the source to the target.
+     *
+     * @param source The source {@link Entity}.
+     * @param target The target {@link Entity}.
+     */
+    public static void copyC3Networks(Entity source, Entity target) {
+        target.setC3UUIDAsString(source.getC3UUIDAsString());
+        target.setC3Master(source.getC3Master(), false);
+        target.setC3MasterIsUUIDAsString(source.getC3MasterIsUUIDAsString());
+
+        // Reassign the C3NetId
+        target.setC3NetId(source.getC3NetId());
+
+        for (int pos = 0; pos < Entity.MAX_C3i_NODES; ++pos) {
+            target.setC3iNextUUIDAsString(pos, source.getC3iNextUUIDAsString(pos));
+            target.setNC3NextUUIDAsString(pos, source.getNC3NextUUIDAsString(pos));
+        }
+    }
 }


### PR DESCRIPTION
Move `RestoreUnitAction::copyC3Networks` from MekHQ to MegaMek's `C3Utils`.

First step to resolving MegaMek/mekhq#6619.