### PR TITLE
Restore Periphery general faction to Rifleman -3N model

### DIFF
--- a/megamek/data/forcegenerator/2950.xml
+++ b/megamek/data/forcegenerator/2950.xml
@@ -6035,7 +6035,7 @@
             </model>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
-				<availability>IS:8,CLAN:2-,HL:8,Periphery.Deep:8,BAN:3</availability>
+				<availability>IS:8,CLAN:2-,Periphery:8,HL:8,Periphery.Deep:8,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Ripper Infantry Transport' unitType='VTOL'>

--- a/megamek/data/forcegenerator/3019.xml
+++ b/megamek/data/forcegenerator/3019.xml
@@ -6311,7 +6311,7 @@
             </model>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
-				<availability>IS:8,CLAN:1-,HL:8,Periphery.Deep:8,BAN:2</availability>
+				<availability>IS:8,CLAN:1-,Periphery:8,HL:8,Periphery.Deep:8,BAN:2</availability>
 			</model>
 			<model name='RFL-4D'>
 				<roles>fire_support,anti_aircraft</roles>

--- a/megamek/data/forcegenerator/3028.xml
+++ b/megamek/data/forcegenerator/3028.xml
@@ -6692,7 +6692,7 @@
 			</model>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
-				<availability>IS:8,FC:6,CLAN:1-,HL:8,Periphery.Deep:8,BAN:2</availability>
+				<availability>IS:8,FC:6,CLAN:1-,Periphery:8,HL:8,Periphery.Deep:8,BAN:2</availability>
 			</model>
 			<model name='RFL-4D'>
 				<roles>fire_support,anti_aircraft</roles>

--- a/megamek/data/forcegenerator/3039.xml
+++ b/megamek/data/forcegenerator/3039.xml
@@ -7600,7 +7600,7 @@
 			</model>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
-				<availability>IS:8,FC:6,CLAN:1-,HL:8,Periphery.Deep:8,BAN:2</availability>
+				<availability>IS:8,FC:6,CLAN:1-,Periphery:8,HL:8,Periphery.Deep:8,BAN:2</availability>
 			</model>
 			<model name='RFL-4D'>
 				<roles>fire_support,anti_aircraft</roles>

--- a/megamek/data/forcegenerator/3049.xml
+++ b/megamek/data/forcegenerator/3049.xml
@@ -8815,7 +8815,7 @@
 			</model>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
-				<availability>IS:8,DC:6,FC:6,CLAN.IS:1-,CIR:8,HL:8,Periphery.Deep:8,BAN:1</availability>
+				<availability>IS:8,DC:6,FC:6,CLAN.IS:1-,Periphery:8,CIR:8,HL:8,Periphery.Deep:8,BAN:1</availability>
 			</model>
 			<model name='RFL-4D'>
 				<roles>fire_support,anti_aircraft</roles>


### PR DESCRIPTION
From the discussion on Discord - Periphery general faction was mistakenly removed from Rifleman -3N model in certain eras, which is now restored.