### PR TITLE
Fix: Added Missing Machine Gun Burst Fire Toggle Label in Edit Unit Dialog

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -1597,6 +1597,7 @@ CustomMekDialog.Active=Active Mine
 CustomMekDialog.Inferno=Inferno Mine
 CustomMekDialog.Command-detonated=Command-detonated Mine
 CustomMekDialog.switchToHotLoading=Hot-Load Ammo
+CustomMekDialog.burstFireMachineGun=({0}) Enable Burst-Fire
 CustomMekDialog.useOwners=Use Owners*
 CustomMekDialog.deployAny=Any
 CustomMekDialog.deployNW=NW

--- a/megamek/src/megamek/client/ui/swing/panels/RapidFireMGPanel.java
+++ b/megamek/src/megamek/client/ui/swing/panels/RapidFireMGPanel.java
@@ -50,7 +50,7 @@ public class RapidFireMGPanel extends JPanel {
     public RapidFireMGPanel(Mounted<?> mounted, Entity entity) {
         this.mounted = mounted;
         int mountedLocation = mounted.getLocation();
-        String stringDescription = Messages.getString("CustomMekDialog.gridBagLayout",
+        String stringDescription = Messages.getString("CustomMekDialog.burstFireMachineGun",
               entity.getLocationAbbr(mountedLocation));
         JLabel labelLocation = new JLabel(stringDescription);
         GridBagLayout gridBagLayout = new GridBagLayout();

--- a/megamek/src/megamek/client/ui/swing/panels/RapidFireMGPanel.java
+++ b/megamek/src/megamek/client/ui/swing/panels/RapidFireMGPanel.java
@@ -24,6 +24,11 @@
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
  * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package megamek.client.ui.swing.panels;
 


### PR DESCRIPTION
### Dev Notes
The label for toggling machine gun burst fire was missing. I added it back.

![image](https://github.com/user-attachments/assets/9806e53a-9c7c-4e94-80ad-8f161f3d9444)
