### PR TITLE
Issue MML#1895: Make sure every SC and DS has a placeholder engine

### DIFF
--- a/megamek/src/megamek/common/SmallCraft.java
+++ b/megamek/src/megamek/common/SmallCraft.java
@@ -80,6 +80,11 @@ public class SmallCraft extends Aero {
                                                                              AvailabilityValue.F)
                                                                        .setStaticTechLevel(SimpleTechLevel.STANDARD);
 
+    public SmallCraft() {
+        // A placeholder engine for SC and DS
+        setEngine(new Engine(400, 0, 0));
+    }
+
     @Override
     public int getUnitType() {
         return UnitType.SMALL_CRAFT;

--- a/megamek/src/megamek/common/loaders/BLKDropshipFile.java
+++ b/megamek/src/megamek/common/loaders/BLKDropshipFile.java
@@ -131,8 +131,6 @@ public class BLKDropshipFile extends BLKFile implements IMekLoader {
         }
         a.setOriginalWalkMP(dataFile.getDataAsInt("SafeThrust")[0]);
 
-        a.setEngine(new Engine(400, 0, 0));
-
         // Switch older files with standard armor to aerospace
         int at = EquipmentType.T_ARMOR_AEROSPACE;
         if (dataFile.exists("armor_type")) {

--- a/megamek/src/megamek/common/loaders/BLKSmallCraftFile.java
+++ b/megamek/src/megamek/common/loaders/BLKSmallCraftFile.java
@@ -122,8 +122,6 @@ public class BLKSmallCraftFile extends BLKFile implements IMekLoader {
         }
         a.setOriginalWalkMP(dataFile.getDataAsInt("SafeThrust")[0]);
 
-        a.setEngine(new Engine(400, 0, 0));
-
         // Switch older files with standard armor to aerospace
         int at = EquipmentType.T_ARMOR_AEROSPACE;
         if (dataFile.exists("armor_type")) {


### PR DESCRIPTION
Fixes MegaMek/megameklab#1895
SC and DS used to get a placeholder engine when loading from blk but not when constructing a blank unit. This PR moves that engine to the SC constructor so it's always there so the engine weight shows in MML. I did not investigate if it can be removed entirely.