### PR TITLE
Fix: #6967 Battlemech Shields are non-functional

### DIFF
--- a/megamek/src/megamek/common/MekWithArms.java
+++ b/megamek/src/megamek/common/MekWithArms.java
@@ -18,12 +18,12 @@
  */
 package megamek.common;
 
-import megamek.common.equipment.MiscMounted;
-import megamek.common.options.OptionsConstants;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import megamek.common.equipment.MiscMounted;
+import megamek.common.options.OptionsConstants;
 
 /**
  * This class acts as a superclass to BipedMek and TripodMek to unify code that is shared between them, most of it arm-related as both have
@@ -85,7 +85,7 @@ public abstract class MekWithArms extends Mek {
             MiscType type = m.getType();
             if (((m.getLocation() == Mek.LOC_LARM) || (m.getLocation() == Mek.LOC_RARM))
                 && type.isShield()
-                && m.isInoperable()
+                && !m.isInoperable()
                 && (getInternal(m.getLocation()) > 0)) {
                 for (int slot = 0; slot < getNumberOfCriticals(m.getLocation()); slot++) {
                     CriticalSlot cs = getCritical(m.getLocation(), slot);


### PR DESCRIPTION
Fixes #6967 

Shields should require the equipment to be operable, not inoperable