### PR TITLE
TRO fixes for Aero

### DIFF
--- a/megamek/src/megamek/common/templates/AeroTROView.java
+++ b/megamek/src/megamek/common/templates/AeroTROView.java
@@ -25,6 +25,7 @@ import megamek.common.Aero;
 import megamek.common.AmmoType;
 import megamek.common.Entity;
 import megamek.common.EntityFluff;
+import megamek.common.EquipmentType;
 import megamek.common.FighterSquadron;
 import megamek.common.Messages;
 import megamek.common.MiscType;
@@ -34,6 +35,11 @@ import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.verifier.EntityVerifier;
 import megamek.common.verifier.TestAero;
+import megamek.common.weapons.CLIATMWeapon;
+import megamek.common.weapons.lrms.LRMWeapon;
+import megamek.common.weapons.missiles.ATMWeapon;
+import megamek.common.weapons.missiles.MMLWeapon;
+import megamek.common.weapons.srms.SRMWeapon;
 
 /**
  * Creates a TRO template model for aerospace and conventional fighters.
@@ -172,14 +178,50 @@ public class AeroTROView extends TROView {
         return nameWidth;
     }
 
+    
+    /**
+     * Computes any modification to the aerospace AV for linked Artemis, Apollo, or PPC capacitor
+     *
+     * @param weapon   The type of weapon
+     * @param linkedBy The type of equipment the weapon is linked by
+     * @param bay      Whether the weapon is part of a weapon bay
+     * @return         The AV modification, if any
+     */
+    private int aeroAVMod(WeaponType weapon, EquipmentType linkedBy, boolean bay) {
+        if (linkedBy.hasFlag(MiscType.F_ARTEMIS)
+                || linkedBy.hasFlag(MiscType.F_ARTEMIS_V)) {
+            // The 9 and 10 rows of the cluster hits table is only different in the 3 column
+            if (weapon.getAtClass() == WeaponType.CLASS_MML) {
+                if (weapon.getRackSize() >= 7) {
+                    return 2;
+                } else if ((weapon.getRackSize() >= 5) || linkedBy.hasFlag(MiscType.F_ARTEMIS_V)) {
+                    return 1;
+                }
+            } else if (weapon instanceof LRMWeapon) {
+                return weapon.getRackSize() / 5;
+            } else if (weapon instanceof SRMWeapon) {
+                return 2;
+            }
+        } else if (linkedBy.hasFlag(MiscType.F_ARTEMIS_PROTO) && weapon.getRackSize() == 2) {
+            // The +1 cluster hit bonus only adds a missile hit for SRM2
+            return 2;
+        } else if (bay && linkedBy.hasFlag(MiscType.F_PPC_CAPACITOR)) {
+            // PPC capacitors in weapon bays are treated as if always charged
+            return 5;
+        }
+        return 0;
+    }
+
     private Map<String, Object> createBayRow(WeaponMounted bay) {
         final Map<EquipmentKey, Integer> weaponCount = new HashMap<>();
         int heat = 0;
+        int baysrv = 0;
         int srv = 0;
         int mrv = 0;
         int lrv = 0;
         int erv = 0;
-        final int multiplier = bay.getType().isCapital() ? 10 : 1;
+        final boolean isCapital = bay.getType().isCapital();
+        final int multiplier = isCapital ? 10 : 1;
         Mounted<?> linker = null;
         // FIXME: Consider new AmmoType::equals / BombType::equals
         final Map<AmmoType, Integer> shotsByAmmoType = bay.getBayAmmo()
@@ -192,11 +234,35 @@ public class AeroTROView extends TROView {
                 linker = wMount.getLinkedBy();
             }
             weaponCount.merge(new EquipmentKey(wtype, wMount.getSize()), 1, Integer::sum);
+            int bonus = 0;
             heat += wtype.getHeat();
-            srv += (int) (wtype.getShortAV() * multiplier);
-            mrv += (int) (wtype.getMedAV() * multiplier);
-            lrv += (int) (wtype.getLongAV() * multiplier);
-            erv += (int) (wtype.getExtAV() * multiplier);
+            int av = (int) (wtype.getShortAV() * multiplier) + bonus;
+            if (!isCapital) {
+                if (wtype instanceof ATMWeapon || wtype instanceof CLIATMWeapon) {
+                    if (wtype instanceof CLIATMWeapon) {
+                        av = (int) wtype.getShortAV() * multiplier;
+                    } else {
+                        av = (int) Math.ceil(wtype.getShortAV() * multiplier * 0.5);
+                    }
+                    baysrv += Math.round(Math.ceil(av * 1.5) / 10.0);
+                    srv += Math.ceil(av * 1.5);
+                    mrv += av;
+                    lrv += Math.ceil(av * 0.5);
+                    erv += Math.ceil(av * 0.5);
+                    continue;
+                }
+                if (linker != null) {
+                    bonus = aeroAVMod(wtype, linker.getType(), true);
+                }
+                if (wtype instanceof MMLWeapon) {
+                    av *= 2; // SRM ammo
+                }
+            }
+            baysrv += Math.round(av / 10.0);
+            srv += (int) (wtype.getShortAV() * multiplier) + bonus;
+            mrv += (int) (wtype.getMedAV() * multiplier) + bonus;
+            lrv += (int) (wtype.getLongAV() * multiplier) + bonus;
+            erv += (int) (wtype.getExtAV() * multiplier) + bonus;
         }
         final Map<String, Object> retVal = new HashMap<>();
         final List<String> weapons = new ArrayList<>();
@@ -214,7 +280,7 @@ public class AeroTROView extends TROView {
               Messages.getString("TROView.shots"))));
         retVal.put("weapons", weapons);
         retVal.put("heat", heat);
-        retVal.put("srv", Math.round(srv / 10.0) + "(" + srv + ")");
+        retVal.put("srv", baysrv + "(" + srv + ")");
         retVal.put("mrv", Math.round(mrv / 10.0) + "(" + mrv + ")");
         retVal.put("lrv", Math.round(lrv / 10.0) + "(" + lrv + ")");
         retVal.put("erv", Math.round(erv / 10.0) + "(" + erv + ")");


### PR DESCRIPTION
This PR correct the Aero TRO to match the output of the MML record sheets for the following weapons:
- any weapon with Artemis/Apollo/PPCCapacitator
- ATM and IATM weapons
- MML weapons

Fixes #6911

