### PR TITLE
fix: issue #7123, now show possible moves and show best modifiers don't count illegal moves

### DIFF
--- a/megamek/src/megamek/client/ui/swing/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/swing/ClientGUI.java
@@ -1015,18 +1015,14 @@ public class ClientGUI extends AbstractClientGUI
                 break;
             case VIEW_MOVE_ENV:
                 GUIP.setMoveEnvelope(!GUIP.getMoveEnvelope());
-                if (curPanel instanceof MovementDisplay) {
+                if (curPanel instanceof MovementDisplay movementDisplay) {
                     Entity entity = getUnitDisplay().getCurrentEntity();
-                    if (!entity.isAero()) {
-                        ((MovementDisplay) curPanel).computeMovementEnvelope(entity);
-                    } else {
-                        ((MovementDisplay) curPanel).computeAeroMovementEnvelope(entity);
-                    }
+                    movementDisplay.computeMovementEnvelope(entity);
                 }
                 break;
             case VIEW_MOVE_MOD_ENV:
-                if (curPanel instanceof MovementDisplay) {
-                    ((MovementDisplay) curPanel).computeModifierEnvelope();
+                if (curPanel instanceof MovementDisplay movementDisplay) {
+                    movementDisplay.computeModifierEnvelope();
                 }
                 break;
             case VIEW_CHANGE_THEME:

--- a/megamek/src/megamek/client/ui/swing/boardview/spriteHandler/MovementModifierSpriteHandler.java
+++ b/megamek/src/megamek/client/ui/swing/boardview/spriteHandler/MovementModifierSpriteHandler.java
@@ -48,7 +48,10 @@ public class MovementModifierSpriteHandler extends BoardViewSpriteHandler {
 
     public void renewSprites(Collection<MovePath> movePaths) {
         clear();
-        movePaths.stream().map(path -> new MovementModifierEnvelopeSprite(boardView, path)).forEach(currentSprites::add);
+        movePaths.stream()
+              .filter(MovePath::isMoveLegal)
+              .map(path -> new MovementModifierEnvelopeSprite(boardView, path))
+              .forEach(currentSprites::add);
         boardView.addSprites(currentSprites);
     }
 

--- a/megamek/src/megamek/client/ui/swing/phaseDisplay/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/swing/phaseDisplay/MovementDisplay.java
@@ -67,8 +67,6 @@ import megamek.client.ui.swing.widget.MegaMekButton;
 import megamek.client.ui.swing.widget.MekPanelTabStrip;
 import megamek.codeUtilities.MathUtility;
 import megamek.common.*;
-import megamek.common.moves.MovePath;
-import megamek.common.moves.MovePath.MoveStepType;
 import megamek.common.actions.AirMekRamAttackAction;
 import megamek.common.actions.ChargeAttackAction;
 import megamek.common.actions.DfaAttackAction;
@@ -77,6 +75,8 @@ import megamek.common.annotations.Nullable;
 import megamek.common.equipment.MiscMounted;
 import megamek.common.event.GamePhaseChangeEvent;
 import megamek.common.event.GameTurnChangeEvent;
+import megamek.common.moves.MovePath;
+import megamek.common.moves.MovePath.MoveStepType;
 import megamek.common.moves.MoveStep;
 import megamek.common.options.GameOptions;
 import megamek.common.options.IGameOptions;
@@ -255,10 +255,9 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void computeEnvelope() {
-        if (ce() != null && ce().isAero()) {
-            computeAeroMovementEnvelope(ce());
-        } else {
-            computeMovementEnvelope(ce());
+        Entity currentEntity = ce();
+        if (currentEntity != null) {
+            computeMovementEnvelope(currentEntity);
         }
     }
 
@@ -2349,7 +2348,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             setDecEnabled(false);
         }
 
-        // allow accelerate/decelerate next if acceleration/deceleration hasn't been used
+        // allow to accelerate/decelerate next if acceleration/deceleration hasn't been used
         setAccNEnabled(false);
         setDecNEnabled(false);
         if (Stream.of(MoveStepType.ACC, MoveStepType.DEC, MoveStepType.DECN)
@@ -4471,6 +4470,21 @@ public class MovementDisplay extends ActionPhaseDisplay {
         return maxMP;
     }
 
+
+    /**
+     * Computes all the possible moves for an {@link Entity}. The {@link Entity} can either be a suggested
+     * {@link Entity} or the currently selected one.
+     *
+     * @param suggestion The suggested Entity to use to compute the movement envelope.
+     */
+    public void computeMovementEnvelope(Entity suggestion) {
+        if (suggestion.isAero()) {
+            computeAeroMovementEnvelope(suggestion);
+        } else {
+            computeSimpleMovementEnvelope(suggestion);
+        }
+    }
+
     /**
      * Computes all the possible moves for an {@link Entity} in a particular gear. The {@link Entity} can either be a
      * suggested {@link Entity} or the currently selected one. If there is a selected entity (which implies it's the
@@ -4480,66 +4494,77 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * @param suggestion The suggested Entity to use to compute the movement envelope. If used, the gear will be set to
      *                   {@link #GEAR_LAND}. This takes precedence over the currently selected unit.
      */
-    public void computeMovementEnvelope(Entity suggestion) {
+    private void computeSimpleMovementEnvelope(Entity suggestion) {
         // do nothing if deactivated in the settings
         if (!GUIP.getMoveEnvelope()) {
             // Issue #5700: Move envelope doesn't clear when turning off move envelopes from the menu or shortcut.
+            // this here makes sure to clear it next time this function is called
             clientgui.clearMovementEnvelope();
             return;
         }
 
-        Entity en = ce();
-        int mvMode = gear;
+        Entity entity = ce();
+        int movementGear = gear;
 
-        if ((en == null) && (suggestion == null)) {
+        if ((entity == null) && (suggestion == null)) {
             return;
-        } else if (en == null) {
-            en = suggestion;
-            mvMode = GEAR_LAND;
+        } else if (entity == null) {
+            entity = suggestion;
+            movementGear = GEAR_LAND;
         } else {
-            en = suggestion;
+            entity = suggestion;
         }
 
-        if (en.isDone()) {
+        if (entity.isDone()) {
             return;
         }
 
-        Map<Coords, MovePath> mvEnvData;
-        MovePath mp = new MovePath(clientgui.getClient().getGame(), en);
+        MovePath movePath = new MovePath(clientgui.getClient().getGame(), entity);
 
-        MoveStepType stepType = (mvMode == GEAR_BACKUP) ? MoveStepType.BACKWARDS : MoveStepType.FORWARDS;
-        if (mvMode == GEAR_JUMP || mvMode == GEAR_DFA) {
-            mp.addStep(MoveStepType.START_JUMP);
+        MoveStepType stepType = (movementGear == GEAR_BACKUP) ? MoveStepType.BACKWARDS : MoveStepType.FORWARDS;
+        if (movementGear == GEAR_JUMP || movementGear == GEAR_DFA) {
+            movePath.addStep(MoveStepType.START_JUMP);
             if (jumpSubGear == GEAR_SUB_MEKBOOSTERS) {
-                mp.addStep(MoveStepType.JUMP_MEK_MECHANICAL_BOOSTER);
+                movePath.addStep(MoveStepType.JUMP_MEK_MECHANICAL_BOOSTER);
             }
         }
 
-        int maxMP = maxMP(en, mvMode);
+        int maxMP = maxMP(entity, movementGear);
 
-        // Create a pathfinder to find possible moves; if aerodyne, use a custom Aero pathfinder.
+        // Create a pathfinder to find possible moves;
+        // if aerodyne, use a custom Aero pathfinder.
+        ShortestPathFinder shortestPathFinder = getShortestPathFinder(entity, maxMP, stepType);
+        shortestPathFinder.run(movePath);
+
+        Map<Coords, MovePath> movePathForEachCoordsMap = shortestPathFinder.getAllComputedPaths();
+        Map<Coords, Integer> movementEnvelopeMP = new HashMap<>((int) ((movePathForEachCoordsMap.size() * 1.25) + 1));
+        for (Coords coords : movePathForEachCoordsMap.keySet()) {
+            var candidateMovePath = movePathForEachCoordsMap.get(coords);
+            if (candidateMovePath.isMoveLegal()) {
+                movementEnvelopeMP.put(coords, candidateMovePath.countMp(movementGear == GEAR_JUMP));
+            }
+        }
+        clientgui.showMovementEnvelope(entity, movementEnvelopeMP, movementGear);
+    }
+
+    private static ShortestPathFinder getShortestPathFinder(Entity en, int maxMP, MoveStepType stepType) {
         ShortestPathFinder shortestPathFinder;
-        if (!en.isAerodyne()) {
-            shortestPathFinder = ShortestPathFinder.newInstanceOfOneToAll(maxMP, stepType, en.getGame());
-        } else {
+        if (en.isAerodyne() && !en.isAeroLandedOnGroundMap()) {
             shortestPathFinder = ShortestPathFinder.newInstanceOfOneToAllAero(maxMP, stepType, en.getGame());
+        } else {
+            shortestPathFinder = ShortestPathFinder.newInstanceOfOneToAll(maxMP, stepType, en.getGame());
         }
-
-        shortestPathFinder.run(mp);
-        mvEnvData = shortestPathFinder.getAllComputedPaths();
-        Map<Coords, Integer> mvEnvMP = new HashMap<>((int) ((mvEnvData.size() * 1.25) + 1));
-        for (Coords coords : mvEnvData.keySet()) {
-            mvEnvMP.put(coords, mvEnvData.get(coords).countMp(mvMode == GEAR_JUMP));
-        }
-        clientgui.showMovementEnvelope(en, mvEnvMP, mvMode);
+        return shortestPathFinder;
     }
 
     /**
+     * <b>Important: You should call {@link MovementDisplay#computeMovementEnvelope} instead!</b>
+     * <p>
      * Computes possible moves for entities of Aero units. This is similar to the
      * {@link MovementDisplay#computeMovementEnvelope(Entity)} method; however, it uses the {@link MovePath} final
      * velocity to temporarily set unit velocity to draw the move envelope. This method always sets the original entity
      * velocity back to its original.
-     *
+     * </p>
      * @param entity - Suggested {@link Entity} to use to compute {@link Aero} move envelope.
      */
     public void computeAeroMovementEnvelope(Entity entity) {
@@ -4562,7 +4587,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
         // Refresh the new velocity envelope on the map.
         try {
-            computeMovementEnvelope(entity);
+            computeSimpleMovementEnvelope(entity);
             updateMove();
         } catch (Exception e) {
             LOGGER.error(e, "An error occurred trying to compute the move envelope for an Aero.");
@@ -4574,36 +4599,39 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     public void computeModifierEnvelope() {
-        if (ce() == null) {
+        Entity currentEntity = ce();
+        if (currentEntity == null) {
             return;
         }
         int maxMP;
         if (gear == GEAR_JUMP) {
-            maxMP = ce().getJumpMP();
+            maxMP = currentEntity.getJumpMP();
         } else if (gear == GEAR_BACKUP) {
-            maxMP = ce().getWalkMP();
-        } else if (ce() instanceof Mek &&
-                         !(ce() instanceof QuadVee) &&
-                         ce().getMovementMode() == EntityMovementMode.TRACKED) {
+            maxMP = currentEntity.getWalkMP();
+        } else if (
+              (currentEntity instanceof Mek mek) &&
+                    !(mek instanceof QuadVee) &&
+                    (mek.getMovementMode() == EntityMovementMode.TRACKED))
+        {
             // A non-QuadVee `Mek that is using tracked movement (or converting to it) is limited to walking
-            maxMP = ce().getWalkMP();
+            maxMP = mek.getWalkMP();
         } else {
-            maxMP = ce().getRunMP();
+            maxMP = currentEntity.getRunMP();
         }
         MoveStepType stepType = (gear == GEAR_BACKUP) ? MoveStepType.BACKWARDS : MoveStepType.FORWARDS;
-        MovePath mp = new MovePath(clientgui.getClient().getGame(), ce());
+        MovePath movePath = new MovePath(clientgui.getClient().getGame(), currentEntity);
         if (gear == GEAR_JUMP) {
-            mp.addStep(MoveStepType.START_JUMP);
+            movePath.addStep(MoveStepType.START_JUMP);
             if (jumpSubGear == GEAR_SUB_MEKBOOSTERS) {
-                mp.addStep(MoveStepType.JUMP_MEK_MECHANICAL_BOOSTER);
+                movePath.addStep(MoveStepType.JUMP_MEK_MECHANICAL_BOOSTER);
             }
         }
-        LongestPathFinder lpf = LongestPathFinder.newInstanceOfLongestPath(maxMP, stepType, ce().getGame());
+        LongestPathFinder lpf = LongestPathFinder.newInstanceOfLongestPath(maxMP, stepType, currentEntity.getGame());
         final int timeLimit = PreferenceManager.getClientPreferences().getMaxPathfinderTime();
         AbstractPathFinder.StopConditionTimeout<MovePath> timeoutCondition = new AbstractPathFinder.StopConditionTimeout<>(
               timeLimit * 10);
         lpf.addStopCondition(timeoutCondition);
-        lpf.run(mp);
+        lpf.run(movePath);
         clientgui.showMovementModifiers(lpf.getLongestComputedPaths());
     }
 
@@ -4618,13 +4646,13 @@ public class MovementDisplay extends ActionPhaseDisplay {
     //
     @Override
     public synchronized void actionPerformed(ActionEvent ev) {
-        final Entity ce = ce();
+        final Entity entity = ce();
         final String actionCmd = ev.getActionCommand();
         if (actionCmd.equals(MoveCommand.MOVE_NEXT.getCmd())) {
             selectEntity(clientgui.getClient().getNextEntityNum(currentEntity));
         }
 
-        if (ce == null) {
+        if (entity == null) {
             return;
         }
 
@@ -4641,7 +4669,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             selectNextPlayer();
         } else if (actionCmd.equals(MoveCommand.MOVE_CANCEL.getCmd())) {
             clear();
-            computeMovementEnvelope(ce);
+            computeMovementEnvelope(entity);
             updateMove();
         } else if (ev.getSource().equals(getBtn(MoveCommand.MOVE_MORE))) {
             currentButtonGroup++;
@@ -4653,13 +4681,13 @@ public class MovementDisplay extends ActionPhaseDisplay {
             if ((gear == MovementDisplay.GEAR_JUMP) ||
                       (gear == MovementDisplay.GEAR_CHARGE) ||
                       (gear == MovementDisplay.GEAR_DFA) ||
-                      ((cmd.getMpUsed() > ce.getWalkMP()) &&
+                      ((cmd.getMpUsed() > entity.getWalkMP()) &&
                              !(cmd.getLastStep().isOnlyPavementOrRoad() &&
-                                     (cmd.getMpUsed() <= (ce.getWalkMP() + 1)))) ||
+                                     (cmd.getMpUsed() <= (entity.getWalkMP() + 1)))) ||
                       (opts.booleanOption("tacops_tank_crews") &&
                              (cmd.getMpUsed() > 0) &&
-                             (ce instanceof Tank) &&
-                             (ce.getCrew().getSize() < 2)) ||
+                             (entity instanceof Tank) &&
+                             (entity.getCrew().getSize() < 2)) ||
                       (gear == MovementDisplay.GEAR_SWIM) ||
                       (gear == MovementDisplay.GEAR_RAM)) {
 
@@ -4685,7 +4713,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             Color walkColor = GUIP.getMoveDefaultColor();
             clientgui.getBoardView().setHighlightColor(walkColor);
             gear = MovementDisplay.GEAR_LAND;
-            computeMovementEnvelope(ce);
+            computeMovementEnvelope(entity);
         } else if (actionCmd.equals(MoveCommand.MOVE_JUMP.getCmd())) {
             if ((gear != MovementDisplay.GEAR_JUMP) &&
                       !((cmd.getLastStep() != null) &&
@@ -4695,7 +4723,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             }
             gear = MovementDisplay.GEAR_JUMP;
             jumpSubGear = GEAR_SUB_STANDARD;
-            if (mustChooseJumpType(ce)) {
+            if (mustChooseJumpType(entity)) {
                 Object jumpChoice = JOptionPane.showInputDialog(JOptionPane.getFrameForComponent(this),
                       "Choose jump type:",
                       "Choose Jump Type",
@@ -4707,7 +4735,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                     jumpSubGear = GEAR_SUB_MEKBOOSTERS;
                 }
             } else {
-                if ((ce instanceof Mek mek) && (mek.getMechanicalJumpBoosterMP() > 0) && (ce.getJumpMP() == 0)) {
+                if ((entity instanceof Mek mek) && (mek.getMechanicalJumpBoosterMP() > 0) && (mek.getJumpMP() == 0)) {
                     jumpSubGear = GEAR_SUB_MEKBOOSTERS;
                 }
             }
@@ -4716,44 +4744,44 @@ public class MovementDisplay extends ActionPhaseDisplay {
             }
             Color jumpColor = GUIP.getMoveJumpColor();
             clientgui.getBoardView().setHighlightColor(jumpColor);
-            computeMovementEnvelope(ce);
+            computeMovementEnvelope(entity);
         } else if (actionCmd.equals(MoveCommand.MOVE_SWIM.getCmd())) {
             if (gear != MovementDisplay.GEAR_SWIM) {
                 clear();
             }
 
             gear = MovementDisplay.GEAR_SWIM;
-            ce.setMovementMode((ce instanceof BipedMek) ? EntityMovementMode.BIPED_SWIM : EntityMovementMode.QUAD_SWIM);
+            entity.setMovementMode((entity instanceof BipedMek) ? EntityMovementMode.BIPED_SWIM : EntityMovementMode.QUAD_SWIM);
         } else if (actionCmd.equals(MoveCommand.MOVE_MODE_CONVERT.getCmd())) {
-            EntityMovementMode nextMode = ce.nextConversionMode(cmd.getFinalConversionMode());
+            EntityMovementMode nextMode = entity.nextConversionMode(cmd.getFinalConversionMode());
             // LAMs may have to skip the next mode due to damage
-            if (ce instanceof LandAirMek) {
-                if (!((LandAirMek) ce).canConvertTo(nextMode)) {
-                    nextMode = ce.nextConversionMode(nextMode);
+            if (entity instanceof LandAirMek landAirMek) {
+                if (!landAirMek.canConvertTo(nextMode)) {
+                    nextMode = landAirMek.nextConversionMode(nextMode);
                 }
-                if (!((LandAirMek) ce).canConvertTo(nextMode)) {
-                    nextMode = ce.getMovementMode();
+                if (!landAirMek.canConvertTo(nextMode)) {
+                    nextMode = landAirMek.getMovementMode();
                 }
             }
             adjustConvertSteps(nextMode);
         } else if (actionCmd.equals(MoveCommand.MOVE_MODE_LEG.getCmd())) {
-            if ((ce.getEntityType() & Entity.ETYPE_QUAD_MEK) == Entity.ETYPE_QUAD_MEK) {
+            if (entity instanceof QuadVee) {
                 adjustConvertSteps(EntityMovementMode.QUAD);
-            } else if ((ce.getEntityType() & Entity.ETYPE_TRIPOD_MEK) == Entity.ETYPE_TRIPOD_MEK) {
+            } else if (entity instanceof TripodMek) {
                 adjustConvertSteps(EntityMovementMode.TRIPOD);
-            } else if ((ce.getEntityType() & Entity.ETYPE_BIPED_MEK) == Entity.ETYPE_BIPED_MEK) {
+            } else if (entity instanceof BipedMek) {
                 adjustConvertSteps(EntityMovementMode.BIPED);
             }
         } else if (actionCmd.equals(MoveCommand.MOVE_MODE_VEE.getCmd())) {
-            if (ce instanceof QuadVee && ((QuadVee) ce).getMotiveType() == QuadVee.MOTIVE_WHEEL) {
+            if (entity instanceof QuadVee quadVee && quadVee.getMotiveType() == QuadVee.MOTIVE_WHEEL) {
                 adjustConvertSteps(EntityMovementMode.WHEELED);
-            } else if ((ce instanceof Mek && ((Mek) ce).hasTracks()) || ce instanceof QuadVee) {
+            } else if ((entity instanceof Mek mek && mek.hasTracks()) || (entity instanceof QuadVee)) {
                 adjustConvertSteps(EntityMovementMode.TRACKED);
-            } else if (ce instanceof LandAirMek && ((LandAirMek) ce).getLAMType() == LandAirMek.LAM_STANDARD) {
+            } else if (entity instanceof LandAirMek landAirMek && landAirMek.getLAMType() == LandAirMek.LAM_STANDARD) {
                 adjustConvertSteps(EntityMovementMode.WIGE);
             }
         } else if (actionCmd.equals(MoveCommand.MOVE_MODE_AIR.getCmd())) {
-            if (ce instanceof LandAirMek) {
+            if (entity instanceof LandAirMek) {
                 adjustConvertSteps(EntityMovementMode.AERODYNE);
             }
         } else if (actionCmd.equals(MoveCommand.MOVE_TURN.getCmd())) {
@@ -4766,7 +4794,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             gear = MovementDisplay.GEAR_BACKUP; // on purpose...
             Color backColor = GUIP.getMoveBackColor();
             clientgui.getBoardView().setHighlightColor(backColor);
-            computeMovementEnvelope(ce);
+            computeMovementEnvelope(entity);
         } else if (actionCmd.equals(MoveCommand.MOVE_LONGEST_RUN.getCmd())) {
             if (gear == MovementDisplay.GEAR_JUMP) {
                 clear();
@@ -4779,7 +4807,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             gear = MovementDisplay.GEAR_LONGEST_WALK;
         } else if (actionCmd.equals(MoveCommand.MOVE_CLEAR.getCmd())) {
             clear();
-            if (!clientgui.getClient().getGame().containsMinefield(ce.getPosition())) {
+            if (!clientgui.getClient().getGame().containsMinefield(entity.getPosition())) {
                 String title = Messages.getString("MovementDisplay.CantClearMinefield");
                 String body = Messages.getString("MovementDisplay.NoMinefield");
                 clientgui.doAlertDialog(title, body);
@@ -4806,7 +4834,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             }
 
             // need to choose a mine
-            List<Minefield> mfs = clientgui.getClient().getGame().getMinefields(ce.getPosition());
+            List<Minefield> mfs = clientgui.getClient().getGame().getMinefields(entity.getPosition());
             String[] choices = new String[mfs.size()];
             for (int loop = 0; loop < choices.length; loop++) {
                 choices[loop] = Minefield.getDisplayableName(mfs.get(loop).getType());
@@ -4841,13 +4869,13 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 clear();
             }
             gear = MovementDisplay.GEAR_CHARGE;
-            computeMovementEnvelope(ce);
+            computeMovementEnvelope(entity);
         } else if (actionCmd.equals(MoveCommand.MOVE_DFA.getCmd())) {
             if (gear != MovementDisplay.GEAR_JUMP) {
                 clear();
             }
             gear = MovementDisplay.GEAR_DFA;
-            computeMovementEnvelope(ce);
+            computeMovementEnvelope(entity);
             if (!cmd.isJumping()) {
                 initializeJumpMovePath();
             }
@@ -4855,24 +4883,24 @@ public class MovementDisplay extends ActionPhaseDisplay {
             if (gear != MovementDisplay.GEAR_LAND) {
                 clear();
             }
-            if (ce.isAirborneVTOLorWIGE()) {
+            if (entity.isAirborneVTOLorWIGE()) {
                 gear = MovementDisplay.GEAR_CHARGE;
             } else {
                 gear = MovementDisplay.GEAR_RAM;
             }
-            computeMovementEnvelope(ce);
+            computeMovementEnvelope(entity);
         } else if (actionCmd.equals(MoveCommand.MOVE_GET_UP.getCmd())) {
             // if the unit has a hull down step, then don't clear the moves
             if (!cmd.contains(MoveStepType.HULL_DOWN)) {
                 clear();
             }
 
-            if (opts.booleanOption(OptionsConstants.ADVGRNDMOV_TACOPS_CAREFUL_STAND) && (ce.getWalkMP() > 2)) {
+            if (opts.booleanOption(OptionsConstants.ADVGRNDMOV_TACOPS_CAREFUL_STAND) && (entity.getWalkMP() > 2)) {
                 String title = Messages.getString("MovementDisplay.CarefulStand.title");
                 String body = Messages.getString("MovementDisplay.CarefulStand.message");
                 boolean response = clientgui.doYesNoDialog(title, body);
                 if (response) {
-                    ce.setCarefulStand(true);
+                    entity.setCarefulStand(true);
                     if (cmd.getFinalProne() || cmd.getFinalHullDown()) {
                         addStepToMovePath(MoveStepType.CAREFUL_STAND);
                     }
@@ -4944,22 +4972,22 @@ public class MovementDisplay extends ActionPhaseDisplay {
             }
             ready();
         } else if (actionCmd.equals(MoveCommand.MOVE_EJECT.getCmd())) {
-            if (ce instanceof Tank) {
+            if (entity instanceof Tank) {
                 if (clientgui.doYesNoDialog(Messages.getString("MovementDisplay.AbandonDialog.title"),
                       Messages.getString("MovementDisplay.AbandonDialog.message"))) {
                     clear();
                     addStepToMovePath(MoveStepType.EJECT);
                     ready();
                 }
-            } else if (ce.isLargeCraft()) {
+            } else if (entity.isLargeCraft()) {
                 if (clientgui.doYesNoDialog(Messages.getString("MovementDisplay.AbandonDialog.title"),
                       Messages.getString("MovementDisplay.AbandonDialog.message"))) {
                     clear();
                     // If we're abandoning while grounded, find a legal position to put an
                     // EjectedCrew unit
-                    if (!ce.isSpaceborne() && ce.getAltitude() == 0) {
-                        Coords pos = getEjectPosition(ce);
-                        addStepToMovePath(MoveStepType.EJECT, ce, pos);
+                    if (!entity.isSpaceborne() && entity.getAltitude() == 0) {
+                        Coords pos = getEjectPosition(entity);
+                        addStepToMovePath(MoveStepType.EJECT, entity, pos);
                     } else {
                         addStepToMovePath(MoveStepType.EJECT);
                     }
@@ -5061,16 +5089,16 @@ public class MovementDisplay extends ActionPhaseDisplay {
         if (actionCmd.equals(MoveCommand.MOVE_RAISE_ELEVATION.getCmd())) {
             addStepToMovePath(MoveStepType.UP);
         } else if (actionCmd.equals(MoveCommand.MOVE_LOWER_ELEVATION.getCmd())) {
-            if (ce.isAero()) {
+            if (entity.isAero()) {
                 PlanetaryConditions conditions = clientgui.getClient().getGame().getPlanetaryConditions();
-                boolean spheroidOrLessThanThin = ((IAero) ce).isSpheroid() ||
+                boolean spheroidOrLessThanThin = ((IAero) entity).isSpheroid() ||
                                                        conditions.getAtmosphere().isLighterThan(Atmosphere.THIN);
                 if ((null != cmd.getLastStep()) &&
                           (cmd.getLastStep().getNDown() == 1) &&
                           (cmd.getLastStep().getVelocity() < 12) &&
                           !spheroidOrLessThanThin) {
                     addStepToMovePath(MoveStepType.ACC, true);
-                    computeAeroMovementEnvelope(ce);
+                    computeMovementEnvelope(entity);
                 }
             }
             addStepToMovePath(MoveStepType.DOWN);
@@ -5093,29 +5121,29 @@ public class MovementDisplay extends ActionPhaseDisplay {
             } else {
                 addStepToMovePath(MoveStepType.CLIMB_MODE_ON);
             }
-            computeMovementEnvelope(ce);
+            computeMovementEnvelope(entity);
         } else if (actionCmd.equals(MoveCommand.MOVE_LAY_MINE.getCmd())) {
             int i = chooseMineToLay();
             if (i != -1) {
-                MiscMounted m = (MiscMounted) ce.getEquipment(i);
+                MiscMounted m = (MiscMounted) entity.getEquipment(i);
                 if (m.getMineType() == MiscMounted.MINE_VIBRABOMB) {
                     VibrabombSettingDialog vsd = new VibrabombSettingDialog(clientgui.getFrame());
                     vsd.setVisible(true);
                     m.setVibraSetting(vsd.getSetting());
                 }
                 if (cmd.getLastStep() == null &&
-                          ce instanceof BattleArmor &&
-                          ce.getMovementMode().equals(EntityMovementMode.INF_JUMP)) {
+                          entity instanceof BattleArmor &&
+                          entity.getMovementMode().equals(EntityMovementMode.INF_JUMP)) {
                     initializeJumpMovePath();
                     gear = GEAR_JUMP;
                     Color jumpColor = GUIP.getMoveJumpColor();
                     clientgui.getBoardView().setHighlightColor(jumpColor);
-                    computeMovementEnvelope(ce);
+                    computeMovementEnvelope(entity);
                 }
                 addStepToMovePath(MoveStepType.LAY_MINE, i);
             }
         } else if (actionCmd.equals(MoveCommand.MOVE_CALL_SUPPORT.getCmd())) {
-            ((Infantry) ce).createLocalSupport();
+            ((Infantry) entity).createLocalSupport();
             clientgui.getClient().sendUpdateEntity(ce());
         } else if (actionCmd.equals(MoveCommand.MOVE_DIG_IN.getCmd())) {
             addStepToMovePath(MoveStepType.DIG_IN);
@@ -5134,7 +5162,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 addStepToMovePath(MoveStepType.NONE);
             }
             cmd.setVTOLBombStep(cmd.getFinalCoords());
-            cmd.compile(clientgui.getClient().getGame(), ce, false);
+            cmd.compile(clientgui.getClient().getGame(), entity, false);
             updateMove();
         } else if (actionCmd.equals(MoveCommand.MOVE_ACCN.getCmd())) {
             removeIllegalSteps();
@@ -5144,10 +5172,10 @@ public class MovementDisplay extends ActionPhaseDisplay {
             addStepToMovePath(MoveStepType.DECN);
         } else if (actionCmd.equals(MoveCommand.MOVE_ACC.getCmd())) {
             addStepToMovePath(MoveStepType.ACC);
-            computeAeroMovementEnvelope(ce);
+            computeMovementEnvelope(entity);
         } else if (actionCmd.equals(MoveCommand.MOVE_DEC.getCmd())) {
             addStepToMovePath(MoveStepType.DEC);
-            computeAeroMovementEnvelope(ce);
+            computeMovementEnvelope(entity);
         } else if (actionCmd.equals(MoveCommand.MOVE_EVADE.getCmd())) {
             addStepToMovePath(MoveStepType.EVADE);
         } else if (actionCmd.equals(MoveCommand.MOVE_BOOTLEGGER.getCmd())) {
@@ -5179,18 +5207,18 @@ public class MovementDisplay extends ActionPhaseDisplay {
             addStepToMovePath(MoveStepType.ROLL);
         } else if (actionCmd.equals(MoveCommand.MOVE_HOVER.getCmd())) {
             addStepToMovePath(MoveStepType.HOVER);
-            if (ce instanceof LandAirMek && ce.getMovementMode() == EntityMovementMode.WIGE && ce.isAirborne()) {
+            if (entity instanceof LandAirMek && entity.getMovementMode() == EntityMovementMode.WIGE && entity.isAirborne()) {
                 gear = GEAR_LAND;
             }
         } else if (actionCmd.equals(MoveCommand.MOVE_MANEUVER.getCmd())) {
             ManeuverChoiceDialog choiceDialog = new ManeuverChoiceDialog(clientgui.getFrame(),
-                  Messages.getString("MovementDisplay.ManeuverDialog.title"),
-                  "huh?");
-            IAero a = (IAero) ce;
+                  Messages.getString("MovementDisplay.ManeuverDialog.title"));
+
+            IAero a = (IAero) entity;
             MoveStep last = cmd.getLastStep();
             int vel = a.getCurrentVelocity();
-            int altitude = ce.getAltitude();
-            Coords pos = ce.getPosition();
+            int altitude = entity.getAltitude();
+            Coords pos = entity.getPosition();
             int distance = 0;
             if (null != last) {
                 vel = last.getVelocityLeft();
@@ -5402,7 +5430,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
         // If small craft / DropShip that has unloaded units, then only allowed to
         // unload more
-        if (ce.hasUnloadedUnitsFromBays()) {
+        if (entity.hasUnloadedUnitsFromBays()) {
             disableButtons();
             updateLoadButtons();
             butDone.setEnabled(true);

--- a/megamek/src/megamek/client/ui/swing/phaseDisplay/dialog/ManeuverChoiceDialog.java
+++ b/megamek/src/megamek/client/ui/swing/phaseDisplay/dialog/ManeuverChoiceDialog.java
@@ -24,7 +24,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-
+import java.io.Serial;
 import javax.swing.AbstractButton;
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
@@ -48,13 +48,14 @@ import megamek.common.moves.MovePath;
  * @author suvarov454@sourceforge.net
  */
 public class ManeuverChoiceDialog extends JDialog implements ActionListener {
+    @Serial
     private static final long serialVersionUID = 3093043054221558221L;
 
     private boolean confirm;
 
-    private JPanel panButtons = new JPanel();
-    private JButton butOK = new JButton(Messages.getString("Okay"));
-    private JButton butCancel = new JButton(Messages.getString("Cancel"));
+    private final JPanel panButtons = new JPanel();
+    private final JButton butOK = new JButton(Messages.getString("Okay"));
+    private final JButton butCancel = new JButton(Messages.getString("Cancel"));
 
     /**
      * The checkboxes for available choices.
@@ -65,11 +66,9 @@ public class ManeuverChoiceDialog extends JDialog implements ActionListener {
      * Create and initialize the dialog.
      *
      * @param parent - the <code>Frame</code> that is locked by this dialog.
-     * @param question - <code>String</code> displayed above the choices. The
-     *            question string is tokenised on "\n".
      * @param choices - an array of <code>String</code>s to be displayed.
      */
-    private void initialize(JFrame parent, String question, String[] choices) {
+    private void initialize(JFrame parent, String[] choices) {
         super.setResizable(false);
 
         GridBagLayout gridbag = new GridBagLayout();
@@ -139,16 +138,12 @@ public class ManeuverChoiceDialog extends JDialog implements ActionListener {
 
         pack();
         Dimension size = getSize();
-        boolean updateSize = false;
+
         if (size.width < GUIPreferences.getInstance().getMinimumSizeWidth()) {
             size.width = GUIPreferences.getInstance().getMinimumSizeWidth();
         }
         if (size.height < GUIPreferences.getInstance().getMinimumSizeHeight()) {
             size.height = GUIPreferences.getInstance().getMinimumSizeHeight();
-        }
-        if (updateSize) {
-            setSize(size);
-            size = getSize();
         }
         setLocation(parent.getLocation().x + parent.getSize().width / 2
                 - size.width / 2, parent.getLocation().y
@@ -188,16 +183,35 @@ public class ManeuverChoiceDialog extends JDialog implements ActionListener {
      *
      * @param parent - the <code>Frame</code> that is locked by this dialog.
      * @param title - the title <code>String</code> for this dialog.
+     */
+    public ManeuverChoiceDialog(JFrame parent, String title) {
+        super(parent, title, true);
+        String[] choices = new String[ManeuverType.MAN_SIZE];
+        for (int type = 0; type < ManeuverType.MAN_SIZE; type++) {
+            choices[type] = ManeuverType.getTypeName(type);
+        }
+        initialize(parent, choices);
+    }
+
+    /**
+     * Create a choice dialog. The player can choose any or all of the choices.
+     * If no choices are passed in, this will be a very boring dialog, but it
+     * will not suffer an exception.
+     *
+     * @param parent - the <code>Frame</code> that is locked by this dialog.
+     * @param title - the title <code>String</code> for this dialog.
      * @param question - <code>String</code> displayed above the choices. The
      *            question string is tokenised on "\n".
+     * @deprecated question is never used, use the other constructor instead.
      */
+    @Deprecated(since = "0.50.07", forRemoval = true)
     public ManeuverChoiceDialog(JFrame parent, String title, String question) {
         super(parent, title, true);
         String[] choices = new String[ManeuverType.MAN_SIZE];
         for (int type = 0; type < ManeuverType.MAN_SIZE; type++) {
             choices[type] = ManeuverType.getTypeName(type);
         }
-        initialize(parent, question, choices);
+        initialize(parent, choices);
     }
 
     @Override

--- a/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
@@ -265,22 +265,22 @@ public class ShortestPathFinder extends MovePathFinder<MovePath> {
      * maxMp move points.
      *
      * @param maxMP    maximum MP that entity can use
-     * @param stepType
+     * @param stepType the type of step to use
      * @param game     The current {@link Game}
      */
     public static ShortestPathFinder newInstanceOfOneToAll(final int maxMP, final MoveStepType stepType,
             final Game game) {
-        final ShortestPathFinder spf = new ShortestPathFinder(
+        ShortestPathFinder shortestPathFinder = new ShortestPathFinder(
                 new ShortestPathFinder.MovePathRelaxer(),
                 new ShortestPathFinder.MovePathMPCostComparator(),
                 stepType, game);
-        spf.addFilter(new MovePathLengthFilter(maxMP));
-        spf.addFilter(new MovePathLegalityFilter(game));
-        return spf;
+        shortestPathFinder.addFilter(new MovePathLengthFilter(maxMP));
+        shortestPathFinder.addFilter(new MovePathLegalityFilter(game));
+        return shortestPathFinder;
     }
 
     /**
-     * See {@link newInstanceOfOneToAll} - this returns a customized
+     * See {@link ShortestPathFinder#newInstanceOfOneToAll} - this returns a customized
      * ShortestPathFinder to support Aerodyne units.
      *
      * @param maxMP    maximum MP that entity can use


### PR DESCRIPTION
# What it does?

This change makes so that only possible moves are shown in the "show possible moves" and "show best modifier" actions.

## Before

The hexes would light up as long as it is inside the max MP for the unit, even if such movement would be considered illegal (over water you cant run, only walk)

<img width="852" alt="Screenshot 2025-05-24 at 11 41 23" src="https://github.com/user-attachments/assets/5ee73193-51c2-41f5-98d5-e086a5653f1b" />

## After

All illegal moves are now not shown anymore (manual tests made with fast and slow units, also with VTOL, conventional wing and ASF units to make sure all is as correct as it should be)
<img width="787" alt="Screenshot 2025-05-24 at 11 33 13" src="https://github.com/user-attachments/assets/5be43274-2724-427c-b036-75a16e838490" />

The "Show best modifier" is also updated with this functionality. Just remember that it will show you the best possible, not how to obtain it ;)

<img width="746" alt="Screenshot 2025-05-24 at 12 11 35" src="https://github.com/user-attachments/assets/540241d5-7569-4fe5-ae09-bb0bb39785aa" />


