### PR TITLE
Adv board search no tag

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/advancedSearchMap/AdvancedSearchMapDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/advancedSearchMap/AdvancedSearchMapDialog.java
@@ -356,12 +356,12 @@ public class AdvancedSearchMapDialog extends AbstractButtonDialog {
     }
 
     private boolean matchTag(List<String> tags) {
-        List<String> include = listBoardTags.getSelectedValuesList();
-
         if (listBoardTags.isSelectionEmpty()) {
             return true;
         }
 
+        List<String> include = listBoardTags.getSelectedValuesList();
+        
         if (boardTagsAllCheckBox.isSelected()) {
             return !include.isEmpty() && include.stream().allMatch(tags::contains);
         } else {

--- a/megamek/src/megamek/client/ui/dialogs/advancedSearchMap/AdvancedSearchMapDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/advancedSearchMap/AdvancedSearchMapDialog.java
@@ -358,6 +358,10 @@ public class AdvancedSearchMapDialog extends AbstractButtonDialog {
     private boolean matchTag(List<String> tags) {
         List<String> include = listBoardTags.getSelectedValuesList();
 
+        if (listBoardTags.isSelectionEmpty()) {
+            return true;
+        }
+
         if (boardTagsAllCheckBox.isSelected()) {
             return !include.isEmpty() && include.stream().allMatch(tags::contains);
         } else {


### PR DESCRIPTION
- correct issue with advanced board search filter not returning boards with no tags

![image](https://github.com/user-attachments/assets/b80da980-39e5-4a67-bd06-25419cccaa8a)
