### PR TITLE
chat retain focus, blinking cursor

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -34,6 +34,8 @@ import java.awt.event.ActionListener;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -85,7 +87,6 @@ import megamek.client.ui.swing.lobby.ChatLounge;
 import megamek.client.ui.swing.lobby.PlayerSettingsDialog;
 import megamek.client.ui.swing.minimap.Minimap;
 import megamek.client.ui.swing.phaseDisplay.*;
-import megamek.client.ui.swing.phaseDisplay.TargetingPhaseDisplay;
 import megamek.client.ui.swing.unitDisplay.UnitDisplay;
 import megamek.client.ui.swing.util.BASE64ToolKit;
 import megamek.client.ui.swing.util.MegaMekController;
@@ -259,6 +260,7 @@ public class ClientGUI extends AbstractClientGUI
     public MegaMekController controller;
     private ChatterBox cb;
     public ChatterBoxOverlay cb2;
+    private boolean wasBoardFocused = false;
     private BoardView bv;
     private MovementEnvelopeSpriteHandler movementEnvelopeHandler;
     private MovementModifierSpriteHandler movementModifierSpriteHandler;
@@ -416,6 +418,21 @@ public class ClientGUI extends AbstractClientGUI
         registerCommand(new BotHelpCommand(this));
     }
 
