### PR TITLE
Don't double-count beast damage divisor

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/customMek/InfantryArmorPanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/customMek/InfantryArmorPanel.java
@@ -189,7 +189,7 @@ public class InfantryArmorPanel extends JPanel {
             infantry.setArmorKit(armorKits.get(cbArmorKit.getSelectedIndex() - 1));
         } else {
             infantry.setArmorKit(null);
-            infantry.setArmorDamageDivisor(MathUtility.parseDouble(fldDivisor.getText(), 0.0));
+            infantry.setCustomArmorDamageDivisor(MathUtility.parseDouble(fldDivisor.getText(), 0.0));
             infantry.setArmorEncumbering(chEncumber.isSelected());
             infantry.setSpaceSuit(chSpaceSuit.isSelected());
             infantry.setDEST(chDEST.isSelected());

--- a/megamek/src/megamek/common/EntityListFile.java
+++ b/megamek/src/megamek/common/EntityListFile.java
@@ -924,9 +924,9 @@ public class EntityListFile {
             // Save some values for conventional infantry
             if (entity.isConventionalInfantry()) {
                 Infantry inf = (Infantry) entity;
-                if (inf.getArmorDamageDivisor() != 1) {
+                if (inf.getCustomArmorDamageDivisor() != 1) {
                     output.write("\" " + MULParser.ATTR_ARMOR_DIVISOR + "=\"");
-                    output.write(inf.getArmorDamageDivisor() + "");
+                    output.write(inf.getCustomArmorDamageDivisor() + "");
                 }
                 if (inf.isArmorEncumbering()) {
                     output.write("\" " + MULParser.ATTR_ARMOR_ENC + "=\"1");

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -101,7 +101,7 @@ public class Infantry extends Entity {
     private int secondaryWeaponsPerSquad = 0;
 
     // Armor
-    private double damageDivisor = 1.0;
+    private double customArmorDamageDivisor = 1.0;
     private boolean encumbering = false;
     private boolean spaceSuit = false;
     private boolean dest = false;
@@ -1285,7 +1285,7 @@ public class Infantry extends Entity {
             divisor = ((MiscType) armorKit).getDamageDivisor();
         } else {
             // For custom armor kits, which aren't found by getArmorKit()
-            divisor = getArmorDamageDivisor();
+            divisor = getCustomArmorDamageDivisor();
         }
         // TSM implant reduces divisor to 0.5 if no other armor is worn
         if ((divisor == 1.0) && hasAbility(OptionsConstants.MD_TSM_IMPLANT)) {
@@ -1302,12 +1302,12 @@ public class Infantry extends Entity {
         return divisor;
     }
 
-    public double getArmorDamageDivisor() {
-        return damageDivisor;
+    public double getCustomArmorDamageDivisor() {
+        return customArmorDamageDivisor;
     }
 
-    public void setArmorDamageDivisor(double d) {
-        damageDivisor = d;
+    public void setCustomArmorDamageDivisor(double d) {
+        customArmorDamageDivisor = d;
     }
 
     public boolean isArmorEncumbering() {
@@ -1521,7 +1521,6 @@ public class Infantry extends Entity {
                 setOriginalWalkMP(mount.getSecondaryGroundMP());
                 setOriginalJumpMP(mount.getMP());
             }
-            setArmorDamageDivisor(mount.getDamageDivisor());
         }
         calcDamageDivisor();
     }

--- a/megamek/src/megamek/common/Infantry.java
+++ b/megamek/src/megamek/common/Infantry.java
@@ -1302,10 +1302,21 @@ public class Infantry extends Entity {
         return divisor;
     }
 
+    /**
+     * Gets the damage divisor of this entity's custom armor kit.
+     * Meaningless when the infantry possesses a normal, non-custom armor kit, so check for one first.
+     * @return The damage divisor of the custom armor kit, or 1.0 for no armor.
+     */
     public double getCustomArmorDamageDivisor() {
         return customArmorDamageDivisor;
     }
 
+    /**
+     * Creates a custom armor kit for this entity.
+     * Should not be set for anything other than a custom armor kit, see {@link #calcDamageDivisor()}
+     *  to add any other source of damage divisor.
+     * @param d The damage divisor of the custom armor kit. Set it to 1.0 for no armor.
+     */
     public void setCustomArmorDamageDivisor(double d) {
         customArmorDamageDivisor = d;
     }

--- a/megamek/src/megamek/common/MULParser.java
+++ b/megamek/src/megamek/common/MULParser.java
@@ -925,7 +925,7 @@ public class MULParser {
             Infantry inf = (Infantry) entity;
             String armorDiv = entityTag.getAttribute(ATTR_ARMOR_DIVISOR);
             if (!armorDiv.isBlank()) {
-                inf.setArmorDamageDivisor(Double.parseDouble(armorDiv));
+                inf.setCustomArmorDamageDivisor(Double.parseDouble(armorDiv));
             }
 
             if (!entityTag.getAttribute(ATTR_ARMOR_ENC).isBlank()) {

--- a/megamek/src/megamek/common/cost/InfantryCostCalculator.java
+++ b/megamek/src/megamek/common/cost/InfantryCostCalculator.java
@@ -54,7 +54,7 @@ public class InfantryCostCalculator {
             armorCost = armor.getCost(infantry, false, Infantry.LOC_INFANTRY);
         } else {
             // add in infantry armor cost
-            if (infantry.getArmorDamageDivisor() > 1) {
+            if (infantry.getCustomArmorDamageDivisor() > 1) {
                 if (infantry.isArmorEncumbering()) {
                     armorCost += 1600;
                 } else {

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -942,8 +942,8 @@ public class BLKFile {
                 blk.writeBlockData("Secondary", infantry.getSecondaryWeapon().getInternalName());
             }
 
-            if (infantry.getArmorDamageDivisor() != 1) {
-                blk.writeBlockData("armordivisor", Double.toString(infantry.getArmorDamageDivisor()));
+            if (infantry.getCustomArmorDamageDivisor() != 1) {
+                blk.writeBlockData("armordivisor", Double.toString(infantry.getCustomArmorDamageDivisor()));
             }
             if (infantry.isArmorEncumbering()) {
                 blk.writeBlockData("encumberingarmor", "true");

--- a/megamek/src/megamek/common/loaders/BLKInfantryFile.java
+++ b/megamek/src/megamek/common/loaders/BLKInfantryFile.java
@@ -47,7 +47,7 @@ public class BLKInfantryFile extends BLKFile implements IMekLoader {
         infantry.autoSetInternal();
 
         if (dataFile.exists("InfantryArmor")) {
-            infantry.setArmorDamageDivisor(dataFile.getDataAsInt("InfantryArmor")[0]);
+            infantry.setCustomArmorDamageDivisor(dataFile.getDataAsInt("InfantryArmor")[0]);
         }
 
         if (!dataFile.exists("motion_type")) {
@@ -172,7 +172,7 @@ public class BLKInfantryFile extends BLKFile implements IMekLoader {
 
         if (dataFile.exists("armordivisor")) {
             try {
-                infantry.setArmorDamageDivisor(Double.parseDouble(dataFile.getDataAsString("armordivisor")[0]));
+                infantry.setCustomArmorDamageDivisor(Double.parseDouble(dataFile.getDataAsString("armordivisor")[0]));
             } catch (NumberFormatException ex) {
                 throw new EntityLoadingException("Could not read armor divisor");
             }


### PR DESCRIPTION
Fixes MegaMek/megameklab#1920.

The infantry's innate "Damage Divisor" property is only for custom armor kits, and should not be set for any other reason. 
In this case, it was set by the beast, which meant that the damage divisor would be applied twice: once for the beast, and once for the custom armor kit the beast created.

This PR fixes the creation of the custom armor kit, and renames the `ArmorDamageDivisor` fields to make their purpose more clear.

Must be merged together with MegaMek/megameklab#1962 and MegaMek/mekhq#7308.