### PR TITLE
Now saved mechs wont default to autoEject

### DIFF
--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -1308,7 +1308,7 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
                 mek.setCondEjectCTDest(true);
                 mek.setCondEjectHeadshot(true);
             } else {
-                mek.setAutoEject(!entity.hasCase() && !entity.hasCASEII());
+                mek.setAutoEject(!entity.hasCase() && !entity.hasCASEII() && mek.isAutoEject());
             }
         }
 


### PR DESCRIPTION
fixes #7006

This took way longer then I planned due to having a test Mul with advanced Meks that were letting me save autoEjection state.

