### PR TITLE
Improvement: Added Faction Leadership Tracking to Faction Overhaul

### DIFF
--- a/megamek/src/megamek/common/universe/Faction2.java
+++ b/megamek/src/megamek/common/universe/Faction2.java
@@ -48,6 +48,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import megamek.MMConstants;
 import megamek.client.ratgenerator.FactionRecord;
+import megamek.common.annotations.Nullable;
 
 /**
  * This is a Faction class that unifies MHQ's Faction and the RATGenerator's FactionRecord and makes it available to all
@@ -72,7 +73,7 @@ import megamek.client.ratgenerator.FactionRecord;
 @JsonPropertyOrder({ "key", "name", "nameChanges", "capital", "capitalChanges", "yearsActive", "successor", "tags",
                      "color", "logo", "background", "camos", "camosChanges", "nameGenerator", "eraMods", "ratingLevels",
                      "fallBackFactions", "preInvasionHonorRating", "postInvasionHonorRating", "formationBaseSize",
-                     "formationGrouping", "rankSystem" })
+                     "formationGrouping", "rankSystem", "factionLeaders" })
 public class Faction2 {
     private static final int UNKNOWN = -1;
     private static final String DEFAULT_RANK_SYSTEM_INNER_SPHERE = "SLDF";
@@ -103,6 +104,7 @@ public class Faction2 {
     private int formationBaseSize = UNKNOWN;
     private int formationGrouping = UNKNOWN;
     private String rankSystem = null;
+    private List<FactionLeaderData> factionLeaders = new ArrayList<>();
 
     public List<String> getRatingLevels() {
         return ratingLevels;
@@ -267,6 +269,49 @@ public class Faction2 {
         return isClan() ? DEFAULT_RANK_SYSTEM_CLAN : DEFAULT_RANK_SYSTEM_INNER_SPHERE;
     }
 
+    /**
+     * Returns the list of leaders for this faction.
+     *
+     * @return a list containing all {@link FactionLeaderData} objects associated with this faction
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public List<FactionLeaderData> getFactionLeaders() {
+        return factionLeaders;
+    }
+
+    /**
+     * Sets the list of leaders for this faction.
+     *
+     * @param factionLeaders the list of {@link FactionLeaderData} to associate with this faction
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public void setFactionLeaders(List<FactionLeaderData> factionLeaders) {
+        this.factionLeaders = factionLeaders;
+    }
+
+    /**
+     * Retrieves the faction leader in power during the specified year.
+     *
+     * @param year the year to check for a valid leader
+     *
+     * @return the {@link FactionLeaderData} for the leader valid in the given year, or {@code null} if none found
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public @Nullable FactionLeaderData getFactionLeaderForYear(final int year) {
+        for (FactionLeaderData leader : factionLeaders) {
+            if (leader.isValidInYear(year)) {
+                return leader;
+            }
+        }
+        return null;
+    }
+
     @JsonIgnore
     public boolean isClan() {
         return is(FactionTag.CLAN);
@@ -387,6 +432,11 @@ public class Faction2 {
     @JsonGetter("rankSystem")
     private String originalRankSystem() {
         return !Objects.equals(rankSystem, UNKNOWN + "") ? rankSystem : null;
+    }
+
+    @JsonGetter("factionLeaders")
+    private List<FactionLeaderData> originalFactionLeaders() {
+        return !Objects.equals(factionLeaders, new ArrayList<>()) ? factionLeaders : null;
     }
 
     @JsonGetter("tags") // sorts tags alphabetically (would be random otherwise)

--- a/megamek/src/megamek/common/universe/FactionLeaderData.java
+++ b/megamek/src/megamek/common/universe/FactionLeaderData.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2009 - Jay Lawson (jaylawson39 at yahoo.com). All Rights Reserved.
+ * Copyright (C) 2009-2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MekHQ.
+ *
+ * MekHQ is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MekHQ is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MekHQ was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.universe;
+
+import megamek.common.annotations.Nullable;
+import megamek.common.enums.Gender;
+
+/**
+ * Stores details about a leader of a faction, including name, gender, and years of tenure.
+ *
+ * <p>This record encapsulates all relevant information about an individual who has led a given faction, such as
+ * their title, full name, gender, period in office, and any additional honorifics. It also provides utility methods for
+ * constructing full display titles and for validating the leader's tenure for a given year.</p>
+ *
+ * @param title     the leader's title (e.g., "Duke", "Commander")
+ * @param firstName the leader's given name
+ * @param surname   the leader's surname; may be {@code null}
+ * @param honorific additional information following the leader's name (e.g., "III"); may be {@code null}
+ * @param gender    the gender of the leader
+ * @param startYear the first year of the leader's tenure, or {@code null} if unknown
+ * @param endYear   the last year of the leader's tenure, or {@code null} if unknown
+ *
+ * @author Illiani
+ * @since 0.50.07
+ */
+public record FactionLeaderData(
+      String title,
+      String firstName,
+      @Nullable String surname,
+      @Nullable String honorific,
+      Gender gender,
+      @Nullable Integer startYear,
+      @Nullable Integer endYear
+) {
+    /** Constant indicating that no year was specified. */
+    final static int NO_YEAR = -1;
+
+    /**
+     * Compact constructor that replaces any {@code null} surname or honorific with empty strings, and sets missing
+     * years to {@link #NO_YEAR}.
+     *
+     * @param title     the leader's title
+     * @param firstName the leader's given name
+     * @param surname   the leader's surname; may be {@code null}
+     * @param honorific additional name information; may be {@code null}
+     * @param gender    the leader's gender
+     * @param startYear the first year of the leader's tenure; may be {@code null}
+     * @param endYear   the last year of the leader's tenure; may be {@code null}
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public FactionLeaderData {
+        if (surname == null) {
+            surname = "";
+        }
+        if (honorific == null) {
+            honorific = "";
+        }
+        if (startYear == null) {
+            startYear = NO_YEAR;
+        }
+        if (endYear == null) {
+            endYear = NO_YEAR;
+        }
+    }
+
+    /**
+     * Returns the full name of the leader, constructed from the first name and surname.
+     *
+     * @return the full name (first name and surname separated by a space)
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public String getFullName() {
+        return firstName + " " + surname;
+    }
+
+    /**
+     * Constructs and returns the full formal title of the leader.
+     *
+     * @param excludeFirstOfTheirName if true, omits the honorific "I" (used for the first of their name)
+     *
+     * @return the complete title line for the leader, including honorifics
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public String getFullTitle(boolean excludeFirstOfTheirName) {
+        String honorificToUse = honorific;
+        if (honorific.equals("I") && excludeFirstOfTheirName) {
+            honorificToUse = "";
+        }
+
+        if (!honorificToUse.isBlank()) {
+            honorificToUse += ' ';
+        }
+
+        return title + ' ' + getFullName() + honorificToUse;
+    }
+
+    /**
+     * Determines if this leader was in office during the specified year.
+     *
+     * @param year the year to check for validity
+     *
+     * @return {@code true} if the year is within the leader's tenure, {@code false} otherwise
+     *
+     * @author Illiani
+     * @since 0.50.07
+     */
+    public boolean isValidInYear(int year) {
+        return (startYear == NO_YEAR || year >= startYear)
+                     && (endYear == NO_YEAR || year < endYear);
+    }
+}


### PR DESCRIPTION
This PR allows us to store information about a faction's leaders in their YAML entry. It doesn't do anything on its own, but I opted to include the data separately as it's liable to be fairly hefty. Below is an excerpt from a completed YAML entry:

<img width="218" alt="image" src="https://github.com/user-attachments/assets/a886d12f-7584-47c8-9ed6-3ec941929554" />
