### PR TITLE
Fix cbf class cast exception

### DIFF
--- a/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
+++ b/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
@@ -484,7 +484,7 @@ public class ArtilleryTargetingControl {
                             if (attackOnAirborneEntity || attackOnEntity) {
                                 // Homing rounds can't hit flying Aerospace units because TAG can't hit them.
                                 boolean homing = ammo.getType().getMunitionType().contains(AmmoType.Munitions.M_HOMING);
-                                damageValue = (target.isAirborne()) ? 0 : damage;
+                                damageValue = (target.isAirborne() && homing) ? 0 : damage;
                             } else {
                                 if (!isADA) {
                                     damageValue = calculateDamageValue(damage, (HexTarget) target, shooter, game, owner);

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -630,8 +630,14 @@ public class WeaponFireInfo {
             String msg = realToHitData.getCumulativePlainDesc();
             ToHitData thd;
             if (game.getPhase() != GamePhase.FIRING) {
-                // Check if any spotters can help us out...
                 Entity te = (target.getTargetType() == Targetable.TYPE_ENTITY) ? (Entity) target : null;
+
+                // Can't hit flying Aerospace with Homing
+                if (te != null && te.isAirborne()) {
+                    return new ToHitData(ToHitData.AUTOMATIC_FAIL, "Aerospace cannot be TAGged, auto-miss");
+                }
+
+                // Check if any spotters can help us out...
                 Entity spotter = Compute.findTAGSpotter(game, shooter, target, false);
                 if (spotter != null) {
                     // Chance of getting a TAG spot is, at base, the spotter's gunnery skill


### PR DESCRIPTION
Also prevents Princess firing Homing munitions at airplanes (seen during testing of the above fix).

The issue is that we narrowed our check for flak target unit types (correctly) but this exposed that we've been handling
Counter-Battery Fire targets against off-board units _incorrectly_.
After some discussion we decided not to change how CBF targeting works at this late date, but we do wish to prevent the Class Cast exception.
Since we only damage the target off-board unit when making CBF attacks, we should treat the damage value the same as for Flak: only the target itself will be damaged.

I also added some clauses to try to prevent Princess from firing Homing rounds at Airborne Aerospace units.
While the other prerequisites might be in place (TAG unit near target, Homing round does more damage, Firing phase) it's not possible to guide Homing munitions to these units so the effective possible damage _is_ zero.

Testing:
- Ran stress game with multiple ASFs, on-board and off-board artillery, and varied munitions.
- Ran all 3 projects' unit tests.