### PR TITLE
feat: add stale action to deal with ever growing number of issues that may not even be valid anymore

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/stale@v9
         with:
           stale-issue-message: 'This issue is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 15 days.'
-          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 15 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 15 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 15 days with no activity.'
           days-before-issue-stale: 45

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,24 @@
+name: 'Close stale issues and PRs'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 15 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 15 days with no activity.'
+          days-before-issue-stale: 45
+          days-before-pr-stale: 45
+          days-before-issue-close: 15
+          days-before-pr-close: 15

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: 'This issue is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-issue-message: 'This issue is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 15 days.'
           stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 15 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 15 days with no activity.'


### PR DESCRIPTION
# What it does?

Adds the action `staler` which closes stale issues and PRs based on a set of very simple rules.

Can be configured to consider issues and PRs exempt if they were assigned to specific people or have specific labels or milestones.

This PR is more for you Tex, as you will be the one with the permission level to finish its setup.