### PR TITLE
Homing Artillery should work direct fire when targeting a hex

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -2316,12 +2316,6 @@ public class WeaponAttackAction extends AbstractAttackAction {
                         return Messages.getString("WeaponAttackAction.TooLongForDirectArty");
                     }
                 }
-                if (isHoming) {
-                    if ((te == null) || (te.getTaggedBy() == UNASSIGNED)) {
-                        // Homing missiles must target a tagged entity
-                        return Messages.getString("WeaponAttackAction.MustTargetTagged");
-                    }
-                }
             }
 
             // Indirect artillery attacks


### PR DESCRIPTION
I think this was just some old code, with the improvements to artillery this works fine with this check removed. Sleet thinks it "might be based on a misreading of the rule about a TAG+Homing unit designating and firing on the same unit as direct fire". The rules for shooting at things less than 17 hexes away with artillery confuse me. 