### PR TITLE
Added FWL RATs from FM:U

### DIFF
--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Aerospace/FWL DropShips 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Aerospace/FWL DropShips 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL DropShips 3067 (FMU)
+Mammoth (2808),1
+Intruder (3056),2
+Hamilcar (3054),3
+Fury (3056),4
+Leopard (3056),5
+Union (3065),6
+Leopard CV (3054),5
+Condor (3054),4
+Gazelle (3055),3
+Merlin (3063),2
+Hannibal (3055),1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Aerospace/Heavy/FWL Heavy Aerospace Fighters 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Aerospace/Heavy/FWL Heavy Aerospace Fighters 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Heavy Aerospace Fighters 3067 (FMU)
+Thunderbird TRB-D36,1
+Chippewa CHP-W5,2
+Hammerhead HMR-HD,3
+Riever F-100,4
+Eagle EGL-R5,5
+Riever F-100,6
+Riever F-700,5
+Riever F-100B,4
+Transgressor TR-14,3
+Riever F-100A,2
+Riever F-100A,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Aerospace/Light/FWL Light Aerospace Fighters 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Aerospace/Light/FWL Light Aerospace Fighters 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Light Aerospace Fighters 3067 (FMU)
+SYD Z1 Seydlitz,1
+Centurion CNT-1D,2
+Cheetah F11-R,3
+Thrush TR-7,4
+F12S Cheetah,5
+F11RR Cheetah,6
+F14S Cheetah,5
+F12S Cheetah,4
+F10 Cheetah,3
+F10 Cheetah,2
+Sabre S-27,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Aerospace/Medium/FWL Medium Aerospace Fighters 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Aerospace/Medium/FWL Medium Aerospace Fighters 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Medium Aerospace Fighters 3067 (FMU)
+Corsair CSR-V12M,1
+Hellcat HCT-213,2
+F92 Stingray,3
+F92 Stingray,4
+F90 Stingray,5
+F94 Stingray,6
+F94 Stingray,5
+Ironsides IRN-SD1,4
+Lightning LTN-G15,3
+TR11 Transit,2
+TR10 Transit,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech A 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech A 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Assault Mech A 3067 (FMU)
+Albatross ALB-3U,1
+Grand Crusader GRN-D-01,2
+Sirrocco SRC-3C,3
+Stalker STK-5M,4
+Awesome AWS-9M,5
+BattleMaster BLR-5M,6
+Longbow LGB-7Q,5
+Atlas AS7-K,4
+Grand Titan T-IT-N10M,3
+Sirrocco SRC-3C,2
+Cerebus MR-V2,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech B 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech B 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Assault Mech B 3067 (FMU)
+Albatross ALB-3U,1
+Longbow LGB-7Q,2
+CP 11-A Cyclops,3
+Victor VTR-9K,4
+CP 11-A Cyclops,5
+Stalker STK-5M,6
+BattleMaster BLR-5M,5
+Awesome AWS-9M,4
+Sirrocco SRC-3C,3
+Banshee BNC-5S,2
+Cerebus MR-V2,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech C 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech C 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Assault Mech C 3067 (FMU)
+Awesome AWS-8Q,1
+Awesome AWS-9M,2
+Cyclops CP-11A,3
+Stalker STK-5M,4
+Stalker STK-3F,5
+BattleMaster BLR-1G,6
+Victor VTR-9B,5
+BattleMaster BLR-5M,4
+Banshee BNC-3E,3
+Goliath GOL-3M,2
+Banshee BNC-5S,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech D 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech D 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Assault Mech D 3067 (FMU)
+Charger CGR-1A1,1
+Awesome AWS-9M,2
+Awesome AWS-8Q,3
+Goliath GOL-1H,4
+Stalker STK-3F,5
+BattleMaster BLR-1G,6
+Cyclops CP-10Z,5
+Stalker STK-5M,4
+Victor VTR-9B,3
+Banshee BNC-3E,2
+Zeus ZEU-6S,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech F 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Assault/FWL Assault Mech F 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Assault Mech F 3067 (FMU)
+Zeus ZEU-6S,1
+Goliath GOL-1H,2
+Charger CGR-1A1,3
+Awesome AWS-8Q,4
+Stalker STK-3F,5
+BattleMaster BLR-1G,6
+Stalker STK-3F,5
+Victor VTR-9B,4
+Cyclops CP-10Z,3
+Banshee BNC-3E,2
+Awesome AWS-9M,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech A 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech A 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Heavy Mech A 3067 (FMU)
+Quickdraw QKD-5M,1
+Anvil ANV-3M,2
+Ostsol OTL-7M,3
+Marauder MAD-9M,4
+Rifleman RFL-7M,5
+Thunderbolt TDR-9M,6
+Archer ARC-8M,5
+Orion ON2-M,4
+Yeoman YMN-6Y,3
+Tempest TMP-3M,2
+P1 Perseus,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech B 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech B 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Heavy Mech B 3067 (FMU)
+Yeoman YMN-6Y,1
+Quickdraw QKD-5M,2
+Rifleman RFL-7M,3
+Marauder MAD-9M,4
+Archer ARC-8M,5
+Thunderbolt TDR-9M,6
+Ostsol OTL-7M,5
+Guillotine GLT-5M,4
+Tempest TMP-3M,3
+P1 Perseus,2
+Orion ON1-M,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech C 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech C 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Heavy Mech C 3067 (FMU)
+Ostsol OTL-5M,1
+Quickdraw QKD-4G,2
+Archer ARC-4M,3
+Archer ARC-8M,4
+Thunderbolt TDR-5S,5
+Orion ON-1M,6
+Marauder MAD-5M,5
+Warhammer WHM-6R,4
+Tempest TMP-3M,3
+Hercules HRC-LS-9000,2
+Guillotine GLT-5M,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech D 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech D 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Heavy Mech D 3067 (FMU)
+Ostsol OTL-4D,1
+Rifleman RFL-3N,2
+Warhammer WHM-6R,3
+Marauder MAD-5M,4
+Thunderbolt TDR-5S,5
+Archer ARC-4M,6
+Orion ON-1K,5
+Crusader CRD-3R,4
+Quickdraw QKD-4G,3
+Marauder MAD-3M,2
+Catapult CPLT-C1,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech F 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Heavy/FWL Heavy Mech F 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Heavy Mech F 3067 (FMU)
+Ostsol OTL-4D,1
+Warhammer WHM-6R,2
+Marauder MAD-3M,3
+Thunderbolt TDR-5S,4
+Archer ARC-2R,5
+Orion ON-1K,6
+Crusader CRD-3R,5
+Quickdraw QKD-4G,4
+Rifleman RFL-3N,3
+Grasshopper GHR-5H,2
+Archer ARC-4M,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Light/FWL Light Mech A 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Light/FWL Light Mech A 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Light Mech A 3067 (FMU)
+FireStarter FS9-0,1
+Falcon Hawk FNHK-9K,2
+Tarantula ZPH-1A,3
+Eagle EGL-1M,4
+Locust LCT-5M,5
+Stinger STG-5M,6
+Hermes HER-3S,5
+Hammer HMR-3M,4
+Spider SDR-7M,3
+1532 Jackal JA-KL,2
+Owens OW-1,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Light/FWL Light Mech B 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Light/FWL Light Mech B 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Light Mech B 3067 (FMU)
+Raven RVN-3L,1
+Tarantula ZPH-1A,2
+Wasp WSP-3M,3
+Stinger STG-5M,4
+Stinger STG-5M,5
+Locust LCT-3M,6
+Locust LCT-5M,5
+Eagle EGL-1M,4
+Spider SDR-7M,3
+Hermes HER-3S,2
+Hammer HMR-3M,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Light/FWL Light Mech C 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Light/FWL Light Mech C 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Light Mech C 3067 (FMU)
+Tarantula ZPH-1A,1
+OstScout OTT-7J,2
+Stinger STG-5M,3
+Javelin JVN-10P,4
+Stinger STG-3R,5
+Wasp WSP-3M,6
+Hammer HMR-3M,5
+Locust LCT-3M,4
+Panther PNT-9R,3
+Jenner JR7-D,2
+Locust LCT-5M,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Light/FWL Light Mech D 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Light/FWL Light Mech D 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Light Mech D 3067 (FMU)
+Locust LCT-5M,1
+Ostscout OTT-7J,2
+Javelin JVN-10N,3
+UrbanMech UM-R60,4
+Stinger STG-3R,5
+Wasp WSP-1A,6
+Locust LCT-1V,5
+Hammer HMR-3M,4
+Firestarter FS9-H,3
+Panther PNT-9R,2
+Jenner JR7-D,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Light/FWL Light Mech F 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Light/FWL Light Mech F 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Light Mech F 3067 (FMU)
+UrbanMech UM-R60,1
+Javelin JVN-10N,2
+Firestarter FS9-H,3
+Stinger STG-3R,4
+Wasp WSP-1A,5
+Locust LCT-1V,6
+Spider SDR-5V,5
+Spider SDR-5V,4
+Javelin JVN-10N,3
+Javelin JVN-10N,2
+Panther PNT-9R,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Medium/FWL Medium Mech A 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Medium/FWL Medium Mech A 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Medium Mech A 3067 (FMU)
+Apollo APL-1M,1
+Phoenix Hawk PXH-3M,2
+Shadow Hawk SHD-7M,3
+Wolverine WVR-7M,4
+Hermes II HER-5S,5
+Trebuchet TBT-7M,6
+Griffin GRF-5M,5
+B1-HND Bloodhound,4
+Wraith TR-1,3
+Vulcan VT-5M,2
+Blackjack BJ2-O,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Medium/FWL Medium Mech B 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Medium/FWL Medium Mech B 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Medium Mech B 3067 (FMU)
+Apollo APL-1M,1
+Scorpion SCP-10,2
+Cicada CDA-3M,3
+Shadow Hawk SHD-7M,4
+Hermes II HER-5S,5
+Trebuchet TBT-7M,6
+Griffin GRF-5M,5
+Wolverine WVR-7,4
+Griffin GRF-3M,3
+Wraith TR-1,2
+Blackjack BJ2-O,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Medium/FWL Medium Mech C 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Medium/FWL Medium Mech C 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Medium Mech C 3067 (FMU)
+Scorpion SCP-10,1
+Hunchback HBK-5M,2
+Apollo APL-1M,3
+Griffin GRF-3M,4
+Phoenix Hawk PXH-3M,5
+Shadow Hawk SHD-5M,6
+Trebuchet TBT-7M,5
+Hermes II HER-5S,4
+Wraith TR-1,3
+Shadow Hawk SHD-2H,2
+Griffin GRF-5M,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Medium/FWL Medium Mech D 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Medium/FWL Medium Mech D 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Medium Mech D 3067 (FMU)
+Griffin GRF-3M,1
+Trebuchet TBT-5J,2
+Phoenix Hawk PCH-3M,3
+Hunchback HBK-4G,4
+Shadow Hawk SHD-2H,5
+Phoenix Hawk PXH-1,6
+Wolverine WVR-6M,5
+Hermes II HER-2S,4
+Dervish DV-6M,3
+Vulcan VL-2T,2
+Scorpion SCP-1N,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Medium/FWL Medium Mech F 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Mech/Medium/FWL Medium Mech F 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Medium Mech F 3067 (FMU)
+Griffin GRF-1N,1
+Trebuchet TBT-5N,2
+Hunchback HBK-4G,3
+Shadow Hawk SHD-2H,4
+Hermes II HER-2S,5
+Phoenix Hawk PXH-1,6
+Whitworth WTH-1,5
+Cicada CDA-2A,4
+Dervish DV-6M,3
+Centurion CN9-A,2
+Wolverine WVR-6M,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Vehicle/Assault/FWL Assault Vehicles 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Vehicle/Assault/FWL Assault Vehicles 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Assault Vehicles 3067 (FMU)
+Schiltron,1
+Behemoth,2
+Schrek,3
+Partisan,4
+Demolisher,5
+Ontos,6
+Schrek,5
+Ontos,4
+Partisan Air Defense Tank (XL),3
+Behemoth,2
+SturmFeur,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Vehicle/Heavy/FWL Heavy Vehicles 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Vehicle/Heavy/FWL Heavy Vehicles 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Heavy Vehicles 3067 (FMU)
+Zhukov,1
+Patton,2
+Po,3
+Manticore,4
+Pike,5
+LRM Carrier,6
+SRM Carrier,5
+Bulldog,4
+Von Luckner,3
+Brutus,2
+Pike,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Vehicle/Light/FWL Light Vehicles 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Vehicle/Light/FWL Light Vehicles 3067 (FMU).txt
@@ -9,4 +9,4 @@ Hawk Moth Gunship,5
 Pegasus Scout Hover Tank (3058 Upgrade),4
 Galleon,3
 Saladin Assault Hover Tank (LB-X),2
