### PR TITLE
Fix: #7052 Prevent Princess from freezing if theres a stacking violation while trying to abandon a unit

### DIFF
--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -3438,6 +3438,9 @@ public class Princess extends BotClient {
 
                             path.addStep(MoveStepType.UNLOAD, loadedEntity, dismountLocation);
                             return;
+                        } else {
+                            // Still increase the index so the loop finishes!
+                            dismountIndex++;
                         }
                     }
                 } else {


### PR DESCRIPTION
Fixes #7052 

Prevent infinite loop in `Princess.abandonShipOneUnit(Entity, Vector<Transporter>, MovePath`