### PR TITLE
Fix accidental fall damage doing insufficient damage to victims under falling unit

### DIFF
--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -2551,8 +2551,8 @@ public class Compute {
     /**
      * Damage that a mek does with a accidental fall from above.
      */
-    public static int getAffaDamageFor(Entity entity) {
-        return (int) entity.getWeight() / 10;
+    public static int getAffaDamageFor(Entity entity, int fallElevation) {
+        return (fallElevation *  (int) Math.ceil(entity.getWeight() / 10));
     }
 
     /**

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -8885,7 +8885,7 @@ public class TWGameManager extends AbstractGameManager {
 
                 if (diceRoll.getIntValue() >= toHit.getValue()) {
                     // deal damage to target
-                    int damage = Compute.getAffaDamageFor(entity);
+                    int damage = Compute.getAffaDamageFor(entity, fallElevation);
                     r = new Report(2220);
                     r.subject = affaTarget.getId();
                     r.addDesc(affaTarget);

--- a/megamek/unittests/megamek/common/ComputeTest.java
+++ b/megamek/unittests/megamek/common/ComputeTest.java
@@ -405,4 +405,47 @@ class ComputeTest {
         HexTarget hTarget = new HexTarget(new Coords(5, 5), HexTarget.TYPE_HEX_ARTILLERY);
         assertTrue(Compute.allEnemiesOutsideBlast(hTarget, attacker, mockLTAmmoType, true, false, false, game));
     }
+
+    // Section: Accidental Fall From Above damage
+    @Test
+    void accidentalFallDamage2Levels50Tons() {
+        double weight = 50.0;
+        int elevation = 2;
+        int expectedDamage = (int) ((weight/10.0) * elevation);
+
+        Mek faller = createMek("Faller", "ATK-1", "Alice");
+        faller.setOwnerId(player1.getId());
+        faller.setId(1);
+        faller.setWeight(weight);
+
+        assertEquals(expectedDamage, Compute.getAffaDamageFor(faller, elevation));
+    }
+
+    @Test
+    void accidentalFallDamage5Levels90Tons() {
+        double weight = 90.0;
+        int elevation = 5;
+        int expectedDamage = (int) ((weight/10.0) * elevation);
+
+        Mek faller = createMek("Faller", "ATK-1", "Alice");
+        faller.setOwnerId(player1.getId());
+        faller.setId(1);
+        faller.setWeight(weight);
+
+        assertEquals(expectedDamage, Compute.getAffaDamageFor(faller, elevation));
+    }
+
+    @Test
+    void accidentalFallDamage4Levels75Tons() {
+        double weight = 75.0;
+        int elevation = 4;
+        int expectedDamage = 32;
+
+        Mek faller = createMek("Faller", "ATK-1", "Alice");
+        faller.setOwnerId(player1.getId());
+        faller.setId(1);
+        faller.setWeight(weight);
+
+        assertEquals(expectedDamage, Compute.getAffaDamageFor(faller, elevation));
+    }
 }


### PR DESCRIPTION
We were ignoring the fall distance when calculating Accidental Fall From Above damage applied to victims under the falling unit, although not in any _other_ location.

This should deal considerably more damage when units are stacked within buildings that collapse, or when shoved off a cliff onto victims below:
<img width="782" alt="image" src="https://github.com/user-attachments/assets/6d50a771-ec08-4652-82a6-9704c90e402e" />

Testing:
- Added some unit tests for the AFFA damage calcs
- Ran several scenarios showing correct damage applied to victims
- Ran all 3 projects' unit tests

Close #6388 