### PR TITLE
WAA refactor after move

### DIFF
--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -4189,7 +4189,6 @@ WeaponAttackAction.CantAttackOtherBoard=Cannot target a different board with thi
 WeaponAttackAction.CantShootWithInferno=Can not target that unit type with Inferno rounds.
 WeaponAttackAction.CantTAGAero=Can not target airborne units with TAG.
 WeaponAttackAction.CantTAGInf=Can not target infantry with TAG.
-WeaponAttackAction.DeadZone=target is in dead-zone.
 WeaponAttackAction.GroundedSpheroidDropshipAftWeaponRestriction=grounded spheroids cannot use aft weapons except against units directly underneath.
 WeaponAttackAction.HomingMapsheetOnly=Off board homing shot must target a map sheet.
 WeaponAttackAction.InsideBuilding=Targeting building from inside (are you SURE this is a good idea?)

--- a/megamek/i18n/megamek/client/messages.properties
+++ b/megamek/i18n/megamek/client/messages.properties
@@ -4189,6 +4189,7 @@ WeaponAttackAction.CantAttackOtherBoard=Cannot target a different board with thi
 WeaponAttackAction.CantShootWithInferno=Can not target that unit type with Inferno rounds.
 WeaponAttackAction.CantTAGAero=Can not target airborne units with TAG.
 WeaponAttackAction.CantTAGInf=Can not target infantry with TAG.
+WeaponAttackAction.DeadZone=target is in dead-zone.
 WeaponAttackAction.GroundedSpheroidDropshipAftWeaponRestriction=grounded spheroids cannot use aft weapons except against units directly underneath.
 WeaponAttackAction.HomingMapsheetOnly=Off board homing shot must target a map sheet.
 WeaponAttackAction.InsideBuilding=Targeting building from inside (are you SURE this is a good idea?)

--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -33,15 +33,7 @@
  */
 package megamek.common;
 
-import java.util.ArrayList;
-import java.util.EnumMap;
-import java.util.EnumSet;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Vector;
+import java.util.*;
 
 import megamek.common.annotations.Nullable;
 import megamek.common.equipment.WeaponMounted;
@@ -218,6 +210,13 @@ public class AmmoType extends EquipmentType {
          */
         public static AmmoTypeEnum fromIndex(int index) {
             return INDEX_LOOKUP.getOrDefault(index, NA);
+        }
+
+        /**
+         * @return True if this ammo type is any of the given types
+         */
+        public boolean isAnyOf(AmmoTypeEnum type, AmmoTypeEnum... otherTypes) {
+            return (this == type) || Arrays.stream(otherTypes).anyMatch(t -> this == t);
         }
     }
 

