### PR TITLE
optimizations for RawImagePanel

### DIFF
--- a/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
@@ -36,6 +36,7 @@ import java.awt.*;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.awt.image.VolatileImage;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileReader;
@@ -95,6 +96,7 @@ import megamek.client.ui.clientGUI.tooltip.PilotToolTip;
 import megamek.client.ui.util.MegaMekController;
 import megamek.client.ui.util.UIUtil;
 import megamek.client.ui.widget.MegaMekButton;
+import megamek.client.ui.widget.RawImagePanel;
 import megamek.client.ui.widget.SkinSpecification;
 import megamek.client.ui.widget.SkinSpecification.UIComponents;
 import megamek.client.ui.widget.SkinXMLHandler;
@@ -130,6 +132,7 @@ import megamek.server.Server;
 import megamek.server.sbf.SBFGameManager;
 import megamek.server.totalwarfare.TWGameManager;
 import megamek.utilities.xml.MMXMLUtility;
+import megamek.common.util.ImageUtil;
 
 public class MegaMekGUI implements IPreferenceChangeListener {
     private static final MMLogger LOGGER = MMLogger.create(MegaMekGUI.class);
@@ -148,9 +151,9 @@ public class MegaMekGUI implements IPreferenceChangeListener {
     private IGameManager gameManager;
     private CommonSettingsDialog settingsDialog;
     private Image splashImage;
-    private Image logoImage;
-    private Image medalImage;
-    JPanel splashPanel;
+    private VolatileImage logoImage;
+    private VolatileImage medalImage;
+    private RawImagePanel splashPanel;
     private TipOfTheDay tipOfTheDay;
 
     private static MegaMekController controller;
@@ -352,11 +355,11 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         // displays aren't as large as their secondary displays.
         Dimension scaledMonitorSize = UIUtil.getScaledScreenSize(frame);
         splashImage = getImage(FILENAME_MEGAMEK_SPLASH, scaledMonitorSize.width, scaledMonitorSize.height);
-        logoImage = getImage(FILENAME_LOGO, scaledMonitorSize.width, scaledMonitorSize.height);
-        medalImage = getImage(FILENAME_MEDAL, scaledMonitorSize.width, scaledMonitorSize.height);
+        logoImage = ImageUtil.convertToVolatileImage(getImage(FILENAME_LOGO, scaledMonitorSize.width, scaledMonitorSize.height), Transparency.TRANSLUCENT);
+        medalImage = ImageUtil.convertToVolatileImage(getImage(FILENAME_MEDAL, scaledMonitorSize.width, scaledMonitorSize.height), Transparency.TRANSLUCENT);
         Dimension splashPanelPreferredSize = calculateSplashPanelPreferredSize(scaledMonitorSize, splashImage);
         // This is an empty panel that will contain the splash image
-        splashPanel = new JPanel() {
+        splashPanel = new RawImagePanel(splashImage) {
             @Override
             public void paint(Graphics g) {
                 super.paint(g); // Draw background, border, and children first
@@ -366,10 +369,6 @@ public class MegaMekGUI implements IPreferenceChangeListener {
                     int panelHeight = this.getHeight();
                     int padding = 20;
                     int targetMedalWidth = 0;
-                    // Draw the main splash image, scaled to fill the panel
-                    if (splashImage != null) {
-                        g2d.drawImage(splashImage, 0, 0, panelWidth, panelHeight, null);
-                    }
 
                     // Draw Tip of the Day
                     if (tipOfTheDay != null) {

--- a/megamek/src/megamek/client/ui/widget/RawImagePanel.java
+++ b/megamek/src/megamek/client/ui/widget/RawImagePanel.java
@@ -35,27 +35,35 @@ package megamek.client.ui.widget;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsEnvironment;
 import java.awt.Image;
 import java.awt.RenderingHints;
+import java.awt.Transparency;
+import java.awt.image.VolatileImage;
+
 import javax.swing.JComponent;
 
 /**
+ * @author drake
+ * 
  * A panel that displays a raw image, scaling it to fit the component's size.
  */
 public class RawImagePanel extends JComponent {
-    private Image image;
+    private Image originalImage;
+    private VolatileImage cachedImage;
+    private Dimension lastSize;
 
     public RawImagePanel(Image image) {
-        this.image = image;
-        if (image != null) {
-            setPreferredSize(new Dimension(image.getWidth(null), image.getHeight(null)));
-        } else {
-            setPreferredSize(new Dimension(0, 0));
-        }
+        setImage(image);
+        setDoubleBuffered(true);
+        setOpaque(false);
     }
 
     public void setImage(Image image) {
-        this.image = image;
+        this.originalImage = image;
+        invalidateCache();
+        
         if (image != null) {
             setPreferredSize(new Dimension(image.getWidth(null), image.getHeight(null)));
         } else {
@@ -65,22 +73,115 @@ public class RawImagePanel extends JComponent {
         repaint();
     }
 
+    private void invalidateCache() {
+        if (cachedImage != null) {
+            cachedImage.flush();
+            cachedImage = null;
+        }
+        lastSize = null;
+    }
+
+    private VolatileImage createScaledImage(int width, int height) {
+        if (originalImage == null || width <= 0 || height <= 0) {
+            return null;
+        }
+
+        GraphicsConfiguration gc = GraphicsEnvironment.getLocalGraphicsEnvironment()
+                .getDefaultScreenDevice().getDefaultConfiguration();
+        
+        VolatileImage scaledImage = gc.createCompatibleVolatileImage(width, height, Transparency.TRANSLUCENT);
+        
+        do {
+            int validationCode = scaledImage.validate(gc);
+            if (validationCode == VolatileImage.IMAGE_RESTORED) {
+                // Image was restored, need to re-render
+                renderScaledImage(scaledImage, width, height);
+            } else if (validationCode == VolatileImage.IMAGE_INCOMPATIBLE) {
+                // Image is incompatible, create a new one
+                scaledImage.flush();
+                scaledImage = gc.createCompatibleVolatileImage(width, height, Transparency.TRANSLUCENT);
+                renderScaledImage(scaledImage, width, height);
+            }
+        } while (scaledImage.contentsLost());
+
+        if (scaledImage.validate(gc) == VolatileImage.IMAGE_OK) {
+            renderScaledImage(scaledImage, width, height);
+        }
+
+        return scaledImage;
+    }
+
+        private void renderScaledImage(VolatileImage targetImage, int width, int height) {
+        Graphics2D g2d = targetImage.createGraphics();
+        try {
+            g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+            g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+            g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_SPEED);
+            
+            // Clear the image
+            g2d.setComposite(java.awt.AlphaComposite.Clear);
+            g2d.fillRect(0, 0, width, height);
+            g2d.setComposite(java.awt.AlphaComposite.SrcOver);
+            
+            // Draw the scaled image
+            g2d.drawImage(originalImage, 0, 0, width, height, null);
+        } finally {
+            g2d.dispose();
+        }
+    }
+
     @Override
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);
-        if (image != null && getWidth() > 0 && getHeight() > 0) {
+        if (originalImage == null || getWidth() <= 0 || getHeight() <= 0) {
+            return;
+        }
+        Dimension currentSize = new Dimension(getWidth(), getHeight());
+        if (cachedImage == null || lastSize == null || !lastSize.equals(currentSize)) {
+            invalidateCache();
+            cachedImage = createScaledImage(getWidth(), getHeight());
+            lastSize = currentSize;
+        }
+        // Validate the cached image before drawing
+        if (cachedImage != null) {
+            GraphicsConfiguration gc = getGraphicsConfiguration();
+            if (gc != null) {
+                int validationCode = cachedImage.validate(gc);
+                if (validationCode == VolatileImage.IMAGE_RESTORED || 
+                    validationCode == VolatileImage.IMAGE_INCOMPATIBLE) {
+                    // Recreate the image if it was lost or is incompatible
+                    cachedImage.flush();
+                    cachedImage = createScaledImage(getWidth(), getHeight());
+                }
+            }
+        }
+
+        // Draw the cached image
+        if (cachedImage != null && !cachedImage.contentsLost()) {
             Graphics2D g2d = (Graphics2D) g.create();
             try {
-                // Apply high-quality rendering hints
+                // Final draw
+                g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_SPEED);
+                g2d.drawImage(cachedImage, 0, 0, null);
+            } finally {
+                g2d.dispose();
+            }
+        } else {
+            // Fallback to direct drawing if cached image is lost
+            Graphics2D g2d = (Graphics2D) g.create();
+            try {
                 g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
-                g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
                 g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-                
-                // Draw the image, scaling it to the component's current bounds
-                g2d.drawImage(image, 0, 0, getWidth(), getHeight(), null);
+                g2d.drawImage(originalImage, 0, 0, getWidth(), getHeight(), null);
             } finally {
                 g2d.dispose();
             }
         }
+    }
+    
+    @Override
+    public void removeNotify() {
+        super.removeNotify();
+        invalidateCache();
     }
 }

--- a/megamek/src/megamek/client/ui/widget/RawImagePanel.java
+++ b/megamek/src/megamek/client/ui/widget/RawImagePanel.java
@@ -41,6 +41,7 @@ import java.awt.Image;
 import java.awt.RenderingHints;
 import java.awt.Transparency;
 import java.awt.image.VolatileImage;
+import megamek.common.util.ImageUtil;
 
 import javax.swing.JComponent;
 
@@ -81,55 +82,6 @@ public class RawImagePanel extends JComponent {
         lastSize = null;
     }
 
-    private VolatileImage createScaledImage(int width, int height) {
-        if (originalImage == null || width <= 0 || height <= 0) {
-            return null;
-        }
-
-        GraphicsConfiguration gc = GraphicsEnvironment.getLocalGraphicsEnvironment()
-                .getDefaultScreenDevice().getDefaultConfiguration();
-        
-        VolatileImage scaledImage = gc.createCompatibleVolatileImage(width, height, Transparency.TRANSLUCENT);
-        
-        do {
-            int validationCode = scaledImage.validate(gc);
-            if (validationCode == VolatileImage.IMAGE_RESTORED) {
-                // Image was restored, need to re-render
-                renderScaledImage(scaledImage, width, height);
-            } else if (validationCode == VolatileImage.IMAGE_INCOMPATIBLE) {
-                // Image is incompatible, create a new one
-                scaledImage.flush();
-                scaledImage = gc.createCompatibleVolatileImage(width, height, Transparency.TRANSLUCENT);
-                renderScaledImage(scaledImage, width, height);
-            }
-        } while (scaledImage.contentsLost());
-
-        if (scaledImage.validate(gc) == VolatileImage.IMAGE_OK) {
-            renderScaledImage(scaledImage, width, height);
-        }
-
-        return scaledImage;
-    }
-
-        private void renderScaledImage(VolatileImage targetImage, int width, int height) {
-        Graphics2D g2d = targetImage.createGraphics();
-        try {
-            g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
-            g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
-            g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_SPEED);
-            
-            // Clear the image
-            g2d.setComposite(java.awt.AlphaComposite.Clear);
-            g2d.fillRect(0, 0, width, height);
-            g2d.setComposite(java.awt.AlphaComposite.SrcOver);
-            
-            // Draw the scaled image
-            g2d.drawImage(originalImage, 0, 0, width, height, null);
-        } finally {
-            g2d.dispose();
-        }
-    }
-
     @Override
     protected void paintComponent(Graphics g) {
         super.paintComponent(g);
@@ -139,7 +91,7 @@ public class RawImagePanel extends JComponent {
         Dimension currentSize = new Dimension(getWidth(), getHeight());
         if (cachedImage == null || lastSize == null || !lastSize.equals(currentSize)) {
             invalidateCache();
-            cachedImage = createScaledImage(getWidth(), getHeight());
+            cachedImage = ImageUtil.convertToVolatileImage(originalImage, Transparency.OPAQUE, getWidth(), getHeight());
             lastSize = currentSize;
         }
         // Validate the cached image before drawing
@@ -151,7 +103,7 @@ public class RawImagePanel extends JComponent {
                     validationCode == VolatileImage.IMAGE_INCOMPATIBLE) {
                     // Recreate the image if it was lost or is incompatible
                     cachedImage.flush();
-                    cachedImage = createScaledImage(getWidth(), getHeight());
+                    cachedImage = ImageUtil.convertToVolatileImage(originalImage, Transparency.OPAQUE, getWidth(), getHeight());
                 }
             }
         }

--- a/megamek/src/megamek/common/Report.java
+++ b/megamek/src/megamek/common/Report.java
@@ -727,11 +727,8 @@ public class Report implements ReportEntry {
 
     public static void setupStylesheet(JTextPane pane) {
         pane.setContentType("text/html");
-        StyleSheet styleSheet = new StyleSheet();
-        setupStylesheet(styleSheet);
-        HTMLEditorKit newKit = new HTMLEditorKit();
-        newKit.setStyleSheet(styleSheet);
-        pane.setEditorKit(newKit);
+        StyleSheet styleSheet = ((HTMLEditorKit) pane.getEditorKit()).getStyleSheet();
+        Report.setupStylesheet(styleSheet);
     }
 
     public static void setupStylesheet(StyleSheet styleSheet) {

--- a/megamek/src/megamek/common/strategicBattleSystems/SBFReportEntry.java
+++ b/megamek/src/megamek/common/strategicBattleSystems/SBFReportEntry.java
@@ -52,11 +52,8 @@ public class SBFReportEntry implements ReportEntry {
 
     public static void setupStylesheet(JTextPane pane) {
         pane.setContentType("text/html");
-        StyleSheet styleSheet = new StyleSheet();
-        setupStylesheet(styleSheet);
-        HTMLEditorKit newKit = new HTMLEditorKit();
-        newKit.setStyleSheet(styleSheet);
-        pane.setEditorKit(newKit);
+        StyleSheet styleSheet = ((HTMLEditorKit) pane.getEditorKit()).getStyleSheet();
+        Report.setupStylesheet(styleSheet);
     }
 
     public static void setupStylesheet(StyleSheet styleSheet) {

--- a/megamek/src/megamek/common/util/ImageUtil.java
+++ b/megamek/src/megamek/common/util/ImageUtil.java
@@ -23,6 +23,7 @@ import java.awt.image.ImageFilter;
 import java.awt.image.ImageObserver;
 import java.awt.image.ImageProducer;
 import java.awt.image.Kernel;
+import java.awt.image.VolatileImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -616,4 +617,91 @@ public final class ImageUtil {
         }
         return new Kernel(width, width, data);
     }
+
+    
+    /**
+     * Converts a regular Image to a hardware-accelerated VolatileImage with specified transparency.
+     * 
+     * @param sourceImage the source Image to convert
+     * @return a VolatileImage copy of the source image, or null if conversion fails
+     */
+    public static @Nullable VolatileImage convertToVolatileImage(@Nullable Image sourceImage) {
+        return convertToVolatileImage(sourceImage, Transparency.TRANSLUCENT);
+    }
+
+    /**
+     * Converts a regular Image to a hardware-accelerated VolatileImage with specified transparency.
+     * 
+     * @param sourceImage the source Image to convert
+     * @param transparency the transparency type (Transparency.OPAQUE, BITMASK, or TRANSLUCENT)
+     * @return a VolatileImage copy of the source image, or null if conversion fails
+     */
+    public static @Nullable VolatileImage convertToVolatileImage(@Nullable Image sourceImage, int transparency) {
+        if (sourceImage == null) {
+            return null;
+        }
+        int width = sourceImage.getWidth(null);
+        int height = sourceImage.getHeight(null);
+        if (width <= 0 || height <= 0) {
+            return null;
+        }
+        return convertToVolatileImage(sourceImage, transparency, width, height);
+    }
+
+    /**
+     * Converts a regular Image to a hardware-accelerated VolatileImage with specified transparency.
+     * 
+     * @param sourceImage the source Image to convert
+     * @param transparency the transparency type (Transparency.OPAQUE, BITMASK, or TRANSLUCENT)
+     * @param width the desired width of the VolatileImage
+     * @param height the desired height of the VolatileImage
+     * @return a VolatileImage copy of the source image, or null if conversion fails
+     */
+    public static @Nullable VolatileImage convertToVolatileImage(@Nullable Image sourceImage, int transparency, int width, int height) {
+        if (sourceImage == null) {
+            return null;
+        }
+        
+        GraphicsConfiguration gc = GraphicsEnvironment.getLocalGraphicsEnvironment()
+                .getDefaultScreenDevice().getDefaultConfiguration();
+        
+        if (width <= 0 || height <= 0) {
+            return null;
+        }
+        
+        VolatileImage volatileImage = gc.createCompatibleVolatileImage(width, height, transparency);
+        
+        do {
+            int validationCode = volatileImage.validate(gc);
+            if (validationCode == VolatileImage.IMAGE_RESTORED || 
+                validationCode == VolatileImage.IMAGE_INCOMPATIBLE) {
+                
+                if (validationCode == VolatileImage.IMAGE_INCOMPATIBLE) {
+                    volatileImage.flush();
+                    volatileImage = gc.createCompatibleVolatileImage(width, height, transparency);
+                }
+                
+                Graphics2D g2d = volatileImage.createGraphics();
+                try {
+                    g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+                    g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+                    g2d.setRenderingHint(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_SPEED);
+
+                    // Only clear if we need transparency
+                    if (transparency != Transparency.OPAQUE) {
+                        g2d.setComposite(AlphaComposite.Clear);
+                        g2d.fillRect(0, 0, width, height);
+                        g2d.setComposite(AlphaComposite.SrcOver);
+                    }
+                    g2d.drawImage(sourceImage, 0, 0, width, height, null);
+                } finally {
+                    g2d.dispose();
+                }
+            }
+        } while (volatileImage.contentsLost());
+        
+        return volatileImage;
+    }
+
+
 }

--- a/megamek/src/megamek/common/util/TipOfTheDay.java
+++ b/megamek/src/megamek/common/util/TipOfTheDay.java
@@ -395,8 +395,8 @@ public class TipOfTheDay {
             float labelWidth = (float) labelLayout.getBounds().getWidth();
             String actualTipContentToRender = mapVariables(currentTipOfTheDay);
             // We unwrap and wrap the tip content with HTML to ensure it is displayed correctly
-            actualTipContentToRender = wrapTextWithHtml(unwrapHtml(actualTipContentToRender));
-            JTextPane htmlPane = createHtmlPane(actualTipContentToRender, tipFont, currentAvailableTextWidth, position);
+            actualTipContentToRender = wrapTextWithHtml(unwrapHtml(actualTipContentToRender), tipFont, currentAvailableTextWidth, position);
+            JTextPane htmlPane = createHtmlPane(actualTipContentToRender, tipFont, currentAvailableTextWidth);
             float totalTipHeight = htmlPane.getPreferredSize().height;
 
             // Positioning
@@ -601,41 +601,34 @@ public class TipOfTheDay {
         return bodyContent;
     }
 
-    private String wrapTextWithHtml(String bodyContent) {
+    private String wrapTextWithHtml(String bodyContent, Font font, int width, Position position) {
         if (bodyContent == null) {
             bodyContent = "";
         }
-        return "<html>" + bodyContent + "</html>";
-    }
-
-    /**
-     * Creates a JTextPane configured for HTML rendering
-     */
-    private JTextPane createHtmlPane(String htmlText, Font font, int width, Position position) {
-        JTextPane textPane = new JTextPane();
-        textPane.setContentType("text/html");
-        textPane.setFont(font);
-        StyleSheet styleSheet = new StyleSheet();
         String fontWeight = font.isBold() ? "bold" : "normal";
         String textAlign = switch (position) {
             case BOTTOM_LEFT_CORNER -> "left";
             case BOTTOM_RIGHT_CORNER -> "right";
             default -> "center"; // BOTTOM_BORDER
         };
-        styleSheet.addRule("html { " +
-            "font-family: '" + font.getFamily() + "'; " +
+        final String style = "font-family: '" + font.getFamily() + "'; " +
             "font-size: " + Math.ceil(font.getSize()*0.75) + "pt; " +
             "font-weight: " + fontWeight + "; " +
             "margin: 0; " +
             "padding: 0; " +
             "width: " + width + "px; " +
             "max-width: " + width + "px; " +
-            "text-align: " + textAlign + "; " +
-            "}");
+            "text-align: " + textAlign + "; ";
+        return "<html style=\""+style+"\">" + bodyContent + "</html>";
+    }
 
-        HTMLEditorKit newKit = new HTMLEditorKit();
-        newKit.setStyleSheet(styleSheet);
-        textPane.setEditorKit(newKit);
+    /**
+     * Creates a JTextPane configured for HTML rendering
+     */
+    private JTextPane createHtmlPane(String htmlText, Font font, int width) {
+        JTextPane textPane = new JTextPane();
+        textPane.setContentType("text/html");
+        textPane.setFont(font);
         textPane.setMargin(new Insets(0, 0, 0, 0));
         textPane.setBorder(null);
         textPane.setText(htmlText);


### PR DESCRIPTION
This PR optimizes RawImagePanel by using a cached scaled image with H/W acceleration. Improves massively the repainting speed.

It also:
- add new common method ImageUtil.convertToVolatileImage()
- uses RawImagePanel for MM startup GUI