+    private void initializeFocusTracking() {
+        bv.getPanel().addFocusListener(new FocusListener() {
+            @Override
+            public void focusGained(FocusEvent e) {
+                wasBoardFocused = true;
+            }
+    
+            @Override
+            public void focusLost(FocusEvent e) {
+                wasBoardFocused = false;
+                bv.setChatterBoxActive(false);
+            }
+        });
+    }
+
     @Override
     public BoardView getBoardView() {
         return bv;
@@ -432,6 +449,7 @@ public class ClientGUI extends AbstractClientGUI
 
     public void setUnitDisplayDialog(final UnitDisplayDialog unitDisplayDialog) {
         this.unitDisplayDialog = unitDisplayDialog;
+        this.unitDisplayDialog.setFocusableWindowState(false);
     }
 
     public ForceDisplayPanel getForceDisplayPanel() {
@@ -448,6 +466,7 @@ public class ClientGUI extends AbstractClientGUI
 
     public void setForceDisplayDialog(final ForceDisplayDialog forceDisplayDialog) {
         this.forceDisplayDialog = forceDisplayDialog;
+        this.forceDisplayDialog.setFocusableWindowState(false);
     }
 
     public JDialog getMiniMapDialog() {
@@ -456,6 +475,7 @@ public class ClientGUI extends AbstractClientGUI
 
     public void setMiniMapDialog(final JDialog miniMapDialog) {
         minimapW = miniMapDialog;
+        minimapW.setFocusableWindowState(false);
     }
 
     public JDialog getBotCommandsDialog() {
@@ -480,6 +500,7 @@ public class ClientGUI extends AbstractClientGUI
 
     public void setMiniReportDisplayDialog(final MiniReportDisplayDialog miniReportDisplayDialog) {
         this.miniReportDisplayDialog = miniReportDisplayDialog;
+        this.miniReportDisplayDialog.setFocusableWindowState(false);
     }
 
     public PlayerListDialog getPlayerListDialog() {
@@ -488,6 +509,7 @@ public class ClientGUI extends AbstractClientGUI
 
     public void setPlayerListDialog(final PlayerListDialog playerListDialog) {
         this.playerListDialog = playerListDialog;
+        this.playerListDialog.setFocusableWindowState(false);
     }
 
     @Override
@@ -592,6 +614,7 @@ public class ClientGUI extends AbstractClientGUI
             panTop.add(splitPaneA, BorderLayout.CENTER);
 
             bv.addBoardViewListener(this);
+            initializeFocusTracking();
         } catch (Exception ex) {
             logger.fatal(ex, "initialize");
             doAlertDialog(Messages.getString("ClientGUI.FatalError.title"),
@@ -730,6 +753,7 @@ public class ClientGUI extends AbstractClientGUI
             setPlayerListDialog(new PlayerListDialog(frame, client, false));
         }
         getPlayerListDialog().setVisible(true);
+        conditionalRequestFocus();
     }
 
     public void miniReportDisplayAddReportPages() {
@@ -1487,6 +1511,17 @@ public class ClientGUI extends AbstractClientGUI
         GUIP.setMinimapEnabled(GUIP.getUnitDisplayEnabled());
     }
 
+    private void conditionalRequestFocus() {
+        if (wasBoardFocused) {
+            requestFocus();
+        }
+    }
+
+    private void requestFocus() {
+        frame.requestFocusInWindow();
+        bv.getPanel().requestFocusInWindow();
+    }
+
     /**
      * Toggles the accessibility window
      */
@@ -1593,18 +1628,21 @@ public class ClientGUI extends AbstractClientGUI
     void setMapVisible(boolean visible) {
         if (getMiniMapDialog() != null) {
             getMiniMapDialog().setVisible(visible);
+            if (visible) conditionalRequestFocus();
         }
     }
 
     void setMiniReportVisible(boolean visible) {
         if (getMiniReportDisplayDialog() != null) {
             setMiniReportLocation(visible);
+            if (visible) conditionalRequestFocus();
         }
     }
 
     void setPlayerListVisible(boolean visible) {
         if (visible) {
             showPlayerList();
+            conditionalRequestFocus();
         } else {
             if (getPlayerListDialog() != null) {
                 getPlayerListDialog().setVisible(visible);
@@ -1684,6 +1722,7 @@ public class ClientGUI extends AbstractClientGUI
     void setBotCommandsDialogVisible(boolean visible) {
         if (getBotCommandsDialog() != null) {
             getBotCommandsDialog().setVisible(visible);
+            if (visible) conditionalRequestFocus();
         }
     }
 
@@ -1700,6 +1739,7 @@ public class ClientGUI extends AbstractClientGUI
     public void setForceDisplayVisible(boolean visible) {
         if (getForceDisplayDialog() != null) {
             getForceDisplayDialog().setVisible(visible);
+            if (visible) conditionalRequestFocus();
         }
     }
 
@@ -1759,6 +1799,7 @@ public class ClientGUI extends AbstractClientGUI
                     getUnitDisplay().setVisible(visible);
                     getUnitDisplay().setTitleVisible(false);
                     hideEmptyPanel(panA1, splitPaneA, 0.0);
+                    if (visible) conditionalRequestFocus();
                     break;
                 case 1:
                     panA2.add(boardViewsContainer.getPanel());
@@ -1768,6 +1809,7 @@ public class ClientGUI extends AbstractClientGUI
                     getUnitDisplay().setVisible(visible);
                     getUnitDisplay().setTitleVisible(true);
                     hideEmptyPanel(panA1, splitPaneA, 0.0);
+                    if (visible) conditionalRequestFocus();
                     break;
             }
         } else {
@@ -1780,6 +1822,7 @@ public class ClientGUI extends AbstractClientGUI
                     getUnitDisplay().setVisible(visible);
                     getUnitDisplay().setTitleVisible(false);
                     hideEmptyPanel(panA2, splitPaneA, 1.0);
+                    if (visible) conditionalRequestFocus();
                     break;
                 case 1:
                     panA1.add(boardViewsContainer.getPanel());
@@ -1789,6 +1832,7 @@ public class ClientGUI extends AbstractClientGUI
                     getUnitDisplay().setVisible(visible);
                     getUnitDisplay().setTitleVisible(true);
                     hideEmptyPanel(panA2, splitPaneA, 1.0);
+                    if (visible) conditionalRequestFocus();
                     break;
             }
         }
@@ -1810,6 +1854,7 @@ public class ClientGUI extends AbstractClientGUI
                     getMiniReportDisplayDialog().setVisible(visible);
                     getMiniReportDisplay().setVisible(visible);
                     hideEmptyPanel(panA1, splitPaneA, 0.0);
+                    if (visible) conditionalRequestFocus();
                     break;
                 case 1:
                     panA2.add(boardViewsContainer.getPanel());
@@ -1818,6 +1863,7 @@ public class ClientGUI extends AbstractClientGUI
                     getMiniReportDisplayDialog().setVisible(false);
                     getMiniReportDisplay().setVisible(visible);
                     hideEmptyPanel(panA1, splitPaneA, 0.0);
+                    if (visible) conditionalRequestFocus();
                     break;
             }
         } else {
@@ -1829,6 +1875,7 @@ public class ClientGUI extends AbstractClientGUI
                     getMiniReportDisplayDialog().setVisible(visible);
                     getMiniReportDisplay().setVisible(visible);
                     hideEmptyPanel(panA2, splitPaneA, 1.0);
+                    if (visible) conditionalRequestFocus();
                     break;
                 case 1:
                     panA1.add(boardViewsContainer.getPanel());
@@ -1837,12 +1884,14 @@ public class ClientGUI extends AbstractClientGUI
                     getMiniReportDisplayDialog().setVisible(false);
                     getMiniReportDisplay().setVisible(visible);
                     hideEmptyPanel(panA2, splitPaneA, 1.0);
+                    if (visible) conditionalRequestFocus();
                     break;
             }
         }
 
         revalidatePanels();
         setsetDividerLocations();
+        conditionalRequestFocus();
     }
 
     private boolean fillPopup(Coords coords) {
@@ -2456,8 +2505,6 @@ public class ClientGUI extends AbstractClientGUI
                 // and the equals function of Player isn't powerful enough.
                 bv.setLocalPlayer(client.getLocalPlayer());
             }
-            // Make sure the ChatterBox starts out deactivated.
-            bv.setChatterBoxActive(false);
 
             // Swap to this phase's panel.
             GamePhase phase = getClient().getGame().getPhase();


### PR DESCRIPTION
This PR makes all the dialogs during a game NOT steal focus.
There is also a tracking for the focus of the main window and, if it was in focus when a new dialog appears, it will try to retake it.
Additionally, the cursor is now blinking and the input text doesn't disappear if the focus is lost (on purpose or not)

Fixes #1058
