### PR TITLE
fix: makes aerodyne stop thinking it will overlap itself while taxing after deployment

### DIFF
--- a/megamek/src/megamek/common/Aero.java
+++ b/megamek/src/megamek/common/Aero.java
@@ -32,6 +32,7 @@ import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.options.OptionsConstants;
 import megamek.common.planetaryconditions.PlanetaryConditions;
+import megamek.common.util.ConditionalStringJoiner;
 import megamek.logging.MMLogger;
 import megamek.common.TechAdvancement.AdvancementPhase;
 import megamek.common.ITechnology;
@@ -2098,14 +2099,7 @@ public abstract class Aero extends Entity implements IAero, IBomber {
         }
 
         // grounded aerospace have the same prohibitions as wheeled tanks
-        return hex.containsTerrain(Terrains.WOODS) ||
-                     hex.containsTerrain(Terrains.ROUGH) ||
-                     ((hex.terrainLevel(Terrains.WATER) > 0) && !hex.containsTerrain(Terrains.ICE)) ||
-                     hex.containsTerrain(Terrains.RUBBLE) ||
-                     hex.containsTerrain(Terrains.MAGMA) ||
-                     hex.containsTerrain(Terrains.JUNGLE) ||
-                     (hex.terrainLevel(Terrains.SNOW) > 1) ||
-                     (hex.terrainLevel(Terrains.GEYSER) == 2);
+        return taxingAeroProhibitedTerrains(hex);
     }
 
     @Override
