### PR TITLE
fix: wrong access for weapon arc

### DIFF
--- a/megamek/src/megamek/ai/dataset/UnitAction.java
+++ b/megamek/src/megamek/ai/dataset/UnitAction.java
@@ -185,8 +185,9 @@ public class UnitAction extends EntityDataMap<UnitAction.Field> {
         List<Integer> weaponData = new ArrayList<>();
         entity.getWeaponList().forEach(weapon -> {
             int damage = Compute.computeTotalDamage(weapon);
-            int facing = weapon.isRearMounted() ? -entity.getWeaponArc(weapon.getLocation()) :
-                               entity.getWeaponArc(weapon.getLocation());
+            int equipmentId = entity.getEquipmentNum(weapon);
+            int facing = weapon.isRearMounted() ? -entity.getWeaponArc(equipmentId) :
+                               entity.getWeaponArc(equipmentId);
             int shortRange = weapon.getType().getShortRange();
             int mediumRange = weapon.getType().getMediumRange();
             int longRange = weapon.getType().getLongRange();

--- a/megamek/src/megamek/ai/dataset/UnitState.java
+++ b/megamek/src/megamek/ai/dataset/UnitState.java
@@ -164,8 +164,9 @@ public class UnitState extends EntityDataMap<UnitState.Field> {
         List<Integer> weaponData = new ArrayList<>();
         entity.getWeaponList().forEach(weapon -> {
             int damage = Compute.computeTotalDamage(weapon);
-            int facing = weapon.isRearMounted() ? -entity.getWeaponArc(weapon.getLocation()) :
-                               entity.getWeaponArc(weapon.getLocation());
+            int equipmentId = entity.getEquipmentNum(weapon);
+            int facing = weapon.isRearMounted() ? -entity.getWeaponArc(equipmentId) :
+                               entity.getWeaponArc(equipmentId);
             int shortRange = weapon.getType().getShortRange();
             int mediumRange = weapon.getType().getMediumRange();
             int longRange = weapon.getType().getLongRange();


### PR DESCRIPTION
A tipical error caused by primitive obsession.

Function should be called with equipment ID/number but instead I was passing the equipment location.