### PR TITLE
(Multimap) Key dispatcher adaptations, remove unit load failure dlg

### DIFF
--- a/megamek/src/megamek/client/ui/clientGUI/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/ClientGUI.java
@@ -2461,7 +2461,7 @@ public class ClientGUI extends AbstractClientGUI
                         miniMaps.get(boardId).dispose();
                     }
                     BoardView boardView = new BoardView(client.getGame(), controller, ClientGUI.this, boardId);
-                    MinimapDialog newMinimap = new MinimapDialog(frame,ClientGUI.this);
+                    MinimapDialog newMinimap = new MinimapDialog(frame);
                     newMinimap.add(new MinimapPanel(newMinimap, client.getGame(), boardView, ClientGUI.this, null,
                           boardId));
                     newMinimap.setVisible(true);

--- a/megamek/src/megamek/client/ui/dialogs/minimap/MinimapDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/minimap/MinimapDialog.java
@@ -32,14 +32,12 @@
  */
 package megamek.client.ui.dialogs.minimap;
 
-import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 
 import megamek.client.ui.Messages;
-import megamek.client.ui.clientGUI.ClientGUI;
 import megamek.client.ui.clientGUI.GUIPreferences;
 import megamek.client.ui.util.UIUtil;
 
@@ -55,22 +53,19 @@ import megamek.client.ui.util.UIUtil;
  */
 public class MinimapDialog extends JDialog {
 
-    private final ClientGUI clientGUI;
     private static final GUIPreferences GUIP = GUIPreferences.getInstance();
 
     /**
      * Creates a new MiniMapDialog.
      *
-     * @param frame the parent frame for this dialog
-     * @param clientGUI the ClientGUI reference, which can be null for standalone usage
+     * @param frame     the parent frame for this dialog
      */
-    public MinimapDialog(final JFrame frame, final ClientGUI clientGUI) {
+    public MinimapDialog(final JFrame frame) {
         super(frame, "", false);
-        this.clientGUI = clientGUI;
-        this.setTitle(Messages.getString("ClientGUI.Minimap"));
+        setTitle(Messages.getString("ClientGUI.Minimap"));
 
-        this.setLocation(GUIP.getMinimapPosX(), GUIP.getMinimapPosY());
-        this.setResizable(false);
+        setLocation(GUIP.getMinimapPosX(), GUIP.getMinimapPosY());
+        setResizable(false);
 
         UIUtil.updateWindowBounds(this);
 
@@ -84,20 +79,18 @@ public class MinimapDialog extends JDialog {
     //endregion Constructors
 
     /**
-     * Saves the current size and position of the dialog to preferences.
-     * Different settings are stored based on whether the display is in
-     * tabbed or non-tabbed mode.
+     * Saves the current size and position of the dialog to preferences. Different settings are stored based on whether
+     * the display is in tabbed or non-tabbed mode.
      */
     public void saveSettings() {
-        if ((getSize().width * getSize().height) > 0) {
+        if (getSize().width * getSize().height > 0) {
             GUIP.setMinimapPosX(getLocation().x);
             GUIP.setMinimapPosY(getLocation().y);
         }
     }
 
     /**
-     * Overrides the default window event processing to save settings when
-     * the window is deactivated or closing.
+     * Overrides the default window event processing to save settings when the window is deactivated or closing.
      *
      * @param e the window event
      */
@@ -106,26 +99,6 @@ public class MinimapDialog extends JDialog {
         super.processWindowEvent(e);
         if ((e.getID() == WindowEvent.WINDOW_DEACTIVATED) || (e.getID() == WindowEvent.WINDOW_CLOSING)) {
             saveSettings();
-        }
-    }
-
-    /**
-     * Processes key events and forwards them to the client GUI to enable
-     * hotkey functionality throughout the application.
-     *
-     * @param evt the key event to process
-     */
-    @Override
-    protected void processKeyEvent(KeyEvent evt) {
-        if (clientGUI != null) {
-            evt.setSource(clientGUI);
-            clientGUI.getMenuBar().dispatchEvent(evt);
-            // Make the source be the ClientGUI and not the dialog
-            // This prevents a ClassCastException in ToolTipManager
-            clientGUI.getCurrentPanel().dispatchEvent(evt);
-        }
-        if (!evt.isConsumed()) {
-            super.processKeyEvent(evt);
         }
     }
 }

--- a/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/MegaMekUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/MegaMekUnitSelectorDialog.java
@@ -34,6 +34,7 @@ import megamek.common.enums.Gender;
 import megamek.common.options.OptionsConstants;
 import megamek.common.preference.ClientPreferences;
 import megamek.common.preference.PreferenceManager;
+import megamek.logging.MMLogger;
 
 import javax.swing.*;
 import java.awt.*;
@@ -44,6 +45,7 @@ import java.util.Map;
 public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
 
     private static final long serialVersionUID = -5717009055093904636L;
+    MMLogger LOGGER = MMLogger.create(MegaMekUnitSelectorDialog.class);
     //region Variable Declarations
     private ClientGUI clientGUI;
     private JComboBox<String> comboPlayer = new JComboBox<>();
@@ -200,8 +202,7 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
         if (mscInstance.isInitialized()) {
             final Map<String, String> hFailedFiles = MekSummaryCache.getInstance().getFailedFiles();
             if ((hFailedFiles != null) && !hFailedFiles.isEmpty()) {
-                // self-showing dialog
-                new UnitFailureDialog(frame, hFailedFiles);
+                LOGGER.warn("Unit loading errors: " + hFailedFiles);
             }
         }
     }

--- a/megamek/src/megamek/client/ui/panels/BoardEditorPanel.java
+++ b/megamek/src/megamek/client/ui/panels/BoardEditorPanel.java
@@ -1108,7 +1108,7 @@ public class BoardEditorPanel extends JPanel
         add(scrCenterPanel, BorderLayout.CENTER);
         add(panButtons, BorderLayout.PAGE_END);
 
-        minimapW = new MinimapDialog(frame, null);
+        minimapW = new MinimapDialog(frame);
         minimapW.add(new MinimapPanel(minimapW, game, bv, null, null, 0));
         minimapW.setVisible(guip.getMinimapEnabled());
     }


### PR DESCRIPTION
- Changes the boardview handler to make any boardviews that aren't shown (in a multimap game) to not listen to key presses. 
- Prevents the "unit loading failures" dialog from showing up everywhere (lobby, scenarios), instead adds a warning in the log (we have 4 errors atm)
- Removes a key listener from the minimap dialog class because it created exceptions in java's internal DefaultKeyDispatcher. I believe it's not necessary as the focus of minimaps is being managed elsewhere, but maybe we have to revisit that at some point.