### PR TITLE
Fix for LBX/IATM weapon damage and Cargo Bombs on Aero

### DIFF
--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -17,6 +17,7 @@ MEGAMEK VERSION HISTORY:
 + Fix #6958: First iteration to deal with issue #6951 by adding scroll on unit display dialog (tabbed view).
 + Fix #6957: BA Artillery doing no damage
 + Fix #6966: SVs with no engine can't have MP
++ PR #6972: Fix for LBX and IATM Aero Damage (Fix MML/#1810)
 
 0.50.05 (2025-04-25 1800 UTC)
 + Fix #6652: ProtoMek BV fixed for melee weapons and LRM-1

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -521,7 +521,7 @@ public abstract class Aero extends Entity implements IAero, IBomber {
 
     @Override
     public int getMaxBombPoints() {
-        return maxExtBombPoints + maxIntBombPoints;
+        return maxExtBombPoints + getMaxIntBombPoints();
     }
 
     @Override

--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -521,7 +521,7 @@ public abstract class Aero extends Entity implements IAero, IBomber {
 
     @Override
     public int getMaxBombPoints() {
-        return maxExtBombPoints + getMaxIntBombPoints();
+        return getMaxExtBombPoints() + getMaxIntBombPoints();
     }
 
     @Override

--- a/megamek/src/megamek/common/weapons/CLIATMWeapon.java
+++ b/megamek/src/megamek/common/weapons/CLIATMWeapon.java
@@ -118,4 +118,11 @@ public abstract class CLIATMWeapon extends MissileWeapon {
     public String getSortingName() {
         return "ATM IMP " + ((rackSize < 10) ? "0" + rackSize : rackSize);
     }
+
+    /**
+     * This is a streak weapon, so we use the rack size for the Aero damage.
+     */
+    protected double getBaseAeroDamage() {
+        return Math.ceil(2 * this.getRackSize());
+    }
 }

--- a/megamek/src/megamek/common/weapons/LBXHandler.java
+++ b/megamek/src/megamek/common/weapons/LBXHandler.java
@@ -58,21 +58,6 @@ public class LBXHandler extends AmmoWeaponHandler {
         return 1;
     }
 
-    /**
-     * Calculate the attack value based on range
-     *
-     * @return an <code>int</code> representing the attack value at that range.
-     */
-    @Override
-    protected int calcAttackValue() {
-        int av = super.calcAttackValue();
-        if (usesClusterTable()) {
-            // basically 60% of normal
-            return (int) Math.floor(0.6 * av);
-        }
-        return av;
-    }
-
     /*
      * (non-Javadoc)
      *

--- a/megamek/src/megamek/common/weapons/autocannons/CLLB10XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/CLLB10XAC.java
@@ -40,8 +40,8 @@ public class CLLB10XAC extends LBXACWeapon {
         this.criticals = 5;
         this.bv = 148;
         this.cost = 400000;
-        this.shortAV = 10;
-        this.medAV = 10;
+        this.shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        this.medAV = this.shortAV;
         this.maxRange = RANGE_MED;
         rulesRefs = "207, TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)

--- a/megamek/src/megamek/common/weapons/autocannons/CLLB10XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/CLLB10XAC.java
@@ -40,7 +40,7 @@ public class CLLB10XAC extends LBXACWeapon {
         this.criticals = 5;
         this.bv = 148;
         this.cost = 400000;
-        this.shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        shortAV = getBaseAeroDamage();
         this.medAV = this.shortAV;
         this.maxRange = RANGE_MED;
         rulesRefs = "207, TM";

--- a/megamek/src/megamek/common/weapons/autocannons/CLLB20XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/CLLB20XAC.java
@@ -40,7 +40,7 @@ public class CLLB20XAC extends LBXACWeapon {
         criticals = 9;
         bv = 237;
         cost = 600000;
-        shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        shortAV = getBaseAeroDamage();
         medAV = shortAV;
         maxRange = RANGE_MED;
         rulesRefs = "207, TM";

--- a/megamek/src/megamek/common/weapons/autocannons/CLLB20XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/CLLB20XAC.java
@@ -40,8 +40,8 @@ public class CLLB20XAC extends LBXACWeapon {
         criticals = 9;
         bv = 237;
         cost = 600000;
-        shortAV = 20;
-        medAV = 20;
+        shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        medAV = shortAV;
         maxRange = RANGE_MED;
         rulesRefs = "207, TM";
         flags = flags.andNot(F_PROTO_WEAPON);

--- a/megamek/src/megamek/common/weapons/autocannons/CLLB2XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/CLLB2XAC.java
@@ -41,7 +41,7 @@ public class CLLB2XAC extends LBXACWeapon {
         criticals = 3;
         bv = 47;
         cost = 150000;
-        shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        shortAV = getBaseAeroDamage();
         medAV = shortAV;
         longAV = shortAV;
         extAV = shortAV;

--- a/megamek/src/megamek/common/weapons/autocannons/CLLB2XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/CLLB2XAC.java
@@ -41,10 +41,10 @@ public class CLLB2XAC extends LBXACWeapon {
         criticals = 3;
         bv = 47;
         cost = 150000;
-        shortAV = 2;
-        medAV = 2;
-        longAV = 2;
-        extAV = 2;
+        shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        medAV = shortAV;
+        longAV = shortAV;
+        extAV = shortAV;
         maxRange = RANGE_EXT;
         rulesRefs = "207, TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)

--- a/megamek/src/megamek/common/weapons/autocannons/CLLB5XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/CLLB5XAC.java
@@ -41,9 +41,9 @@ public class CLLB5XAC extends LBXACWeapon {
         criticals = 4;
         bv = 93;
         cost = 250000;
-        shortAV = 5;
-        medAV = 5;
-        longAV = 5;
+        shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        medAV = shortAV;
+        longAV = shortAV;
         maxRange = RANGE_LONG;
         rulesRefs = "207, TM";
         techAdvancement.setTechBase(TECH_BASE_CLAN)

--- a/megamek/src/megamek/common/weapons/autocannons/CLLB5XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/CLLB5XAC.java
@@ -41,7 +41,7 @@ public class CLLB5XAC extends LBXACWeapon {
         criticals = 4;
         bv = 93;
         cost = 250000;
-        shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        shortAV = getBaseAeroDamage();
         medAV = shortAV;
         longAV = shortAV;
         maxRange = RANGE_LONG;

--- a/megamek/src/megamek/common/weapons/autocannons/ISLB10XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISLB10XAC.java
@@ -39,8 +39,8 @@ public class ISLB10XAC extends LBXACWeapon {
         this.criticals = 6;
         this.bv = 148;
         this.cost = 400000;
-        this.shortAV = 10;
-        this.medAV = 10;
+        this.shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        this.medAV = this.shortAV;
         this.maxRange = RANGE_MED;
         rulesRefs = "207, TM";
         techAdvancement.setTechBase(TECH_BASE_IS)

--- a/megamek/src/megamek/common/weapons/autocannons/ISLB10XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISLB10XAC.java
@@ -39,7 +39,7 @@ public class ISLB10XAC extends LBXACWeapon {
         this.criticals = 6;
         this.bv = 148;
         this.cost = 400000;
-        this.shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        this.shortAV = getBaseAeroDamage();
         this.medAV = this.shortAV;
         this.maxRange = RANGE_MED;
         rulesRefs = "207, TM";

--- a/megamek/src/megamek/common/weapons/autocannons/ISLB20XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISLB20XAC.java
@@ -39,7 +39,7 @@ public class ISLB20XAC extends LBXACWeapon {
         criticals = 11;
         bv = 237;
         cost = 600000;
-        shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        shortAV = getBaseAeroDamage();
         medAV = shortAV;
         maxRange = RANGE_MED;
         rulesRefs = "207, TM";

--- a/megamek/src/megamek/common/weapons/autocannons/ISLB20XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISLB20XAC.java
@@ -39,8 +39,8 @@ public class ISLB20XAC extends LBXACWeapon {
         criticals = 11;
         bv = 237;
         cost = 600000;
-        shortAV = 20;
-        medAV = 20;
+        shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        medAV = shortAV;
         maxRange = RANGE_MED;
         rulesRefs = "207, TM";
         techAdvancement.setTechBase(TECH_BASE_IS)

--- a/megamek/src/megamek/common/weapons/autocannons/ISLB2XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISLB2XAC.java
@@ -41,10 +41,10 @@ public class ISLB2XAC extends LBXACWeapon {
         criticals = 4;
         bv = 42;
         cost = 150000;
-        shortAV = 2;
-        medAV = 2;
-        longAV = 2;
-        extAV = 2;
+        shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        medAV = shortAV;
+        longAV = shortAV;
+        extAV = shortAV;
         maxRange = RANGE_EXT;
         rulesRefs = "207, TM";
         techAdvancement.setTechBase(TECH_BASE_IS)

--- a/megamek/src/megamek/common/weapons/autocannons/ISLB2XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISLB2XAC.java
@@ -41,7 +41,7 @@ public class ISLB2XAC extends LBXACWeapon {
         criticals = 4;
         bv = 42;
         cost = 150000;
-        shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        shortAV = getBaseAeroDamage();
         medAV = shortAV;
         longAV = shortAV;
         extAV = shortAV;

--- a/megamek/src/megamek/common/weapons/autocannons/ISLB5XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISLB5XAC.java
@@ -41,9 +41,9 @@ public class ISLB5XAC extends LBXACWeapon {
         criticals = 5;
         bv = 83;
         cost = 250000;
-        shortAV = 5;
-        medAV = 5;
-        longAV = 5;
+        shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        medAV = shortAV;
+        longAV = shortAV;
         maxRange = RANGE_LONG;
         rulesRefs = "207, TM";
         techAdvancement.setTechBase(TECH_BASE_IS)

--- a/megamek/src/megamek/common/weapons/autocannons/ISLB5XAC.java
+++ b/megamek/src/megamek/common/weapons/autocannons/ISLB5XAC.java
@@ -41,7 +41,7 @@ public class ISLB5XAC extends LBXACWeapon {
         criticals = 5;
         bv = 83;
         cost = 250000;
-        shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        shortAV = getBaseAeroDamage();
         medAV = shortAV;
         longAV = shortAV;
         maxRange = RANGE_LONG;

--- a/megamek/src/megamek/common/weapons/autocannons/LBXACWeapon.java
+++ b/megamek/src/megamek/common/weapons/autocannons/LBXACWeapon.java
@@ -76,4 +76,11 @@ public abstract class LBXACWeapon extends AmmoWeapon {
     public int getBattleForceClass() {
         return BFCLASS_FLAK;
     }
+
+    /**
+     * This is an LBX weapon, the Aero AV is 60% of normal.
+     */
+    protected double getBaseAeroDamage() {
+        return Math.ceil(0.6 * this.damage);
+    }
 }

--- a/megamek/src/megamek/common/weapons/gaussrifles/ISSilverBulletGauss.java
+++ b/megamek/src/megamek/common/weapons/gaussrifles/ISSilverBulletGauss.java
@@ -53,9 +53,9 @@ public class ISSilverBulletGauss extends GaussWeapon {
         criticals = 7;
         bv = 198;
         cost = 350000;
-        shortAV = 15; // Due to LBXHandler
-        medAV = 15;   // Due to LBXHandler
-        longAV = 15;  // Due to LBXHandler
+        shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        medAV = shortAV;
+        longAV = shortAV;
         maxRange = RANGE_LONG;
         ammoType = AmmoType.T_SBGAUSS;
         // SB Gauss rifles can neither benefit from a targeting computer nor

--- a/megamek/src/megamek/common/weapons/gaussrifles/ISSilverBulletGauss.java
+++ b/megamek/src/megamek/common/weapons/gaussrifles/ISSilverBulletGauss.java
@@ -53,7 +53,7 @@ public class ISSilverBulletGauss extends GaussWeapon {
         criticals = 7;
         bv = 198;
         cost = 350000;
-        shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        shortAV = getBaseAeroDamage();
         medAV = shortAV;
         longAV = shortAV;
         maxRange = RANGE_LONG;

--- a/megamek/src/megamek/common/weapons/gaussrifles/ISSilverBulletGauss.java
+++ b/megamek/src/megamek/common/weapons/gaussrifles/ISSilverBulletGauss.java
@@ -104,4 +104,11 @@ public class ISSilverBulletGauss extends GaussWeapon {
     public int getBattleForceClass() {
         return BFCLASS_FLAK;
     }
+    
+    /**
+     * This is an LBX weapon, the Aero AV is 60% of normal.
+     */
+    protected double getBaseAeroDamage() {
+        return Math.ceil(0.6 * this.damage);
+    }
 }

--- a/megamek/src/megamek/common/weapons/missiles/CLIATM12.java
+++ b/megamek/src/megamek/common/weapons/missiles/CLIATM12.java
@@ -39,7 +39,7 @@ public class CLIATM12 extends CLIATMWeapon {
         this.criticals = 5;
         this.bv = 333; // Ammo BV is 78
         this.cost = 700000;
-        this.shortAV = 2*getRackSize(); // This is a streak weapon so we use the rack size for the AV
+        this.shortAV = this.getBaseAeroDamage(); // This is a streak weapon so we use the rack size for the AV
         this.medAV = this.shortAV;
         this.maxRange = RANGE_MED;
         rulesRefs = "65, IO";

--- a/megamek/src/megamek/common/weapons/missiles/CLIATM12.java
+++ b/megamek/src/megamek/common/weapons/missiles/CLIATM12.java
@@ -39,8 +39,8 @@ public class CLIATM12 extends CLIATMWeapon {
         this.criticals = 5;
         this.bv = 333; // Ammo BV is 78
         this.cost = 700000;
-        this.shortAV = 24;
-        this.medAV = 24;
+        this.shortAV = 2*getRackSize(); // This is a streak weapon so we use the rack size for the AV
+        this.medAV = this.shortAV;
         this.maxRange = RANGE_MED;
         rulesRefs = "65, IO";
         techAdvancement.setTechBase(TECH_BASE_CLAN)

--- a/megamek/src/megamek/common/weapons/missiles/CLIATM3.java
+++ b/megamek/src/megamek/common/weapons/missiles/CLIATM3.java
@@ -39,7 +39,7 @@ public class CLIATM3 extends CLIATMWeapon {
         this.criticals = 2;
         this.bv = 83; // Ammo BV is 21
         this.cost = 100000;
-        this.shortAV = 2*getRackSize(); // This is a streak weapon so we use the rack size for the AV
+        this.shortAV = this.getBaseAeroDamage(); // This is a streak weapon so we use the rack size for the AV
         this.medAV = this.shortAV;
         this.maxRange = RANGE_MED;
         rulesRefs = "65, IO";

--- a/megamek/src/megamek/common/weapons/missiles/CLIATM3.java
+++ b/megamek/src/megamek/common/weapons/missiles/CLIATM3.java
@@ -39,8 +39,8 @@ public class CLIATM3 extends CLIATMWeapon {
         this.criticals = 2;
         this.bv = 83; // Ammo BV is 21
         this.cost = 100000;
-        this.shortAV = 6; // Seems to be for aero
-        this.medAV = 6; // Seems to be for aero
+        this.shortAV = 2*getRackSize(); // This is a streak weapon so we use the rack size for the AV
+        this.medAV = this.shortAV;
         this.maxRange = RANGE_MED;
         rulesRefs = "65, IO";
         techAdvancement.setTechBase(TECH_BASE_CLAN)

--- a/megamek/src/megamek/common/weapons/missiles/CLIATM6.java
+++ b/megamek/src/megamek/common/weapons/missiles/CLIATM6.java
@@ -39,8 +39,8 @@ public class CLIATM6 extends CLIATMWeapon {
         this.criticals = 3;
         this.bv = 165; // Ammo BV is 39
         this.cost = 250000;
-        this.shortAV = 12;
-        this.medAV = 12;
+        this.shortAV = 2*getRackSize(); // This is a streak weapon so we use the rack size for the AV
+        this.medAV = this.shortAV;
         this.maxRange = RANGE_MED;
         rulesRefs = "65, IO";
         techAdvancement.setTechBase(TECH_BASE_CLAN)

--- a/megamek/src/megamek/common/weapons/missiles/CLIATM6.java
+++ b/megamek/src/megamek/common/weapons/missiles/CLIATM6.java
@@ -39,7 +39,7 @@ public class CLIATM6 extends CLIATMWeapon {
         this.criticals = 3;
         this.bv = 165; // Ammo BV is 39
         this.cost = 250000;
-        this.shortAV = 2*getRackSize(); // This is a streak weapon so we use the rack size for the AV
+        this.shortAV = this.getBaseAeroDamage(); // This is a streak weapon so we use the rack size for the AV
         this.medAV = this.shortAV;
         this.maxRange = RANGE_MED;
         rulesRefs = "65, IO";

--- a/megamek/src/megamek/common/weapons/missiles/CLIATM9.java
+++ b/megamek/src/megamek/common/weapons/missiles/CLIATM9.java
@@ -39,8 +39,8 @@ public class CLIATM9 extends CLIATMWeapon {
         this.criticals = 4;
         this.bv = 231; // Ammo BV is 54
         this.cost = 450000;
-        this.shortAV = 18;
-        this.medAV = 18;
+        this.shortAV = 2*getRackSize(); // This is a streak weapon so we use the rack size for the AV
+        this.medAV = this.shortAV;
         this.maxRange = RANGE_MED;
         rulesRefs = "65, IO";
         techAdvancement.setTechBase(TECH_BASE_CLAN)

--- a/megamek/src/megamek/common/weapons/missiles/CLIATM9.java
+++ b/megamek/src/megamek/common/weapons/missiles/CLIATM9.java
@@ -39,7 +39,7 @@ public class CLIATM9 extends CLIATMWeapon {
         this.criticals = 4;
         this.bv = 231; // Ammo BV is 54
         this.cost = 450000;
-        this.shortAV = 2*getRackSize(); // This is a streak weapon so we use the rack size for the AV
+        this.shortAV = this.getBaseAeroDamage(); // This is a streak weapon so we use the rack size for the AV
         this.medAV = this.shortAV;
         this.maxRange = RANGE_MED;
         rulesRefs = "65, IO";

--- a/megamek/src/megamek/common/weapons/prototypes/ISLB10XACPrototype.java
+++ b/megamek/src/megamek/common/weapons/prototypes/ISLB10XACPrototype.java
@@ -50,7 +50,7 @@ public class ISLB10XACPrototype extends LBXACWeapon {
         longRange = 18;
         extremeRange = 24;
         tonnage = 11.0;
-        shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        shortAV = getBaseAeroDamage();
         medAV = shortAV;
         longAV = shortAV;
         extAV = shortAV;

--- a/megamek/src/megamek/common/weapons/prototypes/ISLB10XACPrototype.java
+++ b/megamek/src/megamek/common/weapons/prototypes/ISLB10XACPrototype.java
@@ -50,6 +50,10 @@ public class ISLB10XACPrototype extends LBXACWeapon {
         longRange = 18;
         extremeRange = 24;
         tonnage = 11.0;
+        shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        medAV = shortAV;
+        longAV = shortAV;
+        extAV = shortAV;
         bv = 148;
         cost = 2000000; // Cost in the AoW is 160000 but not making another version for one field.
         rulesRefs = "71, IO";

--- a/megamek/src/megamek/common/weapons/unofficial/ISTHBLB20XAC.java
+++ b/megamek/src/megamek/common/weapons/unofficial/ISTHBLB20XAC.java
@@ -38,6 +38,10 @@ public class ISTHBLB20XAC extends LBXACWeapon {
         extremeRange = 14;
         tonnage = 14.0;
         criticals = 10;
+        shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        medAV = shortAV;
+        longAV = shortAV;
+        extAV = shortAV;
         bv = 204;
         cost = 700000;
         // Since this are the Tactical Handbook Weapons I'm using the TM Stats.

--- a/megamek/src/megamek/common/weapons/unofficial/ISTHBLB20XAC.java
+++ b/megamek/src/megamek/common/weapons/unofficial/ISTHBLB20XAC.java
@@ -38,7 +38,7 @@ public class ISTHBLB20XAC extends LBXACWeapon {
         extremeRange = 14;
         tonnage = 14.0;
         criticals = 10;
-        shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        shortAV = getBaseAeroDamage();
         medAV = shortAV;
         longAV = shortAV;
         extAV = shortAV;

--- a/megamek/src/megamek/common/weapons/unofficial/ISTHBLB2XAC.java
+++ b/megamek/src/megamek/common/weapons/unofficial/ISTHBLB2XAC.java
@@ -39,7 +39,7 @@ public class ISTHBLB2XAC extends LBXACWeapon {
         this.extremeRange = 36;
         this.tonnage = 6.0;
         this.criticals = 4;
-        this.shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        this.shortAV = getBaseAeroDamage();
         this.medAV = this.shortAV;
         this.longAV = this.shortAV;
         this.extAV = this.shortAV;

--- a/megamek/src/megamek/common/weapons/unofficial/ISTHBLB2XAC.java
+++ b/megamek/src/megamek/common/weapons/unofficial/ISTHBLB2XAC.java
@@ -39,6 +39,10 @@ public class ISTHBLB2XAC extends LBXACWeapon {
         this.extremeRange = 36;
         this.tonnage = 6.0;
         this.criticals = 4;
+        this.shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        this.medAV = this.shortAV;
+        this.longAV = this.shortAV;
+        this.extAV = this.shortAV;
         this.bv = 40;
         this.cost = 200000;
         // Since this are the Tactical Handbook Weapons I'm using the TM Stats.

--- a/megamek/src/megamek/common/weapons/unofficial/ISTHBLB5XAC.java
+++ b/megamek/src/megamek/common/weapons/unofficial/ISTHBLB5XAC.java
@@ -39,7 +39,7 @@ public class ISTHBLB5XAC extends LBXACWeapon {
         this.extremeRange = 30;
         this.tonnage = 8.0;
         this.criticals = 6;
-        this.shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        this.shortAV = getBaseAeroDamage();
         this.medAV = this.shortAV;
         this.longAV = this.shortAV;
         this.extAV = this.shortAV;

--- a/megamek/src/megamek/common/weapons/unofficial/ISTHBLB5XAC.java
+++ b/megamek/src/megamek/common/weapons/unofficial/ISTHBLB5XAC.java
@@ -39,6 +39,10 @@ public class ISTHBLB5XAC extends LBXACWeapon {
         this.extremeRange = 30;
         this.tonnage = 8.0;
         this.criticals = 6;
+        this.shortAV = Math.ceil(damage * 0.6); // This is an LBX weapon, so Aero AV is 60% of normal
+        this.medAV = this.shortAV;
+        this.longAV = this.shortAV;
+        this.extAV = this.shortAV;
         this.bv = 85;
         this.cost = 300000;
         // Since this are the Tactical Handbook Weapons I'm using the TM Stats.


### PR DESCRIPTION
This PR solves
- the problem of LBX weapons not displaying the correct Aero damage values by moving the calculation of the 60% damage from calcAttackValue() to the proper Aero variables.
- it changes to IATM Aero damage values to being properly calculated instead of hardcoded with magic numbers.
- Fixes the check on IBB quirk for internal cargo bombs

Fixes: https://github.com/MegaMek/megameklab/issues/1810
Fixes: https://github.com/MegaMek/megameklab/issues/1806

Linked to https://github.com/MegaMek/megameklab/pull/1870
