### PR TITLE
Improvement: Added Rank System Code to Faction Data

### DIFF
--- a/megamek/data/universe/factions/ARC.yml
+++ b/megamek/data/universe/factions/ARC.yml
@@ -28,3 +28,4 @@ eraMods:
   - 0
   - 3
   - 3
+rankSystem: ACM

--- a/megamek/data/universe/factions/CC.yml
+++ b/megamek/data/universe/factions/CC.yml
@@ -37,3 +37,4 @@ ratingLevels:
   - A
 fallBackFactions:
   - IS
+rankSystem: CCAF

--- a/megamek/data/universe/factions/CS.yml
+++ b/megamek/data/universe/factions/CS.yml
@@ -27,3 +27,4 @@ fallBackFactions:
   - IS
 formationBaseSize: 6
 formationGrouping: 6
+rankSystem: CG

--- a/megamek/data/universe/factions/DC.yml
+++ b/megamek/data/universe/factions/DC.yml
@@ -39,3 +39,4 @@ ratingLevels:
   - A
 fallBackFactions:
   - IS
+rankSystem: DCMS

--- a/megamek/data/universe/factions/FC.yml
+++ b/megamek/data/universe/factions/FC.yml
@@ -39,3 +39,4 @@ ratingLevels:
 fallBackFactions:
   - LA
   - FS
+rankSystem: AFFC

--- a/megamek/data/universe/factions/FRR.yml
+++ b/megamek/data/universe/factions/FRR.yml
@@ -39,3 +39,4 @@ ratingLevels:
   - A
 fallBackFactions:
   - IS
+rankSystem: KA

--- a/megamek/data/universe/factions/FS.yml
+++ b/megamek/data/universe/factions/FS.yml
@@ -36,3 +36,4 @@ ratingLevels:
   - A
 fallBackFactions:
   - IS
+rankSystem: AFFS

--- a/megamek/data/universe/factions/FWL.yml
+++ b/megamek/data/universe/factions/FWL.yml
@@ -37,3 +37,4 @@ ratingLevels:
   - A
 fallBackFactions:
   - IS
+rankSystem: FWLM

--- a/megamek/data/universe/factions/LA.yml
+++ b/megamek/data/universe/factions/LA.yml
@@ -40,3 +40,4 @@ ratingLevels:
   - A
 fallBackFactions:
   - IS
+rankSystem: LCAF

--- a/megamek/data/universe/factions/MH.yml
+++ b/megamek/data/universe/factions/MH.yml
@@ -36,3 +36,4 @@ ratingLevels:
 fallBackFactions:
   - Periphery.ME
 formationBaseSize: 5
+rankSystem: MHAF

--- a/megamek/data/universe/factions/MOC.yml
+++ b/megamek/data/universe/factions/MOC.yml
@@ -35,3 +35,4 @@ ratingLevels:
   - A
 fallBackFactions:
   - Periphery.CM
+rankSystem: MAF

--- a/megamek/data/universe/factions/OA.yml
+++ b/megamek/data/universe/factions/OA.yml
@@ -37,3 +37,4 @@ ratingLevels:
   - A
 fallBackFactions:
   - Periphery.OS
+rankSystem: AMC

--- a/megamek/data/universe/factions/TC.yml
+++ b/megamek/data/universe/factions/TC.yml
@@ -35,3 +35,4 @@ ratingLevels:
   - A
 fallBackFactions:
   - Periphery.HR
+rankSystem: TDF

--- a/megamek/data/universe/factions/WOB.yml
+++ b/megamek/data/universe/factions/WOB.yml
@@ -24,3 +24,4 @@ fallBackFactions:
   - IS
 formationBaseSize: 6
 formationGrouping: 6
+rankSystem: WOBM