--- a/megamek/src/megamek/common/BTObject.java
+++ b/megamek/src/megamek/common/BTObject.java
@@ -387,7 +387,10 @@ public interface BTObject {
      * <p>
      * Note that this is not equivalent to "this instanceof Aero" as LAMs are not an Aero subclass. It is also not
      * equivalent to "this instanceof IAero" as LAMs are always IAero but only return true for isAero() when they are
-     * in fighter conversion mode.
+     * in fighter conversion mode. The following cast can be safely made:
+     * <pre>{@code if (entity.isAero()) {
+     *     IAero iAero = (IAero) entity;
+     * }}</pre>
      *
      * @return True when this may use aerospace movement (aerospace and LAM units)
      */

--- a/megamek/src/megamek/common/Compute.java
+++ b/megamek/src/megamek/common/Compute.java
@@ -1765,20 +1765,6 @@ public class Compute {
     }
 
     /**
-     * If BAP setting is enbabled and unit has a BAP.
-     * check if target is within BAP range.
-     * check if entity is Affected by ECM.
-     *
-     * @return if target si in range and entity is not affected
-     */
-    public static boolean bapInRange(Game game, Entity entity, Entity target) {
-        return entity.hasBAP()
-            && (target != null) && !target.isOffBoard() && (target.getPosition() != null)
-            && (entity.getBAPRange() >= Compute.effectiveDistance(game, entity, target))
-            && !ComputeECM.isAffectedByECM(entity, entity.getPosition(), target.getPosition());
-    }
-
-    /**
      * Finds the effective distance between an attacker and a target. Includes
      * the distance bonus if the attacker and target are in the same building
      * and on different levels. Also takes account of altitude differences

--- a/megamek/src/megamek/common/Entity.java
+++ b/megamek/src/megamek/common/Entity.java
@@ -11946,6 +11946,10 @@ public abstract class Entity extends TurnOrdered
         return false;
     }
 
+    /**
+     * @return The ID of a unit that this unit is grappling or grappled by; Entity.NONE if not grappling anything and
+     *       not being grappled.
+     */
     public int getGrappled() {
         return Entity.NONE;
     }

--- a/megamek/src/megamek/common/EquipmentType.java
+++ b/megamek/src/megamek/common/EquipmentType.java
@@ -526,6 +526,9 @@ public class EquipmentType implements ITechnology {
         return flags.get(flag);
     }
 
+    /**
+     * @return True when the equipment has at least one of the given flags.
+     */
     public boolean hasAnyFlag(EquipmentFlag... flags) {
         return Arrays.stream(flags).anyMatch(this::hasFlag);
     }

--- a/megamek/src/megamek/common/WeaponType.java
+++ b/megamek/src/megamek/common/WeaponType.java
@@ -72,8 +72,6 @@ import megamek.common.weapons.tag.ISTAG;
 import megamek.common.weapons.unofficial.*;
 import megamek.logging.MMLogger;
 
-// TODO add XML support back in.
-
 /**
  * A type of mek or vehicle weapon. There is only one instance of this weapon
  * for all weapons of this type.
@@ -283,32 +281,6 @@ public class WeaponType extends EquipmentType {
     // Used for BA vs BA damage for BA Plasma Rifle
     public static final int WEAPON_PLASMA = 15;
 
-    public static String[] classNames = {
-            "Unknown",
-            "Laser",
-            "Point Defense",
-            "PPC",
-            "Pulse Laser",
-            "Artillery",
-            "Plasma",
-            "AC",
-            "LBX",
-            "LRM",
-            "SRM",
-            "MRM",
-            "ATM",
-            "Rocket Launcher",
-            "Capital Laser",
-            "Capital PPC",
-            "Capital AC",
-            "Capital Gauss",
-            "Capital Missile",
-            "AR10", "Screen",
-            "Sub Capital Cannon",
-            "Capital Mass Driver",
-            "AMS"
-    };
-
     public static final int BFCLASS_STANDARD = 0;
     public static final int BFCLASS_LRM = 1;
     public static final int BFCLASS_SRM = 2;
@@ -365,13 +337,6 @@ public class WeaponType extends EquipmentType {
     protected boolean subCapital = false;
     protected int atClass = CLASS_NONE;
 
-    /**
-     * @return true if the weapon type is able to be fired indirectly.
-     */
-    public boolean canIndirect() {
-        return false;
-    }
-
     public void setDamage(int inD) {
         damage = inD;
     }
@@ -383,20 +348,6 @@ public class WeaponType extends EquipmentType {
 
     public void setMinimumRange(int inMR) {
         minimumRange = inMR;
-    }
-
-    public void setRanges(int sho, int med, int lon, int ext) {
-        shortRange = sho;
-        mediumRange = med;
-        longRange = lon;
-        extremeRange = ext;
-    }
-
-    public void setWaterRanges(int sho, int med, int lon, int ext) {
-        waterShortRange = sho;
-        waterMediumRange = med;
-        waterLongRange = lon;
-        waterExtremeRange = ext;
     }
 
     public void setAmmoType(AmmoTypeEnum inAT) {
@@ -738,63 +689,39 @@ public class WeaponType extends EquipmentType {
      */
     public EquipmentType getBayType(boolean capitalOnly) {
         // Return the correct weapons bay for the given type of weapon
-        switch (getAtClass()) {
-            case CLASS_LASER:
-                return EquipmentType.get(EquipmentTypeLookup.LASER_BAY);
-            case CLASS_AMS:
-                return EquipmentType.get(EquipmentTypeLookup.AMS_BAY);
-            case CLASS_POINT_DEFENSE:
-                return EquipmentType.get(EquipmentTypeLookup.POINT_DEFENSE_BAY);
-            case CLASS_PPC:
-                return EquipmentType.get(EquipmentTypeLookup.PPC_BAY);
-            case CLASS_PULSE_LASER:
-                return EquipmentType.get(EquipmentTypeLookup.PULSE_LASER_BAY);
-            case CLASS_ARTILLERY:
-                return EquipmentType.get(EquipmentTypeLookup.ARTILLERY_BAY);
-            case CLASS_PLASMA:
-                return EquipmentType.get(EquipmentTypeLookup.PLASMA_BAY);
-            case CLASS_AC:
-                return EquipmentType.get(EquipmentTypeLookup.AC_BAY);
-            case CLASS_LBX_AC:
-                return EquipmentType.get(EquipmentTypeLookup.LBX_AC_BAY);
-            case CLASS_LRM:
-                return EquipmentType.get(EquipmentTypeLookup.LRM_BAY);
-            case CLASS_SRM:
-                return EquipmentType.get(EquipmentTypeLookup.SRM_BAY);
-            case CLASS_MRM:
-                return EquipmentType.get(EquipmentTypeLookup.MRM_BAY);
-            case CLASS_MML:
-                return EquipmentType.get(EquipmentTypeLookup.MML_BAY);
-            case CLASS_THUNDERBOLT:
-                return EquipmentType.get(EquipmentTypeLookup.THUNDERBOLT_BAY);
-            case CLASS_ATM:
-                return EquipmentType.get(EquipmentTypeLookup.ATM_BAY);
-            case CLASS_ROCKET_LAUNCHER:
-                return EquipmentType.get(EquipmentTypeLookup.ROCKET_LAUNCHER_BAY);
-            case CLASS_CAPITAL_LASER:
-                return (isSubCapital() && !capitalOnly) ? EquipmentType.get(EquipmentTypeLookup.SCL_BAY)
+        return switch (getAtClass()) {
+            case CLASS_LASER -> EquipmentType.get(EquipmentTypeLookup.LASER_BAY);
+            case CLASS_AMS -> EquipmentType.get(EquipmentTypeLookup.AMS_BAY);
+            case CLASS_POINT_DEFENSE -> EquipmentType.get(EquipmentTypeLookup.POINT_DEFENSE_BAY);
+            case CLASS_PPC -> EquipmentType.get(EquipmentTypeLookup.PPC_BAY);
+            case CLASS_PULSE_LASER -> EquipmentType.get(EquipmentTypeLookup.PULSE_LASER_BAY);
+            case CLASS_ARTILLERY -> EquipmentType.get(EquipmentTypeLookup.ARTILLERY_BAY);
+            case CLASS_PLASMA -> EquipmentType.get(EquipmentTypeLookup.PLASMA_BAY);
+            case CLASS_AC -> EquipmentType.get(EquipmentTypeLookup.AC_BAY);
+            case CLASS_LBX_AC -> EquipmentType.get(EquipmentTypeLookup.LBX_AC_BAY);
+            case CLASS_LRM -> EquipmentType.get(EquipmentTypeLookup.LRM_BAY);
+            case CLASS_SRM -> EquipmentType.get(EquipmentTypeLookup.SRM_BAY);
+            case CLASS_MRM -> EquipmentType.get(EquipmentTypeLookup.MRM_BAY);
+            case CLASS_MML -> EquipmentType.get(EquipmentTypeLookup.MML_BAY);
+            case CLASS_THUNDERBOLT -> EquipmentType.get(EquipmentTypeLookup.THUNDERBOLT_BAY);
+            case CLASS_ATM -> EquipmentType.get(EquipmentTypeLookup.ATM_BAY);
+            case CLASS_ROCKET_LAUNCHER -> EquipmentType.get(EquipmentTypeLookup.ROCKET_LAUNCHER_BAY);
+            case CLASS_CAPITAL_LASER ->
+                  (isSubCapital() && !capitalOnly) ? EquipmentType.get(EquipmentTypeLookup.SCL_BAY)
                         : EquipmentType.get(EquipmentTypeLookup.CAPITAL_LASER_BAY);
-            case CLASS_CAPITAL_PPC:
-                return EquipmentType.get(EquipmentTypeLookup.CAPITAL_PPC_BAY);
-            case CLASS_CAPITAL_AC:
-                return (isSubCapital() && !capitalOnly) ? EquipmentType.get(EquipmentTypeLookup.SCC_BAY)
-                        : EquipmentType.get(EquipmentTypeLookup.CAPITAL_AC_BAY);
-            case CLASS_CAPITAL_GAUSS:
-                return EquipmentType.get(EquipmentTypeLookup.CAPITAL_GAUSS_BAY);
-            case CLASS_CAPITAL_MD:
-                return EquipmentType.get(EquipmentTypeLookup.CAPITAL_MASS_DRIVER_BAY);
-            case CLASS_CAPITAL_MISSILE:
-                return (isSubCapital() && !capitalOnly) ? EquipmentType.get(EquipmentTypeLookup.SC_MISSILE_BAY)
+            case CLASS_CAPITAL_PPC -> EquipmentType.get(EquipmentTypeLookup.CAPITAL_PPC_BAY);
+            case CLASS_CAPITAL_AC -> (isSubCapital() && !capitalOnly) ? EquipmentType.get(EquipmentTypeLookup.SCC_BAY)
+                  : EquipmentType.get(EquipmentTypeLookup.CAPITAL_AC_BAY);
+            case CLASS_CAPITAL_GAUSS -> EquipmentType.get(EquipmentTypeLookup.CAPITAL_GAUSS_BAY);
+            case CLASS_CAPITAL_MD -> EquipmentType.get(EquipmentTypeLookup.CAPITAL_MASS_DRIVER_BAY);
+            case CLASS_CAPITAL_MISSILE ->
+                  (isSubCapital() && !capitalOnly) ? EquipmentType.get(EquipmentTypeLookup.SC_MISSILE_BAY)
                         : EquipmentType.get(EquipmentTypeLookup.CAPITAL_MISSILE_BAY);
-            case CLASS_TELE_MISSILE:
-                return EquipmentType.get(EquipmentTypeLookup.TELE_CAPITAL_MISSILE_BAY);
-            case CLASS_AR10:
-                return EquipmentType.get(EquipmentTypeLookup.AR10_BAY);
-            case CLASS_SCREEN:
-                return EquipmentType.get(EquipmentTypeLookup.SCREEN_LAUNCHER_BAY);
-            default:
-                return EquipmentType.get(EquipmentTypeLookup.MISC_BAY);
-        }
+            case CLASS_TELE_MISSILE -> EquipmentType.get(EquipmentTypeLookup.TELE_CAPITAL_MISSILE_BAY);
+            case CLASS_AR10 -> EquipmentType.get(EquipmentTypeLookup.AR10_BAY);
+            case CLASS_SCREEN -> EquipmentType.get(EquipmentTypeLookup.SCREEN_LAUNCHER_BAY);
+            default -> EquipmentType.get(EquipmentTypeLookup.MISC_BAY);
+        };
     }
 
     /**

--- a/megamek/src/megamek/common/WeaponTypeFlag.java
+++ b/megamek/src/megamek/common/WeaponTypeFlag.java
@@ -118,5 +118,10 @@ public enum WeaponTypeFlag implements EquipmentFlag {
      * A weapon with this flag is not an actual weapon but only used as an internal representation of an attack. It
      * should be hidden in the readout, tooltip and RS but shown in the unit display's weapon list where it is used.
      */
-    INTERNAL_REPRESENTATION
+    INTERNAL_REPRESENTATION,
+
+    /**
+     * Denotes Clan Heavy Lasers (S, M, L)
+     */
+    HEAVY_LASER
 }

--- a/megamek/src/megamek/common/actions/ComputeAeroAttackerToHitMods.java
+++ b/megamek/src/megamek/common/actions/ComputeAeroAttackerToHitMods.java
@@ -40,6 +40,7 @@ import megamek.common.equipment.WeaponMounted;
 import megamek.common.options.OptionsConstants;
 
 import java.util.EnumSet;
+import java.util.function.Predicate;
 
 class ComputeAeroAttackerToHitMods {
 
@@ -49,7 +50,7 @@ class ComputeAeroAttackerToHitMods {
      * TH penalty? Those are in other methods.
      *
      * @param game                The current {@link Game}
-     * @param ae                  The Entity making this attack
+     * @param attacker            The Entity making this attack
      * @param target              The Targetable object being attacked
      * @param ttype               The targetable object type
      * @param toHit               The running total ToHitData for this WeaponAttackAction
@@ -66,10 +67,11 @@ class ComputeAeroAttackerToHitMods {
      * @param isStrafing          flag that indicates whether this is an aero strafing attack
      * @param usesAmmo            flag that indicates if the WeaponType being used is ammo-fed
      */
-    static ToHitData compileAeroAttackerToHitMods(Game game, Entity ae, Targetable target, int ttype,
+    static ToHitData compileAeroAttackerToHitMods(Game game, Entity attacker, Targetable target, int ttype,
           ToHitData toHit, int aimingAt, AimingMode aimingMode, int eistatus, WeaponType wtype, WeaponMounted weapon,
           AmmoType atype, EnumSet<AmmoType.Munitions> munition, boolean isArtilleryIndirect, boolean isFlakAttack,
           boolean isNemesisConfused, boolean isStrafing, boolean usesAmmo) {
+
         if (toHit == null) {
             // Without valid toHit data, the rest of this will fail
             toHit = new ToHitData();
@@ -81,31 +83,31 @@ class ComputeAeroAttackerToHitMods {
             te = (Entity) target;
         }
 
-        boolean isBombing = wtype != null &&
+        boolean isBombing = (wtype != null) &&
                                   (wtype.hasFlag(WeaponType.F_ALT_BOMB) || wtype.hasFlag(WeaponType.F_DIVE_BOMB));
 
         // Generic modifiers that apply to airborne and ground attackers
 
         // actuator & sensor damage to attacker (includes partial repairs)
         if (weapon != null) {
-            toHit.append(Compute.getDamageWeaponMods(ae, weapon));
+            toHit.append(Compute.getDamageWeaponMods(attacker, weapon));
         }
 
         // heat
-        if (ae.getHeatFiringModifier() != 0) {
-            toHit.addModifier(ae.getHeatFiringModifier(), Messages.getString("WeaponAttackAction.Heat"));
+        if (attacker.getHeatFiringModifier() != 0) {
+            toHit.addModifier(attacker.getHeatFiringModifier(), Messages.getString("WeaponAttackAction.Heat"));
         }
 
         // Secondary targets modifier, if this is not a iNarc Nemesis confused attack
         // Also does not apply to attacks that are intrinsically multi-target (altitude bombing and strafing)
         if (!isNemesisConfused && wtype != null && !wtype.hasFlag(WeaponType.F_ALT_BOMB) && !isStrafing) {
-            toHit.append(Compute.getSecondaryTargetMod(game, ae, target));
+            toHit.append(Compute.getSecondaryTargetMod(game, attacker, target));
         }
 
         // add targeting computer (except with LBX cluster ammo)
         if (aimingMode.isTargetingComputer() && (aimingAt != Entity.LOC_NONE)) {
-            if (ae.hasActiveEiCockpit()) {
-                if (ae.hasTargComp()) {
+            if (attacker.hasActiveEiCockpit()) {
+                if (attacker.hasTargComp()) {
                     toHit.addModifier(2, Messages.getString("WeaponAttackAction.AimWithTCompEi"));
                 } else {
                     toHit.addModifier(6, Messages.getString("WeaponAttackAction.AimWithEiOnly"));
@@ -113,90 +115,89 @@ class ComputeAeroAttackerToHitMods {
             } else {
                 toHit.addModifier(3, Messages.getString("WeaponAttackAction.AimWithTCompOnly"));
             }
-        } else {
+        } else if (attacker.hasTargComp()
+                         && (wtype != null)
+                         && wtype.hasFlag(WeaponType.F_DIRECT_FIRE)
+                         && !wtype.hasFlag(WeaponType.F_CWS)
+                         && !wtype.hasFlag(WeaponType.F_TASER)) {
+
             // LB-X cluster, HAG flak, flak ammo ineligible for TC bonus
             boolean usesLBXCluster = usesAmmo &&
                                            (atype != null) &&
                                            (atype.getAmmoType() == AmmoType.AmmoTypeEnum.AC_LBX ||
                                                   atype.getAmmoType() == AmmoType.AmmoTypeEnum.AC_LBX_THB) &&
                                            munition.contains(AmmoType.Munitions.M_CLUSTER);
-            boolean usesHAGFlak = usesAmmo && (atype != null) && atype.getAmmoType() == AmmoType.AmmoTypeEnum.HAG && isFlakAttack;
-            boolean isSBGauss = usesAmmo && (atype != null) && atype.getAmmoType() == AmmoType.AmmoTypeEnum.SBGAUSS;
+            boolean usesHAGFlak = usesAmmo && (atype != null) && (atype.getAmmoType() == AmmoType.AmmoTypeEnum.HAG)
+                                        && isFlakAttack;
+            boolean isSBGauss = usesAmmo && (atype != null) && (atype.getAmmoType() == AmmoType.AmmoTypeEnum.SBGAUSS);
             boolean isFlakAmmo = usesAmmo && (atype != null) && (munition.contains(AmmoType.Munitions.M_FLAK));
-            if (ae.hasTargComp() &&
-                      wtype != null &&
-                      wtype.hasFlag(WeaponType.F_DIRECT_FIRE) &&
-                      !wtype.hasFlag(WeaponType.F_CWS) &&
-                      !wtype.hasFlag(WeaponType.F_TASER) &&
-                      (!usesAmmo || !(usesLBXCluster || usesHAGFlak || isSBGauss || isFlakAmmo))) {
+            if (!usesAmmo || !(usesLBXCluster || usesHAGFlak || isSBGauss || isFlakAmmo)) {
                 toHit.addModifier(-1, Messages.getString("WeaponAttackAction.TComp"));
             }
         }
 
         // Modifiers for aero units, including fighter LAMs
-        if (ae.isAero()) {
-            IAero aero = (IAero) ae;
+        if (attacker.isAero()) {
+            IAero aero = (IAero) attacker;
 
             // check for heavy gauss rifle on fighter or small craft
-            // Arguably a weapon effect, except that it only applies when used by a fighter
-            // (isn't recoil fun?)
+            // Arguably a weapon effect, except that it only applies when used by a fighter (isn't recoil fun?)
             // So it's here instead of with other weapon mods that apply across the board
-            if ((wtype != null) &&
-                      ((wtype.ammoType == AmmoType.AmmoTypeEnum.GAUSS_HEAVY) || (wtype.ammoType == AmmoType.AmmoTypeEnum.IGAUSS_HEAVY)) &&
-                      !(ae instanceof Dropship) &&
-                      !(ae instanceof Jumpship)) {
+            if ((wtype != null)
+                      && ((wtype.ammoType == AmmoType.AmmoTypeEnum.GAUSS_HEAVY)
+                             || (wtype.ammoType == AmmoType.AmmoTypeEnum.IGAUSS_HEAVY))
+                      && !(attacker instanceof Dropship)
+                      && !(attacker instanceof Jumpship)) {
                 toHit.addModifier(+1, Messages.getString("WeaponAttackAction.FighterHeavyGauss"));
             }
 
             // Space ECM
-            if (ae.isSpaceborne() && game.onTheSameBoard(ae, target) &&
-                      game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ECM)) {
-                int ecm = ComputeECM.getLargeCraftECM(ae, ae.getPosition(), target.getPosition());
-                if (!ae.isLargeCraft()) {
-                    ecm += ComputeECM.getSmallCraftECM(ae, ae.getPosition(), target.getPosition());
+            if (attacker.isSpaceborne() && game.onTheSameBoard(attacker, target)
+                      && game.getOptions().booleanOption(OptionsConstants.ADVAERORULES_STRATOPS_ECM)) {
+                int ecm = ComputeECM.getLargeCraftECM(attacker, attacker.getPosition(), target.getPosition());
+                if (!attacker.isLargeCraft()) {
+                    ecm += ComputeECM.getSmallCraftECM(attacker, attacker.getPosition(), target.getPosition());
                 }
                 ecm = Math.min(4, ecm);
                 int eccm = 0;
-                if (ae.isLargeCraft()) {
-                    eccm = ((Aero) ae).getECCMBonus();
+                if (attacker.isLargeCraft()) {
+                    eccm = ((Aero) attacker).getECCMBonus();
                 }
                 if (ecm > 0) {
                     toHit.addModifier(ecm, Messages.getString("WeaponAttackAction.ECM"));
                     if (eccm > 0) {
-                        toHit.addModifier(-1 * Math.min(ecm, eccm), Messages.getString("WeaponAttackAction.ECCM"));
+                        toHit.addModifier(-1 * Math.min(ecm, eccm),
+                              Messages.getString("WeaponAttackAction.ECCM"));
                     }
                 }
             }
 
             // +4 attack penalty for locations hit by ASEW missiles
-            if (ae instanceof Dropship) {
-                Dropship d = (Dropship) ae;
+            if (attacker instanceof Dropship dropship) {
                 if (weapon != null) {
-                    int loc = weapon.getLocation();
-                    if (d.getASEWAffected(loc) > 0) {
+                    if (dropship.getASEWAffected(weapon.getLocation()) > 0) {
                         toHit.addModifier(4, Messages.getString("WeaponAttackAction.AeArcAsewAffected"));
                     }
                 }
-            } else if (ae instanceof Jumpship) {
-                Jumpship j = (Jumpship) ae;
+            } else if (attacker instanceof Jumpship jumpship) {
                 if (weapon != null) {
-                    int loc = weapon.getLocation();
-                    if (j.getASEWAffected(loc) > 0) {
+                    if (jumpship.getASEWAffected(weapon.getLocation()) > 0) {
                         toHit.addModifier(4, Messages.getString("WeaponAttackAction.AeArcAsewAffected"));
                     }
                 }
             } else {
-                if (ae.getASEWAffected() > 0) {
+                if (attacker.getASEWAffected() > 0) {
                     toHit.addModifier(4, Messages.getString("WeaponAttackAction.AeAsewAffected"));
                 }
             }
+
             // Altitude-related mods for air-to-air combat
-            if (Compute.isAirToAir(game, ae, target)) {
+            if (Compute.isAirToAir(game, attacker, target)) {
                 if (target.isAirborneVTOLorWIGE()) {
                     toHit.addModifier(+5, Messages.getString("WeaponAttackAction.TeNonAeroAirborne"));
                 }
-                if (ae.isNOE()) {
-                    if (ae.isOmni()) {
+                if (attacker.isNOE()) {
+                    if (attacker.isOmni()) {
                         toHit.addModifier(+1, Messages.getString("WeaponAttackAction.AeOmniNoe"));
                     } else {
                         toHit.addModifier(+2, Messages.getString("WeaponAttackAction.AeNoe"));
@@ -205,37 +206,39 @@ class ComputeAeroAttackerToHitMods {
             }
 
             // A2G attacks
-            if (Compute.isAirToGround(ae, target) || (ae.isMakingVTOLGroundAttack())) {
+            if (Compute.isAirToGround(attacker, target) || (attacker.isMakingVTOLGroundAttack())) {
                 // TW p.243
                 if (isBombing) {
                     toHit.addModifier(2, Messages.getString("WeaponAttackAction.Bombing"));
                     if (wtype.hasFlag(WeaponType.F_ALT_BOMB)) {
-                        toHit.addModifier(ae.getAltitude(), Messages.getString("WeaponAttackAction.BombAltitude"));
+                        toHit.addModifier(attacker.getAltitude(), Messages.getString("WeaponAttackAction.BombAltitude"));
                     }
                     // CO p.75
-                    if (ae.hasAbility(OptionsConstants.GUNNERY_GOLDEN_GOOSE)) {
+                    if (attacker.hasAbility(OptionsConstants.GUNNERY_GOLDEN_GOOSE)) {
                         toHit.addModifier(-2, Messages.getString("WeaponAttackAction.GoldenGoose"));
                     }
+
                 } else if (isStrafing) {
                     toHit.addModifier(+4, Messages.getString("WeaponAttackAction.Strafing"));
-                    if (ae.isNOE()) {
+                    if (attacker.isNOE()) {
                         toHit.addModifier(+2, Messages.getString("WeaponAttackAction.StrafingNoe"));
                         // Nap-of-Earth terrain effects
-                        Coords prevCoords = ae.passedThroughPrevious(target.getPosition());
-                        Hex prevHex = game.getHex(prevCoords, ae.getPassedThroughBoardId());
+                        Coords prevCoords = attacker.passedThroughPrevious(target.getPosition());
+                        Hex prevHex = game.getHex(prevCoords, attacker.getPassedThroughBoardId());
                         toHit.append(Compute.getStrafingTerrainModifier(game, eistatus, prevHex));
                     }
+
                 } else { // Striking
                     toHit.addModifier(+2, Messages.getString("WeaponAttackAction.AtgStrike"));
                     // CO p.75
-                    if (ae.hasAbility(OptionsConstants.GUNNERY_GOLDEN_GOOSE)) {
+                    if (attacker.hasAbility(OptionsConstants.GUNNERY_GOLDEN_GOOSE)) {
                         toHit.addModifier(-1, Messages.getString("WeaponAttackAction.GoldenGoose"));
                     }
                 }
             }
 
             // units making A2G attacks are easier to hit by A2A attacks, TW p.241
-            if (Compute.isAirToAir(game, ae, target) && (te != null)) {
+            if (Compute.isAirToAir(game, attacker, target) && (te != null)) {
                 for (EntityAction action : game.getActionsVector()) {
                     if (action instanceof WeaponAttackAction attack) {
                         if ((attack.getEntityId() == te.getId()) && attack.isAirToGround(game)) {
@@ -247,26 +250,27 @@ class ComputeAeroAttackerToHitMods {
             }
 
             // grounded aero
-            if (!ae.isAirborne() && !ae.isSpaceborne()) {
-                if (ae.isFighter()) {
+            if (!attacker.isAirborne() && !attacker.isSpaceborne()) {
+                if (attacker.isFighter()) {
                     toHit.addModifier(+2, Messages.getString("WeaponAttackAction.GroundedAero"));
                 } else if (!target.isAirborne() && !isArtilleryIndirect) {
                     toHit.addModifier(-2, Messages.getString("WeaponAttackAction.GroundedDs"));
                 }
             }
+
             // out of control
             if (aero.isOutControlTotal()) {
                 toHit.addModifier(+2, Messages.getString("WeaponAttackAction.AeroOoc"));
             }
         }
+
         // Situational modifiers for aero units, not including LAMs.
-        if (ae instanceof Aero) {
-            Aero aero = (Aero) ae;
+        if (attacker instanceof Aero aero) {
 
             // sensor hits
             int sensors = aero.getSensorHits();
 
-            if (!ae.isCapitalFighter()) {
+            if (!aero.isCapitalFighter()) {
                 if ((sensors > 0) && (sensors < 3)) {
                     toHit.addModifier(sensors, Messages.getString("WeaponAttackAction.SensorDamage"));
                 }
@@ -276,39 +280,35 @@ class ComputeAeroAttackerToHitMods {
             }
 
             // FCS hits
-            int fcs = aero.getFCSHits();
+            int fireControlHits = aero.getFCSHits();
 
-            if ((fcs > 0) && !aero.isCapitalFighter()) {
-                toHit.addModifier(fcs * 2, Messages.getString("WeaponAttackAction.FcsDamage"));
+            if ((fireControlHits > 0) && !aero.isCapitalFighter()) {
+                toHit.addModifier(fireControlHits * 2, Messages.getString("WeaponAttackAction.FcsDamage"));
             }
 
             // CIC hits
-            if (aero instanceof Jumpship) {
-                Jumpship js = (Jumpship) aero;
-                int cic = js.getCICHits();
-                if (cic > 0) {
-                    toHit.addModifier(cic * 2, Messages.getString("WeaponAttackAction.CicDamage"));
+            if (aero instanceof Jumpship jumpship) {
+                int cicHits = jumpship.getCICHits();
+                if (cicHits > 0) {
+                    toHit.addModifier(cicHits * 2, Messages.getString("WeaponAttackAction.CicDamage"));
                 }
             }
 
             // targeting mods for evasive action by large craft
             // Per TW, this does not apply when firing Capital Missiles
-            if (aero.isEvading() &&
-                      wtype != null &&
-                      (!(wtype.getAtClass() == WeaponType.CLASS_CAPITAL_MISSILE ||
-                               wtype.getAtClass() == WeaponType.CLASS_AR10 ||
-                               wtype.getAtClass() == WeaponType.CLASS_TELE_MISSILE))) {
+            if (aero.isEvading() && (wtype != null)
+                      && (!(wtype.getAtClass() == WeaponType.CLASS_CAPITAL_MISSILE ||
+                                  wtype.getAtClass() == WeaponType.CLASS_AR10 ||
+                                  wtype.getAtClass() == WeaponType.CLASS_TELE_MISSILE))) {
                 toHit.addModifier(+2, Messages.getString("WeaponAttackAction.AeEvading"));
             }
 
-            // stratops page 113: ECHO maneuvers for large craft
-            if (((aero instanceof Warship) || (aero instanceof Dropship)) &&
-                      (aero.getFacing() != aero.getSecondaryFacing())) {
-                // if we're computing this for an "attack preview", then we add 2 MP to
-                // the mp used, as we haven't used the MP yet. If we're actually processing
-                // the attack, then the entity will be marked as 'done' and we have already
-                // added
-                // the 2 MP, so we don't need to double-count it
+            // SO p.113: ECHO maneuvers for large craft
+            if (((aero instanceof Warship) || (aero instanceof Dropship))
+                      && (aero.getFacing() != aero.getSecondaryFacing())) {
+                // if we're computing this for an "attack preview", then we add 2 MP to the mp used, as we haven't
+                // used the MP yet. If we're actually processing the attack, then the entity will be marked as 'done'
+                // and we have already added the 2 MP, so we don't need to double-count it
                 int extraMP = aero.isDone() ? 0 : 2;
                 boolean willUseRunMP = aero.mpUsed + extraMP > aero.getWalkMP();
                 int mod = willUseRunMP ? 2 : 1;
@@ -316,70 +316,56 @@ class ComputeAeroAttackerToHitMods {
             }
 
             // check for particular kinds of weapons in weapon bays
-            if (ae.usesWeaponBays() && wtype != null && weapon != null) {
+            if (attacker.usesWeaponBays() && (wtype != null) && (weapon != null)) {
 
                 // any heavy lasers
-                if (wtype.getAtClass() == WeaponType.CLASS_LASER &&
-                          weapon.getBayWeapons()
-                                .stream()
-                                .map(WeaponMounted::getType)
-                                .map(WeaponType::getInternalName)
-                                .anyMatch(i -> i.startsWith("CLHeavyLaser"))) {
+                if (wtype.hasFlag(WeaponTypeFlag.HEAVY_LASER)) {
                     toHit.addModifier(+1, Messages.getString("WeaponAttackAction.HeavyLaserInBay"));
                 }
+
                 // barracuda missiles
                 else if (wtype.getAtClass() == WeaponType.CLASS_CAPITAL_MISSILE) {
-                    boolean onlyBarracuda = true;
-                    for (WeaponMounted bweap : weapon.getBayWeapons()) {
-                        AmmoMounted bammo = bweap.getLinkedAmmo();
-                        if (bammo != null) {
-                            AmmoType batype = bammo.getType();
-                            if (batype.getAmmoType() != AmmoType.AmmoTypeEnum.BARRACUDA) {
-                                onlyBarracuda = false;
-                            }
-                        }
-                    }
-                    if (onlyBarracuda) {
+                    if (bayHasOnlyAmmoType(weapon, t -> t.getAmmoType() == AmmoType.AmmoTypeEnum.BARRACUDA)) {
                         toHit.addModifier(-2, Messages.getString("WeaponAttackAction.Barracuda"));
                     }
                 }
-                // barracuda missiles in an AR10 launcher (must all be
-                // barracuda)
+
+                // barracuda missiles in an AR10 launcher (must all be barracuda)
                 else if (wtype.getAtClass() == WeaponType.CLASS_AR10) {
-                    boolean onlyBarracuda = true;
-                    for (WeaponMounted bweap : weapon.getBayWeapons()) {
-                        AmmoMounted bammo = bweap.getLinkedAmmo();
-                        if (bammo != null) {
-                            AmmoType batype = bammo.getType();
-                            if (!batype.hasFlag(AmmoType.F_AR10_BARRACUDA)) {
-                                onlyBarracuda = false;
-                            }
-                        }
-                    }
-                    if (onlyBarracuda) {
+                    if (bayHasOnlyAmmoType(weapon, t -> t.hasFlag(AmmoType.F_AR10_BARRACUDA))) {
                         toHit.addModifier(-2, Messages.getString("WeaponAttackAction.Barracuda"));
                     }
                 }
+
                 // LBX cluster
                 else if (wtype.getAtClass() == WeaponType.CLASS_LBX_AC) {
-                    boolean onlyCluster = true;
-                    for (WeaponMounted bweap : weapon.getBayWeapons()) {
-                        AmmoMounted bammo = bweap.getLinkedAmmo();
-                        if (bammo != null) {
-                            AmmoType batype = bammo.getType();
-                            if (!batype.getMunitionType().contains(AmmoType.Munitions.M_CLUSTER)) {
-                                onlyCluster = false;
-                                break;
-                            }
-                        }
-                    }
-                    if (onlyCluster) {
+                    if (bayHasOnlyAmmoType(weapon, t -> t.getMunitionType().contains(AmmoType.Munitions.M_CLUSTER))) {
                         toHit.addModifier(-1, Messages.getString("WeaponAttackAction.ClusterAmmo"));
                     }
                 }
             }
         }
         return toHit;
+    }
+
+    /**
+     * @param weaponBay The bay to test
+     * @param ammoTest  An AmmoType test
+     *
+     * @return True when all weapons in the given weapon bay are linked to ammo that satisfy the given ammoTest. Weapons
+     *       that are not linked to ammo are ignored.
+     */
+    private static boolean bayHasOnlyAmmoType(WeaponMounted weaponBay, Predicate<AmmoType> ammoTest) {
+        for (WeaponMounted weaponInBay : weaponBay.getBayWeapons()) {
+            AmmoMounted linkedAmmo = weaponInBay.getLinkedAmmo();
+            if (linkedAmmo != null) {
+                AmmoType linkedAmmoType = linkedAmmo.getType();
+                if (!ammoTest.test(linkedAmmoType)) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     private ComputeAeroAttackerToHitMods() { }

--- a/megamek/src/megamek/common/actions/ComputeTerrainMods.java
+++ b/megamek/src/megamek/common/actions/ComputeTerrainMods.java
@@ -38,7 +38,7 @@ import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.options.OptionsConstants;
 
-import java.util.EnumSet;
+import static megamek.common.ToHitData.*;
 
 class ComputeTerrainMods {
 
@@ -49,7 +49,7 @@ class ComputeTerrainMods {
      * Those are in other methods.
      *
      * @param game             The current {@link Game}
-     * @param ae               The Entity making this attack
+     * @param attacker         The Entity making this attack
      * @param target           The Targetable object being attacked
      * @param ttype            The targetable object type
      * @param aElev            An int value representing the attacker's elevation
@@ -64,18 +64,18 @@ class ComputeTerrainMods {
      * @param weapon           The Mounted weapon being used
      * @param weaponId         The id number of the weapon being used - used by some external calculations
      * @param atype            The AmmoType being used for this attack
-     * @param munition         Long indicating the munition type flag being used, if applicable
      * @param inSameBuilding   flag that indicates whether this attack originates from within the same building
      * @param isIndirect       flag that indicates whether this is an indirect attack (LRM, mortar...)
      * @param isPointBlankShot flag that indicates whether or not this is a PBS by a hidden unit
      * @param underWater       flag that indicates whether the weapon being used is underwater
      */
-    static ToHitData compileTerrainAndLosToHitMods(Game game, Entity ae, Targetable target, int ttype,
+    static ToHitData compileTerrainAndLosToHitMods(Game game, Entity attacker, Targetable target, int ttype,
           int aElev, int tElev, int targEl, int distance, LosEffects los, ToHitData toHit, ToHitData losMods,
           int eistatus, WeaponType wtype, WeaponMounted weapon, int weaponId, AmmoType atype, AmmoMounted ammo,
-          EnumSet<AmmoType.Munitions> munition, boolean isAttackerInfantry, boolean inSameBuilding, boolean isIndirect,
+          boolean isAttackerInfantry, boolean inSameBuilding, boolean isIndirect,
           boolean isPointBlankShot, boolean underWater) {
-        if (ae == null || target == null) {
+
+        if (attacker == null || target == null) {
             // Can't handle these attacks without a valid attacker and target
             return toHit;
         }
@@ -85,90 +85,81 @@ class ComputeTerrainMods {
             toHit = new ToHitData();
         }
 
-        // Target's hex
-        Hex targHex = game.getHexOf(target);
+        Entity entityTarget = (target instanceof Entity entity) ? entity : null;
 
-        boolean targetHexContainsWater = targHex != null && targHex.containsTerrain(Terrains.WATER);
-        boolean targetHexContainsFortified = targHex != null && targHex.containsTerrain(Terrains.FORTIFIED);
-
-        Entity te = null;
-        if (ttype == Targetable.TYPE_ENTITY) {
-            // Some of these weapons only target valid entities
-            te = (Entity) target;
-        }
-
-        // Add range mods - If the attacker and target are in the same building
-        // & hex, range mods don't apply (and will cause the shot to fail)
-        // Don't apply this to bomb attacks either, which are going to be at 0 range of
-        // necessity
+        // Add range mods - If the attacker and target are in the same building & hex, range mods don't apply (and
+        // will cause the shot to fail)
+        // Don't apply this to bomb attacks either, which are going to be at 0 range of necessity
         // Also don't apply to ADA Missiles (range computed separately)
-        if (((los.getThruBldg() == null) || !los.getTargetPosition().equals(ae.getPosition())) &&
-                  (wtype != null &&
-                         (!(wtype.hasFlag(WeaponType.F_ALT_BOMB) ||
-                                  wtype.hasFlag(WeaponType.F_DIVE_BOMB) ||
-                                  (atype != null && atype.getMunitionType().contains(AmmoType.Munitions.M_ADA)))) &&
-                         weaponId > WeaponType.WEAPON_NA)) {
-            toHit.append(Compute.getRangeMods(game, ae, weapon, ammo, target));
+        boolean isBombAttack = (wtype != null) && wtype.hasAnyFlag(WeaponType.F_ALT_BOMB, WeaponType.F_DIVE_BOMB);
+        boolean isADA = (atype != null) && atype.getMunitionType().contains(AmmoType.Munitions.M_ADA);
+
+        if (((los.getThruBldg() == null) || !los.getTargetPosition().equals(attacker.getPosition())) &&
+              ((wtype != null) && !isBombAttack && !isADA) && (weaponId > WeaponType.WEAPON_NA)) {
+            toHit.append(Compute.getRangeMods(game, attacker, weapon, ammo, target));
         }
 
         // add in LOS mods that we've been keeping
         toHit.append(losMods);
 
         // Attacker Terrain
-        toHit.append(Compute.getAttackerTerrainModifier(game, ae.getId()));
+        toHit.append(Compute.getAttackerTerrainModifier(game, attacker.getId()));
 
         // Target Terrain
 
         // BMM p. 31, semi-guided indirect missile attacks vs tagged targets ignore
         // terrain modifiers
-        boolean semiGuidedIndirectVsTaggedTarget = isIndirect &&
-                                                         (atype != null) &&
-                                                         atype.getMunitionType()
-                                                               .contains(AmmoType.Munitions.M_SEMIGUIDED) &&
-                                                         Compute.isTargetTagged(target, game);
+        boolean semiGuidedIndirectVsTaggedTarget = isIndirect
+              && (atype != null)
+              && atype.getMunitionType().contains(AmmoType.Munitions.M_SEMIGUIDED)
+              && Compute.isTargetTagged(target, game);
 
         // TW p.111
-        boolean indirectMortarWithoutSpotter = (wtype != null) &&
-                                                     wtype.hasFlag(WeaponType.F_MORTARTYPE_INDIRECT) &&
-                                                     isIndirect &&
-                                                     (Compute.findSpotter(game, ae, target) == null);
+        boolean indirectMortarWithoutSpotter = (wtype != null)
+              && wtype.hasFlag(WeaponType.F_MORTARTYPE_INDIRECT)
+              && isIndirect
+              && (Compute.findSpotter(game, attacker, target) == null);
 
         // Base terrain calculations, not applicable when delivering minefields or bombs
         // also not applicable in pointblank shots from hidden units
-        if ((ttype != Targetable.TYPE_MINEFIELD_DELIVER) &&
-                  !isPointBlankShot &&
-                  !semiGuidedIndirectVsTaggedTarget &&
-                  !indirectMortarWithoutSpotter) {
+        if ((ttype != Targetable.TYPE_MINEFIELD_DELIVER)
+              && !isPointBlankShot
+              && !semiGuidedIndirectVsTaggedTarget
+              && !indirectMortarWithoutSpotter) {
             toHit.append(Compute.getTargetTerrainModifier(game, target, eistatus, inSameBuilding, underWater));
         }
 
+        // Target's hex
+        Hex targetHex = game.getHexOf(target);
+        boolean targetInFortifiedHex = (targetHex != null) && targetHex.containsTerrain(Terrains.FORTIFIED);
+
         // Fortified/Dug-In Infantry
-        if ((target instanceof Infantry) && wtype != null && !wtype.hasFlag(WeaponType.F_FLAMER)) {
-            if (targetHexContainsFortified || (((Infantry) target).getDugIn() == Infantry.DUG_IN_COMPLETE)) {
-                toHit.addModifier(2, megamek.client.ui.Messages.getString("WeaponAttackAction.DugInInf"));
+        if ((target instanceof Infantry infantry) && (wtype != null) && !wtype.hasFlag(WeaponType.F_FLAMER)) {
+            if (targetInFortifiedHex || (infantry.getDugIn() == Infantry.DUG_IN_COMPLETE)) {
+                toHit.addModifier(2, Messages.getString("WeaponAttackAction.DugInInf"));
             }
         }
 
         // target in water?
+        boolean targetInWater = (targetHex != null) && targetHex.containsTerrain(Terrains.WATER);
         int partialWaterLevel = 1;
-        if (te != null && (te instanceof Mek) && ((Mek) te).isSuperHeavy()) {
+        if ((entityTarget instanceof Mek) && entityTarget.isSuperHeavy()) {
             partialWaterLevel = 2;
         }
-        if ((te != null) &&
-                  targetHexContainsWater
-                  // target in partial water
-                  &&
-                  (targHex.terrainLevel(Terrains.WATER) == partialWaterLevel) &&
-                  (targEl == 0) &&
-                  (te.height() > 0)) {
+        if ((entityTarget != null)
+              && targetInWater
+              // target in partial water
+              && (targetHex.terrainLevel(Terrains.WATER) == partialWaterLevel)
+              && (targEl == 0)
+              && (entityTarget.height() > 0)) {
             los.setTargetCover(los.getTargetCover() | LosEffects.COVER_HORIZONTAL);
         }
 
         // Change hit table for partial cover, accommodate for partial underwater (legs)
         if (los.getTargetCover() != LosEffects.COVER_NONE) {
-            if (underWater && (targetHexContainsWater && (targEl == 0) && (te != null && te.height() > 0))) {
+            if (underWater && (targetInWater && (targEl == 0) && (entityTarget != null && entityTarget.height() > 0))) {
                 // weapon underwater, target in partial water
-                toHit.setHitTable(ToHitData.HIT_PARTIAL_COVER);
+                toHit.setHitTable(HIT_PARTIAL_COVER);
                 toHit.setCover(LosEffects.COVER_UPPER);
             } else {
                 if (game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_PARTIAL_COVER)) {
@@ -176,10 +167,10 @@ class ComputeTerrainMods {
                 } else {
                     toHit.setCover(LosEffects.COVER_HORIZONTAL);
                 }
-                // If this is a called shot (high) the table has already been set and should be
-                // used instead of partial cover.
-                if (toHit.getHitTable() != ToHitData.HIT_ABOVE) {
-                    toHit.setHitTable(ToHitData.HIT_PARTIAL_COVER);
+                // If this is a called shot (high) the table has already been set and should be used instead of
+                // partial cover
+                if (toHit.getHitTable() != HIT_ABOVE) {
+                    toHit.setHitTable(HIT_PARTIAL_COVER);
                 }
                 // Set damageable cover state information
                 toHit.setDamagableCoverTypePrimary(los.getDamagableCoverTypePrimary());
@@ -194,31 +185,29 @@ class ComputeTerrainMods {
         }
 
         // Hull Down - Some cover states are dependent on LOS
-        if ((te != null) && te.isHullDown()) {
-            if ((te instanceof Mek) &&
-                      !(te instanceof QuadVee && te.getConversionMode() == QuadVee.CONV_MODE_VEHICLE) &&
-                      (los.getTargetCover() > LosEffects.COVER_NONE)) {
-                toHit.addModifier(2, megamek.client.ui.Messages.getString("WeaponAttackAction.HullDown"));
+        boolean isQuadVeeInVeeMode = (entityTarget instanceof QuadVee)
+              && entityTarget.getConversionMode() == QuadVee.CONV_MODE_VEHICLE;
+
+        if ((entityTarget != null) && entityTarget.isHullDown()) {
+            if ((entityTarget instanceof Mek) && !isQuadVeeInVeeMode
+                  && (los.getTargetCover() > LosEffects.COVER_NONE)) {
+                toHit.addModifier(2, Messages.getString("WeaponAttackAction.HullDown"));
             }
-            // tanks going Hull Down is different rules then 'Meks, the
-            // direction the attack comes from matters
-            else if ((te instanceof Tank ||
-                            (te instanceof QuadVee && te.getConversionMode() == QuadVee.CONV_MODE_VEHICLE)) &&
-                           targetHexContainsFortified) {
-                // TODO make this a LoS mod so that attacks will come in from
-                // directions that grant Hull Down Mods
+
+            // tanks going Hull Down is different rules then 'Meks, the direction the attack comes from matters
+            else if ((entityTarget instanceof Tank || isQuadVeeInVeeMode) && targetInFortifiedHex) {
+                // TODO make this a LoS mod so that attacks will come in from directions that grant Hull Down Mods
                 int moveInDirection;
 
-                if (!((Tank) te).isBackedIntoHullDown()) {
-                    moveInDirection = ToHitData.SIDE_FRONT;
+                if (!(entityTarget instanceof Tank tank) || !tank.isBackedIntoHullDown()) {
+                    moveInDirection = SIDE_FRONT;
                 } else {
-                    moveInDirection = ToHitData.SIDE_REAR;
+                    moveInDirection = SIDE_REAR;
                 }
 
-                if ((te.sideTable(ae.getPosition()) == moveInDirection) ||
-                          (te.sideTable(ae.getPosition()) == ToHitData.SIDE_LEFT) ||
-                          (te.sideTable(ae.getPosition()) == ToHitData.SIDE_RIGHT)) {
-                    toHit.addModifier(2, megamek.client.ui.Messages.getString("WeaponAttackAction.HullDown"));
+                int sideTable = entityTarget.sideTable(attacker.getPosition());
+                if ((sideTable == moveInDirection) || (sideTable == SIDE_LEFT) || (sideTable == SIDE_RIGHT)) {
+                    toHit.addModifier(2, Messages.getString("WeaponAttackAction.HullDown"));
                 }
             }
         }
@@ -230,33 +219,21 @@ class ComputeTerrainMods {
         // we have BAP in range or C3 member has BAP in range
         // we reduce the BTH by 1
         if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_TACOPS_BAP)) {
-            boolean targetWoodsAffectModifier = (te != null) &&
-                                                      !te.isOffBoard() &&
-                                                      (te.getPosition() != null) &&
-                                                      (game.getHexOf(te) != null) &&
-                                                      game.getHexOf(te).hasVegetation() &&
-                                                      !game.getOptions()
-                                                             .booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_WOODS_COVER);
+            boolean targetWoodsAffectModifier = (entityTarget != null)
+                  && !entityTarget.isOffBoard()
+                  && (entityTarget.getPosition() != null)
+                  && (targetHex != null)
+                  && targetHex.hasVegetation()
+                  && !game.getOptions().booleanOption(OptionsConstants.ADVCOMBAT_TACOPS_WOODS_COVER);
             if (los.canSee() && (targetWoodsAffectModifier || los.thruWoods())) {
-                boolean bapInRange = Compute.bapInRange(game, ae, te);
-                boolean c3BAP = false;
-                if (!bapInRange) {
-                    for (Entity en : game.getC3NetworkMembers(ae)) {
-                        if (ae.equals(en)) {
-                            continue;
-                        }
-                        bapInRange = Compute.bapInRange(game, en, te);
-                        if (bapInRange) {
-                            c3BAP = true;
-                            break;
-                        }
-                    }
-                }
-                if (bapInRange) {
-                    if (c3BAP) {
-                        toHit.addModifier(-1, megamek.client.ui.Messages.getString("WeaponAttackAction.BAPInWoodsC3"));
-                    } else {
-                        toHit.addModifier(-1, Messages.getString("WeaponAttackAction.BAPInWoods"));
+                if (bapInRange(game, attacker, entityTarget)) {
+                    toHit.addModifier(-1, Messages.getString("WeaponAttackAction.BAPInWoods"));
+                } else {
+                    boolean bapInRangeUsingC3 = game.getC3NetworkMembers(attacker).stream()
+                          .filter(c3Member -> !attacker.equals(c3Member))
+                          .anyMatch(c3Member -> bapInRange(game, c3Member, entityTarget));
+                    if (bapInRangeUsingC3) {
+                        toHit.addModifier(-1, Messages.getString("WeaponAttackAction.BAPInWoodsC3"));
                     }
                 }
             }
@@ -265,19 +242,17 @@ class ComputeTerrainMods {
         // To-hit table changes with no to-hit modifiers
 
         // Aeros in air-to-air combat can hit above and below
-        if (Compute.isAirToAir(game, ae, target)) {
-            if ((ae.getAltitude() - target.getAltitude()) > 2) {
-                toHit.setHitTable(ToHitData.HIT_ABOVE);
-            } else if ((target.getAltitude() - ae.getAltitude()) > 2) {
-                toHit.setHitTable(ToHitData.HIT_BELOW);
-            } else if (((ae.getAltitude() - target.getAltitude()) > 0) &&
-                             te != null &&
-                             (te.isAero() && ((IAero) te).isSpheroid())) {
-                toHit.setHitTable(ToHitData.HIT_ABOVE);
-            } else if (((ae.getAltitude() - target.getAltitude()) < 0) &&
-                             te != null &&
-                             (te.isAero() && ((IAero) te).isSpheroid())) {
-                toHit.setHitTable(ToHitData.HIT_BELOW);
+        if (Compute.isAirToAir(game, attacker, target)) {
+            int altitudeDelta = attacker.getAltitude() - target.getAltitude();
+
+            if (altitudeDelta > 2) {
+                toHit.setHitTable(HIT_ABOVE);
+            } else if (altitudeDelta < -2) {
+                toHit.setHitTable(HIT_BELOW);
+            } else if ((altitudeDelta > 0) && attacker.isSpheroid()) {
+                toHit.setHitTable(HIT_ABOVE);
+            } else if ((altitudeDelta < 0) && attacker.isSpheroid()) {
+                toHit.setHitTable(HIT_BELOW);
             }
         }
 
@@ -286,39 +261,44 @@ class ComputeTerrainMods {
 
             // Tanks get hit in a random side.
             if (target instanceof Tank) {
-                toHit.setSideTable(ToHitData.SIDE_RANDOM);
+                toHit.setSideTable(SIDE_RANDOM);
             } else if (target instanceof Mek) {
                 // Meks have special tables for shots from above and below.
-                if (aElev > tElev) {
-                    toHit.setHitTable(ToHitData.HIT_ABOVE);
-                } else {
-                    toHit.setHitTable(ToHitData.HIT_BELOW);
-                }
+                toHit.setHitTable((aElev > tElev) ? HIT_ABOVE : HIT_BELOW);
             }
         }
 
         // Ground-to-air attacks always hit from below
-        if (Compute.isGroundToAir(ae, target) && ((target.getAltitude() - ae.getAltitude()) > 2)) {
-            toHit.setHitTable(ToHitData.HIT_BELOW);
+        if (Compute.isGroundToAir(attacker, target) && (target.getAltitude() - attacker.getAltitude() > 2)) {
+            toHit.setHitTable(HIT_BELOW);
         }
 
         // factor in target side
         if (isAttackerInfantry && (0 == distance)) {
-            // Infantry attacks from the same hex are resolved against the
-            // front.
-            toHit.setSideTable(ToHitData.SIDE_FRONT);
+            // Infantry attacks from the same hex are resolved against the front
+            toHit.setSideTable(SIDE_FRONT);
         } else {
             if (weapon != null) {
-                toHit.setSideTable(ComputeSideTable.sideTable(ae, target, weapon.getCalledShot().getCall()));
+                toHit.setSideTable(ComputeSideTable.sideTable(attacker, target, weapon.getCalledShot().getCall()));
             }
         }
 
         // Change hit table for surface naval vessels hit by underwater attacks
-        if (underWater && targetHexContainsWater && (null != te) && te.isSurfaceNaval()) {
-            toHit.setHitTable(ToHitData.HIT_UNDERWATER);
+        if (underWater && targetInWater && (null != entityTarget) && entityTarget.isSurfaceNaval()) {
+            toHit.setHitTable(HIT_UNDERWATER);
         }
 
         return toHit;
+    }
+
+    /**
+     * @return True when the attacker has an active BAP and is not affected by ECM and the target is in range.
+     */
+    private static boolean bapInRange(Game game, Entity attacker, Entity target) {
+        return attacker.hasBAP()
+              && (target != null) && !target.isOffBoard() && (target.getPosition() != null)
+              && (attacker.getBAPRange() >= Compute.effectiveDistance(game, attacker, target))
+              && !ComputeECM.isAffectedByECM(attacker, attacker.getPosition(), target.getPosition());
     }
 
     private ComputeTerrainMods() { }

--- a/megamek/src/megamek/common/actions/ComputeToHit.java
+++ b/megamek/src/megamek/common/actions/ComputeToHit.java
@@ -576,7 +576,7 @@ class ComputeToHit {
               isArtilleryIndirect);
 
         // Collect the modifiers for the crew/pilot
-        toHit = ComputeAttackerToHitMods.compileCrewToHitMods(game, ae, te, toHit, weapon);
+        toHit = ComputeAttackerToHitMods.compileCrewToHitMods(game, ae, toHit, weapon);
 
         // Collect the modifiers for the attacker's condition/actions
         if (ae != null) {
@@ -642,8 +642,6 @@ class ComputeToHit {
         toHit = ComputeTargetToHitMods.compileTargetToHitMods(game,
               ae,
               target,
-              ttype,
-              los,
               toHit,
               aimingAt,
               aimingMode,
@@ -679,7 +677,6 @@ class ComputeToHit {
               weaponId,
               atype,
               ammo,
-              munition,
               isAttackerInfantry,
               inSameBuilding,
               isIndirect,
@@ -1552,7 +1549,7 @@ class ComputeToHit {
 
             // SPAs
             ComputeAbilityMods.processAttackerSPAs(toHit, ae, te, weapon, game);
-            ComputeAbilityMods.processDefenderSPAs(toHit, ae, te, weapon, game);
+            ComputeAbilityMods.processDefenderSPAs(toHit, ae, te, game);
 
             return artilleryIndirectToHit(ae, target, toHit, wtype, weapon, srt);
         }
@@ -1612,7 +1609,7 @@ class ComputeToHit {
 
         // SPAs
         ComputeAbilityMods.processAttackerSPAs(toHit, ae, te, weapon, game);
-        ComputeAbilityMods.processDefenderSPAs(toHit, ae, te, weapon, game);
+        ComputeAbilityMods.processDefenderSPAs(toHit, ae, te, game);
 
         // If an airborne unit occupies the target hex, standard artillery ammo makes a
         // flak attack against it

--- a/megamek/src/megamek/common/actions/ComputeToHitIsImpossible.java
+++ b/megamek/src/megamek/common/actions/ComputeToHitIsImpossible.java
@@ -385,7 +385,7 @@ class ComputeToHitIsImpossible {
         // Only screen launchers may target a hex for screen launch
         if (Targetable.TYPE_HEX_SCREEN == target.getTargetType()) {
             if (wtype != null &&
-                      (!((wtype.getAmmoType() == AmmoType.AmmoTypeEnum.SCREEN_LAUNCHER) ||
+                      (!((wtype.getAmmoType() == SCREEN_LAUNCHER) ||
                                (wtype instanceof ScreenLauncherBayWeapon)))) {
                 return Messages.getString("WeaponAttackAction.ScreenLauncherOnly");
             }
@@ -394,7 +394,7 @@ class ComputeToHitIsImpossible {
         // Screen Launchers can only target hexes
         if ((Targetable.TYPE_HEX_SCREEN != target.getTargetType()) &&
                   (wtype != null &&
-                         ((wtype.getAmmoType() == AmmoType.AmmoTypeEnum.SCREEN_LAUNCHER) ||
+                         ((wtype.getAmmoType() == SCREEN_LAUNCHER) ||
                                 (wtype instanceof ScreenLauncherBayWeapon)))) {
             return Messages.getString("WeaponAttackAction.ScreenHexOnly");
         }
@@ -508,14 +508,14 @@ class ComputeToHitIsImpossible {
 
         // Torpedos must remain in the water over their whole path to the target
         if ((atype != null) &&
-                  ((atype.getAmmoType() == AmmoType.AmmoTypeEnum.LRM_TORPEDO) ||
-                         (atype.getAmmoType() == AmmoType.AmmoTypeEnum.SRM_TORPEDO) ||
-                         (((atype.getAmmoType() == AmmoType.AmmoTypeEnum.SRM) ||
-                                 (atype.getAmmoType() == AmmoType.AmmoTypeEnum.SRM_IMP) ||
-                                 (atype.getAmmoType() == AmmoType.AmmoTypeEnum.MRM) ||
+                  ((atype.getAmmoType() == LRM_TORPEDO) ||
+                         (atype.getAmmoType() == SRM_TORPEDO) ||
+                         (((atype.getAmmoType() == SRM) ||
+                                 (atype.getAmmoType() == SRM_IMP) ||
+                                 (atype.getAmmoType() == MRM) ||
                                  (atype.getAmmoType() == LRM) ||
-                                 (atype.getAmmoType() == AmmoType.AmmoTypeEnum.LRM_IMP) ||
-                                 (atype.getAmmoType() == AmmoType.AmmoTypeEnum.MML)) &&
+                                 (atype.getAmmoType() == LRM_IMP) ||
+                                 (atype.getAmmoType() == MML)) &&
                                 (atype.getMunitionType().contains(AmmoType.Munitions.M_TORPEDO)))) &&
                   (los.getMinimumWaterDepth() < 1)) {
             return Messages.getString("WeaponAttackAction.TorpOutOfWater");
@@ -563,16 +563,11 @@ class ComputeToHitIsImpossible {
         // Hull Down
 
         // Hull down meks cannot fire any leg weapons
-        if (attacker.isHullDown() && weapon != null) {
-            if (((attacker instanceof BipedMek) &&
-                       ((weapon.getLocation() == Mek.LOC_LLEG) || (weapon.getLocation() == Mek.LOC_RLEG))) ||
-                      ((attacker instanceof QuadMek) &&
-                             ((weapon.getLocation() == Mek.LOC_LLEG) ||
-                                    (weapon.getLocation() == Mek.LOC_RLEG) ||
-                                    (weapon.getLocation() == Mek.LOC_LARM) ||
-                                    (weapon.getLocation() == Mek.LOC_RARM)))) {
-                return Messages.getString("WeaponAttackAction.NoLegHullDown");
-            }
+        if (attacker.isHullDown()
+              && attacker instanceof Mek mek
+              && weapon != null
+              && mek.locationIsLeg(weapon.getLocation())) {
+            return Messages.getString("WeaponAttackAction.NoLegHullDown");
         }
 
         // hull down vees can't fire front weapons unless indirect
@@ -595,12 +590,12 @@ class ComputeToHitIsImpossible {
         }
 
         // LAMs carrying certain types of bombs that require a weapon have attacks that cannot be used in mek mode
-        if ((attacker instanceof LandAirMek) &&
-                  wtype != null &&
-                  (attacker.getConversionMode() == LandAirMek.CONV_MODE_MEK) &&
-                  wtype.hasFlag(WeaponType.F_BOMB_WEAPON) &&
-                  wtype.getAmmoType() != AmmoType.AmmoTypeEnum.RL_BOMB &&
-                  !wtype.hasFlag(WeaponType.F_TAG)) {
+        if ((attacker instanceof LandAirMek)
+              && (attacker.getConversionMode() == LandAirMek.CONV_MODE_MEK)
+              && wtype != null
+              && wtype.hasFlag(WeaponType.F_BOMB_WEAPON)
+              && wtype.getAmmoType() != RL_BOMB
+              && !wtype.hasFlag(WeaponType.F_TAG)) {
             return Messages.getString("WeaponAttackAction.NoBombInMekMode");
         }
 
@@ -614,7 +609,7 @@ class ComputeToHitIsImpossible {
                 boolean usable = false;
                 for (WeaponMounted m : weapon.getBayWeapons()) {
                     WeaponType bayWType = m.getType();
-                    boolean bayWUsesAmmo = (bayWType.getAmmoType() != AmmoType.AmmoTypeEnum.NA);
+                    boolean bayWUsesAmmo = (bayWType.getAmmoType() != NA);
                     if (m.canFire()) {
                         if (bayWUsesAmmo) {
                             if ((m.getLinked() != null) && (m.getLinked().getUsableShotsLeft() > 0)) {
@@ -738,11 +733,10 @@ class ComputeToHitIsImpossible {
         // firing arcs are more complicated
         // TW errata 2.1
 
-        if ((Compute.useSpheroidAtmosphere(game, attacker) ||
-                   (attacker.isAero() &&
-                          ((IAero) attacker).isSpheroid() &&
-                          (attacker.getAltitude() == 0) &&
-                          game.isOnGroundMap(attacker))) && (weapon != null)) {
+        if ((Compute.useSpheroidAtmosphere(game, attacker)
+              || (attacker.isAero() && attacker.isSpheroid() && (attacker.getAltitude() == 0)
+                    && game.isOnGroundMap(attacker)))
+              && (weapon != null)) {
             int range = Compute.effectiveDistance(game, attacker, target, false);
             // Only aft-mounted weapons can be fired at range 0 (targets directly underneath)
             if (!attacker.isAirborne() && (range == 0) && (weapon.getLocation() != Aero.LOC_AFT)) {
@@ -763,8 +757,7 @@ class ComputeToHitIsImpossible {
                                isIndirect))) {
                 return Messages.getString("WeaponAttackAction.TooLowForNose");
             }
-            // Front-side-mounted weapons can only be fired at targets at the same altitude
-            // or higher
+            // Front-side-mounted weapons can only be fired at targets at the same altitude or higher
             if ((!weapon.isRearMounted() && (weapon.getLocation() != Aero.LOC_AFT)) &&
                       (altDif < 0) &&
                       wtype != null &&
@@ -996,17 +989,17 @@ class ComputeToHitIsImpossible {
                                 // check the loaded ammo for the Arrow IV flag
                                 AmmoMounted bayWAmmo = bayW.getLinkedAmmo();
                                 AmmoType bAType = bayWAmmo.getType();
-                                if (bAType.getAmmoType() != AmmoType.AmmoTypeEnum.ARROW_IV) {
+                                if (bAType.getAmmoType() != ARROW_IV) {
                                     return Messages.getString("WeaponAttackAction.OnlyArrowArty");
                                 }
                             }
-                        } else if ((wtype.getAmmoType() != AmmoType.AmmoTypeEnum.ARROW_IV) &&
-                                         (wtype.getAmmoType() != AmmoType.AmmoTypeEnum.ARROW_IV_BOMB)) {
+                        } else if ((wtype.getAmmoType() != ARROW_IV) &&
+                                         (wtype.getAmmoType() != ARROW_IV_BOMB)) {
                             // For Fighters, LAMs, Small Craft and VTOLs
                             return Messages.getString("WeaponAttackAction.OnlyArrowArty");
                         }
                     }
-                } else if ((wtype.getAmmoType() == AmmoType.AmmoTypeEnum.ARROW_IV) &&
+                } else if ((wtype.getAmmoType() == ARROW_IV) &&
                                  atype != null &&
                                  atype.getMunitionType().contains(AmmoType.Munitions.M_ADA)) {
                     // Air-Defense Arrow IV can only target airborne enemy units between 1 and 51 hexes away
@@ -1180,7 +1173,7 @@ class ComputeToHitIsImpossible {
 
             // BA NARCs and Tasers can only fire at one target in a round
             if ((attacker instanceof BattleArmor) &&
-                      (wtype.hasFlag(WeaponType.F_TASER) || wtype.getAmmoType() == AmmoType.AmmoTypeEnum.NARC)) {
+                      (wtype.hasFlag(WeaponType.F_TASER) || wtype.getAmmoType() == NARC)) {
                 // Go through all of the current actions to see if a NARC or Taser
                 // has been fired
                 for (Enumeration<EntityAction> i = game.getActions(); i.hasMoreElements(); ) {
@@ -1196,7 +1189,7 @@ class ComputeToHitIsImpossible {
                                   weapon.getType().hasFlag(WeaponType.F_TASER)) {
                             return Messages.getString("WeaponAttackAction.BATaserSameTarget");
                         }
-                        if (prevWtype.getAmmoType() == AmmoType.AmmoTypeEnum.NARC && wtype.getAmmoType() == AmmoType.AmmoTypeEnum.NARC) {
+                        if (prevWtype.getAmmoType() == NARC && wtype.getAmmoType() == NARC) {
                             return Messages.getString("WeaponAttackAction.BANarcSameTarget");
                         }
                     }
@@ -1218,7 +1211,7 @@ class ComputeToHitIsImpossible {
             }
 
             // ASEW Missiles cannot be launched in an atmosphere
-            if ((wtype.getAmmoType() == AmmoType.AmmoTypeEnum.ASEW_MISSILE) && !attacker.isSpaceborne()) {
+            if ((wtype.getAmmoType() == ASEW_MISSILE) && !attacker.isSpaceborne()) {
                 return Messages.getString("WeaponAttackAction.ASEWAtmo");
             }
 
@@ -1313,7 +1306,7 @@ class ComputeToHitIsImpossible {
             }
 
             // BA Micro bombs only when flying
-            if ((atype != null) && (atype.getAmmoType() == AmmoType.AmmoTypeEnum.BA_MICRO_BOMB)) {
+            if ((atype != null) && (atype.getAmmoType() == BA_MICRO_BOMB)) {
                 if (!attacker.isAirborneVTOLorWIGE()) {
                     return Messages.getString("WeaponAttackAction.MinimumAlt1");
                     // and can only target hexes
@@ -1327,7 +1320,7 @@ class ComputeToHitIsImpossible {
 
             // Can't attack a Micro Bomb hex target with other weapons
             if ((target.getTargetType() == Targetable.TYPE_HEX_BOMB) &&
-                      !(usesAmmo && atype != null && (atype.getAmmoType() == AmmoType.AmmoTypeEnum.BA_MICRO_BOMB))) {
+                      !(usesAmmo && atype != null && (atype.getAmmoType() == BA_MICRO_BOMB))) {
                 return Messages.getString("WeaponAttackAction.InvalidForBombing");
             }
 
@@ -1568,7 +1561,7 @@ class ComputeToHitIsImpossible {
             if (isIndirect &&
                       usesAmmo &&
                       atype != null &&
-                      (atype.getAmmoType() == AmmoType.AmmoTypeEnum.MML) &&
+                      (atype.getAmmoType() == MML) &&
                       !atype.hasFlag(AmmoType.F_MML_LRM)) {
                 return Messages.getString("WeaponAttackAction.NoIndirectSRM");
             }
@@ -1667,7 +1660,7 @@ class ComputeToHitIsImpossible {
             }
 
             // NARC and iNARC
-            if ((wtype.getAmmoType() == AmmoType.AmmoTypeEnum.NARC) || (wtype.getAmmoType() == AmmoType.AmmoTypeEnum.INARC)) {
+            if ((wtype.getAmmoType() == NARC) || (wtype.getAmmoType() == INARC)) {
                 // Cannot be used against targets inside buildings
                 if (targetInBuilding) {
                     return Messages.getString("WeaponAttackAction.NoNarcInBuilding");

--- a/megamek/src/megamek/common/actions/ComputeToHitIsImpossible.java
+++ b/megamek/src/megamek/common/actions/ComputeToHitIsImpossible.java
@@ -839,7 +839,7 @@ class ComputeToHitIsImpossible {
                     return Messages.getString("WeaponAttackAction.AttackerTooHigh");
                 }
                 // Additional Nap-of-Earth restrictions for strafing
-                if ((attacker.getAltitude() == 1) && isStrafing) {
+                if ((attacker.isNOE()) && isStrafing) {
                     Vector<Coords> passedThrough = attacker.getPassedThrough();
                     if (passedThrough.isEmpty() || passedThrough.get(0).equals(target.getPosition())) {
                         // TW pg 243 says units flying at NOE have a harder time establishing LoS while strafing and
@@ -848,6 +848,16 @@ class ComputeToHitIsImpossible {
                         // theoretically consider last turns movement, but that's cumbersome, so we'll just assume
                         // it's impossible - Arlith
                         return Messages.getString("WeaponAttackAction.TooCloseForStrafe");
+                    }
+
+                    // Strafing dead-zone, TW pg 243
+                    Coords prevCoords = attacker.passedThroughPrevious(target.getPosition());
+                    Hex prevHex = game.getHex(prevCoords, attacker.getPassedThroughBoardId());
+                    Hex currHex = game.getHexOf(target);
+                    int prevElev = prevHex.getLevel();
+                    int currElev = currHex.getLevel();
+                    if ((prevElev - currElev - target.relHeight()) > 2) {
+                        return Messages.getString("WeaponAttackAction.DeadZone");
                     }
                 }
 

--- a/megamek/src/megamek/common/actions/WeaponAttackAction.java
+++ b/megamek/src/megamek/common/actions/WeaponAttackAction.java
@@ -483,7 +483,7 @@ public class WeaponAttackAction extends AbstractAttackAction {
         toHit = ComputeEnvironmentalToHitMods.compileEnvironmentalToHitMods(game, ae, target, null, null, toHit, false);
 
         // Collect the modifiers for the crew/pilot
-        toHit = ComputeAttackerToHitMods.compileCrewToHitMods(game, ae, te, toHit, null);
+        toHit = ComputeAttackerToHitMods.compileCrewToHitMods(game, ae, toHit, null);
 
         // Collect the modifiers for the attacker's condition/actions
         // Conventional fighter, Aerospace and fighter LAM attackers
@@ -530,8 +530,6 @@ public class WeaponAttackAction extends AbstractAttackAction {
         toHit = ComputeTargetToHitMods.compileTargetToHitMods(game,
               ae,
               target,
-              ttype,
-              los,
               toHit,
               Entity.LOC_NONE,
               AimingMode.NONE,
@@ -567,7 +565,6 @@ public class WeaponAttackAction extends AbstractAttackAction {
               weaponId,
               null,
               null,
-              EnumSet.of(AmmoType.Munitions.M_STANDARD),
               isAttackerInfantry,
               inSameBuilding,
               false,

--- a/megamek/src/megamek/common/weapons/lasers/CLHeavyLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLHeavyLaserLarge.java
@@ -14,6 +14,7 @@
 package megamek.common.weapons.lasers;
 
 import megamek.common.SimpleTechLevel;
+import megamek.common.WeaponTypeFlag;
 
 /**
  * @author Andrew Hunter
@@ -46,6 +47,7 @@ public class CLHeavyLaserLarge extends LaserWeapon {
         shortAV = 16;
         medAV = 16;
         maxRange = RANGE_MED;
+        flags = flags.or(WeaponTypeFlag.HEAVY_LASER);
         rulesRefs = "226, TM";
         //Jan 22 - Errata issued by CGL (Greekfire) for Heavy Lasers
         techAdvancement.setTechBase(TechBase.CLAN)

--- a/megamek/src/megamek/common/weapons/lasers/CLHeavyLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLHeavyLaserMedium.java
@@ -14,6 +14,7 @@
 package megamek.common.weapons.lasers;
 
 import megamek.common.SimpleTechLevel;
+import megamek.common.WeaponTypeFlag;
 
 /**
  * @author Andrew Hunter
@@ -45,6 +46,7 @@ public class CLHeavyLaserMedium extends LaserWeapon {
         cost = 100000;
         shortAV = 10;
         maxRange = RANGE_SHORT;
+        flags = flags.or(WeaponTypeFlag.HEAVY_LASER);
         rulesRefs = "226, TM";
         //Jan 22 - Errata issued by CGL (Greekfire) for Heavy Lasers
         techAdvancement.setTechBase(TechBase.CLAN)

--- a/megamek/src/megamek/common/weapons/lasers/CLHeavyLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/lasers/CLHeavyLaserSmall.java
@@ -14,6 +14,7 @@
 package megamek.common.weapons.lasers;
 
 import megamek.common.SimpleTechLevel;
+import megamek.common.WeaponTypeFlag;
 
 /**
  * @author Andrew Hunter
@@ -45,6 +46,7 @@ public class CLHeavyLaserSmall extends LaserWeapon {
         cost = 20000;
         shortAV = 6;
         maxRange = RANGE_SHORT;
+        flags = flags.or(WeaponTypeFlag.HEAVY_LASER);
         rulesRefs = "226, TM";
         //Jan 22 - Errata issued by CGL (Greekfire) for Heavy Lasers
         techAdvancement.setTechBase(TechBase.CLAN)


### PR DESCRIPTION
This gives the classes that were recently created by splitting WeaponAttackAction a bit of a code renovation, removing unused parameters, loads of reformatting and making code more readable.
~As the only intentional change to functionality this removes a deadzone check from strafing fire; this was already marked as questionable and from reading the strafing rules recently I am fairly sure deadzone rules dont apply.~