### PR TITLE
loading eras during initialization

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -152,7 +152,6 @@ public class RATGenerator {
         initialized = false;
         initializing = false;
         initialize(dir);
-        ratGenerator.getEraSet().forEach(e -> ratGenerator.loadEra(e, dir));
     }
 
     public AvailabilityRating findChassisAvailabilityRecord(int era, String unit, String faction, int year) {
@@ -1383,6 +1382,7 @@ public class RATGenerator {
 
         if (!interrupted) {
             ratGenerator.initialized = true;
+            ratGenerator.getEraSet().forEach(e -> ratGenerator.loadEra(e, dir));
             ratGenerator.notifyListenersOfInitialization();
         }
 


### PR DESCRIPTION
This fixes the issue of the ERAs of RAT Generator not being loaded in MML.
This is needed to have the feature from https://github.com/MegaMek/megamek/pull/7235 work also in MML.