### PR TITLE
Force hull-mounted equipment to be forward-facing

### DIFF
--- a/megamek/src/megamek/common/loaders/BLKSmallCraftFile.java
+++ b/megamek/src/megamek/common/loaders/BLKSmallCraftFile.java
@@ -16,12 +16,15 @@ package megamek.common.loaders;
 import megamek.common.*;
 import megamek.common.util.BuildingBlock;
 import megamek.common.verifier.TestEntity;
+import megamek.logging.MMLogger;
 
 /**
  * @author taharqa
  * @since April 6, 2002, 2:06 AM
  */
 public class BLKSmallCraftFile extends BLKFile implements IMekLoader {
+
+    private final MMLogger logger = MMLogger.create(BLKSmallCraftFile.class);
 
     public BLKSmallCraftFile(BuildingBlock bb) {
         dataFile = bb;
@@ -236,6 +239,15 @@ public class BLKSmallCraftFile extends BLKFile implements IMekLoader {
                 if (etype != null) {
                     try {
                         int useLoc = TestEntity.eqRequiresLocation(t, etype) ? nLoc : SmallCraft.LOC_HULL;
+                        if (useLoc == SmallCraft.LOC_HULL) {
+                            // "Rear hull" isn't a valid mount point on small craft,
+                            // but bugs in unit construction may cause a unit to be saved with
+                            // such an impossible configuration.
+                            rearMount = false;
+                            logger.warn("Unit {} has a rear-facing hull-mounted {}, which is illegal. "
+                                        + "The error has been corrected but the unit data may have been constructed incorrectly.",
+                                  t, etype.getName());
+                        }
                         Mounted<?> mount = t.addEquipment(etype, useLoc, rearMount);
                         // Need to set facing for VGLs
                         if ((etype instanceof WeaponType)


### PR DESCRIPTION
Under certain circumstances, the loader might try to place equipment in the "rear hull" location, which doesn't exist.
This should never happen except due to bugs in MML or hand-built units.
Since it _does_ happen, see MegaMek/megameklab#1953, and the correct location (forward hull) is obvious, we can just ignore that the equipment specified itself to be rear-mounted and move on with loading the unit.