### PR TITLE
(Multimap) Princess

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -304,6 +304,11 @@ public class FireControl {
             return new ToHitData(TH_NULL_POSITION);
         }
 
+        // For now, can't shoot if not on the same board
+        if (shooter.getBoardId() != target.getBoardId()) {
+            return new ToHitData(TH_RNG_TOO_FAR);
+        }
+
         // Is the target in range at all?
         final int maxRange = owner.getMaxWeaponRange(shooter, target.isAirborne());
         if (distance > maxRange) {
@@ -361,7 +366,7 @@ public class FireControl {
         LosEffects los = LosEffects.calculateLOS(game, shooter, target);
 
         // We want to check the target hex _and_ the intervening hexes for woods, smoke, etc.
-        final Hex targetHex = game.getBoard().getHex(targetState.getPosition());
+        final Hex targetHex = game.getBoard(target.getBoardId()).getHex(targetState.getPosition());
         int woodsLevel = targetHex.terrainLevel(Terrains.WOODS) +
             ((los.thruWoods()) ? los.getLightWoods() + los.getHeavyWoods() + los.getUltraWoods() : 0);
         if (targetHex.terrainLevel(Terrains.JUNGLE) > woodsLevel) {
@@ -489,8 +494,8 @@ public class FireControl {
         }
 
         // Check elevation difference.
-        final Hex attackerHex = game.getBoard().getHex(shooterState.getPosition());
-        final Hex targetHex = game.getBoard().getHex(targetState.getPosition());
+        final Hex attackerHex = game.getBoard(target).getHex(shooterState.getPosition());
+        final Hex targetHex = game.getBoard(target).getHex(targetState.getPosition());
         final int attackerElevation = shooter.getElevation() + attackerHex.getLevel();
         final int attackerHeight = shooter.relHeight() + attackerHex.getLevel();
         final int targetElevation = target.getElevation() + targetHex.getLevel();
@@ -789,7 +794,7 @@ public class FireControl {
 
         // Check range.
         int distance = shooterState.getPosition().distance(targetState.getPosition());
-        if (shooterState.isAirborne() && targetState.isAirborne() && game.getBoard().isGround()) {
+        if (shooterState.isAirborne() && targetState.isAirborne() && game.getBoard(target).isGround()) {
             // Aerospace firing at each on the ground map have immense range.
             distance /= 16;
         }
@@ -852,7 +857,7 @@ public class FireControl {
                 targetState.getPosition(), false);
 
         // water is a separate los effect
-        final Hex targetHex = game.getBoard().getHex(targetState.getPosition());
+        final Hex targetHex = game.getBoard(target).getHex(targetState.getPosition());
         Entity targetEntity = null;
         if (target instanceof Entity) {
             targetEntity = (Entity) target;
@@ -1139,7 +1144,7 @@ public class FireControl {
             if (weapon.isGroundBomb()
                     && !(weapon.getType().hasFlag(WeaponType.F_TAG) || weapon.getType().hasFlag(WeaponType.F_MISSILE))
             ) {
-                Hex hex = game.getBoard().getHex(target.getPosition());
+                Hex hex = game.getHexOf(target);
                 // If somehow we get an off-board hex, it's impossible to hit.
                 if (hex == null) {
                     return new ToHitData(TH_NULL_POSITION);
@@ -1739,19 +1744,24 @@ public class FireControl {
 
         // Shooting isn't possible if one of us isn't on the board.
         if ((null == shooter.getPosition()) || shooter.isOffBoard() ||
-                !game.getBoard().contains(shooter.getPosition())) {
+                !game.getBoard(shooter).contains(shooter.getPosition())) {
             logger.error("Shooter's position is NULL/Off Board!");
             return myPlan;
         }
-        if ((null == target.getPosition()) || target.isOffBoard() || !game.getBoard().contains(target.getPosition())) {
+        if ((null == target.getPosition()) || target.isOffBoard() || !game.getBoard(target).contains(target.getPosition())) {
             logger.error("Target's position is NULL/Off Board!");
+            return myPlan;
+        }
+
+        // For now, no shooting at targets on other boards
+        if (shooter.getBoardId() != target.getBoardId()) {
             return myPlan;
         }
 
         if (shooter.isAirborne()
                 && shooter.isLargeCraft()
                 && shooter.isSpheroid()
-                && game.getBoard().isGround()
+                && game.getBoard(shooter).isGround()
                 && !target.isAirborne()) {
             // This process takes a long time for no reason; the likelihood of being able to
             // strike or hit an enemy (other than Aero) is next to nil.
@@ -1881,12 +1891,12 @@ public class FireControl {
 
         // Shooting isn't possible if one of us isn't on the board.
         if ((null == shooter.getPosition()) || shooter.isOffBoard() ||
-                !game.getBoard().contains(shooter.getPosition())) {
+                !game.getBoard(shooter).contains(shooter.getPosition())) {
             logger.error("Shooter's position is NULL/Off Board!");
             return myPlan;
         }
 
-        if ((null == target.getPosition()) || target.isOffBoard() || !game.getBoard().contains(target.getPosition())) {
+        if ((null == target.getPosition()) || target.isOffBoard() || !game.getBoard(target).contains(target.getPosition())) {
             logger.error("Target's position is NULL/Off Board!");
             return myPlan;
         }
@@ -1903,7 +1913,7 @@ public class FireControl {
             return myPlan;
         }
 
-        if (shooter.isAirborne() && shooter.isLargeCraft() && shooter.isSpheroid() && game.getBoard().isGround()) {
+        if (shooter.isAirborne() && shooter.isLargeCraft() && shooter.isSpheroid() && game.getBoard(shooter).isGround()) {
             // This process takes a long time for no reason; the likelihood of being able to
             // strike or hit an enemy Aero is next to nil.
             logger.debug(
@@ -2015,7 +2025,7 @@ public class FireControl {
         // 3. Target is Submarine too far below surface level
         if (target.getTargetType() == Targetable.TYPE_ENTITY) {
             Entity entity = (Entity) target;
-            Hex hex = game.getBoard().getHex(entity.getPosition());
+            Hex hex = game.getHexOf(entity);
             hexToBomb.setTargetLevel((hex != null) ? hex.getLevel() : 0);
 
             if (entity.isAirborne()) {
@@ -2115,11 +2125,11 @@ public class FireControl {
 
         // Shooting isn't possible if one of us isn't on the board.
         if ((null == shooter.getPosition()) || shooter.isOffBoard() ||
-                !game.getBoard().contains(shooter.getPosition())) {
+                !game.getBoard(shooter).contains(shooter.getPosition())) {
             logger.error("Shooter's position is NULL/Off Board!");
             return myPlan;
         }
-        if ((null == target.getPosition()) || target.isOffBoard() || !game.getBoard().contains(target.getPosition())) {
+        if ((null == target.getPosition()) || target.isOffBoard() || !game.getBoard(target).contains(target.getPosition())) {
             logger.error("Target's position is NULL/Off Board!");
             return myPlan;
         }
@@ -3720,7 +3730,7 @@ public class FireControl {
                     continue;
                 }
 
-                for (Entity ent : shooter.getGame().getEntitiesVector(intervening, true)) {
+                for (Entity ent : shooter.getGame().getEntitiesVector(intervening, shooter.getBoardId(), true)) {
                     // don't count ourselves, or the target if it's already lit itself up
                     // or the target if it will be lit up by a previously declared search light
                     if ((ent.getId() == shooter.getId()) || ent.isIlluminated()) {

--- a/megamek/src/megamek/client/bot/princess/IPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/IPathRanker.java
@@ -46,11 +46,12 @@ public interface IPathRanker {
      * Gives the distance to the closest edge
      *
      * @param position Final coordinates of the proposed move.
+     * @param boardId The board on which to look
      * @param homeEdge Unit's home edge.
      * @param game The current {@link Game}
      * @return The distance, in hexes to the unit's home edge.
      */
-    int distanceToHomeEdge(Coords position, CardinalEdge homeEdge, Game game);
+    int distanceToHomeEdge(Coords position, int boardId, CardinalEdge homeEdge, Game game);
 
     /**
      * Returns the best path of a list of ranked paths.

--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -227,13 +227,13 @@ public class PathEnumerator {
                 npf.run(new MovePath(game, mover, wayPoint));
                 paths.addAll(npf.getAllComputedPathsUncategorized());
                 // this handles the case of the mover being an aerospace unit on a space map
-            } else if (mover.isAero() && game.getBoard().isSpace()) {
+            } else if (mover.isAero() && game.getBoard(mover).isSpace()) {
                 AeroSpacePathFinder apf = AeroSpacePathFinder.getInstance(getGame());
                 apf.run(new MovePath(game, mover, wayPoint));
                 paths.addAll(apf.getAllComputedPathsUncategorized());
                 // this handles the case of the mover being a winged aerospace unit on a
                 // low-atmosphere map
-            } else if (mover.isAero() && game.getBoard().isLowAltitude()
+            } else if (mover.isAero() && game.getBoard(mover).isLowAltitude()
                     && !Compute.useSpheroidAtmosphere(game, mover)) {
                 AeroLowAltitudePathFinder apf = AeroLowAltitudePathFinder.getInstance(getGame());
                 apf.run(new MovePath(game, mover, wayPoint));
@@ -287,7 +287,7 @@ public class PathEnumerator {
                     ShortestPathFinder spf = ShortestPathFinder.newInstanceOfOneToAll(mover.getAnyTypeMaxJumpMP(),
                             MoveStepType.FORWARDS, getGame());
                     spf.setComparator(new MovePathMinefieldAvoidanceMinMPMaxDistanceComparator());
-                    spf.run((new MovePath(game, mover, wayPoint)).addStep(MoveStepType.START_JUMP));
+                    spf.run(new MovePath(game, mover, wayPoint).addStep(MoveStepType.START_JUMP));
                     paths.addAll(spf.getAllComputedPathsUncategorized());
                 }
 
@@ -324,7 +324,7 @@ public class PathEnumerator {
             // calculate bounding area for move
             ConvexBoardArea myArea = new ConvexBoardArea();
             myArea.addCoordFacingCombos(getUnitPotentialLocations().get(
-                    mover.getId()).iterator(), owner.getBoard());
+                    mover.getId()).iterator(), owner.getGame().getBoard(mover));
             getUnitMovableAreas().put(mover.getId(), myArea);
 
             return true;
@@ -433,9 +433,9 @@ public class PathEnumerator {
     private void adjustPathForBridge(MovePath path) {
         boolean needsAdjust = false;
         for (Coords c : path.getCoordsSet()) {
-            Hex hex = getGame().getBoard().getHex(c);
+            Hex hex = getGame().getBoard(path.getFinalBoardId()).getHex(c);
             if ((hex != null) && hex.containsTerrain(Terrains.BRIDGE)) {
-                if (getGame().getBoard().getBuildingAt(c).getCurrentCF(c) >= path.getEntity().getWeight()) {
+                if (getGame().getBoard(path.getFinalBoardId()).getBuildingAt(c).getCurrentCF(c) >= path.getEntity().getWeight()) {
                     needsAdjust = true;
                     break;
                 } else {
@@ -550,7 +550,7 @@ public class PathEnumerator {
                 return mapHasBridges.get();
             }
 
-            mapHasBridges = new AtomicBoolean(getGame().getBoard().containsBridges());
+            mapHasBridges = new AtomicBoolean(getGame().hasBridges());
         }
 
         return mapHasBridges.get();

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -438,19 +438,10 @@ public abstract class PathRanker implements IPathRanker {
         return SharedUtility.getPSRList(path);
     }
 
-    /**
-     * Returns distance to the unit's home edge.
-     * Gives the distance to the closest edge
-     *
-     * @param position Final coordinates of the proposed move.
-     * @param homeEdge Unit's home edge.
-     * @param game     The current {@link Game}
-     * @return The distance to the unit's home edge.
-     */
     @Override
-    public int distanceToHomeEdge(Coords position, CardinalEdge homeEdge, Game game) {
-        int width = game.getBoard().getWidth();
-        int height = game.getBoard().getHeight();
+    public int distanceToHomeEdge(Coords position, int boardId, CardinalEdge homeEdge, Game game) {
+        int width = game.getBoard(boardId).getWidth();
+        int height = game.getBoard(boardId).getHeight();
 
         int distance;
         switch (homeEdge) {
@@ -575,6 +566,11 @@ public abstract class PathRanker implements IPathRanker {
         int xTotal = 0;
         int yTotal = 0;
         int friendOnBoardCount = 0;
+        Entity me = game.getEntity(myId);
+        if (me == null) {
+            return null;
+        }
+        Board board = game.getBoard(me);
 
         for (Entity friend : friends) {
             if (friend.getId() == myId) {
@@ -582,11 +578,11 @@ public abstract class PathRanker implements IPathRanker {
             }
 
             // Skip any friends not on the board.
-            if (friend.isOffBoard()) {
+            if (friend.isOffBoard() || !game.onTheSameBoard(me, friend)) {
                 continue;
             }
             Coords friendPosition = friend.getPosition();
-            if ((friendPosition == null) || !game.getBoard().contains(friendPosition)) {
+            if ((friendPosition == null) || !board.contains(friendPosition)) {
                 continue;
             }
 
@@ -603,7 +599,7 @@ public abstract class PathRanker implements IPathRanker {
         int yCenter = Math.round((float) yTotal / friendOnBoardCount);
         Coords center = new Coords(xCenter, yCenter);
 
-        if (!game.getBoard().contains(center)) {
+        if (!board.contains(center)) {
             logger.error("Center of ally group " + center.toFriendlyString()
                     + " not within board boundaries.");
             return null;

--- a/megamek/src/megamek/client/bot/princess/Precognition.java
+++ b/megamek/src/megamek/client/bot/princess/Precognition.java
@@ -817,7 +817,8 @@ public class Precognition implements Runnable {
 
     @SuppressWarnings("unchecked")
     private void receiveBuildingCollapse(Packet packet) {
-        getGame().getBoard().collapseBuilding((Vector<Coords>) packet.getObject(0));
+        int boardId = packet.getIntValue(1);
+        game.getBoard(boardId).collapseBuilding((Vector<Coords>) packet.getObject(0));
     }
 
     /**

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -2193,7 +2193,8 @@ public class Princess extends BotClient {
             return false;
         } else if (!entity.canFlee(entity.getPosition())) {
             return false;
-        } else if (0 < getPathRanker(entity).distanceToHomeEdge(entity.getPosition(), getHomeEdge(entity), getGame())) {
+        } else if (0 < getPathRanker(entity).distanceToHomeEdge(entity.getPosition(), entity.getBoardId(),
+              getHomeEdge(entity), getGame())) {
             return false;
         } else if (!getFleeBoard() && !(entity.isCrippled() && getForcedWithdrawal())) {
             return false;

--- a/megamek/src/megamek/client/bot/princess/UtilityPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/UtilityPathRanker.java
@@ -350,8 +350,11 @@ public class UtilityPathRanker extends BasicPathRanker {
         UnitBehavior.BehaviorType behaviorType = getOwner().getUnitBehaviorTracker().getBehaviorType(movingUnit, getOwner());
         double weight = getOwner().getBehaviorSettings().getSelfPreservationIndex() / 10.0;
         if (behaviorType == UnitBehavior.BehaviorType.ForcedWithdrawal || behaviorType == UnitBehavior.BehaviorType.MoveToDestination) {
-            int newDistanceToHome = distanceToHomeEdge(path.getFinalCoords(), getOwner().getHomeEdge(movingUnit), game);
-            int currentDistanceToHome = distanceToHomeEdge(path.getEntity().getPosition(), getOwner().getHomeEdge(movingUnit), game);
+            int newDistanceToHome = distanceToHomeEdge(path.getFinalCoords(), path.getFinalBoardId(),
+                  getOwner().getHomeEdge(movingUnit),
+                  game);
+            int currentDistanceToHome = distanceToHomeEdge(path.getEntity().getPosition(),
+                  path.getEntity().getBoardId(), getOwner().getHomeEdge(movingUnit), game);
 
             double deltaDistance = currentDistanceToHome - newDistanceToHome;
             double selfPreservationMod;

--- a/megamek/src/megamek/client/ui/util/EntityWreckHelper.java
+++ b/megamek/src/megamek/client/ui/util/EntityWreckHelper.java
@@ -37,7 +37,7 @@ public class EntityWreckHelper {
         // for units that were destroyed by ejection rather than unit destruction
         // for units on top of a bridge (looks kind of stupid)
 
-        if (entity.getGame().getBoard().isSpace() ||
+        if (entity.getGame().getBoard(entity).isSpace() ||
                 (entity instanceof Mek) ||
                 (entity instanceof Infantry) ||
                 (entity instanceof GunEmplacement) ||
@@ -62,7 +62,7 @@ public class EntityWreckHelper {
                 (entity.getMovementMode() != EntityMovementMode.VTOL) &&
                 (entity.getEngine().getEngineType() == Engine.COMBUSTION_ENGINE) &&
                 entity.isPermanentlyImmobilized(false) &&
-                !entity.getGame().getBoard().isSpace() &&
+                !entity.getGame().getBoard(entity).isSpace() &&
                 !entityOnBridge(entity);
     }
 
@@ -76,7 +76,7 @@ public class EntityWreckHelper {
                         (entity.getMovementMode() == EntityMovementMode.TRACKED))
                 &&
                 entity.getSecondaryPositions().isEmpty() &&
-                !entity.getGame().getBoard().isSpace() &&
+                !entity.getGame().getBoard(entity).isSpace() &&
                 !entityOnBridge(entity);
     }
 
@@ -131,7 +131,7 @@ public class EntityWreckHelper {
      * Utility function that determines if the entity is on a bridge
      */
     public static boolean entityOnBridge(Entity entity) {
-        Hex hex = entity.getGame().getBoard().getHex(entity.getPosition());
+        Hex hex = entity.getGame().getBoard(entity).getHex(entity.getPosition());
         if (hex != null) {
             boolean hexHasBridge = hex.containsTerrain(Terrains.BRIDGE_CF);
 

--- a/megamek/src/megamek/common/Board.java
+++ b/megamek/src/megamek/common/Board.java
@@ -1789,6 +1789,9 @@ public class Board implements Serializable {
     }
 
     public boolean containsBridges() {
+        if (isSpace() || isSky()) {
+            return false;
+        }
         for (Coords c : bldgByCoords.keySet()) {
             Hex hex = getHex(c);
             if (hex.containsTerrain(Terrains.BRIDGE)) {

--- a/megamek/src/megamek/common/BulldozerMovePath.java
+++ b/megamek/src/megamek/common/BulldozerMovePath.java
@@ -188,7 +188,7 @@ public class BulldozerMovePath extends MovePath {
      * to a form through which the current unit can move
      */
     public static int calculateLevelingCost(Coords finalCoords, Entity entity) {
-        Board board = entity.getGame().getBoard();
+        Board board = entity.getGame().getBoard(entity);
         Hex destHex = board.getHex(finalCoords);
         int levelingCost = CANNOT_LEVEL;
 

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -4165,7 +4165,7 @@ public class Compute {
                 // In Low Altitude, Airborne aeros can only see ground targets
                 // they overfly, and only at Alt <=8. It should also spot units
                 // next to this; Low-atmo board with ground units isn't implemented
-                if (game.getBoard().isLowAltitude()) {
+                if (game.isOnAtmosphericMap(attackingEntity)) {
                     if (attackingEntity.getAltitude() > 8) {
                         return false;
                     }
@@ -4781,7 +4781,7 @@ public class Compute {
         // For Space games with this option, return something different
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ADVANCED_SENSORS)
                 && target.getTargetType() == Targetable.TYPE_ENTITY
-                && game.getBoard().isSpace()) {
+                && game.getBoard(target).isSpace()) {
             Entity te = (Entity) target;
             return hasSensorContact(ae, te.getId());
         }
@@ -4792,6 +4792,11 @@ public class Compute {
 
         // if either does not have a position then return false
         if ((ae.getPosition() == null) || (target.getPosition() == null)) {
+            return false;
+        }
+
+        // For now, units that are not on the same board are not is sensor range
+        if (!game.onTheSameBoard(ae, target)) {
             return false;
         }
 
@@ -4834,7 +4839,7 @@ public class Compute {
         // find an enemy aero on the map
         // but still won't be able to see it and shoot at it beyond normal visual
         // conditions.
-        if (isAirToAir(game, ae, target) && game.getBoard().isGround()) {
+        if (isAirToAir(game, ae, target) && game.getBoard(ae).isGround()) {
             distance = (int) Math.ceil(distance / 16.0);
         }
         return (distance > minSensorRange) && (distance <= maxSensorRange);

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -4108,7 +4108,7 @@ public class Compute {
         // Use firing solution if Advanced Sensors is on
         if (game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ADVANCED_SENSORS)
                 && target.getTargetType() == Targetable.TYPE_ENTITY
-                && game.getBoard().isSpace()) {
+                && game.getBoard(target).isSpace()) {
             Entity te = (Entity) target;
             return hasAnyFiringSolution(game, te.getId());
         }
@@ -4123,7 +4123,8 @@ public class Compute {
 
         // Target may be in an illuminated hex
         if (!teIlluminated) {
-            teIlluminated = !IlluminationLevel.determineIlluminationLevel(game, target.getPosition()).isNone();
+            teIlluminated = !IlluminationLevel.determineIlluminationLevel(game, target.getBoardId(),
+                  target.getPosition()).isNone();
         }
 
         // if either does not have a position then return false

--- a/megamek/src/megamek/common/Game.java
+++ b/megamek/src/megamek/common/Game.java
@@ -3600,7 +3600,7 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
      *       every 7th game round is a space round (TW p.78)
      */
     public boolean isSpaceRound() {
-        //FIXME only for testing:
+        //FIXME only for testing, so that space units can act every round
         return true;
         // This is correct:
 //        return !hasSpaceAndAtmosphericBoards() || ((getRoundCount() > 0) && (getRoundCount() % 7 == 0));
@@ -3613,5 +3613,12 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
      */
     public boolean isAtmosphericRound() {
         return !hasSpaceAndAtmosphericBoards() || (getRoundCount() % 7 != 0) || getRoundCount() == 0;
+    }
+
+    /**
+     * @return True if any map in this game contains any bridges. Used for Princess calculations.
+     */
+    public boolean hasBridges() {
+        return getBoards().values().stream().anyMatch(Board::containsBridges);
     }
 }

--- a/megamek/src/megamek/common/IGame.java
+++ b/megamek/src/megamek/common/IGame.java
@@ -38,6 +38,8 @@ public interface IGame {
 
     MMLogger LOGGER = MMLogger.create(IGame.class);
 
+    int DEFAULT_BOARD_ID = 0;
+
     // region Player turns
 
     @Nullable

--- a/megamek/src/megamek/common/LosEffects.java
+++ b/megamek/src/megamek/common/LosEffects.java
@@ -69,7 +69,7 @@ public class LosEffects {
         public Coords targetPos;
         // default to the standard single board unless specifically set; los tracing only works on a single board; if
         // attacker and target are on different boards, one must be placed on an assumed position on the other's board
-        public int boardId = 0;
+        public int boardId = IGame.DEFAULT_BOARD_ID;
 
         /**
          * The absolute elevation of the attacker, i.e. the number of levels attacker is placed above a level 0 hex.
@@ -483,6 +483,9 @@ public class LosEffects {
             int atmosphericBoardId = BoardHelper.enclosingBoardId(game, target.getBoardLocation());
             targetPositions.add(BoardHelper.positionOnEnclosingBoard(game, atmosphericBoardId));
             boardId = attacker.getBoardId();
+        } else if (Compute.isAirToGround(attacker, target)) {
+            attackerPositions.clear();
+            attackerPositions.add(target.getPosition());
         }
 
         LosEffects bestLOS = null;
@@ -513,7 +516,7 @@ public class LosEffects {
           final @Nullable Coords targetPosition,
           final boolean spotting) {
         // LEGACY - in time, replace with the correct boardId
-        return  calculateLOS(game, attacker, target, attackerPosition, targetPosition, 0, spotting);
+        return  calculateLOS(game, attacker, target, attackerPosition, targetPosition, IGame.DEFAULT_BOARD_ID, spotting);
     }
 
     /**

--- a/megamek/src/megamek/common/actions/PhysicalAttackAction.java
+++ b/megamek/src/megamek/common/actions/PhysicalAttackAction.java
@@ -105,12 +105,12 @@ public class PhysicalAttackAction extends AbstractAttackAction {
             // target unit in building checks
             final boolean targetInBuilding = Compute.isInBuilding(game, te);
             if (targetInBuilding) {
-                Building TargBldg = game.getBoard().getBuildingAt(te.getPosition());
+                Building TargBldg = game.getBoard(target).getBuildingAt(te.getPosition());
 
                 // Can't target units in buildings (from the outside).
                 if (!Compute.isInBuilding(game, ae)) {
                     return "Target is inside building";
-                } else if (!game.getBoard().getBuildingAt(ae.getPosition()).equals(TargBldg)) {
+                } else if (!game.getBoard(target).getBuildingAt(ae.getPosition()).equals(TargBldg)) {
                     return "Target is inside different building";
                 }
             }
@@ -225,7 +225,7 @@ public class PhysicalAttackAction extends AbstractAttackAction {
                 }
             }
 
-            Hex targHex = game.getBoard().getHex(te.getPosition());
+            Hex targHex = game.getHexOf(te);
             // water partial cover?
             if ((te.height() > 0) && (te.getElevation() == -1)
                     && (targHex.terrainLevel(Terrains.WATER) == te.height())) {

--- a/megamek/src/megamek/common/moves/MoveStep.java
+++ b/megamek/src/megamek/common/moves/MoveStep.java
@@ -508,13 +508,11 @@ public class MoveStep implements Serializable {
             setElevation(getElevation() + 1);
         } else if (isJumping()) {
             Hex hex = game.getBoard(boardId).getHex(getPosition());
-            Optional<Building> optionalBuilding = Optional.ofNullable(game.getBoard()
-                                                                            .getBuildingAt(entity.getPosition()));
+            Optional<Building> optionalBuilding = game.getBuildingAt(entity.getPosition(), boardId);
 
             boolean isInsideTheSameBuilding = false;
             if (optionalBuilding.isPresent()) {
-                Optional<Building> optionalBuildingAtCurrentStep = Optional.ofNullable(game.getBoard()
-                                                                                             .getBuildingAt(getPosition()));
+                Optional<Building> optionalBuildingAtCurrentStep = game.getBuildingAt(getPosition(), boardId);
                 if (optionalBuildingAtCurrentStep.isPresent()) {
                     isInsideTheSameBuilding = optionalBuildingAtCurrentStep.get().equals(optionalBuilding.get());
                 }
@@ -1663,14 +1661,14 @@ public class MoveStep implements Serializable {
         } // end AERO stuff
 
         if (isInfantry && isJumping() && stepType == MoveStepType.DOWN) {
-            if (game.getBoard().getHex(curPos).containsTerrain(Terrains.BUILDING)) {
+            if (game.getBoard(boardId).getHex(curPos).containsTerrain(Terrains.BUILDING)) {
                 Coords startingPosition = entity.getPosition();
                 Coords adjacentCoords = curPos.translated(curPos.direction(startingPosition));
-                Hex adjacentHex = game.getBoard().getHex(adjacentCoords);
+                Hex adjacentHex = game.getHex(adjacentCoords, boardId);
 
                 boolean hasLOS = LosEffects.calculateLOS(game,
                       entity,
-                      new FloorTarget(curPos, game.getBoard(), getElevation())).canSee();
+                      new FloorTarget(curPos, game.getBoard(boardId), getElevation())).canSee();
 
                 if (adjacentHex.ceiling() >= getElevation() || !hasLOS) {
                     return; // can't enter the building from this direction

--- a/megamek/src/megamek/common/pathfinder/AeroGroundPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/AeroGroundPathFinder.java
@@ -301,7 +301,7 @@ public class AeroGroundPathFinder {
 
         boolean firstTurn = true;
         while (mp.length() < STACK_DEPTH && straightLine.getFinalVelocityLeft() > 0 &&
-                game.getBoard().contains(straightLine.getFinalCoords())) {
+                game.getBoard(mp.getFinalBoardId()).contains(straightLine.getFinalCoords())) {
 
             // little dirty hack to get around the problem where if this is the first step
             // of a path

--- a/megamek/src/megamek/common/pathfinder/BoardClusterTracker.java
+++ b/megamek/src/megamek/common/pathfinder/BoardClusterTracker.java
@@ -199,7 +199,7 @@ public class BoardClusterTracker {
         Set<Coords> retVal = Collections.emptySet();
 
         if (entityCluster != null) {
-            retVal = entityCluster.getIntersectingHexes(actualEdge, entity.getGame().getBoard());
+            retVal = entityCluster.getIntersectingHexes(actualEdge, entity.getGame().getBoard(entity));
         }
 
         // try with bridges
@@ -211,7 +211,7 @@ public class BoardClusterTracker {
             }
 
             if (entityCluster != null) {
-                retVal = entityCluster.getIntersectingHexes(actualEdge, entity.getGame().getBoard());
+                retVal = entityCluster.getIntersectingHexes(actualEdge, entity.getGame().getBoard(entity));
             }
         }
 
@@ -313,7 +313,7 @@ public class BoardClusterTracker {
             return clusters;
         }
 
-        Board board = entity.getGame().getBoard();
+        Board board = entity.getGame().getBoard(entity);
         int clusterID = 0;
 
         MovementType movementType = MovementType.getMovementType(entity);
@@ -427,7 +427,7 @@ public class BoardClusterTracker {
         // meks can climb over buildings that won't collapse under them
         // the relative height comparison is handled elsewhere
 
-        Board board = entity.getGame().getBoard();
+        Board board = entity.getGame().getBoard(entity);
         Hex hex = board.getHex(coords);
 
         if (!hex.containsTerrain(Terrains.BLDG_CF) && !hex.containsExit(Terrains.FUEL_TANK_CF)) {

--- a/megamek/src/megamek/common/pathfinder/BoardEdgePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/BoardEdgePathFinder.java
@@ -73,7 +73,7 @@ public class BoardEdgePathFinder {
      * @return the Board.START_ constant representing the "opposite" edge
      */
     private int determineOppositeEdge(Entity entity) {
-        Board board = entity.getGame().getBoard();
+        Board board = entity.getGame().getBoard(entity);
 
         // the easiest part is if the entity is supposed to start on a particular edge.
         // Just return the opposite edge.
@@ -137,13 +137,13 @@ public class BoardEdgePathFinder {
             case Board.START_S:
                 return 3;
             case Board.START_E:
-                if (entity.getPosition().getY() < entity.getGame().getBoard().getHeight() / 2) {
+                if (entity.getPosition().getY() < entity.getGame().getBoard(entity).getHeight() / 2) {
                     return 2;
                 } else {
                     return 1;
                 }
             case Board.START_W:
-                if (entity.getPosition().getY() < entity.getGame().getBoard().getHeight() / 2) {
+                if (entity.getPosition().getY() < entity.getGame().getBoard(entity).getHeight() / 2) {
                     return 4;
                 } else {
                     return 5;
@@ -553,7 +553,7 @@ public class BoardEdgePathFinder {
      */
     protected MoveLegalityIndicator isLegalMove(MovePath movePath) {
         Coords dest = movePath.getFinalCoords();
-        Board board = movePath.getGame().getBoard();
+        Board board = movePath.getGame().getBoard(movePath.getFinalBoardId());
         Hex destHex = board.getHex(dest);
         Building destinationBuilding = board.getBuildingAt(dest);
 
@@ -573,7 +573,7 @@ public class BoardEdgePathFinder {
      */
     private MoveLegalityIndicator isLegalMove(MovePath movePath, Hex destHex, Building destinationBuilding) {
         Coords dest = movePath.getFinalCoords();
-        Board board = movePath.getGame().getBoard();
+        Board board = movePath.getGame().getBoard(movePath.getFinalBoardId());
         Coords src = movePath.getSecondLastStep().getPosition();
         Hex srcHex = board.getHex(src);
         Entity entity = movePath.getEntity();
@@ -749,9 +749,9 @@ public class BoardEdgePathFinder {
             case Board.START_N:
                 return coords.getY() == 0;
             case Board.START_S:
-                return coords.getY() == movePath.getGame().getBoard().getHeight() - 1;
+                return coords.getY() == movePath.getGame().getBoard(movePath.getFinalBoardId()).getHeight() - 1;
             case Board.START_E:
-                return coords.getX() == movePath.getGame().getBoard().getWidth() - 1;
+                return coords.getX() == movePath.getGame().getBoard(movePath.getFinalBoardId()).getWidth() - 1;
             case Board.START_W:
                 return coords.getX() == 0;
             default:

--- a/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
+++ b/megamek/src/megamek/common/pathfinder/DestructionAwareDestinationPathfinder.java
@@ -135,7 +135,7 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
         int bestDistance = Integer.MAX_VALUE;
 
         for (Coords coords : destinationRegion) {
-            if (!entity.getGame().getBoard().contains(coords)) {
+            if (!entity.getGame().getBoard(entity).contains(coords)) {
                 continue;
             }
 
@@ -227,9 +227,9 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
                 (child.getEntity().getMaxElevationDown() == Entity.UNLIMITED_JUMP_DOWN)
                         && (Math.abs(mli.elevationChange) > child.getEntity().getMaxElevationChange());
 
-        boolean destinationUseBridge = child.getGame().getBoard().getHex(destinationCoords)
+        boolean destinationUseBridge = child.getGame().getBoard(child.getFinalBoardId()).getHex(destinationCoords)
                 .getTerrain(Terrains.BRIDGE) != null;
-        int destHexElevation = calculateUnitElevationInHex(child.getGame().getBoard().getHex(destinationCoords),
+        int destHexElevation = calculateUnitElevationInHex(child.getGame().getBoard(child.getFinalBoardId()).getHex(destinationCoords),
                 child.getEntity(), child.getEntity().getMovementMode() == EntityMovementMode.HOVER,
                 child.getCachedEntityState().isAmphibious(),
                 destinationUseBridge);
@@ -278,7 +278,7 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
             return friendlyFireCheckResults.get(position);
         }
 
-        Building building = game.getBoard().getBuildingAt(position);
+        Building building = game.getBoard(shooter).getBuildingAt(position);
 
         // no building, no problem
         if (building == null) {
@@ -290,7 +290,7 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
         // criteria:
         // - is friendly
         // - if we care only about mobile units, has no MP
-        for (Entity entity : game.getEntitiesVector(position, true)) {
+        for (Entity entity : game.getEntitiesVector(position, shooter.getBoardId(), true)) {
             if (!entity.isEnemyOf(shooter)
                     && (includeMobileUnits || (entity.getWalkMP(MPCalculationSetting.STANDARD) == 0))) {
                 friendlyFireCheckResults.put(position, true);
@@ -307,7 +307,7 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
      * breached legs and effectively immobilize it.
      */
     private boolean underwaterLegBreachCheck(BulldozerMovePath path) {
-        Hex hex = path.getGame().getBoard().getHex(path.getFinalCoords());
+        Hex hex = path.getGame().getBoard(path.getFinalBoardId()).getHex(path.getFinalCoords());
 
         // investigate: do we want quad meks with a single breached leg to risk this
         // move? Currently not, but if we did, this is probably where this logic would
@@ -341,7 +341,7 @@ public class DestructionAwareDestinationPathfinder extends BoardEdgePathFinder {
          */
         @Override
         public int compare(BulldozerMovePath first, BulldozerMovePath second) {
-            Board board = first.getGame().getBoard();
+            Board board = first.getGame().getBoard(first.getFinalBoardId());
             boolean backwards = false;
             int h1 = first.getFinalCoords().distance(destination)
                     + ShortestPathFinder.getLevelDiff(first, destination, board, false)

--- a/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/ShortestPathFinder.java
@@ -266,11 +266,8 @@ public class ShortestPathFinder extends MovePathFinder<MovePath> {
      * @param stepType the type of step to use
      * @param game     The current {@link Game}
      */
-    public static ShortestPathFinder newInstanceOfOneToAll(final int maxMP, final MoveStepType stepType,
-            final Game game) {
-        ShortestPathFinder shortestPathFinder = new ShortestPathFinder(
-                new ShortestPathFinder.MovePathRelaxer(),
-                new ShortestPathFinder.MovePathMPCostComparator(),
+    public static ShortestPathFinder newInstanceOfOneToAll(int maxMP, MoveStepType stepType, Game game) {
+        var shortestPathFinder = new ShortestPathFinder(new MovePathRelaxer(), new MovePathMPCostComparator(),
                 stepType, game);
         shortestPathFinder.addFilter(new MovePathLengthFilter(maxMP));
         shortestPathFinder.addFilter(new MovePathLegalityFilter(game));

--- a/megamek/src/megamek/common/util/BoardUtilities.java
+++ b/megamek/src/megamek/common/util/BoardUtilities.java
@@ -1922,7 +1922,7 @@ public class BoardUtilities {
      * @return the Board.START_ constant representing the "opposite" edge
      */
     public static CardinalEdge determineOppositeEdge(Entity entity) {
-        Board board = entity.getGame().getBoard();
+        Board board = entity.getGame().getBoard(entity);
 
         // the easiest part is if the entity is supposed to start on a particular edge. Just return the opposite edge.
         int oppositeEdge = board.getOppositeEdge(entity.getStartingPos());

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -661,7 +661,7 @@ public class TWGameManager extends AbstractGameManager {
             send(connId, createArtilleryPacket(player));
             send(connId, createFlarePacket());
             for (int boardId : game.getBoardIds()) {
-                send(createSpecialHexDisplayPacket(connId, boardId));
+                send(connId, createSpecialHexDisplayPacket(connId, boardId));
             }
             send(connId, new Packet(PacketCommand.PRINCESS_SETTINGS, getGame().getBotSettings()));
             send(connId, new Packet(PacketCommand.UPDATE_GROUND_OBJECTS, getGame().getGroundObjects()));

--- a/megamek/src/megamek/server/totalwarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalwarfare/TWGameManager.java
@@ -10813,7 +10813,7 @@ public class TWGameManager extends AbstractGameManager {
 
         // Get the entity's current hex.
         Coords coords = entity.getPosition();
-        Hex curHex = game.getBoard().getHex(coords);
+        Hex curHex = game.getHexOf(entity);
 
         Report r;
 
@@ -11388,7 +11388,7 @@ TargetRoll nTargetRoll,
                                          ((toHit.getMoS() / 3) >= 1);
 
         // Which building takes the damage?
-        Building bldg = game.getBoard().getBuildingAt(target.getPosition());
+        Building bldg = game.getBoard(target).getBuildingAt(target.getPosition());
 
         if (lastEntityId != paa.getEntityId()) {
             // report who is making the attacks

--- a/megamek/testresources/data/scenarios/test_setups/multiboard_single.mms
+++ b/megamek/testresources/data/scenarios/test_setups/multiboard_single.mms
@@ -17,7 +17,7 @@ options:
     - check_victory
 
 factions:
-- name: P1
+- name: Hooman
   deploy: S
 #  deploy:
 #    area:
@@ -36,24 +36,25 @@ factions:
 
   units:
     - fullname: Grasshopper GHR-5N
-      at: [ 13, 12 ]
+#      at: [ 13, 12 ]
       board: 3
       facing: 0
 
-    - fullname: Atlas AS7-D
-      at: [ 15, 13 ]
-      board: 3
-      facing: 0
+#    - fullname: Atlas AS7-D
+#      at: [ 15, 13 ]
+#      board: 3
+#      facing: 0
 
 
 - name: Princess
+  deploy: N
   units:
     - fullname: Grasshopper GHR-5N
-      at: [ 4, 4 ]
+#      at: [ 4, 4 ]
       board: 3
       facing: 3
 
-    - fullname: Atlas AS7-D
-      at: [ 7, 3 ]
-      board: 3
-      facing: 3
+#    - fullname: Atlas AS7-D
+#      at: [ 7, 3 ]
+#      board: 3
+#      facing: 3

--- a/megamek/testresources/data/scenarios/test_setups/multiboard_single.mms
+++ b/megamek/testresources/data/scenarios/test_setups/multiboard_single.mms
@@ -1,7 +1,8 @@
 MMSVersion: 2
-name: Test Setup no 2 for multiple boards
+name: Multiboard Playtest Scenario
 planet: None
-description: uses a single board of ID != 0 (multiboard requires this to no longer break anywhere)
+description: Your lone Grasshopper is attacked by two Grasshoppers. You have a Sai aerospace fighter to support your 
+  mek.
 map:
   - file: Beginner Box/16x17 Grassland 1.board
     name: Grassland
@@ -16,17 +17,13 @@ map:
         id: 3
     id: 5
 
-#  - file: unofficial/Cakefish/General/50x50 Grass QRF Airbase.board
-#    name: Airport
-#    id: 5
-
 options:
   on:
   off:
     - check_victory
 
 factions:
-- name: Hooman
+- name: Human
 
   deploy:
     area:
@@ -37,14 +34,7 @@ factions:
 
   units:
     - fullname: Grasshopper GHR-5N
-#      at: [ 13, 12 ]
       board: 3
-#      facing: 0
-
-#    - fullname: Atlas AS7-D
-#      at: [ 15, 13 ]
-#      board: 3
-#      facing: 0
 
     - fullname: Sai S-4
       at: [ 30, 10 ]

--- a/megamek/testresources/data/scenarios/test_setups/multiboard_single.mms
+++ b/megamek/testresources/data/scenarios/test_setups/multiboard_single.mms
@@ -7,6 +7,15 @@ map:
     name: Grassland
     id: 3
 
+  - type: sky
+    width: 35
+    height: 20
+    name: Sky
+    embed:
+      - at: [ 31, 11 ]
+        id: 3
+    id: 5
+
 #  - file: unofficial/Cakefish/General/50x50 Grass QRF Airbase.board
 #    name: Airport
 #    id: 5
@@ -18,21 +27,13 @@ options:
 
 factions:
 - name: Hooman
-  deploy: S
-#  deploy:
-#    area:
-#      terrain:
-#        type: woods
-#        maxdistance: 1
-#        boards: 1
-#  deploy:
-#    area:
-#      border:
-#        edges: [ east, north ]
-#        # optional: the minimum distance from the edge; 0 means start at the edge hexes
-#        mindistance: 2
-#        # optional: the maximum distance from the edge
-#        maxdistance: 3
+
+  deploy:
+    area:
+      terrain:
+        type: woods
+        maxdistance: 1
+        boards: 3
 
   units:
     - fullname: Grasshopper GHR-5N
@@ -45,16 +46,18 @@ factions:
 #      board: 3
 #      facing: 0
 
+    - fullname: Sai S-4
+      at: [ 5, 5 ]
+      board: 5
+      facing: 2
+      altitude: 4
+
 
 - name: Princess
   deploy: N
   units:
     - fullname: Grasshopper GHR-5N
-#      at: [ 4, 4 ]
       board: 3
-#      facing: 3
 
-#    - fullname: Atlas AS7-D
-#      at: [ 7, 3 ]
-#      board: 3
-#      facing: 3
+    - fullname: Grasshopper GHR-5N
+      board: 3

--- a/megamek/testresources/data/scenarios/test_setups/multiboard_single.mms
+++ b/megamek/testresources/data/scenarios/test_setups/multiboard_single.mms
@@ -3,39 +3,22 @@ name: Test Setup no 2 for multiple boards
 planet: None
 description: uses a single board of ID != 0 (multiboard requires this to no longer break anywhere)
 map:
-  - file: unofficial/Cakefish/General/50x50 Grass QRF Airbase.board
-    name: Airport
-    id: 5
-#    postprocess:
-#      # addterrain adds terrain in a given area
-#      - type: addterrain
-#      # required: the terrain type to change, as used in board files
-#        terrain: fire
-#      # required: the terrain level
-#        level: 1
-#      # required: an area to apply it to, see "areas" section
-#        area:
-#          list:
-#          - [ 9, 9 ]
+  - file: Beginner Box/16x17 Grassland 1.board
+    name: Grassland
+    id: 3
+
+#  - file: unofficial/Cakefish/General/50x50 Grass QRF Airbase.board
+#    name: Airport
+#    id: 5
 
 options:
   on:
-    - friendly_fire
-    - tacops_start_fire
-    - aero_ground_move
   off:
     - check_victory
 
-#planetaryconditions:                        # default: standard conditions
-#  wind:
-#    strength: moderate gale                 # default: none; other values: light gale, moderate gale, strong gale
-#    direction: NW                           # default: random; other values: N, NE, SE, S, SW, NW
-#    shifting: no                            # default: no
-
-
 factions:
 - name: P1
-#  deploy: W
+  deploy: S
 #  deploy:
 #    area:
 #      terrain:
@@ -52,106 +35,25 @@ factions:
 #        maxdistance: 3
 
   units:
-#  - fullname: Mobile Long Tom Artillery LT-MOB-25
-#    offboard: NORTH
-#    distance: 200
-#    #makes no diff yet
-#    board: 1
-#    # offboard effective distance doesnt work yet
-#
-#  - fullname: Mobile Long Tom Artillery LT-MOB-25
-#    at: [13,10]
-#    board: 1
-#    facing: 2
+    - fullname: Grasshopper GHR-5N
+      at: [ 13, 12 ]
+      board: 3
+      facing: 0
 
-#  - fullname: Black Knight BL-12-KNT
-#    board: 5
-#    at: [ 35, 29 ]
+    - fullname: Atlas AS7-D
+      at: [ 15, 13 ]
+      board: 3
+      facing: 0
 
 
-#  - fullname: Scorpion Light Tank (Armor)
-#    at: [ 6,12 ]
-#    board: 5
-#    facing: 2
-#    crew:
-#      name: Eddie the Eagle
-#      piloting: 8
+- name: Princess
+  units:
+    - fullname: Grasshopper GHR-5N
+      at: [ 4, 4 ]
+      board: 3
+      facing: 3
 
-#  - fullname: Zugvogel Omni Support Aircraft B
-#    at: [ 8,20 ]
-#    board: 5
-#    altitude: 2
-
-#  - fullname: Locust LCT-1V
-#    board: 0
-#    at: [ 4,4 ]
-#    status: hidden
-
-#  - fullname: Grasshopper GHR-5N
-#    at: [ 27, 22 ]
-#    board: 5
-#    facing: 3
-
-#  - fullname: Atlas AS7-D
-#    at: [ 26, 28 ]
-#    board: 5
-#    facing: 3
-#    status: hidden
-#
-#  - fullname: Brave BRV-1Y
-#    board: 5
-#    at: [ 35, 29 ]
-#
-#  - fullname: Cheetah IIC
-#    at: [5, 6]
-#    board: 2
-#    facing: 2
-#    altitude: 5
-#
-#  - fullname: Chippewa CHP-W7T
-#    at: [ 20, 12 ]
-#    board: 2
-#    facing: 4
-#    altitude: 5
-#
-#  - fullname: Cheetah IIC
-#    at: [8, 12]
-#    board: 0
-#    facing: 0
-#    altitude: 5
-#
-#  - fullname: Cheetah IIC
-#    at: [ 8, 2 ]
-#    board: 0
-#    facing: 3
-#    altitude: 5
-
-#  - fullname: Cheetah IIC
-#    at: [ 21, 21 ]
-#    board: 5
-#    facing: 5
-#    altitude: 0
-
-#  - fullname: FWL Advanced Laser Turret (3075)
-#    at: [37,26]
-#    elevation: 1
-#    board: 5
-
-#  - fullname: Mobile Long Tom Artillery LT-MOB-25
-#    at: [ 30, 24 ]
-#    board: 5
-#    facing: 5
-
-
-#  - fullname: Aurora
-#    at: [24, 7]
-#    board: 5
-#    altitude: 0
-#
-#  - fullname: Lyonesse Escort
-#    at: [ 19, 19 ]
-#    board: 5
-#    facing: 5
-#    altitude: 0
-
-  - fullname: Nekohono'o (HQ)
+    - fullname: Atlas AS7-D
+      at: [ 7, 3 ]
+      board: 3
+      facing: 3

--- a/megamek/testresources/data/scenarios/test_setups/multiboard_single.mms
+++ b/megamek/testresources/data/scenarios/test_setups/multiboard_single.mms
@@ -47,7 +47,7 @@ factions:
 #      facing: 0
 
     - fullname: Sai S-4
-      at: [ 5, 5 ]
+      at: [ 30, 10 ]
       board: 5
       facing: 2
       altitude: 4

--- a/megamek/testresources/data/scenarios/test_setups/multiboard_single.mms
+++ b/megamek/testresources/data/scenarios/test_setups/multiboard_single.mms
@@ -38,7 +38,7 @@ factions:
     - fullname: Grasshopper GHR-5N
 #      at: [ 13, 12 ]
       board: 3
-      facing: 0
+#      facing: 0
 
 #    - fullname: Atlas AS7-D
 #      at: [ 15, 13 ]
@@ -52,7 +52,7 @@ factions:
     - fullname: Grasshopper GHR-5N
 #      at: [ 4, 4 ]
       board: 3
-      facing: 3
+#      facing: 3
 
 #    - fullname: Atlas AS7-D
 #      at: [ 7, 3 ]

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -507,7 +507,8 @@ class BasicPathRankerTest {
     void testRankPath() {
         final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
         doReturn(1.0).when(testRanker).getMovePathSuccessProbability(any(MovePath.class));
-        doReturn(20).when(testRanker).distanceToHomeEdge(any(Coords.class), any(CardinalEdge.class), any(Game.class));
+        doReturn(20).when(testRanker).distanceToHomeEdge(any(Coords.class), anyInt(), any(CardinalEdge.class),
+              any(Game.class));
         doReturn(12.0).when(testRanker).distanceToClosestEnemy(any(Entity.class), any(Coords.class), any(Game.class));
         doReturn(0.0).when(testRanker).checkPathForHazards(any(MovePath.class), any(Entity.class), any(Game.class));
 
@@ -550,11 +551,14 @@ class BasicPathRankerTest {
 
         final Game mockGame = mock(Game.class);
         when(mockGame.getBoard()).thenReturn(mockBoard);
+        when(mockGame.getBoard(any(Targetable.class))).thenReturn(mockBoard);
+        when(mockGame.getBoard(anyInt())).thenReturn(mockBoard);
         when(mockGame.getOptions()).thenReturn(mockGameOptions);
         when(mockGame.getArtilleryAttacks()).thenReturn(Collections.emptyEnumeration());
         when(mockGame.getPlanetaryConditions()).thenReturn(mockPC);
         when(mockPrincess.getGame()).thenReturn(mockGame);
         when(mockMover.getGame()).thenReturn(mockGame);
+        when(mockGame.onTheSameBoard(any(Targetable.class), any(Targetable.class))).thenCallRealMethod();
 
         final List<Entity> testEnemies = new ArrayList<>();
 
@@ -850,7 +854,7 @@ class BasicPathRankerTest {
         assertRankedPathEquals(expected, actual);
 
         // TEST CASE 15: Fleeing - closer to home edge
-        doReturn(10).when(testRanker).distanceToHomeEdge(any(Coords.class), any(CardinalEdge.class), any(Game.class));
+        doReturn(10).when(testRanker).distanceToHomeEdge(any(Coords.class), anyInt(), any(CardinalEdge.class), any(Game.class));
         expected = new RankedPath(-51.25,
               mockPath,
               builder.withFallMod(0, 0, 500)
@@ -866,7 +870,7 @@ class BasicPathRankerTest {
         }
 
         // TEST CASE 16: Fleeing - farther from home edge
-        doReturn(30).when(testRanker).distanceToHomeEdge(any(Coords.class), any(CardinalEdge.class), any(Game.class));
+        doReturn(30).when(testRanker).distanceToHomeEdge(any(Coords.class), anyInt(), any(CardinalEdge.class), any(Game.class));
         expected = new RankedPath(-51.25,
               mockPath,
               builder.withFallMod(0, 0, 500)
@@ -883,7 +887,7 @@ class BasicPathRankerTest {
 
         // Reset fleeing settings
         doReturn(20).when(testRanker)
-              .distanceToHomeEdge(nullable(Coords.class), any(CardinalEdge.class), any(Game.class));
+              .distanceToHomeEdge(nullable(Coords.class), anyInt(), any(CardinalEdge.class), any(Game.class));
         when(mockPrincess.wantsToFallBack(eq(mockMover))).thenReturn(false);
         when(mockMover.isCrippled()).thenReturn(false);
 
@@ -975,6 +979,7 @@ class BasicPathRankerTest {
         final Coords position = new Coords(0, 0);
         final Entity me = mock(BipedMek.class);
         final Game mockGame = mock(Game.class);
+        when(mockGame.onTheSameBoard(any(Targetable.class), any(Targetable.class))).thenCallRealMethod();
 
         final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
         doReturn(enemyList).when(mockPrincess).getEnemyEntities();
@@ -1015,7 +1020,9 @@ class BasicPathRankerTest {
         when(mockBoard.contains(any(Coords.class))).thenReturn(true);
 
         final Game mockGame = mock(Game.class);
-        when(mockGame.getBoard()).thenReturn(mockBoard);
+        when(mockGame.getBoard(anyInt())).thenReturn(mockBoard);
+        when(mockGame.getBoard(any(Targetable.class))).thenReturn(mockBoard);
+        when(mockGame.onTheSameBoard(any(Targetable.class), any(Targetable.class))).thenCallRealMethod();
 
         final Entity mockFriend1 = mock(BipedMek.class);
         when(mockFriend1.getId()).thenReturn(myId);
@@ -1023,6 +1030,7 @@ class BasicPathRankerTest {
         final Coords friendPosition1 = new Coords(0, 0);
         when(mockFriend1.getPosition()).thenReturn(friendPosition1);
         friends.add(mockFriend1);
+        when(mockGame.getEntity(myId)).thenReturn(mockFriend1);
 
         final Entity mockFriend2 = mock(BipedMek.class);
         when(mockFriend2.getId()).thenReturn(2);
@@ -1321,6 +1329,7 @@ class BasicPathRankerTest {
         Game mockGame = mock(Game.class);
         Board mockBoard = mock(Board.class);
         when(mockGame.getBoard()).thenReturn(mockBoard);
+        when(mockGame.getBoard(anyInt())).thenReturn(mockBoard);
         for (Coords c : coords) {
             when(mockBoard.getHex(eq(c))).thenReturn(hexes.get(coords.indexOf(c)));
         }
@@ -2206,6 +2215,7 @@ class BasicPathRankerTest {
 
         final Building mockBuilding = mock(Building.class);
         when(mockGame.getBoard().getBuildingAt(eq(testCoordsThree))).thenReturn(mockBuilding);
+
         when(mockBuilding.getCurrentCF(eq(testCoordsThree))).thenReturn(77);
 
         // Test walking onto mud; jumping doesn't change danger because Meks can't bog

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -418,7 +418,7 @@ class PrincessTest {
 
         // Unit is on home edge.
         BasicPathRanker mockRanker = mock(BasicPathRanker.class);
-        when(mockRanker.distanceToHomeEdge(any(Coords.class), any(CardinalEdge.class), any(Game.class))).thenReturn(0);
+        when(mockRanker.distanceToHomeEdge(any(Coords.class), anyInt(), any(CardinalEdge.class), any(Game.class))).thenReturn(0);
         when(mockPrincess.getPathRanker(any(Entity.class))).thenReturn(mockRanker);
 
         // Mock objects so we don't have nulls.
@@ -461,7 +461,7 @@ class PrincessTest {
 
         // The unit can flee, but is no longer on the board edge.
         when(mockMek.canFlee(mockMek.getPosition())).thenReturn(true);
-        when(mockRanker.distanceToHomeEdge(any(Coords.class), any(CardinalEdge.class), any(Game.class))).thenReturn(1);
+        when(mockRanker.distanceToHomeEdge(any(Coords.class), anyInt(), any(CardinalEdge.class), any(Game.class))).thenReturn(1);
         assertFalse(mockPrincess.mustFleeBoard(mockMek));
     }
 

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -472,13 +472,13 @@ class PrincessTest {
 
         Hex mockHex = mock(Hex.class);
         when(mockHex.getLevel()).thenReturn(0);
-        when(mockPrincess.getHex(any(Coords.class))).thenReturn(mockHex);
 
         Game mockGame = mock(Game.class);
         PlanetaryConditions mockPC = new PlanetaryConditions();
         mockPC.setGravity(1.0f);
         when(mockGame.getPlanetaryConditions()).thenReturn(mockPC);
         doReturn(mockGame).when(mockPrincess).getGame();
+        when(mockGame.getHexOf(any(Targetable.class))).thenReturn(mockHex);
 
         BehaviorSettings mockBehavior = mock(BehaviorSettings.class);
         when(mockBehavior.getFallShameIndex()).thenReturn(5);

--- a/megamek/unittests/megamek/client/bot/princess/UnitsMedianCoordinateCalculatorTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/UnitsMedianCoordinateCalculatorTest.java
@@ -35,7 +35,6 @@ package megamek.client.bot.princess;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
@@ -56,7 +55,7 @@ class UnitsMedianCoordinateCalculatorTest {
         List<Entity> enemies = new ArrayList<>();
         Coords myPosition = new Coords(10, 10);
         var unitsMedianCalculator = new UnitsMedianCoordinateCalculator(5);
-        Coords result = unitsMedianCalculator.getEnemiesMedianCoordinate(enemies, myPosition);
+        Coords result = unitsMedianCalculator.getEnemiesMedianCoordinate(enemies, myPosition, 0);
 
         // When no enemies are present, the function should return null
         assertNull(result);
@@ -69,7 +68,7 @@ class UnitsMedianCoordinateCalculatorTest {
         List<Entity> enemies = List.of(enemyMoved(new Coords(5, 5)));
         Coords myPosition = new Coords(10, 10);
         var unitsMedianCalculator = new UnitsMedianCoordinateCalculator(5);
-        Coords result = unitsMedianCalculator.getEnemiesMedianCoordinate(enemies, myPosition);
+        Coords result = unitsMedianCalculator.getEnemiesMedianCoordinate(enemies, myPosition, 0);
 
         // With only one enemy, the median should be that enemy's position
         assertEquals(new Coords(5, 5), result);
@@ -87,7 +86,7 @@ class UnitsMedianCoordinateCalculatorTest {
         Coords myPosition = new Coords(10, 10);
 
         var unitsMedianCalculator = new UnitsMedianCoordinateCalculator(5);
-        Coords result = unitsMedianCalculator.getEnemiesMedianCoordinate(enemies, myPosition);
+        Coords result = unitsMedianCalculator.getEnemiesMedianCoordinate(enemies, myPosition, 0);
 
         // Median of these three positions should be calculated
         // For these coordinates, median should be (8, 8)
@@ -110,7 +109,7 @@ class UnitsMedianCoordinateCalculatorTest {
 
 
         var unitsMedianCalculator = new UnitsMedianCoordinateCalculator(5);
-        Coords result = unitsMedianCalculator.getEnemiesMedianCoordinate(enemies, myPosition);
+        Coords result = unitsMedianCalculator.getEnemiesMedianCoordinate(enemies, myPosition, 0);
 
         // The function should consider only the 5 closest enemies
         // The 5 closest are: (9,9), (11,11), (12,8), (8,12), (5,5)
@@ -130,14 +129,14 @@ class UnitsMedianCoordinateCalculatorTest {
         List<Entity> enemies = List.of(enemy1, enemy2, enemy3);
 
         var unitsMedianCalculator = new UnitsMedianCoordinateCalculator(2);
-        Coords median1 = unitsMedianCalculator.getEnemiesMedianCoordinate(enemies, myPosition);
+        Coords median1 = unitsMedianCalculator.getEnemiesMedianCoordinate(enemies, myPosition, 0);
 
         // With limit 2, only enemy1 and enemy2 are considered
         // Median of (11,11) and (12,10) is (11.5, 10.5) which rounds to (12, 11)
         assertEquals(new Coords(11, 10), median1);
 
         myPosition = new Coords(15, 15);
-        Coords median2 = unitsMedianCalculator.getEnemiesMedianCoordinate(enemies, myPosition);
+        Coords median2 = unitsMedianCalculator.getEnemiesMedianCoordinate(enemies, myPosition, 0);
 
         // Now enemy3 and enemy1 are the closest
         // Median of (14,14) and (11,11) is (12, 12)


### PR DESCRIPTION
This enables Princess to have baseline functionality in a multimap game. Each unit acts as if other maps and units thereon don't exist. Included is a test scenario of 1 Grasshopper and 1 Sai aerospace fighter on an atmospheric map (Human) against 2 Grasshoppers (Princess). The Sai cannot enter the ground map but can make flight paths and strafe/strike. 
This is again a bit of a bigger PR as it required changing many game.getboard() calls across various pathfinders and movepath/movestep among some other adaptations.