### PR TITLE
Fix: #7020 Hide Sprites for Units that mount into bays

### DIFF
--- a/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalwarfare/MovePathHandler.java
@@ -2956,18 +2956,17 @@ class MovePathHandler extends AbstractTWRuleHandler {
 
             // Handle mounting units to small craft/DropShip
             if (step.getType() == MovePath.MoveStepType.MOUNT) {
-                Targetable mountee = step.getTarget(getGame());
-                if (mountee instanceof Entity) {
-                    Entity dropShip = (Entity) mountee;
-                    if (!dropShip.canLoad(entity)) {
+                Targetable targetToMountInto = step.getTarget(getGame());
+                if (targetToMountInto instanceof Entity entityToMountInto ) {
+                    if (!entityToMountInto.canLoad(entity)) {
                         // Something is fishy in Denmark.
                         logger
-                                .error(dropShip.getShortName() + " can not load " + entity.getShortName());
+                                .error(entityToMountInto.getShortName() + " can not load " + entity.getShortName());
                     } else {
                         // Have the indicated unit load this unit.
                         entity.setDone(true);
-                        gameManager.loadUnit(dropShip, entity, entity.getTargetBay());
-                        Bay currentBay = dropShip.getBay(entity);
+                        gameManager.loadUnit(entityToMountInto, entity, entity.getTargetBay());
+                        Bay currentBay = entityToMountInto.getBay(entity);
                         if ((null != currentBay) && (Compute.d6(2) == 2)) {
                             r = new Report(9390);
                             r.subject = entity.getId();
@@ -2977,7 +2976,8 @@ class MovePathHandler extends AbstractTWRuleHandler {
                             currentBay.destroyDoorNext();
                         }
                         // Stop looking.
-                        gameManager.entityUpdate(dropShip.getId());
+                        curPos = entity.getPosition();
+                        gameManager.entityUpdate(entityToMountInto.getId());
                         return;
                     }
                 }


### PR DESCRIPTION
Fixes #7020 

This has been broken for a while it seems, it was broken in 0.50.05. When a unit loads into a transport, its position is updated to null. However, the `MovePathHandler` expects `curPos` to be updated, which it wasn't. This updates the `curPos` of an entity to be the entity's location before returning out of `processSteps()`.