### PR TITLE
Fix: Battle Armor unit does not die with all members dead

### DIFF
--- a/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
@@ -821,6 +821,13 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         final Version version = getVersion(n);
         if (SuiteConstants.VERSION.is(version)) {
             return true;
+        } else if (version.toString().toLowerCase().contains("nightly") &&
+              (version.getMajor() == SuiteConstants.VERSION.getMajor() && 
+                    version.getMinor() == SuiteConstants.VERSION.getMinor() &&
+                    version.getPatch() == SuiteConstants.VERSION.getPatch())
+                && version.toString().contains(SuiteConstants.VERSION.toString())) {
+            // Nightly version of current development version
+            return true;
         } else {
             LOGGER.errorDialog(Messages.getString("MegaMek.LoadGameAlert.title"),
                   Messages.getString("MegaMek.LoadGameIncorrectVersion.message"),

--- a/megamek/src/megamek/common/BattleArmor.java
+++ b/megamek/src/megamek/common/BattleArmor.java
@@ -620,7 +620,7 @@ public class BattleArmor extends Infantry {
     public HitData rollHitLocation(int side, int aimedLocation, AimingMode aimingMode,
             boolean isAttackingConvInfantry) {
         // If this squad was killed, target trooper 1 (just because).
-        if (isDoomed()) {
+        if (isDoomed() || getNumberActiverTroopers() <= 0) {
             return new HitData(1);
         }
 

--- a/megamek/src/megamek/server/totalwarfare/TWDamageManagerModular.java
+++ b/megamek/src/megamek/server/totalwarfare/TWDamageManagerModular.java
@@ -1820,6 +1820,12 @@ public class TWDamageManagerModular extends TWDamageManager implements IDamageMa
                     // potentials?
                     nextHit = battleArmor.getTransferLocation(hit);
                     if (nextHit.getLocation() == Entity.LOC_DESTROYED) {
+
+                        // Entity destroyed.
+                        reportVec.addAll(
+                              manager.destroyEntity(battleArmor, "damage", true, false)
+                        );
+
                         // nowhere for further damage to go
                         damage = 0;
                     } else if (nextHit.getLocation() == Entity.LOC_NONE) {

--- a/megamek/src/megamek/server/totalwarfare/TWPhaseEndManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWPhaseEndManager.java
@@ -134,7 +134,7 @@ class TWPhaseEndManager {
                 gameManager.resolveOnlyWeaponAttacks();
                 gameManager.assignAMS();
                 gameManager.handleAttacks();
-                gameManager.resolveBoobyTraps();  // booby trap says it resolves "imediately"... could be problematic
+                gameManager.resolveBoobyTraps();  // booby trap says it resolves "immediately"... could be problematic
                 gameManager.resolveScheduledNukes();
                 gameManager.resolveScheduledOrbitalBombardments();
                 gameManager.applyBuildingDamage();


### PR DESCRIPTION
During the `damageEntity()` refactoring process, I skipped over a call to `destroyEntity()` in the new Battle Armor-specific function.
Originally it was gated behind a check for `!engineExplosion` and looked like it only applied to Meks and Vehicles, so I removed it.

This caused MegaMek to hang when attempting to destroy BA units because the rollForHitLocation() method would infinitely loop, trying to find the next location to destroy even after all troopers were killed.

Let this be a lesson: Always Destroy Battle Armor!

Patch also adds the ability to load recent nightly saves into the dev code of the same version (but not to or from releases).

Testing:
- Ran repo game with fixes
- Added a new unit test to confirm correct behaviour in both damage managers
- Ran all 3 projects' unit tests

Close #7159 
Close #7160 