### PR TITLE
Change getWeaponArc signature and add JavaDocs

### DIFF
--- a/megamek/src/megamek/client/bot/princess/MultiTargetFireControl.java
+++ b/megamek/src/megamek/client/bot/princess/MultiTargetFireControl.java
@@ -264,7 +264,8 @@ public class MultiTargetFireControl extends FireControl {
         // account for artillery fired during the Targeting (offboard) phase; we reduce the heat capacity and treat
         // the arc's heat as 0 because this arc has already fired - so it can be included in the solution for "free"
         for ( WeaponMounted weapon : shooter.getWeaponList().stream().filter(Mounted::isUsedThisRound).toList()) {
-            int arc = weapon.isRearMounted() ? -shooter.getWeaponArc(weapon.getLocation()) : shooter.getWeaponArc(weapon.getLocation());
+            int arc = weapon.isRearMounted() ? -shooter.getWeaponArc(weapon.getEquipmentNum()) :
+                            shooter.getWeaponArc(weapon.getEquipmentNum());
             if (!arcShots.containsKey(arc)) {
                 heatCapacity -= shooter.getHeatInArc(weapon.getLocation(), weapon.isRearMounted());
                 arcShots.put(arc, new ArrayList<>());

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -1121,8 +1121,8 @@ public abstract class Aero extends Entity implements IAero, IBomber {
     // need to figure out aft-pointed wing weapons
     // need to figure out new arcs
     @Override
-    public int getWeaponArc(int wn) {
-        final Mounted<?> mounted = getEquipment(wn);
+    public int getWeaponArc(int weaponNumber) {
+        final Mounted<?> mounted = getEquipment(weaponNumber);
         if (mounted.getType().hasFlag(WeaponType.F_SPACE_BOMB) ||
                   mounted.getType().hasFlag(WeaponType.F_DIVE_BOMB) ||
                   mounted.getType().hasFlag(WeaponType.F_ALT_BOMB)) {

--- a/megamek/src/megamek/common/BattleArmor.java
+++ b/megamek/src/megamek/common/BattleArmor.java
@@ -13,6 +13,10 @@
  */
 package megamek.common;
 
+import java.text.NumberFormat;
+import java.util.Arrays;
+import java.util.Vector;
+
 import megamek.client.ui.swing.calculationReport.CalculationReport;
 import megamek.client.ui.swing.calculationReport.DummyCalculationReport;
 import megamek.common.cost.BattleArmorCostCalculator;
@@ -27,10 +31,6 @@ import megamek.common.planetaryconditions.Wind;
 import megamek.common.weapons.InfantryAttack;
 import megamek.common.weapons.infantry.InfantryWeapon;
 import megamek.logging.MMLogger;
-
-import java.text.NumberFormat;
-import java.util.Arrays;
-import java.util.Vector;
 
 /**
  * This class represents a squad or point of battle armor equipped infantry,
@@ -1481,7 +1481,7 @@ public class BattleArmor extends Infantry {
     }
 
     @Override
-    public int getWeaponArc(int wn) {
+    public int getWeaponArc(int weaponNumber) {
         return Compute.ARC_360;
     }
 

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -4182,8 +4182,10 @@ public abstract class Entity extends TurnOrdered
 
     /**
      * Returns the Rules.ARC that the weapon, specified by number, fires into.
+     * @param weaponNumber integer equipment number, index from equipment list
+     * @return arc the specified weapon is in
      */
-    public abstract int getWeaponArc(int wn);
+    public abstract int getWeaponArc(int weaponNumber);
 
     /**
      * Returns true if this weapon fires into the secondary facing arc. If false, assume it fires into the primary.

--- a/megamek/src/megamek/common/HandheldWeapon.java
+++ b/megamek/src/megamek/common/HandheldWeapon.java
@@ -127,7 +127,7 @@ public class HandheldWeapon extends Entity {
     }
 
     @Override
-    public int getWeaponArc(int wn) {
+    public int getWeaponArc(int weaponNumber) {
         throw new UnsupportedOperationException("Construction only.");
     }
 

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -779,8 +779,8 @@ public class Infantry extends Entity {
     }
 
     @Override
-    public int getWeaponArc(int wn) {
-        Mounted<?> weapon = getEquipment(wn);
+    public int getWeaponArc(int weaponNumber) {
+        Mounted<?> weapon = getEquipment(weaponNumber);
         // Infantry can fire all around themselves. But field guns are set up to a
         // vehicular turret facing
         if (isFieldWeapon(weapon)) {

--- a/megamek/src/megamek/common/Jumpship.java
+++ b/megamek/src/megamek/common/Jumpship.java
@@ -800,8 +800,8 @@ public class Jumpship extends Aero {
     }
 
     @Override
-    public int getWeaponArc(int wn) {
-        final Mounted<?> mounted = getEquipment(wn);
+    public int getWeaponArc(int weaponNumber) {
+        final Mounted<?> mounted = getEquipment(weaponNumber);
         int arc = switch (mounted.getLocation()) {
             case LOC_NOSE -> mounted.isInWaypointLaunchMode() ? ARC_NOSE_WPL : ARC_NOSE;
             case LOC_FRS -> mounted.isInWaypointLaunchMode() ? ARC_RIGHTSIDE_SPHERE_WPL : ARC_RIGHTSIDE_SPHERE;

--- a/megamek/src/megamek/common/LandAirMek.java
+++ b/megamek/src/megamek/common/LandAirMek.java
@@ -1420,11 +1420,11 @@ public class LandAirMek extends BipedMek implements IAero, IBomber {
      * In fighter mode the weapon arcs need to be translated to Aero arcs.
      */
     @Override
-    public int getWeaponArc(int wn) {
+    public int getWeaponArc(int weaponNumber) {
         if (getConversionMode() != CONV_MODE_FIGHTER) {
-            return super.getWeaponArc(wn);
+            return super.getWeaponArc(weaponNumber);
         }
-        final Mounted<?> mounted = getEquipment(wn);
+        final Mounted<?> mounted = getEquipment(weaponNumber);
         if (mounted.getType().hasFlag(WeaponType.F_SPACE_BOMB) ||
                   mounted.getType().hasFlag(WeaponType.F_DIVE_BOMB) ||
                   mounted.getType().hasFlag(WeaponType.F_ALT_BOMB)) {

--- a/megamek/src/megamek/common/LargeSupportTank.java
+++ b/megamek/src/megamek/common/LargeSupportTank.java
@@ -272,8 +272,8 @@ public class LargeSupportTank extends SupportTank {
     }
 
     @Override
-    public int getWeaponArc(int wn) {
-        final Mounted<?> mounted = getEquipment(wn);
+    public int getWeaponArc(int weaponNumber) {
+        final Mounted<?> mounted = getEquipment(weaponNumber);
 
         // B-Pods need to be special-cased, the have 360 firing arc
         if ((mounted.getType() instanceof WeaponType)

--- a/megamek/src/megamek/common/Mek.java
+++ b/megamek/src/megamek/common/Mek.java
@@ -1898,8 +1898,8 @@ public abstract class Mek extends Entity {
      * Returns the Compute.ARC that the weapon fires into.
      */
     @Override
-    public int getWeaponArc(int wn) {
-        final Mounted<?> mounted = getEquipment(wn);
+    public int getWeaponArc(int weaponNumber) {
+        final Mounted<?> mounted = getEquipment(weaponNumber);
 
         // B-Pods need to be special-cased, the have 360 firing arc
         if ((mounted.getType() instanceof WeaponType)

--- a/megamek/src/megamek/common/ProtoMek.java
+++ b/megamek/src/megamek/common/ProtoMek.java
@@ -594,8 +594,8 @@ public class ProtoMek extends Entity {
     }
 
     @Override
-    public int getWeaponArc(int wn) {
-        final Mounted<?> mounted = getEquipment(wn);
+    public int getWeaponArc(int weaponNumber) {
+        final Mounted<?> mounted = getEquipment(weaponNumber);
         if (mounted.isRearMounted()) {
             return Compute.ARC_REAR;
         } else if (mounted.getType().hasFlag(WeaponType.F_VGL)) {

--- a/megamek/src/megamek/common/QuadMek.java
+++ b/megamek/src/megamek/common/QuadMek.java
@@ -241,8 +241,8 @@ public class QuadMek extends Mek {
     }
 
     @Override
-    public int getWeaponArc(int wn) {
-        final Mounted<?> mounted = getEquipment(wn);
+    public int getWeaponArc(int weaponNumber) {
+        final Mounted<?> mounted = getEquipment(weaponNumber);
 
         // B-Pods need to be special-cased, the have 360 firing arc
         if ((mounted.getType() instanceof WeaponType) && mounted.getType().hasFlag(WeaponType.F_B_POD)) {

--- a/megamek/src/megamek/common/SmallCraft.java
+++ b/megamek/src/megamek/common/SmallCraft.java
@@ -584,8 +584,8 @@ public class SmallCraft extends Aero {
 
     // weapon arcs
     @Override
-    public int getWeaponArc(int wn) {
-        final Mounted<?> mounted = getEquipment(wn);
+    public int getWeaponArc(int weaponNumber) {
+        final Mounted<?> mounted = getEquipment(weaponNumber);
 
         int arc = Compute.ARC_NOSE;
         if (!isSpheroid()) {

--- a/megamek/src/megamek/common/SuperHeavyTank.java
+++ b/megamek/src/megamek/common/SuperHeavyTank.java
@@ -350,8 +350,8 @@ public class SuperHeavyTank extends Tank {
     }
 
     @Override
-    public int getWeaponArc(int wn) {
-        final Mounted<?> mounted = getEquipment(wn);
+    public int getWeaponArc(int weaponNumber) {
+        final Mounted<?> mounted = getEquipment(weaponNumber);
 
         // B-Pods need to be special-cased, the have 360 firing arc
         if ((mounted.getType() instanceof WeaponType)

--- a/megamek/src/megamek/common/Tank.java
+++ b/megamek/src/megamek/common/Tank.java
@@ -984,8 +984,8 @@ public class Tank extends Entity {
      * Returns the Compute.ARC that the weapon fires into.
      */
     @Override
-    public int getWeaponArc(int wn) {
-        final Mounted<?> mounted = getEquipment(wn);
+    public int getWeaponArc(int weaponNumber) {
+        final Mounted<?> mounted = getEquipment(weaponNumber);
 
         // B-Pods need to be special-cased, the have 360 firing arc
         if ((mounted.getType() instanceof WeaponType) && mounted.getType().hasFlag(WeaponType.F_B_POD)) {

--- a/megamek/src/megamek/common/Warship.java
+++ b/megamek/src/megamek/common/Warship.java
@@ -12,13 +12,13 @@
  */
 package megamek.common;
 
-import megamek.client.ui.swing.calculationReport.CalculationReport;
-import megamek.common.cost.WarShipCostCalculator;
-import megamek.common.options.OptionsConstants;
+import static megamek.common.Compute.*;
 
 import java.io.Serial;
 
-import static megamek.common.Compute.*;
+import megamek.client.ui.swing.calculationReport.CalculationReport;
+import megamek.common.cost.WarShipCostCalculator;
+import megamek.common.options.OptionsConstants;
 
 /**
  * @author Jay Lawson
@@ -101,8 +101,8 @@ public class Warship extends Jumpship {
     }
 
     @Override
-    public int getWeaponArc(int wn) {
-        final Mounted<?> mounted = getEquipment(wn);
+    public int getWeaponArc(int weaponNumber) {
+        final Mounted<?> mounted = getEquipment(weaponNumber);
         int arc = switch (mounted.getLocation()) {
             case LOC_NOSE -> mounted.isInWaypointLaunchMode() ? ARC_NOSE_WPL : ARC_NOSE;
             case LOC_FRS -> mounted.isInWaypointLaunchMode() ? ARC_RIGHTSIDE_SPHERE_WPL : ARC_RIGHTSIDE_SPHERE;


### PR DESCRIPTION
After seeing #6885 and seeing I'd made the same mistake in the past too, I've changed the signature of the `getWeaponArc` method so it's `weaponNumber` instead of `wn`, and added JavaDocs specifying it should be the equipment number.

I also fixed this bug in `MultiTargetFireControl`.