### PR TITLE
SV validation updates

### DIFF
--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -44,6 +44,8 @@ import megamek.common.equipment.ArmorType;
 import megamek.common.util.YamlEncDec;
 import megamek.common.util.YamlSerializerEquipmentType;
 import megamek.common.weapons.autocannons.HVACWeapon;
+import megamek.common.weapons.c3.ISC3M;
+import megamek.common.weapons.c3.ISC3MBS;
 import megamek.common.weapons.defensivepods.BPodWeapon;
 import megamek.common.weapons.defensivepods.MPodWeapon;
 import megamek.common.weapons.ppc.PPCWeapon;
@@ -1804,5 +1806,13 @@ public class EquipmentType implements ITechnology {
      */
     public boolean isArmorable() {
         return isHittable();
+    }
+
+    /**
+     * @return True if this equipment type is any type of C3 equipment, meaning C3S/M and variations of those, C3i,
+     * Nova CEWS, NC3 and BA C3. Note that this returns true for some MiscTypes as well as some WeaponTypes.
+     */
+    public boolean isC3Equipment() {
+        return false;
     }
 }

--- a/megamek/src/megamek/common/MiscType.java
+++ b/megamek/src/megamek/common/MiscType.java
@@ -19,6 +19,8 @@ import java.text.NumberFormat;
 import megamek.common.equipment.MiscMounted;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.miscGear.AntiMekGear;
+import megamek.common.weapons.c3.ISC3M;
+import megamek.common.weapons.c3.ISC3MBS;
 import megamek.common.weapons.ppc.CLERPPC;
 import megamek.common.weapons.ppc.ISERPPC;
 import megamek.common.weapons.ppc.ISHeavyPPC;
