### PR TITLE
fix for null clientgui and memory leaks

### DIFF
--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -9,6 +9,7 @@ MEGAMEK VERSION HISTORY:
 + PR #6937: Calculate heat for vibroblades
 + Fix #6946: Fixes the Damage Status box on Label no appearing correctly. #6810
 + Fix #6945: uses bot skill generator when creating armies issue #6927
++ Fix #6954: Fixes NPE and missing portrait/deployment in Mek Customization dialog
 
 0.50.05 (2025-04-25 1800 UTC)
 + Fix #6652: ProtoMek BV fixed for melee weapons and LRM-1

--- a/megamek/src/megamek/client/ui/dialogs/BVDisplayDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/BVDisplayDialog.java
@@ -87,4 +87,9 @@ public class BVDisplayDialog extends AbstractDialog {
         Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
         clipboard.setContents(new StringSelection(reportString), null);
     }
+
+    @Override
+    protected void cancelAction() {
+        dispose();
+    }
 }

--- a/megamek/src/megamek/client/ui/dialogs/UnitDisplayDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/UnitDisplayDialog.java
@@ -26,7 +26,6 @@ import java.awt.event.WindowEvent;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 
-import megamek.client.Client;
 import megamek.client.ui.Messages;
 import megamek.client.ui.swing.ClientGUI;
 import megamek.client.ui.swing.GUIPreferences;
@@ -67,6 +66,7 @@ public class UnitDisplayDialog extends JDialog {
     //region Constructors
     public UnitDisplayDialog(final JFrame frame, final ClientGUI clientGUI) {
         super(frame, "", false);
+        this.clientGUI = clientGUI;
         this.setTitle(Messages.getString("ClientGUI.MekDisplay"));
 
         if (GUIP.getUnitDisplayStartTabbed()) {
@@ -88,7 +88,6 @@ public class UnitDisplayDialog extends JDialog {
             }
         });
 
-        this.clientGUI = clientGUI;
     }
     //endregion Constructors
 

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -1117,6 +1117,53 @@ public class ClientGUI extends AbstractClientGUI
 
     }
 
+    private void cleanupDialogs() {
+        if (unitDisplayDialog != null) {
+            unitDisplayDialog.dispose();
+            unitDisplayDialog = null;
+        }
+        if (forceDisplayDialog != null) {
+            forceDisplayDialog.dispose();
+            forceDisplayDialog = null;
+        }
+        if (minimapW != null) {
+            minimapW.dispose();
+            minimapW = null;
+        }
+        if (miniReportDisplayDialog != null) {
+            miniReportDisplayDialog.dispose();
+            miniReportDisplayDialog = null;
+        }
+        if (gameOptionsDialog != null) {
+            gameOptionsDialog.dispose();
+            gameOptionsDialog = null;
+        }
+        if (mekSelectorDialog != null) {
+            mekSelectorDialog.dispose();
+            mekSelectorDialog = null;
+        }
+        if (playerListDialog != null) {
+            playerListDialog.dispose();
+            playerListDialog = null;
+        }
+        if (randomArmyDialog != null) {
+            randomArmyDialog.dispose();
+            randomArmyDialog = null;
+        }
+        if (conditionsDialog != null) {
+            conditionsDialog.dispose();
+            conditionsDialog = null;
+        }
+        if (setdlg != null) {
+            setdlg.dispose();
+            setdlg = null;
+        }
+        if (help != null) {
+            help.dispose();
+            help = null;
+        }
+    }
+
     @Override
     public void die() {
         // Tell all the displays to remove themselves as listeners.
@@ -1144,16 +1191,21 @@ public class ClientGUI extends AbstractClientGUI
 
         TimerSingleton.getInstance().killTimer();
 
+        cleanupDialogs();
+
         if (controller != null) {
             controller.removeAllActions();
             controller.clientgui = null;
+        }
+        if (aw != null) {
+            aw.dispose();
+            aw = null;
         }
 
         if (menuBar != null) {
             menuBar.die();
             menuBar = null;
         }
-
         if (curPanel instanceof StatusBarPhaseDisplay) {
             ((StatusBarPhaseDisplay) curPanel).stopTimer();
         }

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -1148,6 +1148,7 @@ public class ClientGUI extends AbstractClientGUI
             controller.removeAllActions();
             controller.clientgui = null;
         }
