### PR TITLE
Fix Bind errors in Damage Manager tests: make server port selection more resilient with retry on BindException

### DIFF
--- a/megamek/unittests/megamek/server/totalwarfare/TWDamageManagerTest.java
+++ b/megamek/unittests/megamek/server/totalwarfare/TWDamageManagerTest.java
@@ -52,6 +52,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.BindException;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -85,8 +86,15 @@ class TWDamageManagerTest {
         newMan = new TWDamageManagerModular(gameMan, game);
         
         // Need servers to handle unit destruction (sad face)
-        server = new Server(null, random.nextInt(MMConstants.MIN_PORT_FOR_QUICK_GAME, MMConstants.MAX_PORT),
-              gameMan, false, "", null, true);
+        for (int port=MMConstants.MIN_PORT_FOR_QUICK_GAME; port<=MMConstants.MAX_PORT; port++) {
+            try {
+                server = new Server(null, random.nextInt(MMConstants.MIN_PORT_FOR_QUICK_GAME, MMConstants.MAX_PORT),
+                      gameMan, false, "", null, true);
+                break;
+            } catch (BindException e) {
+                // Try the next one
+            }
+        }
         
         // Player for certain checks and messages
         player = new Player(1, "Test");


### PR DESCRIPTION
This should prevent a reported BindException in these tests that was caused by using randomized server ports without first confirming that the ports were available.

Notes:
1. The test setup may still fail on IOExceptions (which could happen if the local host could not be determined or Java did not have permission to open the ports) but these have not yet been reported.
2. Ports now start at 1024, so should avoid the standard server ports entirely.
3. In the best case, the entire suite of tests should complete in under a second; in the worst case, with all ports in use, each test may take several seconds to fail.

Testing:
- Ran all 3 projects' unit tests
- Ran a stress test focusing on repeated runs of this test suite.