### PR TITLE
Fix 6955: fuel tanks take zero damage from AE

### DIFF
--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -11,6 +11,7 @@ MEGAMEK VERSION HISTORY:
 + Fix #6945: uses bot skill generator when creating armies issue #6927
 + PR #6934: Dereference NPE Removals in MovementDisplay, moved MoveCommand to own class, added tests.
 + Fix #6954: Fixes NPE and missing portrait/deployment in Mek Customization dialog
++ Fix #6955: fuel tanks take zero damage from AE
 + Fix #6956: Correct fluff art for HHWs
 
 0.50.05 (2025-04-25 1800 UTC)

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -31616,7 +31616,8 @@ public class TWGameManager extends AbstractGameManager {
             // Buildings do _not_ shield housed units from artillery damage!
             if ((bldg != null) &&
                       ((altitude < hex.terrainLevel(Terrains.BLDG_ELEV)) ||
-                             (altitude < hex.terrainLevel(Terrains.BRIDGE_ELEV))) &&
+                             (altitude < hex.terrainLevel(Terrains.BRIDGE_ELEV)) ||
+                             (altitude < hex.terrainLevel(Terrains.FUEL_TANK_ELEV))) &&
                       !(asfFlak)) {
                 if (!((ammo != null) && (ammo.getMunitionType().contains(Munitions.M_FLECHETTE)))) {
                     int buildingDamage;

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -31615,9 +31615,9 @@ public class TWGameManager extends AbstractGameManager {
 
             // Buildings do _not_ shield housed units from artillery damage!
             if ((bldg != null) &&
-                      ((altitude < hex.terrainLevel(Terrains.BLDG_ELEV)) ||
-                             (altitude < hex.terrainLevel(Terrains.BRIDGE_ELEV)) ||
-                             (altitude < hex.terrainLevel(Terrains.FUEL_TANK_ELEV))) &&
+                      ((altitude < effectiveLevel + hex.terrainLevel(Terrains.BLDG_ELEV)) ||
+                             (altitude < effectiveLevel + hex.terrainLevel(Terrains.BRIDGE_ELEV)) ||
+                             (altitude < effectiveLevel + hex.terrainLevel(Terrains.FUEL_TANK_ELEV))) &&
                       !(asfFlak)) {
                 if (!((ammo != null) && (ammo.getMunitionType().contains(Munitions.M_FLECHETTE)))) {
                     int buildingDamage;


### PR DESCRIPTION
Identified another level-based issue with AE blast damage: Fuel Tank installations were not having their height checked against the blast height, effectively treating them as buried structures immune to Area Effect damage.

Testing:
1. Tested various AE weapons against Fuel Tanks.
2. Ran all 3 projects' unit tests.

Close #6955 