### PR TITLE
Issue 7179: Fix NPE when cycling targets with no selected weapon

### DIFF
--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -435,6 +435,10 @@ public class WeaponAttackAction extends AbstractAttackAction {
           boolean evenIfAlreadyFired, int ammoId, int ammoCarrier) {
         final Entity ae = game.getEntity(attackerId);
         final WeaponMounted weapon = (WeaponMounted) ae.getEquipment(weaponId);
+        if (weapon == null) {
+            logger.error("Attempted toHit calculation with a null weapon!");
+            return new ToHitData(TargetRoll.IMPOSSIBLE, "No weapon");
+        }
         final AmmoMounted linkedAmmo;
         if (ammoId == UNASSIGNED) {
             linkedAmmo = weapon.getLinkedAmmo();


### PR DESCRIPTION
Fixes #7179
Specifically, when cycling *valid* targets and no weapon is selected. This PR adds a check if a weapon is selected in FiringDisplay to prevent this specific error. 
Also adds a check to WeaponAttackAction so that a call with an invalid weaponId will generate a log entry and an "IMPOSSIBLE" result rather than an NPE. This result is an error, so I did not add a localization for it.