### PR TITLE
Calculate heat for vibroblades

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -1513,6 +1513,14 @@ public class MiscType extends EquipmentType {
                          hasFlag(F_NOVA) ||
                          (hasFlag(F_CLUB) && hasSubType(S_SPOT_WELDER))) {
             return 2;
+        } else if (hasFlag(F_CLUB)) {
+            if (hasSubType(S_VIBRO_SMALL)) {
+                return 3;
+            } else if (hasSubType(S_VIBRO_MEDIUM)) {
+                return 5;
+            } else if (hasSubType(S_VIBRO_LARGE)) {
+                return 7;
+            }
         }
         return 0;
     }


### PR DESCRIPTION
I believe this has no effect in gameplay, but it does mean that Vibroblades on record sheets will show the correct heat value instead of a dash.