### PR TITLE
Fix: Fixed Start Year of the Mercenary's Guild

### DIFF
--- a/megamek/data/universe/factions/MG.yml
+++ b/megamek/data/universe/factions/MG.yml
@@ -2,7 +2,7 @@ key: MG
 name: Mercenary Guild
 capital: Solaris
 yearsActive:
-  - start: 3000
+  - start: 0
   - end: 2789
 tags:
   - IS


### PR DESCRIPTION
`3000` -> `0`