### PR TITLE
Issue 7192: Prevent dig in for Mech. Inf. 

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -2436,6 +2436,8 @@ MekView.InvalidButIllegalQuirk=Illegal Design Quirk, would be invalid because:
 
 MekView.unitType.primitive=Primitive
 MekView.unitType.aerodyne=Aerodyne
+MekView.unitType.mechanized=Mechanized
+MekView.unitType.motorized=Motorized
 MekView.unitType.superHeavy=Superheavy
 MekView.unitType.industrial=Industrial
 MekView.unitType.tripod=Tripod

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -1232,9 +1232,7 @@ public class Infantry extends Entity {
     }
 
     public boolean isMechanized() {
-        return (getMovementMode().isTrackedWheeledOrHover()) ||
-                     (getMovementMode().isSubmarine()) ||
-                     (getMovementMode().isVTOL());
+        return movementMode.isTrackedWheeledOrHover() || movementMode.isVTOL() || movementMode.isSubmarine();
     }
 
     public boolean isXCT() {

--- a/megamek/src/megamek/common/MekView.java
+++ b/megamek/src/megamek/common/MekView.java
@@ -1778,6 +1778,11 @@ public class MekView {
                 result += Messages.getString("MekView.unitType.spheroid") + " ";
             }
         }
+        if (entity instanceof Infantry inf && !entity.isBattleArmor() && inf.isMechanized()) {
+            result += Messages.getString("MekView.unitType.mechanized") + " ";
+        } else if (entity.getMovementMode().isMotorizedInfantry()) {
+            result += Messages.getString("MekView.unitType.motorized") + " ";
+        }
         if (entity.isSuperHeavy()) {
             result += Messages.getString("MekView.unitType.superHeavy") + " ";
         }

--- a/megamek/testresources/data/scenarios/test_setups/various_infantry.mms
+++ b/megamek/testresources/data/scenarios/test_setups/various_infantry.mms
@@ -1,0 +1,39 @@
+MMSVersion: 2
+name: Test Setup for Conventional Infantry
+planet: None
+description: Various conventional infantry on a board with varied terrain for testing digging in etc
+map:
+  - file: unofficial/Cakefish/General/50x50 Grass QRF Airbase.board
+
+options:
+  on:
+    - friendly_fire
+    - tacops_dig_in
+    # apparently "hitting the deck" doesnt exist yet
+  off:
+    - check_victory
+
+factions:
+- name: Player
+
+  units:
+  - fullname: Foot Platoon (MG)
+    at: [ 10, 12 ]
+
+  - fullname: Mechanized Hover Platoon (Rifle)
+    at: [ 17, 26 ]
+
+  - fullname: Beast Infantry (Camel) (Auto-Rifle)
+    at: [ 21, 20 ]
+
+  - fullname: Jump Platoon (Flamer)
+    at: [ 29, 23 ]
+
+  - fullname: Motorized Squad (Rifle)
+    at: [ 36, 18 ]
+
+  - fullname: Clan Field Gun Point (Tracked AC2 Basic)
+    at: [ 35, 24 ]
+
+  - fullname: Field Artillery (Thumper)
+    at: [ 20, 22 ]


### PR DESCRIPTION
Fixes #7192 
- prevents digging in for mechanized infantry
- also prevents digging in together with movement (digging in must be the only action); the code for determining the first step in MoveStep is a bit arcane like everything there, I can only hope this doesnt mess up anything else; in any case, infantry can move a step using 0 mp and this must still prevent digging in with the same move
- shows "Mechanized" and "Motorized" as part of the unit type in the unit readout; most infantry have this in their name but not all and it's a relevant distinction