### PR TITLE
Issue #6904: Flak attacks must target entities, that must be considered when princess is targeting

### DIFF
--- a/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
+++ b/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
@@ -456,7 +456,11 @@ public class ArtilleryTargetingControl {
 
 
                     for (Targetable target : targetSet) {
-                        boolean targetingEntity = target.getTargetType() == Targetable.TYPE_ENTITY;
+                        boolean attackOnAirborneEntity = (target.getTargetType() == Targetable.TYPE_ENTITY) &&
+                                                              (target instanceof Entity targetedEntity) &&
+                                                              ((targetedEntity.isAirborne()) ||
+                                                                     (targetedEntity.isAirborneVTOLorWIGE()) ||
+                                                                     (targetedEntity.isAirborneAeroOnGroundMap()));
                         double damageValue;
                         if (isZeroDamageMunition) {
                             // Skip zero-damage utility munitions for now.
@@ -473,7 +477,7 @@ public class ArtilleryTargetingControl {
                             }
                         } else {
                             // Flak Artillery need to be made during direct fire, not as Indirect
-                            if (targetingEntity) {
+                            if (attackOnAirborneEntity) {
                                 damageValue = damage;
                             } else {
                                 if (!isADA) {
@@ -503,8 +507,14 @@ public class ArtilleryTargetingControl {
                                 } else {
                                     wfi.getAmmo().setSwitchedReason(1503);
                                 }
-                                if (targetingEntity && (isADA || wfi.getAmmo().getType().getMunitionType().stream().anyMatch(aaMunitions::contains)
-                                              || wfi.getAmmo().getType().countsAsFlak())) {
+                                if (attackOnAirborneEntity &&
+                                          (isADA ||
+                                                 wfi.getAmmo()
+                                                       .getType()
+                                                       .getMunitionType()
+                                                       .stream()
+                                                       .anyMatch(aaMunitions::contains) ||
+                                                 wfi.getAmmo().getType().countsAsFlak())) {
                                     // Handle Flak attacks during Direct Fire
                                     topValuedFlakInfos.clear();
                                     maxDamage = damage;
@@ -515,7 +525,7 @@ public class ArtilleryTargetingControl {
                                     topValuedFireInfos.add(wfi);
                                 }
                             } else if ((damageValue == maxDamage) && (damageValue > 0)) {
-                                if (targetingEntity && (wfi.getAmmo().getType().getMunitionType()
+                                if (attackOnAirborneEntity && (wfi.getAmmo().getType().getMunitionType()
                                         .contains(Munitions.M_ADA) || wfi.getAmmo().getType().getMunitionType().stream().anyMatch(aaMunitions::contains)
                                           || wfi.getAmmo().getType().countsAsFlak())) {
                                     topValuedFlakInfos.add(wfi);

--- a/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
+++ b/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
@@ -19,6 +19,12 @@
 
 package megamek.client.bot.princess;
 
+import static megamek.common.AmmoType.FLARE_MUNITIONS;
+import static megamek.common.AmmoType.MINE_MUNITIONS;
+import static megamek.common.AmmoType.Munitions;
+import static megamek.common.AmmoType.SMOKE_MUNITIONS;
+import static megamek.common.AmmoType.isAmmoValid;
+
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.Enumeration;
@@ -35,8 +41,6 @@ import megamek.common.actions.ArtilleryAttackAction;
 import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.options.OptionsConstants;
-
-import static megamek.common.AmmoType.*;
 
 /**
  * This class handles the creation of firing plans for indirect-fire artillery
@@ -452,6 +456,7 @@ public class ArtilleryTargetingControl {
 
 
                     for (Targetable target : targetSet) {
+                        boolean targetingEntity = target.getTargetType() == Targetable.TYPE_ENTITY;
                         double damageValue;
                         if (isZeroDamageMunition) {
                             // Skip zero-damage utility munitions for now.
@@ -468,7 +473,7 @@ public class ArtilleryTargetingControl {
                             }
                         } else {
                             // Flak Artillery need to be made during direct fire, not as Indirect
-                            if (target.getTargetType() == Targetable.TYPE_ENTITY) {
+                            if (targetingEntity) {
                                 damageValue = damage;
                             } else {
                                 if (!isADA) {
@@ -498,8 +503,8 @@ public class ArtilleryTargetingControl {
                                 } else {
                                     wfi.getAmmo().setSwitchedReason(1503);
                                 }
-                                if (isADA || wfi.getAmmo().getType().getMunitionType().stream().anyMatch(aaMunitions::contains)
-                                              || wfi.getAmmo().getType().countsAsFlak()) {
+                                if (targetingEntity && (isADA || wfi.getAmmo().getType().getMunitionType().stream().anyMatch(aaMunitions::contains)
+                                              || wfi.getAmmo().getType().countsAsFlak())) {
                                     // Handle Flak attacks during Direct Fire
                                     topValuedFlakInfos.clear();
                                     maxDamage = damage;
@@ -510,9 +515,9 @@ public class ArtilleryTargetingControl {
                                     topValuedFireInfos.add(wfi);
                                 }
                             } else if ((damageValue == maxDamage) && (damageValue > 0)) {
-                                if (wfi.getAmmo().getType().getMunitionType()
+                                if (targetingEntity && (wfi.getAmmo().getType().getMunitionType()
                                         .contains(Munitions.M_ADA) || wfi.getAmmo().getType().getMunitionType().stream().anyMatch(aaMunitions::contains)
-                                          || wfi.getAmmo().getType().countsAsFlak()) {
+                                          || wfi.getAmmo().getType().countsAsFlak())) {
                                     topValuedFlakInfos.add(wfi);
                                 } else {
                                     topValuedFireInfos.add(wfi);


### PR DESCRIPTION
Fixes #6904 

Conventional unguided Arrow IV rounds are tagged as flak, so when checking if an attack is flak we can't just look at the ammo, we also need to consider if we're targeting an entity or a hex. If it's a hex, it's not flak.