### PR TITLE
check actuator before add damage to shield + fixed shields rules ref

### DIFF
--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -3972,7 +3972,7 @@ public class MiscType extends EquipmentType {
         misc.setModes(modes);
         misc.baseDamageAbsorptionRate = 3;
         misc.baseDamageCapacity = 11;
-        misc.rulesRefs = "103, TO:AR";
+        misc.rulesRefs = "103, TO:AUE";
         // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         misc.techAdvancement.setTechBase(TechBase.IS)
               .setIntroLevel(false)
@@ -4005,7 +4005,7 @@ public class MiscType extends EquipmentType {
         misc.setModes(modes);
         misc.baseDamageAbsorptionRate = 5;
         misc.baseDamageCapacity = 18;
-        misc.rulesRefs = "103, TO:AR";
+        misc.rulesRefs = "103, TO:AUE";
         // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         misc.techAdvancement.setTechBase(TechBase.IS)
               .setIntroLevel(false)
@@ -4038,7 +4038,7 @@ public class MiscType extends EquipmentType {
         misc.setModes(modes);
         misc.baseDamageAbsorptionRate = 7;
         misc.baseDamageCapacity = 25;
-        misc.rulesRefs = "103, TO:AR";
+        misc.rulesRefs = "103, TO:AUE";
         // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         misc.techAdvancement.setTechBase(TechBase.IS)
               .setIntroLevel(false)

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -3972,7 +3972,7 @@ public class MiscType extends EquipmentType {
         misc.setModes(modes);
         misc.baseDamageAbsorptionRate = 3;
         misc.baseDamageCapacity = 11;
-        misc.rulesRefs = "290, TO";
+        misc.rulesRefs = "103, TO:AR";
         // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         misc.techAdvancement.setTechBase(TechBase.IS)
               .setIntroLevel(false)
@@ -4005,7 +4005,7 @@ public class MiscType extends EquipmentType {
         misc.setModes(modes);
         misc.baseDamageAbsorptionRate = 5;
         misc.baseDamageCapacity = 18;
-        misc.rulesRefs = "290, TO";
+        misc.rulesRefs = "103, TO:AR";
         // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         misc.techAdvancement.setTechBase(TechBase.IS)
               .setIntroLevel(false)
@@ -4038,7 +4038,7 @@ public class MiscType extends EquipmentType {
         misc.setModes(modes);
         misc.baseDamageAbsorptionRate = 7;
         misc.baseDamageCapacity = 25;
-        misc.rulesRefs = "290, TO";
+        misc.rulesRefs = "103, TO:AR";
         // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         misc.techAdvancement.setTechBase(TechBase.IS)
               .setIntroLevel(false)

--- a/megamek/src/megamek/common/equipment/MiscMounted.java
+++ b/megamek/src/megamek/common/equipment/MiscMounted.java
@@ -112,17 +112,17 @@ public class MiscMounted extends Mounted<MiscType> {
             }
         }
 
-        if (!entity.hasWorkingSystem(Mek.ACTUATOR_SHOULDER, location)) {
+        if (entity.hasSystem(Mek.ACTUATOR_SHOULDER, location) && !entity.hasWorkingSystem(Mek.ACTUATOR_SHOULDER, location)) {
             base -= 2;
         }
 
-        if (!entity.hasWorkingSystem(Mek.ACTUATOR_LOWER_ARM, location)) {
+        if (entity.hasSystem(Mek.ACTUATOR_LOWER_ARM, location) && !entity.hasWorkingSystem(Mek.ACTUATOR_LOWER_ARM, location)) {
             base--;
         }
-        if (!entity.hasWorkingSystem(Mek.ACTUATOR_UPPER_ARM, location)) {
+        if (entity.hasSystem(Mek.ACTUATOR_UPPER_ARM, location) && !entity.hasWorkingSystem(Mek.ACTUATOR_UPPER_ARM, location)) {
             base--;
         }
-        if (!entity.hasWorkingSystem(Mek.ACTUATOR_HAND, location)) {
+        if (entity.hasSystem(Mek.ACTUATOR_HAND, location) && !entity.hasWorkingSystem(Mek.ACTUATOR_HAND, location)) {
             base--;
         }
 
@@ -168,17 +168,17 @@ public class MiscMounted extends Mounted<MiscType> {
                 }
             }
         }
-        if (!entity.hasWorkingSystem(Mek.ACTUATOR_SHOULDER, location)) {
+        if (entity.hasSystem(Mek.ACTUATOR_SHOULDER, location) && !entity.hasWorkingSystem(Mek.ACTUATOR_SHOULDER, location)) {
             base -= 2;
         }
 
-        if (!entity.hasWorkingSystem(Mek.ACTUATOR_LOWER_ARM, location)) {
+        if (entity.hasSystem(Mek.ACTUATOR_LOWER_ARM, location) && !entity.hasWorkingSystem(Mek.ACTUATOR_LOWER_ARM, location)) {
             base--;
         }
-        if (!entity.hasWorkingSystem(Mek.ACTUATOR_UPPER_ARM, location)) {
+        if (entity.hasSystem(Mek.ACTUATOR_UPPER_ARM, location) && !entity.hasWorkingSystem(Mek.ACTUATOR_UPPER_ARM, location)) {
             base--;
         }
-        if (!entity.hasWorkingSystem(Mek.ACTUATOR_HAND, location)) {
+        if (entity.hasSystem(Mek.ACTUATOR_HAND, location) && !entity.hasWorkingSystem(Mek.ACTUATOR_HAND, location)) {
             base--;
         }
 


### PR DESCRIPTION
This PR fixes fixes the fact that mechs with shields mounted on arms without specific actuators, started with the shield "damaged" (less pips).
Additionally, fixed rules reference.