### PR TITLE
Fix: Adjusted to sync then copy the license files.

### DIFF
--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -150,11 +150,11 @@ ${jvmOptions}
     }
 }
 
-tasks.register("copyLicenseFiles", Sync) {
-    description = "Copy the license files to the root of the folder."
+tasks.register("stageLicenseFiles", Sync) {
+    description = "Copy the license files to the build folder."
     group = 'build'
     from "../"
-    into fileStagingDir
+    into "${layout.buildDirectory.get()}/licenses"
 
     includes = [
             'LICENSE',
@@ -163,6 +163,16 @@ tasks.register("copyLicenseFiles", Sync) {
             'README.md'
     ]
 
+}
+
+tasks.register("copyLicenseFiles", Copy) {
+    description "Copies from the build folder to the staging folder"
+    group = 'build'
+
+    dependsOn stageLicenseFiles
+
+    from "${layout.buildDirectory.get()}/licenses"
+    into fileStagingDir
 }
 
 tasks.register('copyFiles', Copy) {


### PR DESCRIPTION
Adjust build scripts to first sync the license files to the build area then copy to the staging area.