--- a/megamek/src/megamek/common/universe/Faction2.java
+++ b/megamek/src/megamek/common/universe/Faction2.java
@@ -102,7 +102,7 @@ public class Faction2 {
     private final HonorRating postInvasionHonorRating = HonorRating.NONE;
     private int formationBaseSize = UNKNOWN;
     private int formationGrouping = UNKNOWN;
-    private String rankSystem = UNKNOWN + "";
+    private String rankSystem = null;
 
     public List<String> getRatingLevels() {
         return ratingLevels;

--- a/megamek/src/megamek/common/universe/Faction2.java
+++ b/megamek/src/megamek/common/universe/Faction2.java
@@ -35,15 +35,7 @@ package megamek.common.universe;
 import java.awt.Color;
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.Optional;
-import java.util.Set;
-import java.util.TreeMap;
+import java.util.*;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -77,12 +69,14 @@ import megamek.client.ratgenerator.FactionRecord;
  * avoid repetition.
  */
 @SuppressWarnings("unused") // Class fields are assigned when factions are loaded from YAML files
-@JsonPropertyOrder({"key", "name", "nameChanges", "capital", "capitalChanges", "yearsActive", "successor",
-      "tags", "color", "logo", "background", "camos", "camosChanges", "nameGenerator", "eraMods", "ratingLevels",
-      "fallBackFactions", "preInvasionHonorRating", "postInvasionHonorRating", "formationBaseSize", "formationGrouping"})
+@JsonPropertyOrder({ "key", "name", "nameChanges", "capital", "capitalChanges", "yearsActive", "successor", "tags",
+                     "color", "logo", "background", "camos", "camosChanges", "nameGenerator", "eraMods", "ratingLevels",
+                     "fallBackFactions", "preInvasionHonorRating", "postInvasionHonorRating", "formationBaseSize",
+                     "formationGrouping", "rankSystem" })
 public class Faction2 {
-
     private static final int UNKNOWN = -1;
+    private static final String DEFAULT_RANK_SYSTEM_INNER_SPHERE = "SLDF";
+    private static final String DEFAULT_RANK_SYSTEM_CLAN = "CLAN";
 
     private String key;
     private String name;
@@ -108,6 +102,7 @@ public class Faction2 {
     private final HonorRating postInvasionHonorRating = HonorRating.NONE;
     private int formationBaseSize = UNKNOWN;
     private int formationGrouping = UNKNOWN;
+    private String rankSystem = UNKNOWN + "";
 
     public List<String> getRatingLevels() {
         return ratingLevels;
@@ -240,6 +235,38 @@ public class Faction2 {
         return isClan() ? 5 : 3;
     }
 
+    /**
+     * Retrieves the rank system identifier for this faction.
+     *
+     * <p>The method checks the `rankSystem` field; if it is set and not {@link #UNKNOWN}, its value is returned
+     * directly.</p>
+     *
+     * <p>If the rank system is unspecified but there are fallback factions, the method iterates through each
+     * fallback faction, returning the first available rank system found among them.</p>
+     *
+     * <p>If no fallback faction provides a rank system, the method returns a default value based on whether the
+     * faction is a clan or not.</p>
+     *
+     * @return the rank system identifier for this faction, or a default value ({@link #DEFAULT_RANK_SYSTEM_CLAN} for
+     *       Clan factions, {@link #DEFAULT_RANK_SYSTEM_INNER_SPHERE} for non-Clan factions) if not specified.
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public String getRankSystem() {
+        if (!Objects.equals(rankSystem, UNKNOWN + "")) {
+            return rankSystem;
+        } else if (!fallBackFactions.isEmpty()) {
+            for (String factionCode : fallBackFactions) {
+                Optional<Faction2> fallBackFaction = Factions2.getInstance().getFaction(factionCode);
+                if (fallBackFaction.isPresent()) {
+                    return fallBackFaction.get().getRankSystem();
+                }
+            }
+        }
+        return isClan() ? DEFAULT_RANK_SYSTEM_CLAN : DEFAULT_RANK_SYSTEM_INNER_SPHERE;
+    }
+
     @JsonIgnore
     public boolean isClan() {
         return is(FactionTag.CLAN);
@@ -353,8 +380,13 @@ public class Faction2 {
     }
 
     @JsonGetter("formationBaseSize")
-    private Integer originalformationBaseSize() {
+    private Integer originalFormationBaseSize() {
         return formationBaseSize != UNKNOWN ? formationBaseSize : null;
+    }
+
+    @JsonGetter("rankSystem")
+    private String originalRankSystem() {
+        return !Objects.equals(rankSystem, UNKNOWN + "") ? rankSystem : null;
     }
 
     @JsonGetter("tags") // sorts tags alphabetically (would be random otherwise)

--- a/megamek/src/megamek/common/universe/Faction2.java
+++ b/megamek/src/megamek/common/universe/Faction2.java
@@ -238,7 +238,7 @@ public class Faction2 {
     /**
      * Retrieves the rank system identifier for this faction.
      *
-     * <p>The method checks the `rankSystem` field; if it is set and not {@link #UNKNOWN}, its value is returned
+     * <p>The method checks the `rankSystem` field; if it is set and not {@code null}, its value is returned
      * directly.</p>
      *
      * <p>If the rank system is unspecified but there are fallback factions, the method iterates through each
@@ -254,7 +254,7 @@ public class Faction2 {
      * @since 0.50.07
      */
     public String getRankSystem() {
-        if (!Objects.equals(rankSystem, UNKNOWN + "")) {
+        if (rankSystem != null) {
             return rankSystem;
         } else if (!fallBackFactions.isEmpty()) {
             for (String factionCode : fallBackFactions) {


### PR DESCRIPTION
This PR adds Rank System codes to those factions with associated rank systems in MekHQ. This allows us to easily fetch the appropriate rank system in the event we, for example, want to generate NPC personnel with appropriate ranks for their faction.