### PR TITLE
Fix ASF SI damage being applied until dead

### DIFF
--- a/megamek/src/megamek/server/totalwarfare/TWDamageManagerModular.java
+++ b/megamek/src/megamek/server/totalwarfare/TWDamageManagerModular.java
@@ -1153,6 +1153,9 @@ public class TWDamageManagerModular extends TWDamageManager implements IDamageMa
                 }
                 // check for aero crits from natural 12 or threshold; LAMs take damage as meks
                 manager.checkAeroCrits(reportVec, aero, hit, damage_orig, critThresh, critSI, ammoExplosion, nukeS2S);
+                
+                // Return early
+                return;
             }
 
             damage = applyEntityArmorDamage(aero, hit, damage, ammoExplosion, damageIS, areaSatArty, reportVec, mods);
@@ -1265,8 +1268,6 @@ public class TWDamageManagerModular extends TWDamageManager implements IDamageMa
                 reportVec.addElement(report);
                 // check to see if this would destroy the ASF
                 if (aero.getSI() <= 0) {
-                    // Set damage to 0 to avoid infinite loop!
-                    damage = 0;
                     // Lets auto-eject if we can!
                     if (aero.isAutoEject() &&
                               (!game.getOptions().booleanOption(OptionsConstants.RPG_CONDITIONAL_EJECTION) ||
@@ -1284,6 +1285,8 @@ public class TWDamageManagerModular extends TWDamageManager implements IDamageMa
                     }
                 }
             }
+            // All damage should now be handled
+            damage = 0;
         }
 
         // Damage _applied_ by this attack should be original damageThisPhase minus current value

--- a/megamek/unittests/megamek/server/totalwarfare/TWDamageManagerTest.java
+++ b/megamek/unittests/megamek/server/totalwarfare/TWDamageManagerTest.java
@@ -735,4 +735,27 @@ class TWDamageManagerTest {
         assertTrue(gameMan.checkForPSRFromDamage(asf2));
     }
 
+    @Test
+    void damageAeroSIWithHalvedDamageTransfer() throws FileNotFoundException {
+        String unit = "Seydlitz C.blk";
+        AeroSpaceFighter asf = loadASF(unit);
+
+        // Validate starting armor and SI
+        assertEquals(11, asf.getArmor(AeroSpaceFighter.LOC_LWING));
+        assertEquals(11, asf.getSI());
+
+        // Deal 13 points of damage (should fill 11 circles and deal 1 SI damage without overflowing and 
+        // destroying the unit)
+        HitData hit = new HitData(AeroSpaceFighter.LOC_LWING);
+        hit.setGeneralDamageType(HitData.DAMAGE_MISSILE);
+        DamageInfo damageInfo = new DamageInfo(asf, hit, 13);
+        newMan.damageEntity(damageInfo);
+
+        assertEquals(IArmorState.ARMOR_DESTROYED, asf.getArmor(AeroSpaceFighter.LOC_LWING));
+        assertEquals(10, asf.getSI());
+        assertTrue(asf.wasCritThresh());
+        assertTrue(gameMan.checkForPSRFromDamage(asf));
+        assertFalse(asf.isDestroyed());
+        assertFalse(asf.isDoomed());
+    }
 }


### PR DESCRIPTION
Fixes an issue where SI damage that transfers through armor will be applied until the Aerospace unit is destroyed, after being reduced to 1 over repeated iterations but never reaching 0.

The root cause was two-fold:
1. The `while (damage > 0)` loop from the original `damageEntity()` function was retained here, despite ASF damage using an early return to leave this loop in the original code.
2. the damage value, once applied to SI, would never reach 0, remaining at 1 until the unit was destroyed by repeated SI hits.

Fix simplifies the `damageASF()` function by removing the while loop, _and_ explicitly sets damage to 0 after all handling is complete.

Testing:
- Added a unit test to replicate the OP's bug (save game from the reported issue could not be loaded due to changes since the May builds)
- Ran all three projects' unit tests

Close #7276 