### PR TITLE
Fix ProtoMek bays for construction

### DIFF
--- a/megamek/src/megamek/common/MekBay.java
+++ b/megamek/src/megamek/common/MekBay.java
@@ -97,4 +97,9 @@ public final class MekBay extends UnitBay {
     public long getCost() {
         return 20000L * (long) totalSpace;
     }
+
+    @Override
+    public String getNameForRecordSheets() {
+        return "Mech";
+    }
 }

--- a/megamek/src/megamek/common/MekBay.java
+++ b/megamek/src/megamek/common/MekBay.java
@@ -100,6 +100,7 @@ public final class MekBay extends UnitBay {
 
     @Override
     public String getNameForRecordSheets() {
+        // CHECKSTYLE IGNORE ForbiddenWords FOR 1 LINES
         return "Mech";
     }
 }

--- a/megamek/src/megamek/common/ProtoMekBay.java
+++ b/megamek/src/megamek/common/ProtoMekBay.java
@@ -136,6 +136,7 @@ public final class ProtoMekBay extends UnitBay {
 
     @Override
     public String getNameForRecordSheets() {
+        // CHECKSTYLE IGNORE ForbiddenWords FOR 1 LINES
         return "ProtoMech";
     }
 }

--- a/megamek/src/megamek/common/ProtoMekBay.java
+++ b/megamek/src/megamek/common/ProtoMekBay.java
@@ -14,8 +14,9 @@
 package megamek.common;
 
 /**
- * Represents a volume of space set aside for carrying ProtoMeks aboard large spacecraft and mobile
- * structures
+ * Represents a volume of space set aside for carrying ProtoMek points aboard large spacecraft and mobile
+ * structures.
+ *
  */
 public final class ProtoMekBay extends UnitBay {
     private static final long serialVersionUID = 927162989742234173L;
@@ -33,12 +34,12 @@ public final class ProtoMekBay extends UnitBay {
      * weight of the troops (and their equipment) are considered; if you'd like
      * to think that they are stacked like lumber, be my guest.
      *
-     * @param space The weight of troops (in tons) this space can carry.
+     * @param space The number of ProtoMeks that can fit in this bay.
      * @param bayNumber
      */
     public ProtoMekBay(double space, int doors, int bayNumber) {
-        totalSpace = space;
-        currentSpace = space;
+        totalSpace = Math.ceil(space / 5);
+        currentSpace = totalSpace;
         this.doors = doors;
         doorsNext = doors;
         this.bayNumber = bayNumber;
@@ -59,7 +60,7 @@ public final class ProtoMekBay extends UnitBay {
 
         // We must have enough space for the new troops.
         // TODO : POSSIBLE BUG : we may have to take the Math.ceil() of the weight.
-        if (getUnused() < 1) {
+        if (getUnused() < 0.2) {
             result = false;
         }
 
@@ -75,8 +76,8 @@ public final class ProtoMekBay extends UnitBay {
     @Override
     public String getUnusedString(boolean showRecovery) {
         return "ProtoMek " + numDoorsString() + " - "
-                + String.format("%1$,.0f", getUnused())
-                + (getUnused() > 1 ? " units" : " unit");
+                + String.format("%1$,.0f", getUnusedSlots())
+                + (getUnusedSlots() > 1 ? " units" : " unit");
     }
 
     @Override
@@ -86,12 +87,12 @@ public final class ProtoMekBay extends UnitBay {
 
     @Override
     public double getWeight() {
-        return totalSpace * 10;
+        return totalSpace * 50;
     }
 
     @Override
     public int getPersonnel(boolean clan) {
-        return (int) totalSpace * 6;
+        return (int) Math.ceil(totalSpace) * 6;
     }
 
     @Override
@@ -120,6 +121,21 @@ public final class ProtoMekBay extends UnitBay {
     @Override
     public long getCost() {
         // Cost is per five cubicles
-        return 10000L * (long) Math.ceil(totalSpace / 5);
+        return 10000L * (long) Math.ceil(totalSpace);
+    }
+
+    @Override
+    public double spaceForUnit(Entity unit) {
+        return 0.2;
+    }
+
+    @Override
+    public double getUnusedSlots() {
+        return getUnused() * 5;
+    }
+
+    @Override
+    public String getNameForRecordSheets() {
+        return "ProtoMech";
     }
 }

--- a/megamek/src/megamek/common/Transporter.java
+++ b/megamek/src/megamek/common/Transporter.java
@@ -13,10 +13,10 @@
  */
 package megamek.common;
 
-import megamek.common.annotations.Nullable;
-
 import java.io.Serializable;
 import java.util.List;
+
+import megamek.common.annotations.Nullable;
 
 /**
  * Classes that implement this interface have the ability to load, carry, and
@@ -155,5 +155,9 @@ public interface Transporter extends Serializable {
 
     default String getType() {
         return "Unknown";
+    }
+
+    default String getNameForRecordSheets() {
+        return getType();
     }
 }

--- a/megamek/src/megamek/common/verifier/BayData.java
+++ b/megamek/src/megamek/common/verifier/BayData.java
@@ -30,7 +30,7 @@ import megamek.common.InfantryTransporter.PlatoonType;
 public enum BayData {
     MEK ("Mek", 150.0, 2, MekBay.techAdvancement(),
             (size, num) -> new MekBay(size, 1, num)),
-    PROTOMEK ("Protomek", 10.0, 6, ProtoMekBay.techAdvancement(),
+    PROTOMEK ("ProtoMek Point", 50.0, 6, ProtoMekBay.techAdvancement(),
             (size, num) -> new ProtoMekBay(size, 1, num)),
     VEHICLE_HEAVY ("Heavy Vehicle", 100.0, 8, HeavyVehicleBay.techAdvancement(),
             (size, num) -> new HeavyVehicleBay(size, 1, num)),


### PR DESCRIPTION
ProtoMek bays have an awkward requirement of 6 personnel per 5 ProtoMeks, so the existing approach of one single ProtoMek being the "unit" of the ProtoMekBay didn't work. 

By reworking the bay so it now stores points of 5 ProtoMeks, personnel can be calculated properly.

This PR also fixes "ProtoMek" showing up instead of "ProtoMech" in record sheets.

Tested only for construction in MML and not gameplay. As far as I understand, ProtoMek transport just never worked in the first place, and canon units which should have PM bays just left them out, so at the very least this approach not working for gameplay wouldn't be a regression.

Must be merged with MegaMek/megameklab#1963.

Fixes MegaMek/megameklab#1938.