### PR TITLE
Fix Artillery units not losing autohit mod after spending mp

### DIFF
--- a/megamek/src/megamek/common/ArtilleryTracker.java
+++ b/megamek/src/megamek/common/ArtilleryTracker.java
@@ -93,6 +93,7 @@ public class ArtilleryTracker implements Serializable {
     /**
      * Remove all autohit mods from hexes that were hit previously; used when artillery unit moves.
      * This _should_ be thread-safe.
+     * Only autohit mods are lost when an artillery unit spends MPs (TO:AR pg. 150)
      */
     public void clearHitHexMods() {
         for (Vector<ArtilleryModifier> modVector : weapons.values()) {

--- a/megamek/src/megamek/common/ArtilleryTracker.java
+++ b/megamek/src/megamek/common/ArtilleryTracker.java
@@ -1,17 +1,36 @@
 /*
  * MegaMek
  * Copyright (c) 2004 - Ben Mazur (bmazur@sev.org)
- * Copyright (c) 2022 - The MegaMek Team. All Rights Reserved.
+ * Copyright (c) 2022 - 2025 The MegaMek Team. All Rights Reserved.
  *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the Free
- * Software Foundation; either version 2 of the License, or (at your option)
- * any later version.
+ * This file is part of MegaMek.
  *
- * This program is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
- * for more details.
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package megamek.common;
 

--- a/megamek/src/megamek/common/ArtilleryTracker.java
+++ b/megamek/src/megamek/common/ArtilleryTracker.java
@@ -16,7 +16,9 @@
 package megamek.common;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 
@@ -67,6 +69,22 @@ public class ArtilleryTracker implements Serializable {
      */
     public int getSize() {
         return weapons.size();
+    }
+
+    /**
+     * Remove all autohit mods from hexes that were hit previously; used when artillery unit moves.
+     * This _should_ be thread-safe.
+     */
+    public void clearHitHexMods() {
+        for (Vector<ArtilleryModifier> modVector : weapons.values()) {
+            List<ArtilleryModifier> elementsToBeRemoved = new ArrayList<>();
+            for (ArtilleryModifier mod : modVector) {
+                if (mod.getModifier() == TargetRoll.AUTOMATIC_SUCCESS) {
+                    elementsToBeRemoved.add(mod);
+                }
+            }
+            modVector.removeAll(elementsToBeRemoved);
+        }
     }
 
     public boolean weaponInList(Mounted<?> mounted) {

--- a/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
@@ -125,6 +125,12 @@ class MovePathHandler extends AbstractTWRuleHandler {
     }
 
     void processMovement() {
+        if (md.getMpUsed() > 0) {
+            // All auto-hit hexes for this unit (not including preset targets) are cleared
+            // if any MP are expended.
+            entity.aTracker.clearHitHexMods();
+        }
+
         if (md.contains(MovePath.MoveStepType.EJECT)) {
             if (entity.isLargeCraft() && !entity.isCarcass()) {
                 r = new Report(2026);

--- a/megamek/unittests/megamek/common/ArtilleryTrackerTest.java
+++ b/megamek/unittests/megamek/common/ArtilleryTrackerTest.java
@@ -1,0 +1,127 @@
+package megamek.common;
+
+import megamek.common.equipment.WeaponMounted;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ArtilleryTrackerTest {
+
+    protected ArtilleryTracker artilleryTracker = new ArtilleryTracker();
+    protected Tank tank;
+    protected WeaponType sniperType = (WeaponType) EquipmentType.get("IS Sniper");
+
+    @BeforeAll
+    static void beforeAll() {
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void setUp() throws LocationFullException {
+        tank = new Tank();
+        tank.addEquipment(sniperType, Tank.LOC_FRONT);
+        tank.aTracker = artilleryTracker;
+    }
+
+    /**
+     * No-op when no weapons are registered
+     */
+    @Test
+    void test_clearHitHexMods_with_empty_artillery_tracker() {
+        // This should be a no-op and not fail
+        artilleryTracker.clearHitHexMods();
+    }
+
+    /**
+     * No-op when there are no mods
+     */
+    @Test
+    void test_clearHitHexMods_with_no_mods_on_one_weapon() {
+        WeaponMounted weapon = tank.getWeapon(0);
+        artilleryTracker.addWeapon(weapon);
+
+        // Should report one weapon with no mods
+        assertEquals(1, artilleryTracker.getSize());
+        assertEquals(0, artilleryTracker.getWeaponModifiers(weapon).size());
+
+        artilleryTracker.clearHitHexMods();
+
+        // No change is expected
+        assertEquals(1, artilleryTracker.getSize());
+        assertEquals(0, artilleryTracker.getWeaponModifiers(weapon).size());
+    }
+
+    /**
+     * Test to show that standard to-hit mods are not removed
+     */
+    @Test
+    void test_clearHitHexMods_with_standard_mod_on_one_weapon() {
+        WeaponMounted weapon = tank.getWeapon(0);
+        artilleryTracker.addWeapon(weapon);
+
+        artilleryTracker.setModifier(7, new Coords(8, 9));
+
+        // Should report one weapon with base mod
+        assertEquals(1, artilleryTracker.getSize());
+        assertEquals(1, artilleryTracker.getWeaponModifiers(weapon).size());
+
+        artilleryTracker.clearHitHexMods();
+
+        // No change is expected
+        assertEquals(1, artilleryTracker.getSize());
+        assertEquals(1, artilleryTracker.getWeaponModifiers(weapon).size());
+    }
+
+    /**
+     * Test to show that normal mods are left in place after automatic hit mods are removed
+     */
+    @Test
+    void test_clearHitHexMods_with_standard_and_autohit_mods_on_one_weapon() {
+        WeaponMounted weapon = tank.getWeapon(0);
+        artilleryTracker.addWeapon(weapon);
+
+        artilleryTracker.setModifier(7, new Coords(8, 9));
+        artilleryTracker.setModifier(TargetRoll.AUTOMATIC_SUCCESS, new Coords(12, 15));
+
+        // Should report one weapon with base mod and autohit mod
+        assertEquals(1, artilleryTracker.getSize());
+        assertEquals(2, artilleryTracker.getWeaponModifiers(weapon).size());
+
+        artilleryTracker.clearHitHexMods();
+
+        // Autohit mod is removed
+        assertEquals(1, artilleryTracker.getSize());
+        assertEquals(1, artilleryTracker.getWeaponModifiers(weapon).size());
+    }
+
+    /**
+     * This test shows that any automatic hit mods are removed from _all_ weapons at the same
+     * time.
+     * @throws LocationFullException
+     */
+    @Test
+    void test_clearHitHexMods_with_standard_and_autohit_mods_on_two_weapons() throws LocationFullException {
+        tank.addEquipment(sniperType, Tank.LOC_REAR);
+        WeaponMounted weapon1 = tank.getWeapon(0);
+        WeaponMounted weapon2 = tank.getWeapon(0);
+        artilleryTracker.addWeapon(weapon1);
+        artilleryTracker.addWeapon(weapon2);
+
+        artilleryTracker.setModifier(7, new Coords(8, 9));
+        artilleryTracker.setModifier(TargetRoll.AUTOMATIC_SUCCESS, new Coords(12, 15));
+
+        // Should report two weapons with base mod and autohit mod each
+        assertEquals(2, artilleryTracker.getSize());
+        assertEquals(2, artilleryTracker.getWeaponModifiers(weapon1).size());
+        assertEquals(2, artilleryTracker.getWeaponModifiers(weapon2).size());
+
+        artilleryTracker.clearHitHexMods();
+
+        // Autohit mod is removed from both weapons
+        assertEquals(2, artilleryTracker.getSize());
+        assertEquals(1, artilleryTracker.getWeaponModifiers(weapon1).size());
+        assertEquals(1, artilleryTracker.getWeaponModifiers(weapon2).size());
+    }
+}

--- a/megamek/unittests/megamek/common/ArtilleryTrackerTest.java
+++ b/megamek/unittests/megamek/common/ArtilleryTrackerTest.java
@@ -1,3 +1,36 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
 package megamek.common;
 
 import megamek.common.equipment.WeaponMounted;


### PR DESCRIPTION
Fix for Artillery units moving but keeping their auto-hit mods on hexes they've already hit.
This patch adds a new method to the ArtilleryTracker to remove _only_ those autohit mods when a unit expends MP.

Note that other mods (such as base artillery mod, spotter adjustment mod, etc.) should not be modified by this method, as only the auto-hit mod is lost after movement (per TO:AR rules).

Testing:
- Tested with games vs Princess including on- and off-board artillery on various unit types
- Added unit tests
- Ran all 3 projects' unit tests

Close #6929 