### PR TITLE
Fix for ASF Flak shots missing due to erroneous elevation check (ASF Flak uses Altitude)

### DIFF
--- a/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryWeaponIndirectFireHandler.java
@@ -485,16 +485,19 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
             r.add(targetPos.getBoardNum());
             vPhaseReport.addElement(r);
 
-            String artyMsg = "Artillery hit here on round " + game.getRoundCount()
-                    + ", fired by " + game.getPlayer(aaa.getPlayerId()).getName()
-                    + " (this hex is now an auto-hit)";
-            game.getBoard().addSpecialHexDisplay(
-                    targetPos,
-                    new SpecialHexDisplay(Type.ARTILLERY_HIT,
-                            game.getRoundCount(), game.getPlayer(aaa
-                                    .getPlayerId()),
-                            artyMsg));
-
+            if (!isFlak) {
+                String artyMsg = "Artillery hit here on round " +
+                                       game.getRoundCount() +
+                                       ", fired by " +
+                                       game.getPlayer(aaa.getPlayerId()).getName() +
+                                       " (this hex is now an auto-hit)";
+                game.getBoard()
+                      .addSpecialHexDisplay(targetPos,
+                            new SpecialHexDisplay(Type.ARTILLERY_HIT,
+                                  game.getRoundCount(),
+                                  game.getPlayer(aaa.getPlayerId()),
+                                  artyMsg));
+            }
         } else {
             // direct fire artillery only scatters by one d6
             // we do this here to avoid duplicating handle()

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -31680,9 +31680,11 @@ public class TWGameManager extends AbstractGameManager {
                 // Check: is entity excluded?
                 if ((entity == exclude) || alreadyHit.contains(entity.getId())) {
                     continue;
-                    // We now track the blast on a per-level basis
-                } else if ((entity.getElevation() + effectiveLevel > altitude) ||
-                                 (entity.getElevation() + entity.getHeight() + effectiveLevel < altitude)) {
+                // We now track the blast on a per-level basis for non-ASF Flak
+                } else if (!asfFlak && (
+                                 (entity.getElevation() + effectiveLevel > altitude) ||
+                                 (entity.getElevation() + entity.getHeight() + effectiveLevel < altitude)
+                )) {
                     String msg = "Missed due to elevation difference: " +
                                        "entity lvl/ht: " +
                                        hex.getLevel() +


### PR DESCRIPTION
Fixes an issue discovered during other bug fixes: Artillery Flak shots at ASF targets would "hit" but deal no damage.
Root cause was a missing exception to the new elevation check used to place VTOL and WiGE units appropriately within a blast volume.
For ASF targets, we should rely on the ASF-specific altitude check within `artilleryDamageEntity()`.

NOTE: this code does not yet support TacOps Artillery Flak misses correctly.
It should:
1. drift missed shots to another hex at the same altitude;
2. randomly allocate the damage to one unit in the final hex at the correct altitude.
but this has already been identified and is not within scope for this bug fix.

Testing:
- Confirmed correct handling of Flak Artillery hits against ASF in test savegame from #6904 repro
- Ran all 3 projects' unit tests
- Ran large-scale Princess v. Princess battle with multiple AAA units and ASF units, confirming correct targeting behavior and damage delivery.