### PR TITLE
Mek Validation

### DIFF
--- a/megamek/src/megamek/common/verifier/TestMek.java
+++ b/megamek/src/megamek/common/verifier/TestMek.java
@@ -862,15 +862,16 @@ public class TestMek extends TestEntity {
         for (Mounted<?> m : getEntity().getMisc()) {
             final MiscType misc = (MiscType) m.getType();
 
-            if (misc.hasFlag(MiscType.F_UMU) && (mek.getJumpType() != Mek.JUMP_NONE)) {
-                illegal = true;
-                buff.append("UMUs cannot be mounted with jump jets\n");
-            }
-
-            if (!illegal && misc.hasFlag(MiscType.F_UMU)
-                      && !(mek.locationIsTorso(m.getLocation()) || mek.locationIsLeg(m.getLocation()))) {
-                illegal = true;
-                buff.append("UMUs must be mounted in the torso or legs\n");
+            // TO:AUE p.104
+            if (misc.hasFlag(MiscType.F_UMU)) {
+                if (mek.getJumpType() != Mek.JUMP_NONE) {
+                    illegal = true;
+                    buff.append("UMUs cannot be mounted with jump jets\n");
+                }
+                if (!mek.locationIsTorso(m.getLocation()) && !mek.locationIsLeg(m.getLocation())) {
+                    illegal = true;
+                    buff.append("UMUs must be mounted in the torso or legs\n");
+                }
             }
 
             if (misc.hasFlag(MiscType.F_MASC)
@@ -1056,10 +1057,11 @@ public class TestMek extends TestEntity {
                             .append(misc.getName()).append("\n");
                     illegal = true;
                 }
-                if (!illegal &&
-                          (misc.hasFlag(MiscTypeFlag.F_DOUBLE_HEAT_SINK)
+
+                // TM p.71
+                if (misc.hasFlag(MiscTypeFlag.F_DOUBLE_HEAT_SINK)
                                  || misc.hasFlag(MiscTypeFlag.F_COMPACT_HEAT_SINK)
-                                 || misc.hasFlag(MiscTypeFlag.F_IS_DOUBLE_HEAT_SINK_PROTOTYPE))) {
+                                 || misc.hasFlag(MiscTypeFlag.F_IS_DOUBLE_HEAT_SINK_PROTOTYPE)) {
                     buff.append("Industrial Meks may only mount standard single heat sinks\n");
                     illegal = true;
                 }

--- a/megamek/src/megamek/common/verifier/TestMek.java
+++ b/megamek/src/megamek/common/verifier/TestMek.java
@@ -867,6 +867,12 @@ public class TestMek extends TestEntity {
                 buff.append("UMUs cannot be mounted with jump jets\n");
             }
 
+            if (!illegal && misc.hasFlag(MiscType.F_UMU)
+                      && !(mek.locationIsTorso(m.getLocation()) || mek.locationIsLeg(m.getLocation()))) {
+                illegal = true;
+                buff.append("UMUs must be mounted in the torso or legs\n");
+            }
+
             if (misc.hasFlag(MiscType.F_MASC)
                     && misc.hasSubType(MiscType.S_SUPERCHARGER)) {
                 if (mek instanceof LandAirMek) {

--- a/megamek/src/megamek/common/verifier/TestMek.java
+++ b/megamek/src/megamek/common/verifier/TestMek.java
@@ -1050,6 +1050,13 @@ public class TestMek extends TestEntity {
                             .append(misc.getName()).append("\n");
                     illegal = true;
                 }
+                if (!illegal &&
+                          (misc.hasFlag(MiscTypeFlag.F_DOUBLE_HEAT_SINK)
+                                 || misc.hasFlag(MiscTypeFlag.F_COMPACT_HEAT_SINK)
+                                 || misc.hasFlag(MiscTypeFlag.F_IS_DOUBLE_HEAT_SINK_PROTOTYPE))) {
+                    buff.append("Industrial Meks may only mount standard single heat sinks\n");
+                    illegal = true;
+                }
             } else {
                 if (misc.hasFlag(MiscType.F_INDUSTRIAL_TSM)
                         || misc.hasFlag(MiscType.F_ENVIRONMENTAL_SEALING)
@@ -1115,10 +1122,6 @@ public class TestMek extends TestEntity {
             }
             if ((mek.getGyroType() != Mek.GYRO_STANDARD) && (mek.getGyroType() != Mek.GYRO_SUPERHEAVY)) {
                 buff.append("industrial meks can only mount standard gyros\n");
-                illegal = true;
-            }
-            if (hasDoubleHeatSinks()) {
-                buff.append("Industrial Meks cannot mount double heat sinks\n");
                 illegal = true;
             }
             switch (mek.hasEngine() ? engine.getEngineType() : Engine.NONE) {


### PR DESCRIPTION
Adds two validation checks for meks
Fixes MegaMek/MegaMekLab#1939
Fixes MegaMek/MegaMekLab#1922
I'm taking the stance that the MML GUI doesnt have to enforce rules if validation catches them; validation gives feedback which is more helpful than blocking construction