@@ -4301,6 +4303,7 @@ public class MiscType extends EquipmentType {
         misc.criticals = 1;
         misc.cost = 250000;
         misc.flags = misc.flags.or(F_C3S)
+                           .or(MiscTypeFlag.ANY_C3)
                            .or(F_MEK_EQUIPMENT)
                            .or(F_TANK_EQUIPMENT)
                            .or(F_SUPPORT_TANK_EQUIPMENT)
@@ -4336,6 +4339,7 @@ public class MiscType extends EquipmentType {
         // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         // December 2021 - Errata request to change common date
         misc.flags = misc.flags.or(F_C3I)
+                           .or(MiscTypeFlag.ANY_C3)
                            .or(F_MEK_EQUIPMENT)
                            .or(F_TANK_EQUIPMENT)
                            .or(F_SUPPORT_TANK_EQUIPMENT)
@@ -4366,6 +4370,7 @@ public class MiscType extends EquipmentType {
         misc.criticals = 2;
         misc.cost = 500000;
         misc.flags = misc.flags.or(F_C3SBS)
+                           .or(MiscTypeFlag.ANY_C3)
                            .or(F_MEK_EQUIPMENT)
                            .or(F_TANK_EQUIPMENT)
                            .or(F_SUPPORT_TANK_EQUIPMENT)
@@ -4401,6 +4406,7 @@ public class MiscType extends EquipmentType {
         misc.cost = 2800000;
         // TODO: implement game rules
         misc.flags = misc.flags.or(F_C3EM)
+                           .or(MiscTypeFlag.ANY_C3)
                            .or(F_MEK_EQUIPMENT)
                            .or(F_TANK_EQUIPMENT)
                            .or(F_SUPPORT_TANK_EQUIPMENT)
@@ -4438,6 +4444,7 @@ public class MiscType extends EquipmentType {
         misc.criticals = 1;
         misc.cost = 62500;
         misc.flags = misc.flags.or(F_C3S)
+                           .or(MiscTypeFlag.ANY_C3)
                            .or(F_BA_EQUIPMENT)
                            .andNot(F_MEK_EQUIPMENT)
                            .andNot(F_TANK_EQUIPMENT)
@@ -4470,6 +4477,7 @@ public class MiscType extends EquipmentType {
         misc.criticals = 1;
         misc.cost = 125000;
         misc.flags = misc.flags.or(F_C3I)
+                           .or(MiscTypeFlag.ANY_C3)
                            .or(F_BA_EQUIPMENT)
                            .andNot(F_MEK_EQUIPMENT)
                            .andNot(F_TANK_EQUIPMENT)
@@ -5895,6 +5903,7 @@ public class MiscType extends EquipmentType {
         misc.criticals = 1;
         misc.cost = 1100000; // we assume that WOR had a typo there.
         misc.flags = misc.flags.or(F_NOVA)
+                           .or(MiscTypeFlag.ANY_C3)
                            .or(F_ECM)
                            .or(F_BAP)
                            .or(F_MEK_EQUIPMENT)
@@ -7594,6 +7603,7 @@ public class MiscType extends EquipmentType {
         misc.criticals = 0;
         misc.cost = COST_VARIABLE;
         misc.flags = misc.flags.or(F_NAVAL_C3)
+                           .or(MiscTypeFlag.ANY_C3)
                            .or(F_DS_EQUIPMENT)
                            .or(F_JS_EQUIPMENT)
                            .or(F_WS_EQUIPMENT)
@@ -11833,5 +11843,10 @@ public class MiscType extends EquipmentType {
     @Override
     public String toString() {
         return "[Misc] " + internalName;
+    }
+
+    @Override
+    public boolean isC3Equipment() {
+        return hasFlag(MiscTypeFlag.ANY_C3);
     }
 }

--- a/megamek/src/megamek/common/MiscTypeFlag.java
+++ b/megamek/src/megamek/common/MiscTypeFlag.java
@@ -56,6 +56,12 @@ public enum MiscTypeFlag implements EquipmentFlag {
     F_C3SBS,
     F_NAVAL_C3,
 
+    /**
+     * All C3-like equipment (C3, C3i, Naval C3, Nova CEWS and BA C3). Note that C3M and C3MBS are weapons and cannot
+     * have this flag.
+     */
+    ANY_C3,
+
     F_ARTEMIS,
     F_TARGCOMP,
     F_ARTEMIS_V,

--- a/megamek/src/megamek/common/verifier/TestMek.java
+++ b/megamek/src/megamek/common/verifier/TestMek.java
@@ -814,7 +814,7 @@ public class TestMek extends TestEntity {
         boolean illegal = super.hasIllegalEquipmentCombinations(buff);
 
         boolean hasStealth = mek.hasStealth();
-        boolean hasC3 = mek.hasC3();
+        boolean hasC3 = mek.hasAnyC3System();
         boolean hasHarjelII = false;
         boolean hasHarjelIII = false;
         boolean hasNullSig = false;
@@ -1119,7 +1119,7 @@ public class TestMek extends TestEntity {
         if (mek.isIndustrial()) {
             if ((mek.getCockpitType() == Mek.COCKPIT_INDUSTRIAL
                     || mek.getCockpitType() == Mek.COCKPIT_PRIMITIVE_INDUSTRIAL) && hasC3) {
-                buff.append("industrial mek without advanced fire control can't use c3 computer\n");
+                buff.append("Industrial meks without advanced fire control cannot use C3 equipment\n");
                 illegal = true;
             }
             if ((mek.getJumpType() != Mek.JUMP_STANDARD)

--- a/megamek/src/megamek/common/verifier/TestSupportVehicle.java
+++ b/megamek/src/megamek/common/verifier/TestSupportVehicle.java
@@ -1135,7 +1135,7 @@ public class TestSupportVehicle extends TestEntity {
 
         for (WeaponMounted mounted : supportVee.getWeaponList()) {
             if (!isValidWeapon(mounted)) {
-                buff.append(mounted.getType().getName()).append(" is not a valid weapon for this unit.\n");
+                buff.append(mounted.getType().getName()).append(" is not a valid weapon for this unit\n");
                 correct = false;
             }
 
@@ -1153,10 +1153,6 @@ public class TestSupportVehicle extends TestEntity {
             EquipmentType type = mounted.getType();
             if ((type instanceof MiscType) && !type.hasFlag(MiscType.F_SUPPORT_TANK_EQUIPMENT)) {
                 buff.append(type.getName()).append(" cannot be used by support vehicles.\n");
-                correct = false;
-            } else if (isSmallSupportVehicle()
-                    && (type instanceof WeaponType) && !type.hasFlag(WeaponType.F_INFANTRY)) {
-                buff.append("Small support vehicles cannot mount %s\n".formatted(mounted.getName()));
                 correct = false;
             } else if ((type instanceof WeaponType)
                     && !isSmallSupportVehicle()

--- a/megamek/src/megamek/common/verifier/TestSupportVehicle.java
+++ b/megamek/src/megamek/common/verifier/TestSupportVehicle.java
@@ -33,6 +33,7 @@ import megamek.common.*;
 import megamek.common.annotations.Nullable;
 import megamek.common.equipment.ArmorType;
 import megamek.common.equipment.MiscMounted;
+import megamek.common.equipment.WeaponMounted;
 import megamek.common.options.OptionsConstants;
 import megamek.common.util.StringUtil;
 import megamek.common.weapons.flamers.VehicleFlamerWeapon;
@@ -312,7 +313,7 @@ public class TestSupportVehicle extends TestEntity {
          */
         public boolean validFor(Entity supportVehicle) {
             return supportVehicle.isSupportVehicle() && allowedTypes.contains(SVType.getVehicleType(supportVehicle))
-                    && (!smallOnly || (supportVehicle.getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT))
+                    && (!smallOnly || (isSmallSupportVehicle(supportVehicle)))
                     // Hydrofoil has a specific upper weight limit rather than a weight class.
                     && (!this.equals(HYDROFOIL) || supportVehicle.getWeight() <= 100.0)
                     // Can't put a turret on a convertible
@@ -639,10 +640,7 @@ public class TestSupportVehicle extends TestEntity {
      * @return Whether the vehicle can use sponson turrets.
      */
     public static boolean sponsonLegal(SVType type, boolean small) {
-        return !small
-                && (type != SVType.FIXED_WING)
-                && (type != SVType.AIRSHIP)
-                && (type != SVType.SATELLITE);
+        return !small && (type != SVType.FIXED_WING) && (type != SVType.AIRSHIP) && (type != SVType.SATELLITE);
     }
 
     /**
@@ -650,12 +648,11 @@ public class TestSupportVehicle extends TestEntity {
      *
      * @param type  The support vehicle type
      * @param small Whether the {@link Entity} is a small support vehicle
+     *
      * @return Whether the vehicle can use pintle turrets.
      */
     public static boolean pintleLegal(SVType type, boolean small) {
-        return small
-                && (type != SVType.FIXED_WING)
-                && (type != SVType.NAVAL);
+        return small && (type != SVType.FIXED_WING) && (type != SVType.NAVAL);
     }
 
     private final Entity supportVee;
@@ -671,7 +668,7 @@ public class TestSupportVehicle extends TestEntity {
 
     public TestSupportVehicle(Entity supportVehicle, TestEntityOption options, String fileString) {
         super(options, supportVehicle.getEngine(), null);
-        this.supportVee = supportVehicle;
+        supportVee = supportVehicle;
         testTank = supportVehicle instanceof Tank tankVehicle ? new TestTank(tankVehicle, options, fileString) : null;
         testAero = supportVehicle instanceof Aero aeroVehicle ? new TestAero(aeroVehicle, options, fileString) : null;
     }
@@ -750,7 +747,7 @@ public class TestSupportVehicle extends TestEntity {
      * @return The rounded weight, in tons
      */
     private double ceilWeight(double val) {
-        if (supportVee.getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
+        if (isSmallSupportVehicle()) {
             // Deal first with possible variances from floating point precision by rounding
             // to the gram, then round the result up to the next kilogram. Then convert back
             // to metric tons.
@@ -851,7 +848,7 @@ public class TestSupportVehicle extends TestEntity {
 
     @Override
     public double getWeightAmmo() {
-        if (getEntity().getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
+        if (isSmallSupportVehicle()) {
             double weight = 0;
             for (Mounted<?> mounted : getEntity().getWeaponList()) {
                 weight += getSmallSVAmmoWeight(mounted);
@@ -864,10 +861,9 @@ public class TestSupportVehicle extends TestEntity {
 
     @Override
     public double getWeightPowerAmp() {
-        // Small support vees only use infantry weapons, which do not require
-        // amplifiers.
-        if (supportVee.getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
-            return 0.0;
+        // Small support vees only use infantry weapons, which do not require amplifiers
+        if (isSmallSupportVehicle()) {
+            return 0;
         }
 
         if (!engine.isFusion() && (engine.getEngineType() != Engine.FISSION)) {
@@ -895,7 +891,7 @@ public class TestSupportVehicle extends TestEntity {
 
             return ceilWeight(weight / 10);
         }
-        return 0.0;
+        return 0;
     }
 
     private static final EquipmentBitSet EXCLUDE = MiscType.F_BASIC_FIRECONTROL.asEquipmentBitSet().or(MiscType.F_ADVANCED_FIRECONTROL)
@@ -921,13 +917,8 @@ public class TestSupportVehicle extends TestEntity {
 
     @Override
     public int getCountHeatSinks() {
-        // Small support vees can't mount heavy weapons, so no reason to iterate through
-        // them to check.
-        if (supportVee.getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
-            return 0;
-        }
-
-        return heatNeutralHSRequirement();
+        // Small support vees can't mount heavy weapons, so no reason to iterate through them to check.
+        return isSmallSupportVehicle() ? 0 : heatNeutralHSRequirement();
     }
 
     @Override
@@ -960,7 +951,7 @@ public class TestSupportVehicle extends TestEntity {
 
     @Override
     public StringBuffer printAmmo(StringBuffer buff, int posLoc, int posWeight) {
-        if (getEntity().getWeightClass() != EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
+        if (!isSmallSupportVehicle()) {
             return super.printAmmo(buff, posLoc, posWeight);
         }
         for (Mounted<?> mounted : getEntity().getWeaponList()) {
@@ -987,13 +978,11 @@ public class TestSupportVehicle extends TestEntity {
     }
 
     public boolean canUseSponsonTurret() {
-        return sponsonLegal(SVType.getVehicleType(getEntity()),
-                getEntity().getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT);
+        return sponsonLegal(SVType.getVehicleType(getEntity()), isSmallSupportVehicle());
     }
 
     public boolean canUsePintleTurret() {
-        return pintleLegal(SVType.getVehicleType(getEntity()),
-                getEntity().getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT);
+        return pintleLegal(SVType.getVehicleType(getEntity()), isSmallSupportVehicle());
     }
 
     @Override
@@ -1005,8 +994,6 @@ public class TestSupportVehicle extends TestEntity {
         }
 
         if (!allowOverweightConstruction() && !correctWeight(buff)) {
-            buff.insert(0, printTechLevel() + printShortMovement());
-            buff.append(printWeightCalculation()).append("\n");
             correct = false;
         }
 
@@ -1103,6 +1090,8 @@ public class TestSupportVehicle extends TestEntity {
         int hardPoints = 0;
         boolean sponson = false;
         boolean pintle = false;
+        boolean hasAdvancedFireControl = false;
+
         for (Mounted<?> mounted : supportVee.getMisc()) {
             if (mounted.getType().hasFlag(MiscType.F_ARMORED_MOTIVE_SYSTEM)
                     && (getEntity() instanceof Aero || getEntity() instanceof VTOL)) {
@@ -1121,8 +1110,11 @@ public class TestSupportVehicle extends TestEntity {
                 sponson = true;
             } else if (mounted.getType().hasFlag(MiscType.F_PINTLE_TURRET)) {
                 pintle = true;
+            } else if (mounted.getType().hasFlag(MiscTypeFlag.F_ADVANCED_FIRECONTROL)) {
+                hasAdvancedFireControl = true;
             }
         }
+
         if (hardPoints > supportVee.getWeight() / 10.0) {
             buff.append("Exceeds maximum of one external stores hard point per 10 tons.\n");
             correct = false;
@@ -1141,7 +1133,7 @@ public class TestSupportVehicle extends TestEntity {
         }
         double weaponWeight = 0.0;
 
-        for (Mounted<?> mounted : supportVee.getWeaponList()) {
+        for (WeaponMounted mounted : supportVee.getWeaponList()) {
             if (!isValidWeapon(mounted)) {
                 buff.append(mounted.getType().getName()).append(" is not a valid weapon for this unit.\n");
                 correct = false;
@@ -1158,29 +1150,32 @@ public class TestSupportVehicle extends TestEntity {
             correct = false;
         }
         for (Mounted<?> mounted : supportVee.getEquipment()) {
-            if ((mounted.getType() instanceof MiscType)
-                    && !mounted.getType().hasFlag(MiscType.F_SUPPORT_TANK_EQUIPMENT)) {
-                buff.append(mounted.getType().getName()).append(" cannot be used by support vehicles.\n");
+            EquipmentType type = mounted.getType();
+            if ((type instanceof MiscType) && !type.hasFlag(MiscType.F_SUPPORT_TANK_EQUIPMENT)) {
+                buff.append(type.getName()).append(" cannot be used by support vehicles.\n");
                 correct = false;
-            } else if ((supportVee.getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT)
-                    && (((mounted.getType() instanceof WeaponType)
-                            && !mounted.getType().hasFlag(WeaponType.F_INFANTRY))
-                            || ((mounted.getType() instanceof MiscType)
-                                    && mounted.getType().hasFlag(MiscType.F_HEAVY_EQUIPMENT)))) {
-                buff.append("Small support vehicles cannot mount heavy weapons or equipment (")
-                        .append(mounted.getName()).append(").\n");
+            } else if (isSmallSupportVehicle()
+                    && (type instanceof WeaponType) && !type.hasFlag(WeaponType.F_INFANTRY)) {
+                buff.append("Small support vehicles cannot mount %s\n".formatted(mounted.getName()));
                 correct = false;
-            } else if ((mounted.getType() instanceof WeaponType)
-                    && (supportVee.getWeightClass() != EntityWeightClass.WEIGHT_SMALL_SUPPORT)
-                    && !mounted.getType().hasFlag(WeaponType.F_TANK_WEAPON)) {
-                buff.append(mounted.getType().getName()).append(" cannot be used by support vehicles.\n");
+            } else if ((type instanceof WeaponType)
+                    && !isSmallSupportVehicle()
+                    && !type.hasFlag(WeaponType.F_TANK_WEAPON)) {
+                buff.append(type.getName()).append(" cannot be used by support vehicles.\n");
                 correct = false;
-            } else if (!TestTank.legalForMotiveType(mounted.getType(), supportVee.getMovementMode(), true)) {
-                buff.append(mounted.getType().getName()).append(" is incompatible with ")
+            } else if (!TestTank.legalForMotiveType(type, supportVee.getMovementMode(), true)) {
+                buff.append(type.getName()).append(" is incompatible with ")
                         .append(supportVee.getMovementModeAsString());
                 correct = false;
             }
+
+            // TM p.209
+            if (type.isC3Equipment() && !hasAdvancedFireControl) {
+                buff.append("Support vehicles without advanced fire control cannot mount C3 equipment\n");
+                correct = false;
+            }
         }
+
         for (int loc = 0; loc < supportVee.locations(); loc++) {
             int count = 0;
 
@@ -1234,6 +1229,19 @@ public class TestSupportVehicle extends TestEntity {
         }
 
         return correct;
+    }
+
+    private boolean isSmallSupportVehicle() {
+        return isSmallSupportVehicle(getEntity());
+    }
+
+    public static boolean isSmallSupportVehicle(Entity entity) {
+        return entity.isSupportVehicle() && (entity.getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT);
+    }
+
+    public static boolean isSmallSupportVehicleWeapon(EquipmentType type) {
+        // I don't see an explicit rule that excludes archaic weapons but it seems to make sense
+        return (type instanceof InfantryWeapon) && !type.hasFlag(WeaponType.F_INF_ARCHAIC);
     }
 
     @Override
@@ -1321,7 +1329,7 @@ public class TestSupportVehicle extends TestEntity {
                 illegal = true;
             }
 
-            if (mod.smallOnly && (supportVee.getWeightClass() != EntityWeightClass.WEIGHT_SMALL_SUPPORT)) {
+            if (mod.smallOnly && !isSmallSupportVehicle()) {
                 buff.append(mod.equipment.getName())
                         .append(" is only valid with small support vehicles.\n");
                 illegal = true;
@@ -1352,7 +1360,7 @@ public class TestSupportVehicle extends TestEntity {
     boolean hasInsufficientSeating(StringBuffer buff) {
         // Small SVs are required to provide seating for all crew. M/L have
         // seating provided as part of the structure.
-        if (supportVee.getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
+        if (isSmallSupportVehicle()) {
             int minCrew = Compute.getFullCrewSize(supportVee);
 
             // Pillion and ejection seating are subclasses of StandardSeatCargoBay
@@ -1372,13 +1380,13 @@ public class TestSupportVehicle extends TestEntity {
         return false;
     }
 
-    private boolean isValidWeapon(Mounted<?> weapon) {
-        if (supportVee.getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
-            return weapon.getType().hasFlag(WeaponType.F_INFANTRY)
-                    && !weapon.getType().hasFlag(WeaponType.F_INFANTRY_ONLY);
+    private boolean isValidWeapon(WeaponMounted weapon) {
+        if (isSmallSupportVehicle()) {
+            return isSmallSupportVehicleWeapon(weapon.getType());
+        } else {
+            //TODO: Align with UnitUtil.isSupportVehicleEquipment()
+            return weapon.getType().hasFlag(WeaponType.F_TANK_WEAPON);
         }
-
-        return weapon.getType().hasFlag(WeaponType.F_TANK_WEAPON);
     }
 
     public boolean correctCriticals(StringBuffer buff) {
@@ -1397,7 +1405,7 @@ public class TestSupportVehicle extends TestEntity {
             }
         }
 
-        if (supportVee.getWeightClass() != EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
+        if (!isSmallSupportVehicle()) {
             for (Mounted<?> mount : supportVee.getAmmo()) {
                 if ((mount.getLocation() == Entity.LOC_NONE) && !mount.isOneShotAmmo()) {
                     unallocated.add(mount);
@@ -1609,7 +1617,7 @@ public class TestSupportVehicle extends TestEntity {
      */
     public int getAmmoSlots() {
         // Small SV ammo occupies the same slot as the weapon.
-        if (supportVee.getWeightClass() == EntityWeightClass.WEIGHT_SMALL_SUPPORT) {
+        if (isSmallSupportVehicle()) {
             return 0;
         }
 

--- a/megamek/src/megamek/common/weapons/c3/ISC3M.java
+++ b/megamek/src/megamek/common/weapons/c3/ISC3M.java
@@ -58,4 +58,9 @@ public class ISC3M extends TAGWeapon {
                 .setProductionFactions(Faction.DC)
                 .setStaticTechLevel(SimpleTechLevel.STANDARD);
     }
+
+    @Override
+    public boolean isC3Equipment() {
+        return true;
+    }
 }

--- a/megamek/src/megamek/common/weapons/c3/ISC3MBS.java
+++ b/megamek/src/megamek/common/weapons/c3/ISC3MBS.java
@@ -60,4 +60,9 @@ public class ISC3MBS extends TAGWeapon {
                 .setProductionFactions(Faction.FS)
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED);
     }
+
+    @Override
+    public boolean isC3Equipment() {
+        return true;
+    }
 }


### PR DESCRIPTION
Invalidates SV without advanced fire control and C3 equipment
Allows special equipment on small SV, see MegaMek/megameklab#1658
I tried to remove some duplicate (and disagreeing) tests, but there is a whole lot of that going on and not easily resolved as UnitUtil and similar classes of MML would need to be moved to MM and that's not easy as UnitUtil uses other MML stuff that shouldnt be ported.

Merge together with the MML PR.