### PR TITLE
Fix for Command Init applying to entire team when Individual Init is also enabled

### DIFF
--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -639,11 +639,7 @@ public final class Player extends TurnOrdered {
                     .map(Entity.class::cast)
                     .filter(entity ->
                                   (null != entity.getOwner()) &&
-                                        entity.getOwner().equals(this) &&
-                                        !entity.isDestroyed() &&
-                                        entity.getCrew().isActive() &&
-                                        !entity.isCaptured() &&
-                                        !(entity instanceof MekWarrior)
+                                        entity.getOwner().equals(this)
                     ).collect(Collectors.toCollection(ArrayList::new));
         int commandb = 0;
         for (Entity entity : entities) {
@@ -665,8 +661,13 @@ public final class Player extends TurnOrdered {
     public int getIndividualCommandBonus(Entity entity, boolean useCommandInit) {
         int bonus = 0;
         // Only consider this during normal rounds when unit is deployed on board, or about to deploy this round.
-        if ((entity.isDeployed() && !entity.isOffBoard()) ||
-               (entity.getDeployRound() == (game.getCurrentRound() + 1))) {
+        if (!entity.isDestroyed() &&
+                  entity.getCrew().isActive() &&
+                  !entity.isCaptured() &&
+                  !(entity instanceof MekWarrior) &&
+                  (entity.isDeployed() && !entity.isOffBoard()) ||
+                  (entity.getDeployRound() == (game.getCurrentRound() + 1))
+        ) {
             if (useCommandInit) {
                 bonus = entity.getCrew().getCommandBonus();
             }

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Vector;
+import java.util.stream.Collectors;
 
 import megamek.client.ui.swing.util.PlayerColour;
 import megamek.common.hexarea.BorderHexArea;
@@ -625,43 +626,60 @@ public final class Player extends TurnOrdered {
     /**
      * @return the bonus to this player's initiative rolls for the highest value initiative (i.e. the 'commander')
      */
-    public int getCommandBonus() {
+    public int getOverallCommandBonus() {
         if (game == null) {
             return 0;
         }
+        boolean useCommandInit = game.getOptions().booleanOption(OptionsConstants.RPG_COMMAND_INIT);
+        ArrayList<Entity> entities =
+              game.getInGameObjects()
+                    .stream()
+                    .filter(Entity.class::isInstance)
+                    .map(Entity.class::cast)
+                    .filter(entity ->
+                                  (null != entity.getOwner()) &&
+                                        entity.getOwner().equals(this) &&
+                                        !entity.isDestroyed() &&
+                                        entity.getCrew().isActive() &&
+                                        !entity.isCaptured() &&
+                                        !(entity instanceof MekWarrior)
+                    ).collect(Collectors.toCollection(ArrayList::new));
         int commandb = 0;
-        for (InGameObject unit : game.getInGameObjects()) {
-            if (unit instanceof Entity) {
-                Entity entity = (Entity) unit;
-                boolean useCommandInit = game.getOptions().booleanOption(OptionsConstants.RPG_COMMAND_INIT);
-                boolean checkThisTurn = ((null != entity.getOwner()) &&
-                                               entity.getOwner().equals(this) &&
-                                               !entity.isDestroyed() &&
-                                               entity.getCrew().isActive() &&
-                                               !entity.isCaptured() &&
-                                               !(entity instanceof MekWarrior)) &&
-                                              ((entity.isDeployed() && !entity.isOffBoard()) ||
-                                                     (entity.getDeployRound() == (game.getCurrentRound() + 1)));
-                if (checkThisTurn) {
-                    int bonus = 0;
-                    if (useCommandInit) {
-                        bonus = entity.getCrew().getCommandBonus();
-                    }
-                    //Even if the RPG option is not enabled, we still get the command bonus provided by special equipment.
-                    //Since we are not designating a single force commander at this point, we assume a superheavy tripod
-                    //is the force commander if that gives the highest bonus.
-                    if (entity.hasCommandConsoleBonus() || entity.getCrew().hasActiveTechOfficer()) {
-                        bonus += 2;
-                    }
-                    //Once we've gotten the status of the command console (if any), reset the flag that tracks
-                    //the previous turn's action.
-                    if (bonus > commandb) {
-                        commandb = bonus;
-                    }
-                }
+        // entities should only contain units we are concerned with this turn.
+        for (Entity entity : entities) {
+            int bonus = getIndividualCommandBonus(entity, useCommandInit);
+            //Once we've gotten the status of the command console (if any), reset the flag that tracks
+            //the previous turn's action.
+            if (bonus > commandb) {
+                commandb = bonus;
             }
         }
         return commandb;
+    }
+
+    /**
+     * Calculate command bonus for an individual entity within the player's force or team
+     * TODO: move all of this into Entity
+     * @param entity being considered
+     * @param useCommandInit boolean based on game options
+     * @return
+     */
+    public int getIndividualCommandBonus(Entity entity, boolean useCommandInit) {
+        int bonus = 0;
+        // Only consider this during normal rounds when unit is deployed, or about to deploy this round.
+        if ((entity.isDeployed() && !entity.isOffBoard()) ||
+               (entity.getDeployRound() == (game.getCurrentRound() + 1))) {
+            if (useCommandInit) {
+                bonus = entity.getCrew().getCommandBonus();
+            }
+            //Even if the RPG option is not enabled, we still get the command bonus provided by special equipment.
+            //Since we are not designating a single force commander at this point, we assume a superheavy tripod
+            //is the force commander if that gives the highest bonus.
+            if (entity.hasCommandConsoleBonus() || entity.getCrew().hasActiveTechOfficer()) {
+                bonus += 2;
+            }
+        }
+        return bonus;
     }
 
     public String getColorForPlayer() {

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -631,6 +631,7 @@ public final class Player extends TurnOrdered {
             return 0;
         }
         boolean useCommandInit = game.getOptions().booleanOption(OptionsConstants.RPG_COMMAND_INIT);
+        // entities are owned by this player, active, and not individual pilots
         ArrayList<Entity> entities =
               game.getInGameObjects()
                     .stream()
@@ -645,11 +646,8 @@ public final class Player extends TurnOrdered {
                                         !(entity instanceof MekWarrior)
                     ).collect(Collectors.toCollection(ArrayList::new));
         int commandb = 0;
-        // entities should only contain units we are concerned with this turn.
         for (Entity entity : entities) {
             int bonus = getIndividualCommandBonus(entity, useCommandInit);
-            //Once we've gotten the status of the command console (if any), reset the flag that tracks
-            //the previous turn's action.
             if (bonus > commandb) {
                 commandb = bonus;
             }
@@ -666,7 +664,7 @@ public final class Player extends TurnOrdered {
      */
     public int getIndividualCommandBonus(Entity entity, boolean useCommandInit) {
         int bonus = 0;
-        // Only consider this during normal rounds when unit is deployed, or about to deploy this round.
+        // Only consider this during normal rounds when unit is deployed on board, or about to deploy this round.
         if ((entity.isDeployed() && !entity.isOffBoard()) ||
                (entity.getDeployRound() == (game.getCurrentRound() + 1))) {
             if (useCommandInit) {

--- a/megamek/src/megamek/common/Team.java
+++ b/megamek/src/megamek/common/Team.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 
 import megamek.client.ratgenerator.FactionRecord;
 import megamek.common.annotations.Nullable;
+import megamek.common.options.OptionsConstants;
 
 /**
  * The Team class holds information about a team. It holds the initiative for the team, and contains a list of players
@@ -128,7 +129,7 @@ public final class Team extends TurnOrdered {
 
     /**
      * Return the number of "normal" turns that this item requires. This is normally the sum of multi-unit turns and the
-     * other turns. A team without any "normal" turns must return it's number of even turns to produce a fair
+     * other turns. A team without any "normal" turns must return its number of even turns to produce a fair
      * distribution of moves.
      *
      * @return the <code>int</code> number of "normal" turns this item should take in a phase.
@@ -224,7 +225,7 @@ public final class Team extends TurnOrdered {
 
         for (Player player : players) {
             dynamicBonus = Math.max(dynamicBonus, player.getTurnInitBonus());
-            dynamicBonus = Math.max(dynamicBonus, player.getCommandBonus());
+            dynamicBonus = Math.max(dynamicBonus, player.getOverallCommandBonus());
 
             // this is a special case: it's an arbitrary bonus associated with a player
             constantBonus = Math.max(constantBonus, player.getConstantInitBonus());

--- a/megamek/src/megamek/common/TurnOrdered.java
+++ b/megamek/src/megamek/common/TurnOrdered.java
@@ -397,9 +397,10 @@ public abstract class TurnOrdered implements ITurnOrdered {
             // Individual entities are used here if we're using Individual Initiative
             if (initiativeCandidate instanceof Entity entity) {
                 if (entity.getGame() != null) {
-                    final Team team = entity.getGame().getTeamForPlayer(entity.getOwner());
-                    if (team != null) {
-                        bonus = team.getTotalInitBonus(false) + entity.getCrew().getInitBonus();
+                    boolean useCommandInit = entity.getGame().getOptions().booleanOption(OptionsConstants.RPG_COMMAND_INIT);
+                    final Player player = entity.getOwner();
+                    if (player != null) {
+                        bonus = player.getIndividualCommandBonus(entity, useCommandInit) + entity.getCrew().getInitBonus();
                         if (entity.hasAbility(ATOW_COMBAT_SENSE)) {
                             initiativeAptitudeSPA = ATOW_COMBAT_SENSE;
                         } else if (entity.hasAbility(ATOW_COMBAT_PARALYSIS)) {

--- a/megamek/unittests/megamek/common/TeamTest.java
+++ b/megamek/unittests/megamek/common/TeamTest.java
@@ -142,7 +142,7 @@ class TeamTest {
         when(mockPlayer1.getConstantInitBonus()).thenReturn(-1);
         when(mockPlayer2.getConstantInitBonus()).thenReturn(-2);
         when(mockPlayer3.getConstantInitBonus()).thenReturn(-3);
-        when(mockPlayer2.getCommandBonus()).thenReturn(2);
+        when(mockPlayer2.getOverallCommandBonus()).thenReturn(2);
 
         int initBonus = testTeam.getTotalInitBonus(useInitCompBonus);
         assertEquals(1, initBonus);
@@ -166,8 +166,8 @@ class TeamTest {
         when(mockPlayer1.getConstantInitBonus()).thenReturn(-1);
         when(mockPlayer2.getConstantInitBonus()).thenReturn(-2);
         when(mockPlayer3.getConstantInitBonus()).thenReturn(-3);
-        when(mockPlayer1.getCommandBonus()).thenReturn(1);
-        when(mockPlayer2.getCommandBonus()).thenReturn(2);
+        when(mockPlayer1.getOverallCommandBonus()).thenReturn(1);
+        when(mockPlayer2.getOverallCommandBonus()).thenReturn(2);
 
         int initBonus = testTeam.getTotalInitBonus(useInitCompBonus);
         assertEquals(1, initBonus);
@@ -191,9 +191,9 @@ class TeamTest {
         when(mockPlayer1.getConstantInitBonus()).thenReturn(-1);
         when(mockPlayer2.getConstantInitBonus()).thenReturn(-2);
         when(mockPlayer3.getConstantInitBonus()).thenReturn(-3);
-        when(mockPlayer1.getCommandBonus()).thenReturn(1);
-        when(mockPlayer2.getCommandBonus()).thenReturn(2);
-        when(mockPlayer3.getCommandBonus()).thenReturn(4);
+        when(mockPlayer1.getOverallCommandBonus()).thenReturn(1);
+        when(mockPlayer2.getOverallCommandBonus()).thenReturn(2);
+        when(mockPlayer3.getOverallCommandBonus()).thenReturn(4);
 
         int initBonus = testTeam.getTotalInitBonus(useInitCompBonus);
         assertEquals(3, initBonus);
@@ -217,9 +217,9 @@ class TeamTest {
         when(mockPlayer1.getConstantInitBonus()).thenReturn(1);
         when(mockPlayer2.getConstantInitBonus()).thenReturn(2);
         when(mockPlayer3.getConstantInitBonus()).thenReturn(3);
-        when(mockPlayer1.getCommandBonus()).thenReturn(0);
-        when(mockPlayer2.getCommandBonus()).thenReturn(0);
-        when(mockPlayer3.getCommandBonus()).thenReturn(0);
+        when(mockPlayer1.getOverallCommandBonus()).thenReturn(0);
+        when(mockPlayer2.getOverallCommandBonus()).thenReturn(0);
+        when(mockPlayer3.getOverallCommandBonus()).thenReturn(0);
 
         int initBonus = testTeam.getTotalInitBonus(useInitCompBonus);
         assertEquals(3, initBonus);
@@ -243,9 +243,9 @@ class TeamTest {
         when(mockPlayer1.getConstantInitBonus()).thenReturn(1);
         when(mockPlayer2.getConstantInitBonus()).thenReturn(2);
         when(mockPlayer3.getConstantInitBonus()).thenReturn(3);
-        when(mockPlayer1.getCommandBonus()).thenReturn(1);
-        when(mockPlayer2.getCommandBonus()).thenReturn(2);
-        when(mockPlayer3.getCommandBonus()).thenReturn(3);
+        when(mockPlayer1.getOverallCommandBonus()).thenReturn(1);
+        when(mockPlayer2.getOverallCommandBonus()).thenReturn(2);
+        when(mockPlayer3.getOverallCommandBonus()).thenReturn(3);
 
         int initBonus = testTeam.getTotalInitBonus(useInitCompBonus);
         assertEquals(6, initBonus);
@@ -269,9 +269,9 @@ class TeamTest {
         when(mockPlayer1.getConstantInitBonus()).thenReturn(1);
         when(mockPlayer2.getConstantInitBonus()).thenReturn(2);
         when(mockPlayer3.getConstantInitBonus()).thenReturn(3);
-        when(mockPlayer1.getCommandBonus()).thenReturn(1);
-        when(mockPlayer2.getCommandBonus()).thenReturn(2);
-        when(mockPlayer3.getCommandBonus()).thenReturn(3);
+        when(mockPlayer1.getOverallCommandBonus()).thenReturn(1);
+        when(mockPlayer2.getOverallCommandBonus()).thenReturn(2);
+        when(mockPlayer3.getOverallCommandBonus()).thenReturn(3);
         when(mockPlayer1.getTurnInitBonus()).thenReturn(1);
         when(mockPlayer2.getTurnInitBonus()).thenReturn(2);
         when(mockPlayer3.getTurnInitBonus()).thenReturn(3);
@@ -298,9 +298,9 @@ class TeamTest {
         when(mockPlayer1.getConstantInitBonus()).thenReturn(1);
         when(mockPlayer2.getConstantInitBonus()).thenReturn(2);
         when(mockPlayer3.getConstantInitBonus()).thenReturn(3);
-        when(mockPlayer1.getCommandBonus()).thenReturn(1);
-        when(mockPlayer2.getCommandBonus()).thenReturn(2);
-        when(mockPlayer3.getCommandBonus()).thenReturn(3);
+        when(mockPlayer1.getOverallCommandBonus()).thenReturn(1);
+        when(mockPlayer2.getOverallCommandBonus()).thenReturn(2);
+        when(mockPlayer3.getOverallCommandBonus()).thenReturn(3);
         when(mockPlayer1.getTurnInitBonus()).thenReturn(-1);
         when(mockPlayer2.getTurnInitBonus()).thenReturn(-2);
         when(mockPlayer3.getTurnInitBonus()).thenReturn(-3);
@@ -327,9 +327,9 @@ class TeamTest {
         when(mockPlayer1.getConstantInitBonus()).thenReturn(1);
         when(mockPlayer2.getConstantInitBonus()).thenReturn(2);
         when(mockPlayer3.getConstantInitBonus()).thenReturn(3);
-        when(mockPlayer1.getCommandBonus()).thenReturn(1);
-        when(mockPlayer2.getCommandBonus()).thenReturn(2);
-        when(mockPlayer3.getCommandBonus()).thenReturn(3);
+        when(mockPlayer1.getOverallCommandBonus()).thenReturn(1);
+        when(mockPlayer2.getOverallCommandBonus()).thenReturn(2);
+        when(mockPlayer3.getOverallCommandBonus()).thenReturn(3);
         when(mockPlayer1.getTurnInitBonus()).thenReturn(-1);
         when(mockPlayer2.getTurnInitBonus()).thenReturn(-2);
         when(mockPlayer3.getTurnInitBonus()).thenReturn(-3);
@@ -356,9 +356,9 @@ class TeamTest {
         when(mockPlayer1.getConstantInitBonus()).thenReturn(1);
         when(mockPlayer2.getConstantInitBonus()).thenReturn(2);
         when(mockPlayer3.getConstantInitBonus()).thenReturn(3);
-        when(mockPlayer1.getCommandBonus()).thenReturn(1);
-        when(mockPlayer2.getCommandBonus()).thenReturn(2);
-        when(mockPlayer3.getCommandBonus()).thenReturn(3);
+        when(mockPlayer1.getOverallCommandBonus()).thenReturn(1);
+        when(mockPlayer2.getOverallCommandBonus()).thenReturn(2);
+        when(mockPlayer3.getOverallCommandBonus()).thenReturn(3);
         when(mockPlayer1.getTurnInitBonus()).thenReturn(-1);
         when(mockPlayer2.getTurnInitBonus()).thenReturn(-2);
         when(mockPlayer3.getTurnInitBonus()).thenReturn(-3);
@@ -388,9 +388,9 @@ class TeamTest {
         when(mockPlayer1.getConstantInitBonus()).thenReturn(1);
         when(mockPlayer2.getConstantInitBonus()).thenReturn(2);
         when(mockPlayer3.getConstantInitBonus()).thenReturn(3);
-        when(mockPlayer1.getCommandBonus()).thenReturn(1);
-        when(mockPlayer2.getCommandBonus()).thenReturn(2);
-        when(mockPlayer3.getCommandBonus()).thenReturn(3);
+        when(mockPlayer1.getOverallCommandBonus()).thenReturn(1);
+        when(mockPlayer2.getOverallCommandBonus()).thenReturn(2);
+        when(mockPlayer3.getOverallCommandBonus()).thenReturn(3);
         when(mockPlayer1.getTurnInitBonus()).thenReturn(-1);
         when(mockPlayer2.getTurnInitBonus()).thenReturn(-2);
         when(mockPlayer3.getTurnInitBonus()).thenReturn(-3);
@@ -424,10 +424,10 @@ class TeamTest {
         when(mockPlayer2.getConstantInitBonus()).thenReturn(2);
         when(mockPlayer3.getConstantInitBonus()).thenReturn(3);
         when(mockPlayer4.getConstantInitBonus()).thenReturn(0);
-        when(mockPlayer1.getCommandBonus()).thenReturn(1);
-        when(mockPlayer2.getCommandBonus()).thenReturn(2);
-        when(mockPlayer3.getCommandBonus()).thenReturn(3);
-        when(mockPlayer4.getCommandBonus()).thenReturn(0);
+        when(mockPlayer1.getOverallCommandBonus()).thenReturn(1);
+        when(mockPlayer2.getOverallCommandBonus()).thenReturn(2);
+        when(mockPlayer3.getOverallCommandBonus()).thenReturn(3);
+        when(mockPlayer4.getOverallCommandBonus()).thenReturn(0);
         when(mockPlayer1.getTurnInitBonus()).thenReturn(-1);
         when(mockPlayer2.getTurnInitBonus()).thenReturn(-2);
         when(mockPlayer3.getTurnInitBonus()).thenReturn(-3);

--- a/megamek/unittests/megamek/utils/MockGenerators.java
+++ b/megamek/unittests/megamek/utils/MockGenerators.java
@@ -199,7 +199,7 @@ public class MockGenerators {
 		when(mockPlayer.getConstantInitBonus()).thenReturn(0);
 		when(mockPlayer.getTurnInitBonus()).thenReturn(0);
 		when(mockPlayer.getInitCompensationBonus()).thenReturn(0);
-		when(mockPlayer.getCommandBonus()).thenReturn(0);
+		when(mockPlayer.getOverallCommandBonus()).thenReturn(0);
 		return mockPlayer;
 	}
 }


### PR DESCRIPTION
Refactored getCommandBonus into two sections, and applied only the individual unit's command bonus to its initiative when Individual Initiative is enabled.

Testing:
- Confirmed working correctly in save file from original issue.
- Ran all 3 projects' unit tests.

Close #7054 