### PR TITLE
Fix: #6976 Prevent performance issues caused by the unit display's weapon panel from freezing the game

### DIFF
--- a/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/swing/unitDisplay/WeaponPanel.java
@@ -30,8 +30,12 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import javax.swing.*;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
@@ -43,8 +47,8 @@ import megamek.client.ui.GBC;
 import megamek.client.ui.Messages;
 import megamek.client.ui.baseComponents.MMComboBox;
 import megamek.client.ui.swing.ClientGUI;
-import megamek.client.ui.swing.phaseDisplay.FiringDisplay;
 import megamek.client.ui.swing.GUIPreferences;
+import megamek.client.ui.swing.phaseDisplay.FiringDisplay;
 import megamek.client.ui.swing.phaseDisplay.TargetingPhaseDisplay;
 import megamek.client.ui.swing.tooltip.UnitToolTip;
 import megamek.client.ui.swing.widget.BackGroundDrawer;
@@ -2792,6 +2796,7 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         if (weaponSortOrder == null) {
             return;
         }
+        removeListeners();
 
         entity.setWeaponSortOrder(weaponSortOrder);
         ((WeaponListModel) weaponList.getModel()).sort(weaponSortOrder.getWeaponSortComparator(entity));


### PR DESCRIPTION
Fixes #6976 

#6958 fixed some issues with scrolling in the panels. When updating the weapon comparator, it adds new listeners without removing the existing ones. This kills the MegaMek.

Now, when setting the weapon comparator, it will first clear the existing listeners before adding new ones.

Flame graph of the deployment phase before change: 
![image](https://github.com/user-attachments/assets/52995c30-979e-490f-bfb3-8da8d3d782e2)

After:
![image](https://github.com/user-attachments/assets/2f4d34e5-a84e-4710-966e-6f27e977981c)

More importantly, I'm able to get through deployment with a trinary vs battalion engagement. 
