### PR TITLE
Fix: prevent NPE when incorrectly attempting to assign Blowing Sand damage to Land-Air Meks in AirMek Mode

### DIFF
--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -32301,9 +32301,9 @@ public class TWGameManager extends AbstractGameManager {
         Vector<Report> vFullReport = new Vector<>();
         vFullReport.add(new Report(5002, Report.PUBLIC));
         int damage_bonus = Math.max(0, game.getPlanetaryConditions().getWind().ordinal() - Wind.MOD_GALE.ordinal());
-        // cycle through each team and damage 1d6 airborne VTOL/WiGE
+        // cycle through each team and damage 1d6 airborne VTOL/WiGE vehicles
         for (Team team : game.getTeams()) {
-            Vector<Integer> airborne = getAirborneVTOL(team);
+            Vector<Integer> airborne = getAirborneVTOLForSand(team);
             if (!airborne.isEmpty()) {
                 // how many units are affected
                 int unitsAffected = Math.min(Compute.d6(), airborne.size());
@@ -32328,18 +32328,16 @@ public class TWGameManager extends AbstractGameManager {
     }
 
     /**
-     * cycle through entities on team and collect all the airborne VTOL/WIGE
-     *
+     * Cycle through entities on team and collect all the airborne VTOL/WIGE vehicles
+     * Only vehicles can be affected by Blowing Sand (TO:AR 6th Ed. pg. 60)
      * @return a vector of relevant entity ids
      */
-    public Vector<Integer> getAirborneVTOL(Team team) {
+    public Vector<Integer> getAirborneVTOLForSand(Team team) {
         Vector<Integer> units = new Vector<>();
         for (Entity entity : game.getEntitiesVector()) {
             for (Player player : team.players()) {
                 if (entity.getOwner().equals(player)) {
-                    if (((entity instanceof VTOL) || (entity.getMovementMode() == EntityMovementMode.WIGE)) &&
-                              (!entity.isDestroyed()) &&
-                              (entity.getElevation() > 0)) {
+                    if (entity.isAirborneVTOLorWIGE() && !(entity instanceof LandAirMek)) {
                         units.add(entity.getId());
                     }
                 }


### PR DESCRIPTION
It appears that we were trying to generate non-valid Hits on LAMs in AirMek mode because they were using WiGE movement.
The Mek rollHitLocation() function would return `null` when trying to roll a SIDE_RANDOM hit, leading to the NPE.
Since RAW we should _only_ apply this damage to vehicles, which LAMs are not, the simplest solution is to skip LAMs
even if they are using WiGE MP.

This patch refactors the check to use an existing airborne VTOL/WiGE check which uses a superset of the current conditionals, and to filter out LAMs.
I've also renamed the `getAirborneVTOL` method to differentiate it from other functions that find airborne VTOLs and WiGE units.

Testing:
- Replicated OP situation with blowing sand environment, LAMs in all modes, and mixed VTOLs and WiGEs.
- Ran all three projects' unit tests.

Close #7023 