### PR TITLE
stack trace in logs for invalid types

### DIFF
--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -483,7 +483,7 @@ public class AmmoType extends EquipmentType {
         if (flag instanceof AmmoTypeFlag) {
             return super.hasFlag(flag);
         } else {
-            LOGGER.warn("Incorrect flag check: make sure to test only AmmoTypeFlags on an AmmoType.");
+            LOGGER.warn("Incorrect flag check: make sure to test only AmmoTypeFlags on an AmmoType.", new Throwable("Invalid AmmoType"));
             return false;
         }
     }

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -418,7 +418,7 @@ public class MiscType extends EquipmentType {
         if (flag instanceof MiscTypeFlag) {
             return super.hasFlag(flag);
         } else {
-            LOGGER.warn("Incorrect flag check: make sure to test only MiscTypeFlags on a MiscType.");
+            LOGGER.warn("Incorrect flag check: make sure to test only MiscTypeFlags on a MiscType.", new Throwable("Invalid MiscType"));
             return false;
         }
     }

--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -419,7 +419,7 @@ public class WeaponType extends EquipmentType {
         if (flag instanceof WeaponTypeFlag) {
             return super.hasFlag(flag);
         } else {
-            LOGGER.warn("Incorrect flag check: make sure to test only WeaponTypeFlags on a WeaponType.");
+            LOGGER.warn("Incorrect flag check: make sure to test only WeaponTypeFlags on a WeaponType.", new Throwable("Invalid WeaponType"));
             return false;
         }
     }


### PR DESCRIPTION
This PR add a stack trace in the logs when there is a wrong hasFlag() check (example: when a AmmoType.hasFlag() check is done to a MiscType)