### PR TITLE
fix: uses bot skill generator when creating armies

### DIFF
--- a/megamek/src/megamek/client/ui/swing/RandomArmyDialog.java
+++ b/megamek/src/megamek/client/ui/swing/RandomArmyDialog.java
@@ -699,7 +699,7 @@ public class RandomArmyDialog extends JDialog implements ActionListener, TreeSel
                     try {
                         Entity entity = new MekFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
 
-                        autoSetSkillsAndName(entity);
+                        autoSetSkillsAndName(entity, client);
                         entity.setOwner(client.getLocalPlayer());
                         if (!client.getGame().getPhase().isLounge()) {
                             entity.setDeployRound(client.getGame().getRoundCount() + 1);
@@ -1160,12 +1160,12 @@ public class RandomArmyDialog extends JDialog implements ActionListener, TreeSel
         super.setVisible(show);
     }
 
-    private void autoSetSkillsAndName(Entity e) {
+    private void autoSetSkillsAndName(Entity e, Client client) {
         ClientPreferences cs = PreferenceManager.getClientPreferences();
 
         Arrays.fill(e.getCrew().getClanPilots(), e.isClan());
         if (cs.useAverageSkills()) {
-            m_client.getSkillGenerator().setRandomSkills(e);
+            client.getSkillGenerator().setRandomSkills(e);
         }
 
         for (int i = 0; i < e.getCrew().getSlotCount(); i++) {


### PR DESCRIPTION
# What this does?

Selects the skill generator from the correct client when creating random armies for bots using the `Create Random Army...` tool.

## What was wrong with it?

It was using the local player client to grab the skill generator instead of grabing the skill generator from the correct bot client.

## Checks

- [x] The bug was reproduced manually.
- [x] The bug was resolved in all cases.
- [x] It was manually tested multiple times.

- Closes  #6927