### PR TITLE
Allow laser insulators to attach to chem lasers

### DIFF
--- a/megamek/src/megamek/common/MekFileParser.java
+++ b/megamek/src/megamek/common/MekFileParser.java
@@ -28,6 +28,7 @@ import megamek.common.loaders.*;
 import megamek.common.util.BuildingBlock;
 import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.common.verifier.TestInfantry;
+import megamek.common.weapons.lasers.CLChemicalLaserWeapon;
 import megamek.common.weapons.ppc.CLERPPC;
 import megamek.common.weapons.ppc.CLEnhancedPPC;
 import megamek.common.weapons.ppc.CLImprovedPPC;
@@ -288,7 +289,10 @@ public class MekFileParser {
                 Predicate<Mounted<?>> linkable = mount -> (mount.getLinkedBy() == null) &&
                                                                 (mount.getLocation() == m.getLocation()) &&
                                                                 (mount.getType() instanceof WeaponType) &&
-                                                                mount.getType().hasFlag(WeaponType.F_LASER);
+                                                                (
+                                                                      mount.getType().hasFlag(WeaponType.F_LASER) ||
+                                                                      mount.getType() instanceof CLChemicalLaserWeapon
+                                                                );
                 // The laser pulse module is also restricted to non-pulse lasers, IS only
                 if (m.getType().hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE)) {
                     linkable = linkable.and(mount -> !mount.getType().hasFlag(WeaponType.F_PULSE) &&

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -36,6 +36,7 @@ import megamek.common.equipment.MiscMounted;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.util.StringUtil;
 import megamek.common.weapons.battlearmor.BAFlamerWeapon;
+import megamek.common.weapons.lasers.CLChemicalLaserWeapon;
 
 /**
  * Abstract parent class for testing and validating instantiations of
@@ -1644,7 +1645,10 @@ public abstract class TestEntity implements TestEntityOption {
                     ((m.getLinked() == null)
                             || (m.getLinked().getLocation() != m.getLocation())
                             || !(m.getLinked().getType() instanceof WeaponType)
-                            || !m.getLinked().getType().hasFlag(WeaponType.F_LASER))) {
+                            || !(
+                                    m.getLinked().getType().hasFlag(WeaponType.F_LASER)
+                                    || m.getLinked().getType() instanceof CLChemicalLaserWeapon
+                                ))) {
                 buff.append("Laser insulator requires a laser in the same location.\n");
                 illegal = true;
             }


### PR DESCRIPTION
Fixes MegaMek/megameklab#1791.

Chemical Lasers don't have the `F_LASER` flag (and giving them that flag would break code in lots of other places that expect `F_LASER` weapons to not consume ammo), so we check for them separately.