### PR TITLE
Fix: Fixed Quad-Vees Taking PSRs and Falling While in Vehicle Mode

### DIFF
--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -1,7 +1,7 @@
 MEGAMEK VERSION HISTORY:
 ----------------
 0.50.06
-+ PR #6933: 0.50.06 Deprecation Removal and Clean up. 
++ PR #6933: 0.50.06 Deprecation Removal and Clean up.
 + PR #6901: move sprite, spriteHandler, overlay, toolTip, phaseDisplay and phaseDiplay.dialogs classes into packages
 + PR #6864: Added Heroic and Legendary Skill Levels
 + Fix #6915: Fixed Status of Uncrewed Vehicles
@@ -9,21 +9,22 @@ MEGAMEK VERSION HISTORY:
 + PR #6937: Calculate heat for vibroblades
 + Fix #6946: Fixes the Damage Status box on Label no appearing correctly. #6810
 + Fix #6945: uses bot skill generator when creating armies issue #6927
++ Fix #6825: Fixed Quad-Vees Taking PSRs and Falling While in Vehicle Mode
 
 0.50.05 (2025-04-25 1800 UTC)
 + Fix #6652: ProtoMek BV fixed for melee weapons and LRM-1
 + PR #6752: Mek jump boosters and jump jets
 + PR #6758: Removed Deprecated methods from MMLogger and updated impacted calls
 + PR #6764: GitHub CodeQL Error Fixes
-+ PR #6763: MM-side fix for MHQ 6373: Prevent impossible Counter-Battery Fire shots from being taken 
-+ PR #6779: Fixed Missing Prone Modifier in Weapon Attack Calculation 
-+ PR #6777: Added Missing Handheld Weapon Unit Type to Messages Properties 
-+ PR #6776: Corrected Spelling of 'Land Air' Unit Type 
-+ PR #6774: Removed 3 Duplicate Callsigns 
-+ PR #6771: Add missing type check for MiscType 
-+ PR #6770: Fixed ConcurrentModification Exceptions In BV Calculation Methods 
-+ PR #6768: Fixed issues with Implicit narrowing conversion in compound assignment. 
-+ PR #6782: add Save As to the board preview in the lobby 
++ PR #6763: MM-side fix for MHQ 6373: Prevent impossible Counter-Battery Fire shots from being taken
++ PR #6779: Fixed Missing Prone Modifier in Weapon Attack Calculation
++ PR #6777: Added Missing Handheld Weapon Unit Type to Messages Properties
++ PR #6776: Corrected Spelling of 'Land Air' Unit Type
++ PR #6774: Removed 3 Duplicate Callsigns
++ PR #6771: Add missing type check for MiscType
++ PR #6770: Fixed ConcurrentModification Exceptions In BV Calculation Methods
++ PR #6768: Fixed issues with Implicit narrowing conversion in compound assignment.
++ PR #6782: add Save As to the board preview in the lobby
 + PR #6795: Fixes for various Artillery and Artillery Flak issues
 + PR #6796: feat: add a callsign to princess instead of numbers
 + PR #6806: Added Method for Variable Cost Check in MiscType
@@ -34,8 +35,8 @@ MEGAMEK VERSION HISTORY:
 + PR #6790: Data updates - Throw the freebirths a bone, quiaff? Clan conventional infantry
 + PR #6762: Update Stalker STK-8S.mtf
 + PR #6761: Stalker Jamison TechBase Fix: Mixed >>> Clan
-+ PR #6760: Update Tomahawk II (Prime).mtf 
-+ PR #6759: Update Mackie MSK-6S introduction date 
++ PR #6760: Update Tomahawk II (Prime).mtf
++ PR #6759: Update Mackie MSK-6S introduction date
 + Fix #6751: Princess will now deploy mines on her turn instead of at the start of the phase.
 + PR #6829: Expanded MathUtility Integer Parsing
 + PR #6832: Corrects custom armor calculation required for megameklab#1820 that fixes megameklab#1808: Conventional infantry custom armor not appearring on record sheet
@@ -137,7 +138,7 @@ MEGAMEK VERSION HISTORY:
 + PR #6617: Preliminary handheld weapon support
 + Fix #6604: Fuel Air Explosives do no damage to off-board units
 + PR #6615: Feat: More princess commands - ignore player/turret, order offboard artillery
-+ Fix #6622: Putting multiple shields on a mek's arm is not flagged as invalid. 
++ Fix #6622: Putting multiple shields on a mek's arm is not flagged as invalid.
 + Fix #6641: Validate that HHWs can't have multiple different ammo bins for a single weapon kind.
 + Fix #6048: All short range artillery fire now happens in the weapon attack phase and uses attacker movement modifiers
 + Fix #6147: Infantry can now be carried in both infantry and cargo bays on vehicles
@@ -145,11 +146,11 @@ MEGAMEK VERSION HISTORY:
 + PR #6643: Fix MekHQ Issue 3655 - vehicle crew requirements for trailers
 + PR #6645: Support multiselect in the Add Unit dialog
 + PR #6647: Allow pasting units into selected player list (if selected)
