### PR TITLE
Factions fixes

### DIFF
--- a/megamek/src/megamek/common/universe/Faction2.java
+++ b/megamek/src/megamek/common/universe/Faction2.java
@@ -126,10 +126,6 @@ public class Faction2 {
         return (nameByYear == null) ? name : nameByYear.getValue();
     }
 
-    public void setTags(final Set<FactionTag> tags) {
-        this.tags = tags;
-    }
-
     public Set<FactionTag> getTags() {
         return tags;
     }

--- a/megamek/src/megamek/common/universe/Factions2.java
+++ b/megamek/src/megamek/common/universe/Factions2.java
@@ -114,6 +114,17 @@ public final class Factions2 {
     }
 
     /**
+     * This constructor is intended for unit testing only and will load factions *only* from the provided path. The
+     * path is used as it is.
+     *
+     * @param factionsDataPath The path to load factions data from
+     */
+    public Factions2(String factionsDataPath) {
+        ObjectMapper mapper = getLoadMapper();
+        loadFactionsFromDirectory(factionsDataPath, mapper);
+    }
+
+    /**
      * @return All available factions. The returned Collection is a view of the internal faction list and must not be
      *       modified.
      */
@@ -135,10 +146,7 @@ public final class Factions2 {
      */
     private void loadFactionsFromFile() {
         LOGGER.info("Loading Faction and Command data...");
-        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
-        SimpleModule module = new SimpleModule();
-        module.addDeserializer(Color.class, new ColorDeserializer());
-        mapper.registerModule(module);
+        ObjectMapper mapper = getLoadMapper();
         loadFactionsFromDirectory(MMConstants.FACTIONS_DIR, mapper);
         loadFactionsFromDirectory(MMConstants.COMMANDS_DIR, mapper);
         String userDir = PreferenceManager.getClientPreferences().getUserDir();
@@ -147,6 +155,17 @@ public final class Factions2 {
             loadFactionsFromDirectory(new File(userDir, MMConstants.COMMANDS_DIR).toString(), mapper);
         }
         LOGGER.info(String.format("Loaded a total of %d factions and commands", factions.size()));
+    }
+
+    /**
+     * @return The Jackson ObjectMapper that should be used to load factions from the yaml files
+     */
+    private ObjectMapper getLoadMapper() {
+        ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+        SimpleModule module = new SimpleModule();
+        module.addDeserializer(Color.class, new ColorDeserializer());
+        mapper.registerModule(module);
+        return mapper;
     }
 
     /**

--- a/megamek/testresources/data/universe/factions/CBS_test.yml
+++ b/megamek/testresources/data/universe/factions/CBS_test.yml
@@ -1,0 +1,27 @@
+key: CBS
+name: Clan Blood Spirit
+capital: York (Clan)
+yearsActive:
+  - start: 2807
+    end: 3082
+tags:
+  - PLAYABLE
+  - MINOR
+  - CLAN
+  - BATCHALL
+color:
+  red: 255
+  green: 99
+  blue: 71
+logo: Clan/Clan Blood Spirit.png
+background: Clan/Clan Blood Spirit.png
+camos: Clans/Blood Spirit
+nameGenerator: Clan
+ratingLevels:
+  - Provisional Garrison
+  - Solahma
+  - Second Line
+  - Front Line
+  - Keshik
+fallBackFactions:
+  - CLAN.HW

--- a/megamek/testresources/data/universe/factions/LA_test.yml
+++ b/megamek/testresources/data/universe/factions/LA_test.yml
@@ -1,0 +1,42 @@
+key: LA
+name: Lyran Commonwealth
+nameChanges:
+  3058: Lyran Alliance
+  3085: Lyran Commonwealth
+capital: Tharkad
+yearsActive:
+  - start: 2341
+tags:
+  - PLAYABLE
+  - LENIENT
+  - MAJOR
+  - IS
+  - GENEROUS
+color:
+  red: 0
+  green: 114
+  blue: 188
+logo: Inner Sphere/Lyran Commonwealth.png
+background: Inner Sphere/Lyran Commonwealth.png
+camos: Lyran Commonwealth
+nameGenerator: LA
+eraMods:
+  - 0
+  - 0
+  - 0
+  - 1
+  - 1
+  - 2
+  - 2
+  - 0
+  - 0
+  - 1
+  - 0
+ratingLevels:
+  - F
+  - D
+  - C
+  - B
+  - A
+fallBackFactions:
+  - IS

--- a/megamek/unittests/megamek/common/universe/Faction2Test.java
+++ b/megamek/unittests/megamek/common/universe/Faction2Test.java
@@ -39,6 +39,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class Faction2Test {
 
+    static Factions2 getTestFactions2() {
+        return new Factions2("testresources/data/universe/factions");
+    }
+
     @Test
     void isActiveInYear() {
         // A faction with no active year entries must count as always active
@@ -64,13 +68,12 @@ class Faction2Test {
 
     @Test
     void testPerformsBatchall() {
-        // If the following faction codes ever change or their batchall behavior is changed, this test will fail
-        // I assume this isn't likely to happen anytime soon
-        var cbsFaction = Factions2.getInstance().getFaction("CBS");
+        var testFactions = getTestFactions2();
+        var cbsFaction = testFactions.getFaction("CBS");
         assertTrue(cbsFaction.isPresent());
         assertTrue(cbsFaction.get().performsBatchalls());
 
-        var laFaction = Factions2.getInstance().getFaction("LA");
+        var laFaction = testFactions.getFaction("LA");
         assertTrue(laFaction.isPresent());
         assertFalse(laFaction.get().performsBatchalls());
     }


### PR DESCRIPTION
see megamek/mekhq#7247 (merge together)

- removes a setter from faction2 so it is again immutable
- adds a factions2 constructor for test purposes that enables loading test factions from a given directory
- renames test factions so they arent easily confused with real data