### PR TITLE
type name for HHW and proper internals for Infantry

### DIFF
--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -14135,6 +14135,8 @@ public abstract class Entity extends TurnOrdered
             return "Infantry";
         } else if ((typeId & ETYPE_PROTOMEK) == ETYPE_PROTOMEK) {
             return "ProtoMek";
+        } else if ((typeId & ETYPE_HANDHELD_WEAPON) == ETYPE_HANDHELD_WEAPON) {
+            return "Handheld Weapon";
         } else {
             return "Unknown";
         }
@@ -14204,6 +14206,8 @@ public abstract class Entity extends TurnOrdered
             return "VTOL";
         } else if ((typeId & ETYPE_TANK) == ETYPE_TANK) {
             return "Tank";
+        } else if ((typeId & ETYPE_HANDHELD_WEAPON) == ETYPE_HANDHELD_WEAPON) {
+            return "Handheld Weapon";
         } else {
             return "Unknown";
         }

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -726,10 +726,13 @@ public class Infantry extends Entity {
 
     @Override
     public int getOInternal(int loc) {
+        if (!isConventionalInfantry()) {
+            return super.getOInternal(loc);
+        }
         if (loc != LOC_INFANTRY) {
             return 0;
         }
-        return isConventionalInfantry() ? originalTrooperCount : super.getOInternal(loc);
+        return originalTrooperCount;
     }
 
     /**

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -726,6 +726,9 @@ public class Infantry extends Entity {
 
     @Override
     public int getOInternal(int loc) {
+        if (loc != LOC_INFANTRY) {
+            return 0;
+        }
         return isConventionalInfantry() ? originalTrooperCount : super.getOInternal(loc);
     }
 


### PR DESCRIPTION
This PR:
- adds a type name for Handheld Weapons instead of returning Unknown
- fixes the infantry wrongly reporting the original internals when `loc != LOC_INFANTRY`