### PR TITLE
fix: minimap and unit display and mini report dialog priority against other windows

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -1635,6 +1635,7 @@ public class ClientGUI extends AbstractClientGUI
         if (getMiniMapDialog() != null) {
             getMiniMapDialog().setVisible(visible);
             conditionalRequestFocus(visible);
+            getMiniMapDialog().setAlwaysOnTop(visible);
         }
     }
 
@@ -1642,6 +1643,7 @@ public class ClientGUI extends AbstractClientGUI
         if (getMiniReportDisplayDialog() != null) {
             setMiniReportLocation(visible);
             conditionalRequestFocus(visible);
+            getMiniReportDisplayDialog().setAlwaysOnTop(false);
         }
     }
 
@@ -1722,6 +1724,7 @@ public class ClientGUI extends AbstractClientGUI
 
         if (getUnitDisplayDialog() != null) {
             setUnitDisplayLocation(visible);
+            getUnitDisplayDialog().setAlwaysOnTop(visible);
         }
     }
 


### PR DESCRIPTION
# What it does?

Keeps minimap dialog and unit display dialog always ontop of the board view, makes the report dialog not show always ontop of the rest this way it does not cover the save dialogs.