### PR TITLE
Fix for save games containing attached Narc pods (of any kind) failing to load

### DIFF
--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -19,6 +19,7 @@ MEGAMEK VERSION HISTORY:
 + Fix #6966: SVs with no engine can't have MP
 + PR #6972: Fix for LBX and IATM Aero Damage (Fix MML/#1810)
 + Fix #6959: Fixes various memory leaks of dialogs never being disposed
++ Fix #7049: Fix for save games containing attached Narc pods (of any kind) failing to load
 
 0.50.05 (2025-04-25 1800 UTC)
 + Fix #6652: ProtoMek BV fixed for melee weapons and LRM-1

--- a/megamek/docs/history.txt
+++ b/megamek/docs/history.txt
@@ -19,7 +19,6 @@ MEGAMEK VERSION HISTORY:
 + Fix #6966: SVs with no engine can't have MP
 + PR #6972: Fix for LBX and IATM Aero Damage (Fix MML/#1810)
 + Fix #6959: Fixes various memory leaks of dialogs never being disposed
-+ Fix #7049: Fix for save games containing attached Narc pods (of any kind) failing to load
 
 0.50.05 (2025-04-25 1800 UTC)
 + Fix #6652: ProtoMek BV fixed for melee weapons and LRM-1

--- a/megamek/src/megamek/common/util/SerializationHelper.java
+++ b/megamek/src/megamek/common/util/SerializationHelper.java
@@ -27,6 +27,7 @@ import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 
 import megamek.common.Coords;
 import megamek.common.EntityFluff;
+import megamek.common.NarcPod;
 import megamek.common.net.marshalling.SanityInputFilter;
 import megamek.common.options.AbstractOptions;
 import megamek.server.victory.VictoryCondition;
@@ -73,6 +74,8 @@ public class SerializationHelper {
     /**
      * Factory method that produces an XStream object suitable for loading MegaMek
      * save games
+     *
+     * @return XStream instance to deserialize into a Game instance
      */
     public static XStream getLoadSaveGameXStream() {
         XStream xStream = getSaveGameXStream();
@@ -107,6 +110,35 @@ public class SerializationHelper {
                     reader.moveUp();
                 }
                 return (foundX && foundY) ? new Coords(x, y) : null;
+            }
+
+            @Override
+            public void marshal(Object object, HierarchicalStreamWriter writer, MarshallingContext context) {
+                // Unused here
+            }
+        });
+
+        // Necessary because, while Java 17+ supports Record serialization/deserialization, XStream 1.4.x
+        // does not (natively).
+        xStream.registerConverter(new Converter() {
+            @Override
+            public boolean canConvert(Class cls) {
+                return (cls == NarcPod.class);
+            }
+
+            @Override
+            public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+                int team = 0;
+                int location = 0;
+                while (reader.hasMoreChildren()) {
+                    reader.moveDown();
+                    switch (reader.getNodeName()) {
+                        case "team" -> team = Integer.parseInt(reader.getValue());
+                        case "location" -> location = Integer.parseInt(reader.getValue());
+                    }
+                    reader.moveUp();
+                }
+                return new NarcPod(team, location);
             }
 
             @Override

--- a/megamek/src/megamek/common/util/SerializationHelper.java
+++ b/megamek/src/megamek/common/util/SerializationHelper.java
@@ -128,17 +128,22 @@ public class SerializationHelper {
 
             @Override
             public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
-                int team = 0;
-                int location = 0;
+                int team = -1;
+                int location = -1;
                 while (reader.hasMoreChildren()) {
                     reader.moveDown();
-                    switch (reader.getNodeName()) {
-                        case "team" -> team = Integer.parseInt(reader.getValue());
-                        case "location" -> location = Integer.parseInt(reader.getValue());
+                    try {
+                        switch (reader.getNodeName()) {
+                            case "team" -> team = Integer.parseInt(reader.getValue());
+                            case "location" -> location = Integer.parseInt(reader.getValue());
+                        }
+                        reader.moveUp();
+                    } catch (NumberFormatException e) {
+                        // Narc Pods with malformed entries will be silently ignored
+                        return null;
                     }
-                    reader.moveUp();
                 }
-                return new NarcPod(team, location);
+                return ((team > -1) && (location > -1)) ? new NarcPod(team, location) : null;
             }
 
             @Override


### PR DESCRIPTION
This patch adds a custom unmarshaller for the NarcPod record class; this is necessary because native support for handling
Record class instances in XStream is in 1.5.x, but we use 1.4.x.

Testing:
- Tested with new save using one of every kind of Narc pod
- Ran all 3 projects' unit tests.

Close #7038 