+
         if (menuBar != null) {
             menuBar.die();
             menuBar = null;

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -1148,15 +1148,11 @@ public class ClientGUI extends AbstractClientGUI
             controller.removeAllActions();
             controller.clientgui = null;
         }
-        if (aw != null) {
-            aw.dispose();
-            aw = null;
-        }
-
         if (menuBar != null) {
             menuBar.die();
             menuBar = null;
         }
+
         if (curPanel instanceof StatusBarPhaseDisplay) {
             ((StatusBarPhaseDisplay) curPanel).stopTimer();
         }

--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -1117,53 +1117,6 @@ public class ClientGUI extends AbstractClientGUI
 
     }
 
-    private void cleanupDialogs() {
-        if (unitDisplayDialog != null) {
-            unitDisplayDialog.dispose();
-            unitDisplayDialog = null;
-        }
-        if (forceDisplayDialog != null) {
-            forceDisplayDialog.dispose();
-            forceDisplayDialog = null;
-        }
-        if (minimapW != null) {
-            minimapW.dispose();
-            minimapW = null;
-        }
-        if (miniReportDisplayDialog != null) {
-            miniReportDisplayDialog.dispose();
-            miniReportDisplayDialog = null;
-        }
-        if (gameOptionsDialog != null) {
-            gameOptionsDialog.dispose();
-            gameOptionsDialog = null;
-        }
-        if (mekSelectorDialog != null) {
-            mekSelectorDialog.dispose();
-            mekSelectorDialog = null;
-        }
-        if (playerListDialog != null) {
-            playerListDialog.dispose();
-            playerListDialog = null;
-        }
-        if (randomArmyDialog != null) {
-            randomArmyDialog.dispose();
-            randomArmyDialog = null;
-        }
-        if (conditionsDialog != null) {
-            conditionsDialog.dispose();
-            conditionsDialog = null;
-        }
-        if (setdlg != null) {
-            setdlg.dispose();
-            setdlg = null;
-        }
-        if (help != null) {
-            help.dispose();
-            help = null;
-        }
-    }
-
     @Override
     public void die() {
         // Tell all the displays to remove themselves as listeners.
@@ -1190,8 +1143,6 @@ public class ClientGUI extends AbstractClientGUI
         client.die();
 
         TimerSingleton.getInstance().killTimer();
-
-        cleanupDialogs();
 
         if (controller != null) {
             controller.removeAllActions();

--- a/megamek/src/megamek/client/ui/swing/CustomMekDialog.java
+++ b/megamek/src/megamek/client/ui/swing/CustomMekDialog.java
@@ -160,9 +160,9 @@ public class CustomMekDialog extends AbstractButtonDialog
     private boolean okay;
     private int status = CustomMekDialog.DONE;
 
-    private ClientGUI clientGUI;
+    private final ClientGUI clientGUI;
     private final Client client;
-    private boolean space;
+    private final boolean space;
 
     private PilotOptions options;
     private PartialRepairs partReps;
@@ -188,15 +188,26 @@ public class CustomMekDialog extends AbstractButtonDialog
      */
     public CustomMekDialog(ClientGUI clientgui, Client client, List<Entity> entities, boolean editable,
           boolean editableDeployment) {
-        this(clientgui.getFrame(), client, entities, editable, editableDeployment);
+            
+        super(clientgui.getFrame(), "CustomizeMekDialog", "CustomMekDialog.title");
+        this.entities = entities;
         this.clientGUI = clientgui;
+        this.client = client;
         this.space = clientgui.getClient().getMapSettings().getMedium() == Board.T_SPACE;
+        this.editable = editable;
+        this.editableDeployment = editableDeployment;
+
+        // Ensure we have at least one passed entity, anything less makes no sense
+        if (entities.isEmpty()) {
+            throw new IllegalStateException("Must pass at least one Entity!");
+        }
+
+        initialize();
     }
 
     public CustomMekDialog(JFrame frame, Client client, List<Entity> entities, boolean editable,
           boolean editableDeployment) {
         super(frame, "CustomizeMekDialog", "CustomMekDialog.title");
-
         this.entities = entities;
         this.clientGUI = null;
         this.client = client;

--- a/megamek/src/megamek/client/ui/swing/MapMenu.java
+++ b/megamek/src/megamek/client/ui/swing/MapMenu.java
@@ -762,6 +762,7 @@ public class MapMenu extends JPopupMenu {
             UnitEditorDialog med = new UnitEditorDialog(gui.getFrame(), entity);
             gui.getBoardView().setShouldIgnoreKeys(true);
             med.setVisible(true);
+            med.dispose();
             client.sendUpdateEntity(entity);
             gui.getBoardView().setShouldIgnoreKeys(false);
         });

--- a/megamek/src/megamek/client/ui/swing/MapMenu.java
+++ b/megamek/src/megamek/client/ui/swing/MapMenu.java
@@ -749,6 +749,7 @@ public class MapMenu extends JPopupMenu {
             med.refreshOptions();
             gui.getBoardView().setShouldIgnoreKeys(true);
             med.setVisible(true);
+            med.dispose();
             client.sendUpdateEntity(entity);
             gui.getBoardView().setShouldIgnoreKeys(false);
         });

--- a/megamek/src/megamek/client/ui/swing/ScenarioDialog.java
+++ b/megamek/src/megamek/client/ui/swing/ScenarioDialog.java
@@ -68,9 +68,13 @@ public class ScenarioDialog extends JDialog implements ActionListener {
             curButton.setPreferredSize(new Dimension(84, 72));
             curButton.addActionListener(e -> {
                 final CamoChooserDialog ccd = new CamoChooserDialog(frame, curPlayer.getCamouflage());
-                if (ccd.showDialog().isConfirmed()) {
-                    curPlayer.setCamouflage(ccd.getSelectedItem());
-                    curButton.setIcon(curPlayer.getCamouflage().getImageIcon());
+                try {
+                    if (ccd.showDialog().isConfirmed()) {
+                        curPlayer.setCamouflage(ccd.getSelectedItem());
+                        curButton.setIcon(curPlayer.getCamouflage().getImageIcon());
+                    }
+                } finally {
+                    ccd.dispose();
                 }
             });
         }

--- a/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/ChatLounge.java
@@ -464,20 +464,23 @@ public class ChatLounge extends AbstractPhaseDisplay
         }
         Player player = getSelectedClient().getLocalPlayer();
         CamoChooserDialog ccd = new CamoChooserDialog(clientgui.getFrame(), player.getCamouflage());
-        java.util.List<Entity> playerEntities = game().getPlayerEntities(player, false);
-        if (!playerEntities.isEmpty()) {
-            ccd.setDisplayedEntity(CollectionUtil.anyOneElement(playerEntities));
+        try {
+            java.util.List<Entity> playerEntities = game().getPlayerEntities(player, false);
+            if (!playerEntities.isEmpty()) {
+                ccd.setDisplayedEntity(CollectionUtil.anyOneElement(playerEntities));
+            }
+            // If the dialog was canceled or nothing selected, do nothing
+            if (!ccd.showDialog().isConfirmed()) {
+                return;
+            }
+    
+            // Update the player from the camo selection
+            player.setCamouflage(ccd.getSelectedItem());
+            butCamo.setIcon(player.getCamouflage().getImageIcon());
+            getSelectedClient().sendPlayerInfo();
+        } finally {
+            ccd.dispose();
         }
-
-        // If the dialog was canceled or nothing selected, do nothing
-        if (!ccd.showDialog().isConfirmed()) {
-            return;
-        }
-
-        // Update the player from the camo selection
-        player.setCamouflage(ccd.getSelectedItem());
-        butCamo.setIcon(player.getCamouflage().getImageIcon());
-        getSelectedClient().sendPlayerInfo();
     };
 
     private void setupTeamOverview() {

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyActions.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyActions.java
@@ -326,7 +326,10 @@ public class LobbyActions {
 
         if (cmd.isOkay() && (cmd.getStatus() != CustomMekDialog.DONE)) {
             Entity nextEnt = cmd.getNextEntity(cmd.getStatus() == CustomMekDialog.NEXT);
+            cmd.dispose();
             customizeMek(nextEnt);
+        } else {
+            cmd.dispose();
         }
     }
 
@@ -372,6 +375,7 @@ public class LobbyActions {
             } else {
                 doneCustomizing = true;
             }
+            cmd.dispose();
         }
     }
 

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyActions.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyActions.java
@@ -222,6 +222,7 @@ public class LobbyActions {
         Entity entity = CollectionUtil.anyOneElement(entities);
         UnitEditorDialog med = new UnitEditorDialog(frame(), entity);
         med.setVisible(true);
+        med.dispose();
         sendUpdates(entities);
     }
 

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyActions.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyActions.java
@@ -279,21 +279,24 @@ public class LobbyActions {
         Entity entity = CollectionUtil.anyOneElement(entities);
         boolean hasIndividualCamo = entities.stream().anyMatch(e -> !e.getCamouflage().hasDefaultCategory());
         CamoChooserDialog ccd = new CamoChooserDialog(frame(), entity.getCamouflageOrElseOwners(), hasIndividualCamo);
-        ccd.setDisplayedEntity(entity);
-        if (ccd.showDialog().isCancelled()) {
-            return;
+        try {
+            ccd.setDisplayedEntity(entity);
+            if (ccd.showDialog().isCancelled()) {
+                return;
+            }
+            // Choosing the player camo resets the units to have no individual camo.
+            Camouflage selectedItem = ccd.getSelectedItem();
+            Camouflage ownerCamo = entity.getOwner().getCamouflage();
+            boolean noIndividualCamo = selectedItem.equals(ownerCamo);
+    
+            // Update all allowed entities with the camo
+            for (final Entity ent : entities) {
+                ent.setCamouflage(noIndividualCamo ? ownerCamo : selectedItem);
+            }
+            sendUpdates(entities);
+        } finally {
+            ccd.dispose();
         }
-
-        // Choosing the player camo resets the units to have no individual camo.
-        Camouflage selectedItem = ccd.getSelectedItem();
-        Camouflage ownerCamo = entity.getOwner().getCamouflage();
-        boolean noIndividualCamo = selectedItem.equals(ownerCamo);
-
-        // Update all allowed entities with the camo
-        for (final Entity ent : entities) {
-            ent.setCamouflage(noIndividualCamo ? ownerCamo : selectedItem);
-        }
-        sendUpdates(entities);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/lobby/LobbyMekPopup.java
+++ b/megamek/src/megamek/client/ui/swing/lobby/LobbyMekPopup.java
@@ -855,8 +855,12 @@ class LobbyMekPopup {
             miSelectedCamouflage.addActionListener(evt -> {
                 final CamoChooserDialog camoChooserDialog = new CamoChooserDialog(frame,
                         entity.getCamouflageOrElseOwners());
-                if (camoChooserDialog.showDialog().isConfirmed()) {
-                    exportSprite(frame, entity, camoChooserDialog.getSelectedItem(), false);
+                try {
+                    if (camoChooserDialog.showDialog().isConfirmed()) {
+                        exportSprite(frame, entity, camoChooserDialog.getSelectedItem(), false);
+                    }
+                } finally {
+                    camoChooserDialog.dispose();
                 }
             });
             exportUnitSpriteMenu.add(miSelectedCamouflage);
@@ -869,9 +873,13 @@ class LobbyMekPopup {
             miSelectedCamouflageAndCurrentDamage.addActionListener(evt -> {
                 final CamoChooserDialog camoChooserDialog = new CamoChooserDialog(frame,
                         entity.getCamouflageOrElseOwners());
-                if (camoChooserDialog.showDialog().isConfirmed()) {
-                    exportSprite(frame, entity, camoChooserDialog.getSelectedItem(), true);
-                }
+                        try {
+                            if (camoChooserDialog.showDialog().isConfirmed()) {
+                                exportSprite(frame, entity, camoChooserDialog.getSelectedItem(), true);
+                            }
+                        } finally {
+                            camoChooserDialog.dispose();
+                        }
             });
             exportUnitSpriteMenu.add(miSelectedCamouflageAndCurrentDamage);
         }


### PR DESCRIPTION
fixes NPE and the issue preventing to edit deployment and portrait of unit.
This is solved by splitting the two versions of the constructor instead of relying on the one without clientGUI (that would cause the UI initialization without it)
Fixed also some memory leaks caused by this dialog, the damage dialog and the camo dialog.

Fixes https://github.com/MegaMek/megamek/issues/6950