@@ -2446,84 +2440,34 @@ public abstract class Aero extends Entity implements IAero, IBomber {
     }
 
     public String getCritDamageString() {
-        StringBuilder toReturn = new StringBuilder();
-        boolean first = true;
-        if (getSensorHits() > 0) {
-            toReturn.append(String.format(Messages.getString("Aero.sensorDamageString"), getSensorHits()));
-            first = false;
-        }
-        if (getAvionicsHits() > 0) {
-            if (!first) {
-                toReturn.append(", ");
-            }
-            toReturn.append(String.format(Messages.getString("Aero.avionicsDamageString"), getAvionicsHits()));
-            first = false;
-        }
-        if (getFCSHits() > 0) {
-            if (!first) {
-                toReturn.append(", ");
-            }
-            toReturn.append(String.format(Messages.getString("Aero.fcsDamageString"), getFCSHits()));
-            first = false;
-        }
-        if (getCICHits() > 0) {
-            if (!first) {
-                toReturn.append(", ");
-            }
-            toReturn.append(String.format(Messages.getString("Aero.cicDamageString"), getCICHits()));
-            first = false;
-        }
-        if (isGearHit()) {
-            if (!first) {
-                toReturn.append(", ");
-            }
-            toReturn.append(Messages.getString("Aero.landingGearDamageString"));
-            first = false;
-        }
-        if (!hasLifeSupport()) {
-            if (!first) {
-                toReturn.append(", ");
-            }
-            toReturn.append(Messages.getString("Aero.lifeSupportDamageString"));
-            first = false;
-        }
-        if (getLeftThrustHits() > 0) {
-            if (!first) {
-                toReturn.append(", ");
-            }
-            toReturn.append(String.format(Messages.getString("Aero.leftThrusterDamageString"), getLeftThrustHits()));
-            first = false;
-        }
-        if (getRightThrustHits() > 0) {
-            if (!first) {
-                toReturn.append(", ");
-            }
-            toReturn.append(String.format(Messages.getString("Aero.rightThrusterDamageString"), getRightThrustHits()));
-            first = false;
-        }
+        ConditionalStringJoiner conditionalStringJoiner = new ConditionalStringJoiner();
+        conditionalStringJoiner.add(getEngineHits() > 0,
+              () -> String.format(Messages.getString("Aero.engineDamageString"), getEngineHits()));
+        conditionalStringJoiner.add(getSensorHits() > 0,
+              () -> String.format(Messages.getString("Aero.sensorDamageString"), getSensorHits()));
+        conditionalStringJoiner.add(getAvionicsHits() > 0,
+              () -> String.format(Messages.getString("Aero.avionicsDamageString"), getAvionicsHits()));
+        conditionalStringJoiner.add(getFCSHits() > 0,
+              () -> String.format(Messages.getString("Aero.fcsDamageString"), getFCSHits()));
+        conditionalStringJoiner.add(getCICHits() > 0,
+              () -> String.format(Messages.getString("Aero.cicDamageString"), getCICHits()));
+        conditionalStringJoiner.add(isGearHit(),
+              () -> String.format(Messages.getString("Aero.landingGearDamageString"), isGearHit()));
+        conditionalStringJoiner.add(!hasLifeSupport(),
+              () -> Messages.getString("Aero.lifeSupportDamageString"));
+        conditionalStringJoiner.add(getLeftThrustHits() > 0,
+              () -> String.format(Messages.getString("Aero.leftThrusterDamageString"), getLeftThrustHits()));
+        conditionalStringJoiner.add(getRightThrustHits() > 0,
+              () -> String.format(Messages.getString("Aero.rightThrusterDamageString"), getRightThrustHits()));
         // Cargo bays and bay doors for large craft
-        for (Bay next : getTransportBays()) {
-            if (next.getBayDamage() > 0) {
-                if (!first) {
-                    toReturn.append(", ");
-                }
-                toReturn.append(String.format(Messages.getString("Aero.bayDamageString"),
-                      next.getType(),
-                      next.getBayNumber()));
-                first = false;
-            }
-            if (next.getCurrentDoors() < next.getDoors()) {
-                if (!first) {
-                    toReturn.append(", ");
-                }
-                toReturn.append(String.format(Messages.getString("Aero.bayDoorDamageString"),
-                      next.getType(),
-                      next.getBayNumber(),
-                      (next.getDoors() - next.getCurrentDoors())));
-                first = false;
-            }
+        for (Bay transportBay : getTransportBays()) {
+            conditionalStringJoiner.add(transportBay.getBayDamage() > 0,
+                  () -> String.format(Messages.getString("Aero.bayDamageString"), transportBay.getType(), transportBay.getBayNumber()));
+            conditionalStringJoiner.add(transportBay.getCurrentDoors() < transportBay.getDoors(),
+                  () -> String.format(Messages.getString("Aero.bayDoorDamageString"), transportBay.getType(), transportBay.getBayNumber(),
+                        (transportBay.getDoors() - transportBay.getCurrentDoors())));
         }
-        return toReturn.toString();
+        return conditionalStringJoiner.toString();
     }
 
     @Override

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -1,15 +1,43 @@
 /*
- * MegaAero - Copyright (C) 2007 Jay Lawson This program is free software; you
- * can redistribute it and/or modify it under the terms of the GNU General
- * Public License as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
+ * MegaAero - Copyright (C) 2007 Jay Lawson
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
- * details.
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package megamek.common;
+
+import java.io.Serial;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Vector;
 
 import megamek.client.ui.swing.calculationReport.CalculationReport;
 import megamek.common.cost.DropShipCostCalculator;
@@ -18,21 +46,20 @@ import megamek.common.equipment.WeaponMounted;
 import megamek.common.options.OptionsConstants;
 import megamek.common.planetaryconditions.Atmosphere;
 import megamek.common.planetaryconditions.PlanetaryConditions;
-
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Vector;
+import megamek.common.util.ConditionalStringJoiner;
 
 /**
  * @author Jay Lawson
  * @since Jun 17, 2007
  */
 public class Dropship extends SmallCraft {
+
+    @Serial
     private static final long serialVersionUID = 1528728632696989565L;
 
     // ASEW Missile Effects, per location
     // Values correspond to Locations: NOS, Left, Right, AFT
-    private int[] asewAffectedTurns = { 0, 0, 0, 0 };
+    private final int[] asewAffectedTurns = { 0, 0, 0, 0 };
 
     /**
      * Sets the number of rounds a specified firing arc is affected by an ASEW missile
@@ -149,61 +176,54 @@ public class Dropship extends SmallCraft {
 
     @Override
     public String getCritDamageString() {
-        StringBuilder toReturn = new StringBuilder(super.getCritDamageString());
-        boolean first = toReturn.length() == 0;
-        if (isDockCollarDamaged()) {
-            if (!first) {
-                toReturn.append(", ");
-            }
-            toReturn.append(Messages.getString("Dropship.collarDamageString"));
-            first = false;
-        }
-        if (isKFBoomDamaged()) {
-            if (!first) {
-                toReturn.append(", ");
-            }
-            toReturn.append(Messages.getString("Dropship.kfBoomDamageString"));
-            first = false;
-        }
-        return toReturn.toString();
+        ConditionalStringJoiner conditionalStringJoiner = new ConditionalStringJoiner();
+        conditionalStringJoiner.add(super.getCritDamageString());
+        conditionalStringJoiner.add(isDockCollarDamaged(), () -> Messages.getString("Dropship.collarDamageString"));
+        conditionalStringJoiner.add(isKFBoomDamaged(), () -> Messages.getString("Dropship.kfBoomDamageString"));
+        return conditionalStringJoiner.toString();
     }
 
     @Override
-    public boolean isLocationProhibited(Coords c, int currElevation) {
-        Hex hex = game.getBoard().getHex(c);
+    public boolean isLocationProhibited(Coords locationCoords, int currElevation) {
+        Hex hex = game.getBoard().getHex(locationCoords);
         if (currElevation != 0) {
             return hex.containsTerrain(Terrains.IMPASSABLE);
         }
         // Check prohibited terrain
         // treat grounded Dropships like wheeled tanks,
         // plus buildings are prohibited
-        boolean isProhibited = hexContainsProhibitedTerrain(hex);
+        boolean isProhibited = taxingAeroProhibitedTerrains(hex);
         // Also check for any crushable entities
-        var iter = game.getEntities(c);
-        while (iter.hasNext()) {
-            Entity entity = iter.next();
-            isProhibited |= entity.getId() != this.getId();
+        var currentEntitiesIter = game.getEntities(locationCoords);
+        while (currentEntitiesIter.hasNext()) {
+            Entity entity = currentEntitiesIter.next();
+            isProhibited = isProhibited || !this.equals(entity);
             if (isProhibited) {
                 return true;
             }
         }
 
-        HashMap<Integer, Integer> elevations = new HashMap<>();
+        Map<Integer, Integer> elevations = new HashMap<>();
         elevations.put(hex.getLevel(), 1);
+        boolean secondaryHexPresent;
+        Coords secondaryCoords;
         for (int dir = 0; dir < 6; dir++) {
-            Coords secondaryCoord = c.translated(dir);
-            Hex secondaryHex = game.getBoard().getHex(secondaryCoord);
-            iter = game.getEntities(secondaryCoord); // reusing the iter again
-            while (iter.hasNext()) {
-                Entity entity = iter.next();
-                isProhibited |= (entity.getId() != this.getId()) || (secondaryHex == null) || hexContainsProhibitedTerrain(secondaryHex);
-                if (secondaryHex != null) {
-                    int elev = secondaryHex.getLevel();
-                    if (elevations.containsKey(elev)) {
-                        elevations.put(elev, elevations.get(elev) + 1);
-                    } else {
-                        elevations.put(elev, 1);
-                    }
+            secondaryCoords = locationCoords.translated(dir);
+            Hex secondaryHex = game.getBoard().getHex(secondaryCoords);
+            currentEntitiesIter = game.getEntities(secondaryCoords);
+            secondaryHexPresent = secondaryHex != null;
+            isProhibited = isProhibited || !secondaryHexPresent || taxingAeroProhibitedTerrains(secondaryHex);
+            while (!isProhibited && currentEntitiesIter.hasNext()) {
+                Entity entity = currentEntitiesIter.next();
+                isProhibited = !this.equals(entity);
+            }
+
+            if (secondaryHexPresent) {
+                int elev = secondaryHex.getLevel();
+                if (elevations.containsKey(elev)) {
+                    elevations.put(elev, elevations.get(elev) + 1);
+                } else {
+                    elevations.put(elev, 1);
                 }
             }
         }
@@ -224,17 +244,16 @@ public class Dropship extends SmallCraft {
             return true;
         }
 
-        Object[] elevs = elevations.keySet().toArray();
-        int elev1 = (Integer) elevs[0];
-        int elev2 = (Integer) elevs[1];
-        int elevDifference = Math.abs(elev1 - elev2);
+        final Integer[] elevationsKeys = new Integer[elevations.size()];
+        elevations.keySet().toArray(elevationsKeys);
+        int elevDifference = Math.abs(elevationsKeys[0] - elevationsKeys[1]);
         int elevMinCount = 2;
         // Check elevation difference and make sure that the counts of different
         // elevations will allow for a legal deployment to exist
         // TODO: get updated ruling; this code causes a hex with one single lower- or higher-level neighbor
         // to be disqualified, but it would seem that a single lower-level neighbor should be fine.
-        if ((elevDifference > 1) || (elevations.get(elevs[0]) < elevMinCount)
-                || (elevations.get(elevs[1]) < elevMinCount)) {
+        if ((elevDifference > 1) || (elevations.get(elevationsKeys[0]) < elevMinCount)
+                || (elevations.get(elevationsKeys[1]) < elevMinCount)) {
             return true;
         }
 
@@ -243,11 +262,11 @@ public class Dropship extends SmallCraft {
         // The way this is done is we start at the hex directly above the
         // central hex and then move around clockwise and compare the two hexes
         // to see if they share an elevation. We need to have a number of these
-        // adjacencies equal to the number of secondary elevation hexes - 1.
+        // adjacency equal to the number of secondary elevation hexes - 1.
         int numAdjacencies = 0;
         int centralElev = hex.getLevel();
         int secondElev = centralElev;
-        Hex currHex = game.getBoard().getHex(c.translated(5));
+        Hex currHex = game.getBoard().getHex(locationCoords.translated(5));
         // Ensure we aren't trying to deploy off the board
         if (currHex == null) {
             return true;
@@ -256,7 +275,7 @@ public class Dropship extends SmallCraft {
             if (currHex.getLevel() != centralElev) {
                 secondElev = currHex.getLevel();
             }
-            Hex nextHex = game.getBoard().getHex(c.translated(dir));
+            Hex nextHex = game.getBoard().getHex(locationCoords.translated(dir));
             // Ensure we aren't trying to deploy off the board
             if (nextHex == null) {
                 return true;
@@ -271,21 +290,6 @@ public class Dropship extends SmallCraft {
         }
 
         return isProhibited;
-    }
-
-    /**
-     * Worker function that checks if a given hex contains terrain onto which a grounded dropship
-     * cannot deploy.
-     */
-    private boolean hexContainsProhibitedTerrain(Hex hex) {
-        return hex.containsTerrain(Terrains.WOODS) || hex.containsTerrain(Terrains.ROUGH)
-                || ((hex.terrainLevel(Terrains.WATER) > 0) && !hex.containsTerrain(Terrains.ICE))
-                || hex.containsTerrain(Terrains.RUBBLE) || hex.containsTerrain(Terrains.MAGMA)
-                || hex.containsTerrain(Terrains.JUNGLE) || (hex.terrainLevel(Terrains.SNOW) > 1)
-                || (hex.terrainLevel(Terrains.GEYSER) == 2)
-                || hex.containsTerrain(Terrains.BUILDING) || hex.containsTerrain(Terrains.IMPASSABLE)
-                || hex.containsTerrain(Terrains.BRIDGE);
-
     }
 
     public void setDamageDockCollar(boolean b) {

--- a/megamek/src/megamek/common/Dropship.java
+++ b/megamek/src/megamek/common/Dropship.java
@@ -179,9 +179,13 @@ public class Dropship extends SmallCraft {
         // plus buildings are prohibited
         boolean isProhibited = hexContainsProhibitedTerrain(hex);
         // Also check for any crushable entities
-        isProhibited |= game.getEntities(c).hasNext();
-        if (isProhibited) {
-            return true;
+        var iter = game.getEntities(c);
+        while (iter.hasNext()) {
+            Entity entity = iter.next();
+            isProhibited |= entity.getId() != this.getId();
+            if (isProhibited) {
+                return true;
+            }
         }
 
         HashMap<Integer, Integer> elevations = new HashMap<>();
@@ -189,19 +193,17 @@ public class Dropship extends SmallCraft {
         for (int dir = 0; dir < 6; dir++) {
             Coords secondaryCoord = c.translated(dir);
             Hex secondaryHex = game.getBoard().getHex(secondaryCoord);
-            boolean occupied = game.getEntities(secondaryCoord).hasNext();
-            if (secondaryHex == null) {
-                // Don't allow landed dropships to hang off the board
-                isProhibited = true;
-            } else {
-                isProhibited |= hexContainsProhibitedTerrain(secondaryHex);
-                isProhibited |= occupied;
-
-                int elev = secondaryHex.getLevel();
-                if (elevations.containsKey(elev)) {
-                    elevations.put(elev, elevations.get(elev) + 1);
-                } else {
-                    elevations.put(elev, 1);
+            iter = game.getEntities(secondaryCoord); // reusing the iter again
+            while (iter.hasNext()) {
+                Entity entity = iter.next();
+                isProhibited |= (entity.getId() != this.getId()) || (secondaryHex == null) || hexContainsProhibitedTerrain(secondaryHex);
+                if (secondaryHex != null) {
+                    int elev = secondaryHex.getLevel();
+                    if (elevations.containsKey(elev)) {
+                        elevations.put(elev, elevations.get(elev) + 1);
+                    } else {
+                        elevations.put(elev, 1);
+                    }
                 }
             }
         }

--- a/megamek/src/megamek/common/IAero.java
+++ b/megamek/src/megamek/common/IAero.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
 
+import megamek.common.annotations.Nullable;
 import megamek.common.moves.MovePath;
 import megamek.common.moves.MovePath.MoveStepType;
 import megamek.common.moves.MoveStep;
@@ -861,4 +862,22 @@ public interface IAero {
      * @param round
      */
     void setEnginesLostRound(int round);
+
+    /**
+     * Check if the specified hex is a prohibited terrain for Aero units to taxi into
+     * @param hex the hex to check
+     * @return true if the hex is a prohibited terrain for Aero units to taxi into
+     */
+    default boolean taxingAeroProhibitedTerrains(@Nullable Hex hex) {
+        return (hex == null) || // It is illegal to taxi offboard
+                     hex.containsTerrain(Terrains.WOODS) ||
+                     hex.containsTerrain(Terrains.ROUGH) ||
+                     ((hex.terrainLevel(Terrains.WATER) > 0) && !hex.containsTerrain(Terrains.ICE)) ||
+                     hex.containsTerrain(Terrains.RUBBLE) ||
+                     hex.containsTerrain(Terrains.MAGMA) ||
+                     hex.containsTerrain(Terrains.JUNGLE) ||
+                     (hex.terrainLevel(Terrains.SNOW) > 1) ||
+                     (hex.terrainLevel(Terrains.GEYSER) == 2);
+    }
+
 }

--- a/megamek/src/megamek/common/LandAirMek.java
+++ b/megamek/src/megamek/common/LandAirMek.java
@@ -569,14 +569,7 @@ public class LandAirMek extends BipedMek implements IAero, IBomber {
             }
 
             // grounded aeros have the same prohibitions as wheeled tanks
-            return hex.containsTerrain(Terrains.WOODS) ||
-                         hex.containsTerrain(Terrains.ROUGH) ||
-                         ((hex.terrainLevel(Terrains.WATER) > 0) && !hex.containsTerrain(Terrains.ICE)) ||
-                         hex.containsTerrain(Terrains.RUBBLE) ||
-                         hex.containsTerrain(Terrains.MAGMA) ||
-                         hex.containsTerrain(Terrains.JUNGLE) ||
-                         (hex.terrainLevel(Terrains.SNOW) > 1) ||
-                         (hex.terrainLevel(Terrains.GEYSER) == 2);
+            return taxingAeroProhibitedTerrains(hex);
         } else if (getConversionMode() == CONV_MODE_AIRMEK && currElevation > 0) {
             // Cannot enter woods or a building hex in AirMek mode unless using ground movement or flying over the
             // terrain.

--- a/megamek/src/megamek/common/util/ConditionalStringJoiner.java
+++ b/megamek/src/megamek/common/util/ConditionalStringJoiner.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.util;
+
+import java.util.function.Supplier;
+
+/**
+ * A utility class for conditionally joining strings with a delimiter.
+ * @author Luana Coppio
+ */
+public class ConditionalStringJoiner {
+    private static final String DEFAULT_DELIMITER = ", ";
+    private static final int DEFAULT_CAPACITY = 64;
+    private final StringBuilder stringBuilder;
+    private final String delimiter;
+    private boolean isFirst;
+
+    /**
+     * Creates a ConditionalStringJoiner.
+     */
+    public ConditionalStringJoiner() {
+        this(DEFAULT_DELIMITER, DEFAULT_CAPACITY);
+    }
+
+    /**
+     * Creates a ConditionalStringJoiner with the specified delimiter.
+     * @param delimiter the delimiter to use when joining strings
+     */
+    public ConditionalStringJoiner(String delimiter) {
+        this(delimiter, DEFAULT_CAPACITY);
+    }
+
+    /**
+     * Creates a ConditionalStringJoiner with the specified initial capacity.
+     * @param capacity the initial capacity of the ConditionalStringJoiner
+     */
+    public ConditionalStringJoiner(int capacity) {
+        this(DEFAULT_DELIMITER, capacity);
+    }
+
+    /**
+     * Creates a ConditionalStringJoiner with the specified delimiter and initial capacity.
+     * @param delimiter the delimiter to use when joining strings
+     * @param capacity the initial capacity of the ConditionalStringJoiner
+     */
+    public ConditionalStringJoiner(String delimiter, int capacity) {
+        this.stringBuilder = new StringBuilder(capacity);
+        this.delimiter = delimiter;
+        this.isFirst = true;
+    }
+
+    /**
+     * Adds a string to the joiner if the condition is true. Uses a supplier to get the string value, this way it is
+     * not evaluated unless the condition is true.
+     * <pre>
+     *     {@code
+     *     ConditionalStringJoiner conditionalStringJoiner = new ConditionalStringJoiner();
+     *     // This will only add the string if speed > 5
+     *     conditionalStringJoiner.add(speed > 5,
+     *         () -> I18n.getFormattedText("common.speedWarning", calculateDamage())
+     *     );
+     *     // partial string if speed > 5
+     *     //  >> "Risk of taking 75 damage if you fail PSR"
+     *
+     *     // This will add the string if isCriticalHit is true
+     *     conditionalStringJoiner.add(isCriticalHit, () -> I18n.getText("common.criticalHit"));
+     *     String result = conditionalStringJoiner.toString();
+     *
+     *     // The result will be a string like this:
+     *     //  >> "Risk of taking 75 damage if you fail PSR, this unit has a critical hit"
+     *     }
+     * </pre>
+     * @param condition the condition to check
+     * @param messageSupplier the supplier that provides the string to add if the condition is true
+     * @return this instance for method chaining
+     */
+    public ConditionalStringJoiner add(boolean condition, Supplier<String> messageSupplier) {
+        if (!condition || (messageSupplier == null)) {
+            return this;
+        }
+        return this.add(messageSupplier.get());
+    }
+
+    /**
+     * Adds a string to the joiner if the condition is true.
+     * <pre>
+     *     {@code
+     *     ConditionalStringJoiner conditionalStringJoiner = new ConditionalStringJoiner();
+     *     // This will only add the string if speed > 5
+     *     conditionalStringJoiner.add(speed > 5, I18n.getFormattedText("common.speedWarning", calculateDamage()));
+     *     // partial string if speed > 5
+     *     //  >> "Risk of taking 75 damage if you fail PSR"
+     *
+     *     // This will add the string if isCriticalHit is true
+     *     conditionalStringJoiner.add(isCriticalHit, I18n.getText("common.criticalHit"));
+     *     String result = conditionalStringJoiner.toString();
+     *
+     *     // The result will be a string like this:
+     *     //  >> "Risk of taking 75 damage if you fail PSR, this unit has a critical hit"
+     *     }
+     * </pre>
+     * @param condition the condition to check
+     * @param message the string to add if the condition is true
+     * @return this instance for method chaining
+     */
+    public ConditionalStringJoiner add(boolean condition, String message) {
+        if (!condition) {
+            return this;
+        }
+        return this.add(message);
+    }
+
+    /**
+     * Adds a string to the joiner. No condition is checked.
+     * <pre>
+     *     {@code
+     *     ConditionalStringJoiner conditionalStringJoiner = new ConditionalStringJoiner();
+     *     conditionalStringJoiner.add(I18n.getFormattedText("common.speedWarning", calculateDamage()));
+     *     //  >> "Risk of taking 75 damage if you fail PSR"
+     *
+     *     conditionalStringJoiner.add(I18n.getText("common.criticalHit"));
+     *     String result = conditionalStringJoiner.toString();
+     *
+     *     // The result will be a string like this:
+     *     //  >> "Risk of taking 75 damage if you fail PSR, this unit has a critical hit"
+     *     }
+     * </pre>
+     * @param message the string to add
+     * @return this instance for method chaining
+     */
+    public ConditionalStringJoiner add(String message) {
+        if (message == null || message.isEmpty()) {
+            return this;
+        }
+
+        if (!isFirst) {
+            stringBuilder.append(delimiter);
+        }
+        stringBuilder.append(message);
+        isFirst = false;
+
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return stringBuilder.toString();
+    }
+
+}


### PR DESCRIPTION
# What it does?

Allows dropships to move around normally as if they had landed if they are deployed on ground.

There was some situation which would make it think it was overlaping with itself and therefore it would destroy that unit (itself) if it moved, which them limited its movement to... nothing.

![image](https://github.com/user-attachments/assets/7a5badfc-ed9a-4dce-a3c2-05486cda5d4f)



# Related issues

- closes #7104