### PR TITLE
Fix: Mark hexes less than _or equal to_ max distance as visible under Double Blind and adverse conditions

### DIFF
--- a/megamek/src/megamek/client/ui/swing/boardview/FovHighlightingAndDarkening.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/FovHighlightingAndDarkening.java
@@ -172,7 +172,7 @@ public class FovHighlightingAndDarkening {
 
             if (dist == 0) {
                 this.boardView1.drawHexBorder(boardGraph, p, selected_color, pad, lw);
-            } else if (dist < max_dist) {
+            } else if (dist <= max_dist) {
                 LosEffects los = getCachedLosEffects(src, c);
                 if (null != this.boardView1.getSelectedEntity()) {
                     if (los == null) {


### PR DESCRIPTION
Change a `<` comparison to a `<=` comparison.  
This appears to have been the original intent of the author based on some comments within the function.

Testing:
- Reproduced OP's issue before and after the fix, confirming fix operates correctly.
- Ran all 3 projects' unit tests.

Close #6948 