### PR TITLE
fix: Restore firing solution displaying after a torso twist

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -3367,8 +3367,7 @@ public class ClientGUI extends AbstractClientGUI
             return;
         }
 
-        if (curPanel instanceof MovementDisplay) {
-            MovementDisplay md = (MovementDisplay) curPanel;
+        if (curPanel instanceof MovementDisplay md) {
             if (entity.getId() == md.getCurrentEntity()) {
                 firingArcSpriteHandler.update(entity, getDisplayedWeapon().get(), md.getPlannedMovement());
                 return;
@@ -3378,6 +3377,7 @@ public class ClientGUI extends AbstractClientGUI
         // not in an ActionPhase - or - the unit is not the acting unit:
         // show for viewed entity, no move or actions to be taken into account
         firingArcSpriteHandler.update(entity, getDisplayedWeapon().get());
+        showFiringSolutions(entity);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/swing/phaseDisplay/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/phaseDisplay/FiringDisplay.java
@@ -1502,6 +1502,7 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
         }
         updateTarget();
         updateDonePanel();
+        refreshAll();
     }
 
     /**
@@ -1719,7 +1720,6 @@ public class FiringDisplay extends AttackPhaseDisplay implements ItemListener, L
             clearAttacks();
             addAttack(new TorsoTwistAction(currentEntity, direction));
             ce().setSecondaryFacing(direction);
-            clientgui.updateFiringArc(ce());
             updateForNewAction();
         }
     }


### PR DESCRIPTION
# What it does?

Makes the firing solution modifiers keep showing after a torso twist is made.

# Related issues
- Closes #7003 