### PR TITLE
Improvement: Added Aggregate Faction Tag

### DIFF
--- a/megamek/data/universe/factions/ABN.yml
+++ b/megamek/data/universe/factions/ABN.yml
@@ -6,6 +6,7 @@ tags:
   - ABANDONED
   - INACTIVE
   - CHAOS
+  - AGGREGATE
 color:
   red: 0
   green: 0

--- a/megamek/data/universe/factions/BAN.yml
+++ b/megamek/data/universe/factions/BAN.yml
@@ -4,6 +4,7 @@ yearsActive:
   - start: 2830
 tags:
   - CLAN
+  - AGGREGATE
 ratingLevels:
   - Solahma
 fallBackFactions:

--- a/megamek/data/universe/factions/CLAN.yml
+++ b/megamek/data/universe/factions/CLAN.yml
@@ -7,6 +7,7 @@ tags:
   - SPECIAL
   - CLAN
   - BATCHALL
+  - AGGREGATE
 color:
   red: 139
   green: 69

--- a/megamek/data/universe/factions/CM.yml
+++ b/megamek/data/universe/factions/CM.yml
@@ -8,6 +8,7 @@ tags:
   - IS
   - SMALL
   - CHAOS
+  - AGGREGATE
 color:
   red: 169
   green: 169

--- a/megamek/data/universe/factions/DIS.yml
+++ b/megamek/data/universe/factions/DIS.yml
@@ -4,6 +4,7 @@ capital: Terra
 tags:
   - SPECIAL
   - CHAOS
+  - AGGREGATE
 color:
   red: 192
   green: 192

--- a/megamek/data/universe/factions/IND.yml
+++ b/megamek/data/universe/factions/IND.yml
@@ -5,6 +5,7 @@ tags:
   - IS
   - SMALL
   - CHAOS
+  - AGGREGATE
 color:
   red: 191
   green: 179

--- a/megamek/data/universe/factions/IS.yml
+++ b/megamek/data/universe/factions/IS.yml
@@ -1,5 +1,8 @@
 key: IS
 name: Inner Sphere - General
+tags:
+  - IS
+  - AGGREGATE
 ratingLevels:
   - F
   - D

--- a/megamek/data/universe/factions/MERC.yml
+++ b/megamek/data/universe/factions/MERC.yml
@@ -8,6 +8,7 @@ capitalChanges:
 tags:
   - MERC
   - PLAYABLE
+  - AGGREGATE
 color:
   red: 169
   green: 169

--- a/megamek/data/universe/factions/NONE.yml
+++ b/megamek/data/universe/factions/NONE.yml
@@ -7,6 +7,7 @@ tags:
   - ABANDONED
   - INACTIVE
   - CHAOS
+  - AGGREGATE
 color:
   red: 0
   green: 0

--- a/megamek/data/universe/factions/PIR.yml
+++ b/megamek/data/universe/factions/PIR.yml
@@ -4,6 +4,7 @@ capital: Terra
 tags:
   - PLAYABLE
   - PIRATE
+  - AGGREGATE
 color:
   red: 128
   green: 40

--- a/megamek/data/universe/factions/Periphery.yml
+++ b/megamek/data/universe/factions/Periphery.yml
@@ -2,6 +2,7 @@ key: Periphery
 name: Periphery
 tags:
   - PERIPHERY
+  - AGGREGATE
 ratingLevels:
   - F
   - D

--- a/megamek/data/universe/factions/REB.yml
+++ b/megamek/data/universe/factions/REB.yml
@@ -3,6 +3,7 @@ name: Rebels
 capital: Terra
 tags:
   - REBEL
+  - AGGREGATE
 color:
   red: 192
   green: 192

--- a/megamek/data/universe/factions/RON.yml
+++ b/megamek/data/universe/factions/RON.yml
@@ -4,6 +4,7 @@ capital: Predlitz
 tags:
   - MINOR
   - IS
+  - AGGREGATE
 color:
   red: 237
   green: 28

--- a/megamek/data/universe/factions/UND.yml
+++ b/megamek/data/universe/factions/UND.yml
@@ -6,6 +6,7 @@ tags:
   - ABANDONED
   - INACTIVE
   - CHAOS
+  - AGGREGATE
 color:
   red: 0
   green: 0

--- a/megamek/src/megamek/common/universe/Faction2.java
+++ b/megamek/src/megamek/common/universe/Faction2.java
@@ -369,6 +369,20 @@ public class Faction2 {
         return tags.contains(FactionTag.BATCHALL);
     }
 
+    /**
+     * @return {@code true} if the faction is an aggregate of independent 'factions', rather than a singular
+     *       organization.
+     *
+     *       <p>For example, "PIR" (pirates) is used to abstractly represent all pirates, not individual pirate
+     *       groups.</p>
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public boolean isAggregate() {
+        return tags.contains(FactionTag.AGGREGATE);
+    }
+
     @Override
     public String toString() {
         return key;

--- a/megamek/src/megamek/common/universe/FactionTag.java
+++ b/megamek/src/megamek/common/universe/FactionTag.java
@@ -94,5 +94,10 @@ public enum FactionTag {
     /** Faction is lenient with mercenary command rights (Camops p. 42) */
     LENIENT,
     /** Faction performs batchall */
-    BATCHALL
+    BATCHALL,
+    /**
+     * Represents an aggregate of independent 'factions', rather than a singular organization. For example, "PIR"
+     * (pirates) is used to abstractly represent all pirates, not individual pirate groups.
+     */
+    AGGREGATE,
 }


### PR DESCRIPTION
This PR adds a new faction tag `AGGREGATE` that is used to flag that a faction is not a singular entity but an aggregate of different independent factions.

The example I used in the code was the pirate faction. This represents not a singular monolithic pirate organization, but an _aggregate_ of numerous pirate bands.

This was introduced to simplify MekHQ's faction standing so that we can easily exclude aggregate factions from Faction Standing tracking.