-Warrior Attack Helicoper H-8,1
+Warrior Attack Helicopter H-8,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Vehicle/Light/FWL Light Vehicles 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Vehicle/Light/FWL Light Vehicles 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Light Vehicles 3067 (FMU)
+Yellow Jacket,1
+Striker,2
+Mantis,3
+Plainsman (Streak),4
+Main Gauche,5
+Saracen Medium Hover Tank (MRM),6
+Hawk Moth Gunship,5
+Pegasus Scout Hover Tank (3058 Upgrade),4
+Galleon,3
+Saladin Assault Hover Tank (LB-X),2
+Warrior Attack Helicoper H-8,1

--- a/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Vehicle/Medium/FWL Medium Vehicles 3067 (FMU).txt
+++ b/megamek/data/rat/(3067) - FM Updates/Inner Sphere/Free Worlds League/Vehicle/Medium/FWL Medium Vehicles 3067 (FMU).txt
@@ -1,0 +1,12 @@
+FWL Medium Vehicles 3067 (FMU)
+Regulator,1
+Goblin,2
+Hetzer,3
+Drillson,4
+Maxim,5
+Vedette,6
+Hetzer,5
+Condor Heavy Hover Tank,4
+Regulator,3
+Stygian,2
+Condor Heavy Hover Tank,1


### PR DESCRIPTION
This PR adds the static FWL RATs from Field Manual: Updates, resolving Issue #7289.  Note that this revision includes the apparent misprint of a CNT-1D Centurion on the Light ASF table, as it remains in the most recent printing and PDF's, and the book is no longer considered active by CGL as of 9 April 2025, meaning it is unlikely to ever receive a correction.