-+ PR #6667: feat: allow princess to deploy mines in random clear hexes on the map 
++ PR #6667: feat: allow princess to deploy mines in random clear hexes on the map
 + PR #6653: Fixes MekHQ Issue 6026 - Prevents overkilling Aero when they should survive (ACAR)
 + Fix #6654: Prevents crashing when selected skin file is missing
 + Fix #6665: Wind strength adheres to wind min and max settings
-+ PR #6669: Replace Java accent normalization wtih ICU4J, a capable unicode library to normalize text in more scenarios 
++ PR #6669: Replace Java accent normalization wtih ICU4J, a capable unicode library to normalize text in more scenarios
 + PR #6661: Weapon Panel null check and logging
 + Fix #6630: Attempts to fix saving GIFs and improves error messages
 + Fix #6670: Makes gif writer finish the gif at victory phase
@@ -197,11 +198,11 @@ MEGAMEK VERSION HISTORY:
 + Fix MekHQ#6619: Move RestoreUnitAction::copyC3Networks from MekHQ to MegaMek's C3Utils
 + Fix #6867: Excluded Infantry Attack From Edit Unit Damage Dialog
 + PR #6885: fix: wrong access for weapon arc
-+ PR #6886: Change getWeaponArc signature and add JavaDocs 
-+ Fix #6899: fix can not load save in same version 
++ PR #6886: Change getWeaponArc signature and add JavaDocs
++ Fix #6899: fix can not load save in same version
 
 0.50.03 (2025-02-02 2030 UTC)
-+ PR #6335: default the directory filter to Select All in Advanced Board Search 
++ PR #6335: default the directory filter to Select All in Advanced Board Search
 + PR #6335: cleanup duplicate boards
 + PR #6328: Building type enum
 + PR #6340: MML tabbed UI docs update
@@ -228,7 +229,7 @@ MEGAMEK VERSION HISTORY:
 + PR #6409: Campaign Options IIC - MegaMek Portion
 + PR #6415: fixes an error where force consolidation would not set the correct owner of the force
 + PR #6411: Don't load mml scratch files into unit cache
-+ PR #6414: Warnings on Campaign Load - MegaMek Portion 
++ PR #6414: Warnings on Campaign Load - MegaMek Portion
 + Fix #6412: Fix TacOps "Standing Still" modifier description
 + Fix #6373: Fixed "unit that starts and ends a Movement Phase in liquid magma takes an additional damage" so it doesn't apply to units above the magma
 + PR #6427 & #6428: Fix for Princess not ignoring Hidden and Ignored units. - Scoppio

--- a/megamek/src/megamek/common/QuadVee.java
+++ b/megamek/src/megamek/common/QuadVee.java
@@ -3,7 +3,7 @@
  *
  * This file is part of MegaMek.
  *
- * <Package Name> is free software: you can redistribute it and/or modify
+ * MegaMek is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License (GPL),
  * version 3 or (at your option) any later version,
  * as published by the Free Software Foundation.

--- a/megamek/src/megamek/common/QuadVee.java
+++ b/megamek/src/megamek/common/QuadVee.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022-2025 - The MegaMek Team. All Rights Reserved.
  *
- * This file is part of <Package Name>.
+ * This file is part of MegaMek.
  *
  * <Package Name> is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License (GPL),

--- a/megamek/src/megamek/common/QuadVee.java
+++ b/megamek/src/megamek/common/QuadVee.java
@@ -8,7 +8,7 @@
  * version 3 or (at your option) any later version,
  * as published by the Free Software Foundation.
  *
- * <Package Name> is distributed in the hope that it will be useful,
+ * MegaMek is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty
  * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  * See the GNU General Public License for more details.

--- a/megamek/src/megamek/common/QuadVee.java
+++ b/megamek/src/megamek/common/QuadVee.java
@@ -1,20 +1,34 @@
 /*
- * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2022-2025 - The MegaMek Team. All Rights Reserved.
  *
- * This file is part of MegaMek.
+ * This file is part of <Package Name>.
  *
- * MegaMek is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * <Package Name> is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
  *
- * MegaMek is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
+ * <Package Name> is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. <Package Name> was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package megamek.common;
 
@@ -376,7 +390,8 @@ public class QuadVee extends QuadMek {
     @Override
     public boolean canFall(boolean gyroLegDamage) {
         // QuadVees cannot fall due to failed PSR in vehicle mode.
-        return !isProne() || getConversionMode() == CONV_MODE_MEK || (convertingNow && game.getPhase().isMovement());
+        return (getConversionMode() == CONV_MODE_MEK && !isProne()) ||
+                     (convertingNow && game.getPhase().isMovement() && !isProne());
     }
 
     /**


### PR DESCRIPTION
Fix #6825

### Dev Notes
Our earlier attempt to fix the quad-vee PSR issue introduced a new one.

Basically, we had added a check that unintentionally allowed PSRs so long as the quad-vee wasn't prone. This shortcut the other checks that ensured this was only checked if the quad-vee was eligible for falling checks.