### PR TITLE
Distinguish Mek weapons from BA weapons in advanced search

### DIFF
--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -15,6 +15,7 @@ MEGAMEK VERSION HISTORY:
 + Fix #6955: fuel tanks take zero damage from AE
 + Fix #6956: Correct fluff art for HHWs
 + Fix #6957: BA Artillery doing no damage
++ PR #6965: Disambiguate BA vs Mek weapons with the same name
 
 0.50.05 (2025-04-25 1800 UTC)
 + Fix #6652: ProtoMek BV fixed for melee weapons and LRM-1

--- a/megamek/src/megamek/client/ui/advancedsearch/WeaponsTableModel.java
+++ b/megamek/src/megamek/client/ui/advancedsearch/WeaponsTableModel.java
@@ -18,12 +18,12 @@
  */
 package megamek.client.ui.advancedsearch;
 
-import megamek.common.TechConstants;
-import megamek.common.WeaponType;
-
-import javax.swing.table.AbstractTableModel;
 import java.util.ArrayList;
 import java.util.List;
+import javax.swing.table.AbstractTableModel;
+
+import megamek.common.TechConstants;
+import megamek.common.WeaponType;
 
 /**
  * A table model for displaying weapons
@@ -107,7 +107,7 @@ class WeaponsTableModel extends AbstractTableModel {
         }
         WeaponType wp = weapons.get(row);
         return switch (col) {
-            case COL_NAME -> wp.getName();
+            case COL_NAME -> wp.getUniqueName();
             case COL_IS_CLAN -> TechConstants.getTechName(wp.getTechLevel(twAdvancedSearchPanel.gameYear));
             case COL_DMG -> wp.getDamage();
             case COL_HEAT -> wp.getHeat();

--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -136,6 +136,8 @@ public class EquipmentType implements ITechnology {
 
     protected String name = null;
 
+    protected String uniqueName = null;
+
     // Short name for RS Printing
     protected String shortName = "";
 
@@ -231,6 +233,22 @@ public class EquipmentType implements ITechnology {
 
     public String getName(double size) {
         return getName();
+    }
+
+    /**
+     * A user-friendly name, similar to {@link #getName()}, but is less likely to share a name with other equipment.
+     * For example, <i>Medium Laser [BA]</i> instead of <i>Medium Laser</i>.
+     * <p>
+     * The returned name is not guaranteed to actually be unique. In particular, equipment with an IS and Clan
+     * counterpart will still show the same name.
+     * <p>
+     * When this function was created, it was to be used in a list of equipment that separately displayed the tech base.
+     * If you need a truly unique identifier, use {@link #getInternalName()} instead, if you also need it to be
+     * user-friendly, update this method.
+     * @return A user-friendly name.
+     */
+    public String getUniqueName() {
+        return Objects.requireNonNullElse(uniqueName, getName());
     }
 
     public String getDesc() {

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAAPGaussRifle.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAAPGaussRifle.java
@@ -26,6 +26,7 @@ public class CLBAAPGaussRifle extends Weapon {
     public CLBAAPGaussRifle() {
         super();
         name = "Gauss Rifle [Anti-personnel Gauss Rifle]";
+        uniqueName = name + " [BA]";
         shortName = "AP Gauss";
         setInternalName("CLBAAPGaussRifle");
         heat = 1;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAERPulseLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAERPulseLaserMedium.java
@@ -26,6 +26,7 @@ public class CLBAERPulseLaserMedium extends PulseLaserWeapon {
     public CLBAERPulseLaserMedium() {
         super();
         name = "ER Medium Pulse Laser";
+        uniqueName = name + " [BA]";
         setInternalName("BACLERMediumPulseLaser");
         addLookupName("CLBAERMediumPulseLaser");
         addLookupName("BA Clan ER Pulse Med Laser");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAERPulseLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAERPulseLaserSmall.java
@@ -27,6 +27,7 @@ public class CLBAERPulseLaserSmall extends PulseLaserWeapon {
     public CLBAERPulseLaserSmall() {
         super();
         name = "ER Small Pulse Laser";
+        uniqueName = name + " [BA]";
         setInternalName("CLBAERSmallPulseLaser");
         addLookupName("Clan BA ER Pulse Small Laser");
         addLookupName("Clan BA ER Small Pulse Laser");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALRM1.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALRM1.java
@@ -30,6 +30,7 @@ public class CLBALRM1 extends LRMWeapon {
     public CLBALRM1() {
         super();
         name = "LRM 1";
+        uniqueName = name + " [BA]";
         setInternalName("CLBALRM1");
         heat = 0;
         rackSize = 1;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALRM1OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALRM1OS.java
@@ -30,6 +30,7 @@ public class CLBALRM1OS extends LRMWeapon {
     public CLBALRM1OS() {
         super();
         name = "LRM 1 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("CLBALRM1OS");
         heat = 0;
         rackSize = 1;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALRM2.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALRM2.java
@@ -31,6 +31,7 @@ public class CLBALRM2 extends LRMWeapon {
     public CLBALRM2() {
         super();
         name = "LRM 2";
+        uniqueName = name + " [BA]";
         setInternalName("CLBALRM2");
         heat = 0;
         rackSize = 2;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALRM2OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALRM2OS.java
@@ -30,6 +30,7 @@ public class CLBALRM2OS extends LRMWeapon {
     public CLBALRM2OS() {
         super();
         name = "LRM 2 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("CLBALRM2OS");
         heat = 0;
         rackSize = 2;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALRM3.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALRM3.java
@@ -30,6 +30,7 @@ public class CLBALRM3 extends LRMWeapon {
     public CLBALRM3() {
         super();
         name = "LRM 3";
+        uniqueName = name + " [BA]";
         setInternalName("CLBALRM3");
         heat = 0;
         rackSize = 3;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALRM3OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALRM3OS.java
@@ -30,6 +30,7 @@ public class CLBALRM3OS extends LRMWeapon {
     public CLBALRM3OS() {
         super();
         name = "LRM 3 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("CLBALRM3OS");
         heat = 0;
         rackSize = 3;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALRM4.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALRM4.java
@@ -30,6 +30,7 @@ public class CLBALRM4 extends LRMWeapon {
     public CLBALRM4() {
         super();
         name = "LRM 4";
+        uniqueName = name + " [BA]";
         setInternalName("CLBALRM4");
         heat = 0;
         rackSize = 4;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALRM4OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALRM4OS.java
@@ -30,6 +30,7 @@ public class CLBALRM4OS extends LRMWeapon {
     public CLBALRM4OS() {
         super();
         name = "LRM 4 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("CLBALRM4OS");
         heat = 0;
         rackSize = 4;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALRM5.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALRM5.java
@@ -30,6 +30,7 @@ public class CLBALRM5 extends LRMWeapon {
     public CLBALRM5() {
         super();
         name = "LRM 5";
+        uniqueName = name + " [BA]";
         setInternalName("CLBALRM5");
         addLookupName("Clan BA LRM-5");
         addLookupName("Clan BA LRM 5");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALRM5OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALRM5OS.java
@@ -30,6 +30,7 @@ public class CLBALRM5OS extends LRMWeapon {
     public CLBALRM5OS() {
         super();
         name = "LRM 5 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("CLBALRM5 (OS)");
         addLookupName("CLBALRM5OS");
         heat = 2;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALaserERMedium.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALaserERMedium.java
@@ -25,6 +25,7 @@ public class CLBALaserERMedium extends LaserWeapon {
     public CLBALaserERMedium() {
         super();
         name = "ER Medium Laser";
+        uniqueName = name + " [BA]";
         setInternalName("CLBAERMediumLaser");
         addLookupName("Clan BA ER Medium Laser");
         sortingName = "Laser ER C";

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALaserERMicro.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALaserERMicro.java
@@ -27,6 +27,7 @@ public class CLBALaserERMicro extends LaserWeapon {
     public CLBALaserERMicro() {
         super();
         name = "ER Micro Laser";
+        uniqueName = name + " [BA]";
         setInternalName("CLBAERMicroLaser");
         addLookupName("Clan BA ER Micro Laser");
         sortingName = "Laser ER A";

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALaserERSmall.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALaserERSmall.java
@@ -25,6 +25,7 @@ public class CLBALaserERSmall extends LaserWeapon {
     public CLBALaserERSmall() {
         super();
         name = "ER Small Laser";
+        uniqueName = name + " [BA]";
         setInternalName("CLBAERSmallLaser");
         addLookupName("Clan BA ER Small Laser");
         sortingName = "Laser ER B";

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALaserHeavyMedium.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALaserHeavyMedium.java
@@ -25,6 +25,7 @@ public class CLBALaserHeavyMedium extends LaserWeapon {
     public CLBALaserHeavyMedium() {
         super();
         name = "Heavy Medium Laser";
+        uniqueName = name + " [BA]";
         setInternalName("CLBAHeavyMediumLaser");
         addLookupName("Clan BA Medium Heavy Laser");
         sortingName = "Laser Heavy C";

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALaserHeavySmall.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALaserHeavySmall.java
@@ -25,6 +25,7 @@ public class CLBALaserHeavySmall extends LaserWeapon {
     public CLBALaserHeavySmall() {
         super();
         name = "Heavy Small Laser";
+        uniqueName = name + " [BA]";
         setInternalName("CLBAHeavySmallLaser");
         addLookupName("Clan BA Small Heavy Laser");
         sortingName = "Laser Heavy B";

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALaserSmall.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALaserSmall.java
@@ -25,6 +25,7 @@ public class CLBALaserSmall extends LaserWeapon {
     public CLBALaserSmall() {
         super();
         name = "Small Laser";
+        uniqueName = name + " [BA]";
         setInternalName("CLBASmall Laser");
         addLookupName("CL BA Small Laser");
         addLookupName("CLBASmallLaser");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALightTAG.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALightTAG.java
@@ -25,6 +25,7 @@ public class CLBALightTAG extends TAGWeapon {
     public CLBALightTAG() {
         super();
         name = "TAG (Light)";
+        uniqueName = name + " [BA]";
         setInternalName("CLBALightTAG");
         addLookupName("Clan BA Light TAG");
         addLookupName("ISBALightTAG");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAMG.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAMG.java
@@ -25,6 +25,7 @@ public class CLBAMG extends BAMGWeapon {
     public CLBAMG() {
         super();
         name = "Machine Gun (Medium)";
+        uniqueName = name + " [BA]";
         setInternalName("CLBAMG");
         addLookupName("Clan BA Machine Gun");
         addLookupName("ISBAMG");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAMGHeavy.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAMGHeavy.java
@@ -25,6 +25,7 @@ public class CLBAMGHeavy extends BAMGWeapon {
     public CLBAMGHeavy() {
         super();
         name = "Machine Gun (Heavy)";
+        uniqueName = name + " [BA]";
         setInternalName("CLBAHeavyMG");
         addLookupName("Clan BA Heavy Machine Gun");
         addLookupName("ISBAHeavyMachineGun");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAMGLight.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAMGLight.java
@@ -25,6 +25,7 @@ public class CLBAMGLight extends BAMGWeapon {
     public CLBAMGLight() {
         super();
         name = "Machine Gun (Light)";
+        uniqueName = name + " [BA]";
         setInternalName("CLBALightMG");
         addLookupName("Clan BA Light Machine Gun");
         addLookupName("ISBALightMachineGun");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAPulseLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAPulseLaserMedium.java
@@ -25,6 +25,7 @@ public class CLBAPulseLaserMedium extends PulseLaserWeapon {
     public CLBAPulseLaserMedium() {
         super();
         name = "Medium Pulse Laser";
+        uniqueName = name + " [BA]";
         setInternalName("CLBAMediumPulseLaser");
         addLookupName("Clan BA Pulse Med Laser");
         addLookupName("Clan BA Medium Pulse Laser");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAPulseLaserMicro.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAPulseLaserMicro.java
@@ -26,6 +26,7 @@ public class CLBAPulseLaserMicro extends PulseLaserWeapon {
     public CLBAPulseLaserMicro() {
         super();
         name = "Micro Pulse Laser";
+        uniqueName = name + " [BA]";
         setInternalName("CLBAMicroPulseLaser");
         addLookupName("Clan BA Micro Pulse Laser");
         sortingName = "Laser Pulse A";

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBAPulseLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBAPulseLaserSmall.java
@@ -26,6 +26,7 @@ public class CLBAPulseLaserSmall extends PulseLaserWeapon {
     public CLBAPulseLaserSmall() {
         super();
         name = "Small Pulse Laser";
+        uniqueName = name + " [BA]";
         setInternalName("CLBASmallPulseLaser");
         addLookupName("Clan BA Pulse Small Laser");
         addLookupName("Clan BA Small Pulse Laser");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBASRM1.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBASRM1.java
@@ -31,6 +31,7 @@ public class CLBASRM1 extends SRMWeapon {
     public CLBASRM1() {
         super();
         name = "SRM 1";
+        uniqueName = name + " [BA]";
         setInternalName("CLBASRM1");
         addLookupName("Clan BA SRM-1");
         addLookupName("Clan BA SRM 1");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBASRM1OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBASRM1OS.java
@@ -30,6 +30,7 @@ public class CLBASRM1OS extends SRMWeapon {
     public CLBASRM1OS() {
         super();
         name = "SRM 1 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("CLBASRM1OS");
         rackSize = 1;
         shortRange = 3;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBASRM2.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBASRM2.java
@@ -30,6 +30,7 @@ public class CLBASRM2 extends SRMWeapon {
     public CLBASRM2() {
         super();
         name = "SRM 2";
+        uniqueName = name + " [BA]";
         setInternalName("CLBASRM2");
         addLookupName("Clan BA SRM-2");
         addLookupName("Clan BA SRM 2");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBASRM2OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBASRM2OS.java
@@ -31,6 +31,7 @@ public class CLBASRM2OS extends SRMWeapon {
     public CLBASRM2OS() {
         super();
         name = "SRM 2 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("CLBASRM2 (OS)");
         addLookupName("CLBASRM2OS");
         addLookupName("Clan BA OS SRM-2");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBASRM3.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBASRM3.java
@@ -30,6 +30,7 @@ public class CLBASRM3 extends SRMWeapon {
     public CLBASRM3() {
         super();
         name = "SRM 3";
+        uniqueName = name + " [BA]";
         setInternalName("CLBASRM3");
         addLookupName("Clan BA SRM-3");
         addLookupName("Clan BA SRM 3");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBASRM3OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBASRM3OS.java
@@ -38,6 +38,7 @@ public class CLBASRM3OS extends SRMWeapon {
     public CLBASRM3OS() {
         super();
         name = "SRM 3 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("CLBASRM3 (OS)");
         addLookupName("Clan BA SRM 3 (OS)");
         addLookupName("Clan BA OS SRM-3");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBASRM4.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBASRM4.java
@@ -39,6 +39,7 @@ public class CLBASRM4 extends SRMWeapon {
     public CLBASRM4() {
         super();
         name = "SRM 4";
+        uniqueName = name + " [BA]";
         setInternalName("CLBASRM4");
         addLookupName("Clan BA SRM-4");
         addLookupName("Clan BA SRM 4");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBASRM4OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBASRM4OS.java
@@ -38,6 +38,7 @@ public class CLBASRM4OS extends SRMWeapon {
     public CLBASRM4OS() {
         super();
         name = "SRM 4 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("CLBASRM4 (OS)");
         addLookupName("Clan BA OS SRM-4");
         addLookupName("Clan BA SRM 4 (OS)");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBASRM5.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBASRM5.java
@@ -38,6 +38,7 @@ public class CLBASRM5 extends SRMWeapon {
     public CLBASRM5() {
         super();
         name = "SRM 5";
+        uniqueName = name + " [BA]";
         setInternalName("CLBASRM5");
         addLookupName("Clan BA SRM-5");
         addLookupName("Clan BA SRM 5");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBASRM5OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBASRM5OS.java
@@ -38,6 +38,7 @@ public class CLBASRM5OS extends SRMWeapon {
     public CLBASRM5OS() {
         super();
         name = "SRM 5 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("CLBASRM5OS");
         rackSize = 5;
         shortRange = 3;

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBASRM6.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBASRM6.java
@@ -38,6 +38,7 @@ public class CLBASRM6 extends SRMWeapon {
     public CLBASRM6() {
         super();
         name = "SRM 6";
+        uniqueName = name + " [BA]";
         setInternalName("CLBASRM6");
         addLookupName("Clan BA SRM-6");
         addLookupName("Clan BA SRM 6");

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBASRM6OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBASRM6OS.java
@@ -38,6 +38,7 @@ public class CLBASRM6OS extends SRMWeapon {
     public CLBASRM6OS() {
         super();
         name = "SRM 6 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("CLBASRM6 (OS)");
         addLookupName("Clan BA OS SRM-6");
         addLookupName("Clan BA SRM 6 (OS)");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAAPDS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAAPDS.java
@@ -25,6 +25,7 @@ public class ISBAAPDS extends Weapon {
     public ISBAAPDS() {
         super();
         name = "RISC Advanced Point Defense System";
+        uniqueName = name + " [BA]";
         setInternalName("ISBAAPDS");
         tonnage = 0.35;
         criticals = 2;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAGaussRifleMagshot.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAGaussRifleMagshot.java
@@ -24,6 +24,7 @@ public class ISBAGaussRifleMagshot extends Weapon {
     public ISBAGaussRifleMagshot() {
         super();
         name = "Gauss Rifle [Magshot]";
+        uniqueName = name + " [BA]";
         setInternalName("ISBAMagshotGaussRifle");
         addLookupName("ISBAMagshotGR");
         damage = 2;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALRM1.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALRM1.java
@@ -38,6 +38,7 @@ public class ISBALRM1 extends LRMWeapon {
     public ISBALRM1() {
         super();
         name = "LRM 1";
+        uniqueName = name + " [BA]";
         setInternalName("ISBALRM1");
         addLookupName("IS BA LRM-1");
         addLookupName("IS BA LRM 1");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALRM1OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALRM1OS.java
@@ -38,6 +38,7 @@ public class ISBALRM1OS extends LRMWeapon {
     public ISBALRM1OS() {
         super();
         name = "LRM 1 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBALRM1OS");
         addLookupName("IS BA LRM1 OS");
         rackSize = 1;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALRM2.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALRM2.java
@@ -38,6 +38,7 @@ public class ISBALRM2 extends LRMWeapon {
     public ISBALRM2() {
         super();
         name = "LRM 2";
+        uniqueName = name + " [BA]";
         setInternalName("ISBALRM2");
         addLookupName("IS BA LRM-2");
         addLookupName("IS BA LRM 2");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALRM2OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALRM2OS.java
@@ -38,6 +38,7 @@ public class ISBALRM2OS extends LRMWeapon {
     public ISBALRM2OS() {
         super();
         name = "LRM 2 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBALRM2OS");
         addLookupName("IS BA LRM2 OS");
         rackSize = 2;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALRM3.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALRM3.java
@@ -38,6 +38,7 @@ public class ISBALRM3 extends LRMWeapon {
     public ISBALRM3() {
         super();
         name = "LRM 3";
+        uniqueName = name + " [BA]";
         setInternalName("ISBALRM3");
         addLookupName("IS BA LRM-3");
         addLookupName("IS BA LRM3");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALRM3OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALRM3OS.java
@@ -38,6 +38,7 @@ public class ISBALRM3OS extends LRMWeapon {
     public ISBALRM3OS() {
         super();
         name = "LRM 3 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBALRM3OS");
         addLookupName("IS BA LRM3 OS");
         rackSize = 3;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALRM4.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALRM4.java
@@ -38,6 +38,7 @@ public class ISBALRM4 extends LRMWeapon {
     public ISBALRM4() {
         super();
         name = "LRM 4";
+        uniqueName = name + " [BA]";
         setInternalName("ISBALRM4");
         addLookupName("IS BA LRM-4");
         addLookupName("IS BA LRM 4");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALRM4OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALRM4OS.java
@@ -38,6 +38,7 @@ public class ISBALRM4OS extends LRMWeapon {
     public ISBALRM4OS() {
         super();
         name = "LRM 4 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBALRM4OS");
         addLookupName("IS BA LRM4 OS");
         rackSize = 4;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALRM5.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALRM5.java
@@ -38,6 +38,7 @@ public class ISBALRM5 extends LRMWeapon {
     public ISBALRM5() {
         super();
         name = "LRM 5";
+        uniqueName = name + " [BA]";
         setInternalName("ISBALRM5");
         addLookupName("IS BA LRM-5");
         addLookupName("IS BA LRM 5");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALRM5OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALRM5OS.java
@@ -38,6 +38,7 @@ public class ISBALRM5OS extends LRMWeapon {
     public ISBALRM5OS() {
         super();
         name = "LRM 5 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBALRM5OS");
         addLookupName("IS BA OS LRM-5");
         addLookupName("ISBALRM5 (OS)");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALaserERMedium.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALaserERMedium.java
@@ -25,6 +25,7 @@ public class ISBALaserERMedium extends LaserWeapon {
     public ISBALaserERMedium() {
         super();
         name = "ER Medium Laser";
+        uniqueName = name + " [BA]";
         setInternalName("ISBAERMediumLaser");
         addLookupName("IS BA ER Medium Laser");
         sortingName = "Laser ER C";

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALaserERSmall.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALaserERSmall.java
@@ -25,6 +25,7 @@ public class ISBALaserERSmall extends LaserWeapon {
     public ISBALaserERSmall() {
         super();
          name = "ER Small Laser";
+        uniqueName = name + " [BA]";
         setInternalName("ISBAERSmallLaser");
         addLookupName("IS BA ER Small Laser");
         sortingName = "Laser ER B";

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALaserMedium.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALaserMedium.java
@@ -25,6 +25,7 @@ public class ISBALaserMedium extends LaserWeapon {
     public ISBALaserMedium() {
         super();
         name = "Medium Laser";
+        uniqueName = name + " [BA]";
         setInternalName("ISBAMediumLaser");
         addLookupName("IS BA Medium Laser");
         sortingName = "Laser C";

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALaserPulseMedium.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALaserPulseMedium.java
@@ -25,6 +25,7 @@ public class ISBALaserPulseMedium extends PulseLaserWeapon {
     public ISBALaserPulseMedium() {
         super();
         name = "Medium Pulse Laser";
+        uniqueName = name + " [BA]";
         setInternalName("ISBAMediumPulseLaser");
         addLookupName("IS BA Pulse Med Laser");
         addLookupName("IS BA Medium Pulse Laser");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALaserPulseSmall.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALaserPulseSmall.java
@@ -26,6 +26,7 @@ public class ISBALaserPulseSmall extends PulseLaserWeapon {
     public ISBALaserPulseSmall() {
         super();
         name = "Small Pulse Laser";
+        uniqueName = name + " [BA]";
         setInternalName("ISBASmallPulseLaser");
         addLookupName("IS BA Small Pulse Laser");
         addLookupName("ISBASmall Pulse Laser");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALaserSmall.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALaserSmall.java
@@ -25,6 +25,7 @@ public class ISBALaserSmall extends LaserWeapon {
     public ISBALaserSmall() {
         super();
         name = "Small Laser";
+        uniqueName = name + " [BA]";
         setInternalName("ISBASmallLaser");
         addLookupName("ISBASmall Laser");
         sortingName = "Laser B";

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALaserVSPMedium.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALaserVSPMedium.java
@@ -26,6 +26,7 @@ public class ISBALaserVSPMedium extends VariableSpeedPulseLaserWeapon {
     public ISBALaserVSPMedium() {
         super();
         name = "Medium VSP Laser";
+        uniqueName = name + " [BA]";
         setInternalName("ISBAMediumVSPLaser");
         addLookupName("ISBAMVSPL");
         addLookupName("ISBAMediumVariableSpeedLaser");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALaserVSPSmall.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALaserVSPSmall.java
@@ -27,6 +27,7 @@ public class ISBALaserVSPSmall extends VariableSpeedPulseLaserWeapon {
     public ISBALaserVSPSmall() {
         super();
         name = "Small VSP Laser";
+        uniqueName = name + " [BA]";
         setInternalName("ISBASmallVSPLaser");
         addLookupName("ISBASVSPL");
         addLookupName("ISBASmallVariableSpeedLaser");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBALightTAG.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBALightTAG.java
@@ -30,6 +30,7 @@ public class ISBALightTAG extends TAGWeapon {
     public ISBALightTAG() {
         super();
         this.name = "TAG (Light)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBALightTAG");
         this.addLookupName("IS BA Light TAG");
         this.tonnage = 0.035;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMG.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMG.java
@@ -27,6 +27,7 @@ public class ISBAMG extends BAMGWeapon {
     public ISBAMG() {
         super();
         name = "Machine Gun (Medium)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBAMG");
         addLookupName("IS BA Machine Gun");
         addLookupName("ISBAMachine Gun");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMGHeavy.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMGHeavy.java
@@ -28,6 +28,7 @@ public class ISBAMGHeavy extends BAMGWeapon {
     public ISBAMGHeavy() {
         super();
         name = "Machine Gun (Heavy)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBAHeavyMachineGun");
         addLookupName("IS BA Heavy Machine Gun");
         addLookupName("ISBAHeavyMG");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMGLight.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMGLight.java
@@ -29,6 +29,7 @@ public class ISBAMGLight extends BAMGWeapon {
     public ISBAMGLight() {
         super();
         name = "Machine Gun (Light)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBALightMachineGun");
         addLookupName("IS BA Light Machine Gun");
         addLookupName("ISBALightMG");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM1.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM1.java
@@ -32,6 +32,7 @@ public class ISBAMRM1 extends MRMWeapon {
     public ISBAMRM1() {
         super();
         this.name = "MRM 1";
+        uniqueName = name + " [BA]";
         this.setInternalName("ISBAMRM1");
         this.addLookupName("BA MRM-1");
         this.addLookupName("IS BA MRM 1");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM1OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM1OS.java
@@ -38,6 +38,7 @@ public class ISBAMRM1OS extends MRMWeapon {
     public ISBAMRM1OS() {
         super();
         name = "MRM 1 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBAMRM1OS");
         addLookupName("IS BA MRM1 OS");
         rackSize = 1;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM2.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM2.java
@@ -31,6 +31,7 @@ public class ISBAMRM2 extends MRMWeapon {
     public ISBAMRM2() {
         super();
         this.name = "MRM 2";
+        uniqueName = name + " [BA]";
         this.setInternalName("ISBAMRM2");
         this.addLookupName("BA MRM-2");
         this.addLookupName("IS BA MRM 2");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM2OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM2OS.java
@@ -38,6 +38,7 @@ public class ISBAMRM2OS extends MRMWeapon {
     public ISBAMRM2OS() {
         super();
         name = "MRM 2 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBAMRM2OS");
         addLookupName("IS BA MRM2 OS");
         rackSize = 2;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM3.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM3.java
@@ -31,6 +31,7 @@ public class ISBAMRM3 extends MRMWeapon {
     public ISBAMRM3() {
         super();
         this.name = "MRM 3";
+        uniqueName = name + " [BA]";
         this.setInternalName("ISBAMRM3");
         this.addLookupName("BA MRM-3");
         this.addLookupName("IS BA MRM 3");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM3OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM3OS.java
@@ -38,6 +38,7 @@ public class ISBAMRM3OS extends MRMWeapon {
     public ISBAMRM3OS() {
         super();
         name = "MRM 3 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBAMRM3OS");
         addLookupName("IS BA MRM3 OS");
         rackSize = 3;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM4.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM4.java
@@ -31,6 +31,7 @@ public class ISBAMRM4 extends MRMWeapon {
     public ISBAMRM4() {
         super();
         this.name = "MRM 4";
+        uniqueName = name + " [BA]";
         this.setInternalName("ISBAMRM4");
         this.addLookupName("BA MRM-4");
         this.addLookupName("IS BA MRM 4");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM4OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM4OS.java
@@ -38,6 +38,7 @@ public class ISBAMRM4OS extends MRMWeapon {
     public ISBAMRM4OS() {
         super();
         name = "MRM 4 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBAMRM4OS");
         addLookupName("IS BA MRM4 OS");
         rackSize = 4;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM5.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM5.java
@@ -31,6 +31,7 @@ public class ISBAMRM5 extends MRMWeapon {
     public ISBAMRM5() {
         super();
         this.name = "MRM 5";
+        uniqueName = name + " [BA]";
         this.setInternalName("ISBAMRM5");
         this.addLookupName("BA MRM-5");
         this.addLookupName("IS BA MRM 5");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM5OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBAMRM5OS.java
@@ -38,6 +38,7 @@ public class ISBAMRM5OS extends MRMWeapon {
     public ISBAMRM5OS() {
         super();
         name = "MRM 5 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBAMRM5OS");
         addLookupName("IS BA MRM5 OS");
         rackSize = 5;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBARL1.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBARL1.java
@@ -32,6 +32,7 @@ public class ISBARL1 extends RLWeapon {
     public ISBARL1() {
         super();
         name = "Rocket Launcher 1";
+        uniqueName = name + " [BA]";
         setInternalName("ISBARL1");
         addLookupName("BA RL 1");
         addLookupName("BARL1");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBARL2.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBARL2.java
@@ -32,6 +32,7 @@ public class ISBARL2 extends RLWeapon {
     public ISBARL2() {
         super();
         name = "Rocket Launcher 2";
+        uniqueName = name + " [BA]";
         setInternalName("ISBARL2");
         addLookupName("BARL2");
         addLookupName("BA RL 2");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBARL3.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBARL3.java
@@ -32,6 +32,7 @@ public class ISBARL3 extends RLWeapon {
     public ISBARL3() {
         super();
         name = "Rocket Launcher 3";
+        uniqueName = name + " [BA]";
         setInternalName("ISBARL3");
         addLookupName("BA RL 3");
         addLookupName("BARL3");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBARL4.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBARL4.java
@@ -32,6 +32,7 @@ public class ISBARL4 extends RLWeapon {
     public ISBARL4() {
         super();
         name = "Rocket Launcher 4";
+        uniqueName = name + " [BA]";
         setInternalName("ISBARL4");
         addLookupName("BA RL 4");
         addLookupName("BARL4");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBARL5.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBARL5.java
@@ -32,6 +32,7 @@ public class ISBARL5 extends RLWeapon {
     public ISBARL5() {
         super();
         name = "Rocket Launcher 5";
+        uniqueName = name + " [BA]";
         setInternalName("ISBARL5");
         addLookupName("BARL5");
         addLookupName("ISBARocketLauncher5");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBASRM1.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBASRM1.java
@@ -30,6 +30,7 @@ public class ISBASRM1 extends SRMWeapon {
     public ISBASRM1() {
         super();
         name = "SRM 1";
+        uniqueName = name + " [BA]";
         setInternalName("ISBASRM1");
         addLookupName("IS BA SRM-1");
         addLookupName("IS BA SRM 1");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBASRM1OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBASRM1OS.java
@@ -30,6 +30,7 @@ public class ISBASRM1OS extends SRMWeapon {
     public ISBASRM1OS() {
         super();
         name = "SRM 1 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBASRM1OS");
         addLookupName("IS BA SRM1 OS");
         rackSize = 1;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBASRM2.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBASRM2.java
@@ -30,6 +30,7 @@ public class ISBASRM2 extends SRMWeapon {
     public ISBASRM2() {
         super();
         name = "SRM 2";
+        uniqueName = name + " [BA]";
         setInternalName("ISBASRM2");
         addLookupName("IS BA SRM-2");
         addLookupName("IS BA SRM 2");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBASRM2OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBASRM2OS.java
@@ -30,6 +30,7 @@ public class ISBASRM2OS extends SRMWeapon {
     public ISBASRM2OS() {
         super();
         name = "SRM 2 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBASRM2OS");
         addLookupName("ISBASRM2 (OS)"); // mtf
         addLookupName("IS BA SRM 2 (OS)"); // tdb

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBASRM3.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBASRM3.java
@@ -30,6 +30,7 @@ public class ISBASRM3 extends SRMWeapon {
     public ISBASRM3() {
         super();
         name = "SRM 3";
+        uniqueName = name + " [BA]";
         setInternalName("ISBASRM3");
         addLookupName("IS BA SRM-3");
         addLookupName("IS BA SRM 3");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBASRM3OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBASRM3OS.java
@@ -30,6 +30,7 @@ public class ISBASRM3OS extends SRMWeapon {
     public ISBASRM3OS() {
         super();
         name = "SRM 3 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBASRM3OS");
         addLookupName("IS BA SRM3 OS");
         rackSize = 3;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBASRM4.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBASRM4.java
@@ -24,6 +24,7 @@ public class ISBASRM4 extends SRMWeapon {
     public ISBASRM4() {
         super();
         this.name = "SRM 4";
+        uniqueName = name + " [BA]";
         this.setInternalName("ISBASRM4");
         this.addLookupName("IS BA SRM-4");
         this.addLookupName("IS BA SRM 4");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBASRM4OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBASRM4OS.java
@@ -30,6 +30,7 @@ public class ISBASRM4OS extends SRMWeapon {
     public ISBASRM4OS() {
         super();
         name = "SRM 4 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBASRM4OS");
         addLookupName("ISBASRM4 (OS)"); // mtf
         addLookupName("IS BA SRM 4 (OS)"); // tdb

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBASRM5.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBASRM5.java
@@ -30,6 +30,7 @@ public class ISBASRM5 extends SRMWeapon {
     public ISBASRM5() {
         super();
         name = "SRM 5";
+        uniqueName = name + " [BA]";
         setInternalName("ISBASRM5");
         addLookupName("IS BA SRM-5");
         addLookupName("IS BA SRM 5");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBASRM5OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBASRM5OS.java
@@ -30,6 +30,7 @@ public class ISBASRM5OS extends SRMWeapon {
     public ISBASRM5OS() {
         super();
         name = "SRM 5 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBASRM5OS");
         addLookupName("IS BA SRM5 OS");
         rackSize = 5;

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBASRM6.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBASRM6.java
@@ -24,6 +24,7 @@ public class ISBASRM6 extends SRMWeapon {
     public ISBASRM6() {
         super();
         this.name = "SRM 6";
+        uniqueName = name + " [BA]";
         this.setInternalName("ISBASRM6");
         this.addLookupName("IS BA SRM-6");
         this.addLookupName("IS BA SRM 6");

--- a/megamek/src/megamek/common/weapons/battlearmor/ISBASRM6OS.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/ISBASRM6OS.java
@@ -30,6 +30,7 @@ public class ISBASRM6OS extends SRMWeapon {
     public ISBASRM6OS() {
         super();
         name = "SRM 6 (OS)";
+        uniqueName = name + " [BA]";
         setInternalName("ISBASRM6OS");
         addLookupName("ISBASRM6 (OS)"); // mtf
         addLookupName("IS BA SRM 6 (OS)"); // tdb


### PR DESCRIPTION
Adds a new `uniqueName` attribute to `EquipmentType`s which can be set when the equipment shares it's name with something else. Currently only distinguishes BA weapons from Mek weapons, but this should make it easier to resolve other collisions which I didn't know about at time of making this PR.

Closes #6924.