### PR TITLE
Add GT and GTE comparisons to SkillLevel (Required for MHQ RFE 7116)

### DIFF
--- a/megamek/src/megamek/common/enums/SkillLevel.java
+++ b/megamek/src/megamek/common/enums/SkillLevel.java
@@ -126,6 +126,14 @@ public enum SkillLevel {
     public boolean isHeroicOrGreater() {
         return isHeroic() || isLegendary();
     }
+    
+    public boolean isGreaterThan(SkillLevel skillLevel) {
+        return (!this.equals(skillLevel) && this.experienceLevel > skillLevel.experienceLevel);
+    }
+    
+    public boolean equalsOrGreaterThan(SkillLevel skillLevel) {
+        return (this.equals(skillLevel) || (this.isGreaterThan(skillLevel)));
+    }
     // endregion Boolean Comparisons
 
     /**


### PR DESCRIPTION
Update to SkillLevel class for cleaner comparisons of skill vs some threshold level.

Testing:
- Ran with RFE 7116 unit tests
- Ran with all 3 projects' unit tests

Prerequisite for: MegaMek/mekhq#7123