### PR TITLE
feat: dataset logger opt-out reset

### DIFF
--- a/megamek/src/megamek/common/preference/ClientPreferences.java
+++ b/megamek/src/megamek/common/preference/ClientPreferences.java
@@ -49,7 +49,7 @@ public class ClientPreferences extends PreferenceStoreProxy {
     public static final String GAMELOG_FILENAME = "GameLogFilename";
     public static final String AUTO_RESOLVE_GAMELOG_FILENAME = "AutoResolveGameLogFilename";
     public static final String STAMP_FILENAMES = "StampFilenames";
-    public static final String DATA_LOGGING = "DataLogging";
+    public static final String DATA_LOGGING = "GameDatasetLogging";
     public static final String STAMP_FORMAT = "StampFormat";
     public static final String SHOW_UNIT_ID = "ShowUnitId";
     public static final String UNIT_START_CHAR = "UnitStartChar";


### PR DESCRIPTION
# What does it do?

Changes the underlying variable name for the dataset logger config, this way any dedicated server that was deployed with a prior version which had the default off will be changed to default on.