### PR TITLE
Correct BV values for some BA LRM launchers

### DIFF
--- a/megamek/src/megamek/common/AmmoType.java
+++ b/megamek/src/megamek/common/AmmoType.java
@@ -8358,7 +8358,7 @@ public class AmmoType extends EquipmentType {
         ammo.rackSize = 3;
         ammo.ammoType = AmmoTypeEnum.LRM;
         ammo.shots = 100;
-        ammo.bv = 5;
+        ammo.bv = 4;
         ammo.kgPerShot = 24.99;
         /*
          * Per Herb all ProtoMek launcher use the ProtoMek Chassis progression. But
@@ -13769,7 +13769,7 @@ public class AmmoType extends EquipmentType {
         ammo.ammoType = AmmoTypeEnum.LRM;
         ammo.flags = ammo.flags.or(F_BATTLEARMOR);
         ammo.shots = 1;
-        ammo.bv = 5;
+        ammo.bv = 4;
         ammo.kgPerShot = 25;
         ammo.rulesRefs = "261, TM";
         ammo.techAdvancement.setTechBase(TechBase.CLAN)

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALRM3.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALRM3.java
@@ -36,7 +36,7 @@ public class CLBALRM3 extends LRMWeapon {
         minimumRange = WEAPON_NA;
         tonnage = 0.105;
         criticals = 3;
-        bv = 35;
+        bv = 34;
         cost = 18000;
         flags = flags.or(F_NO_FIRES).or(F_BA_WEAPON).andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON).andNot(F_AERO_WEAPON).andNot(F_PROTO_WEAPON);
         rulesRefs = "261, TM";

--- a/megamek/src/megamek/common/weapons/battlearmor/CLBALRM5.java
+++ b/megamek/src/megamek/common/weapons/battlearmor/CLBALRM5.java
@@ -38,7 +38,7 @@ public class CLBALRM5 extends LRMWeapon {
         minimumRange = WEAPON_NA;
         tonnage = .175;
         criticals = 4;
-        bv = 0;
+        bv = 55;
         cost = 30000;
         flags = flags.or(F_NO_FIRES).or(F_BA_WEAPON).andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON).andNot(F_AERO_WEAPON).andNot(F_PROTO_WEAPON);
         rulesRefs = "261, TM";

--- a/megamek/src/megamek/common/weapons/lrms/CLLRM3.java
+++ b/megamek/src/megamek/common/weapons/lrms/CLLRM3.java
@@ -29,7 +29,7 @@ public class CLLRM3 extends LRMWeapon {
         minimumRange = WEAPON_NA;
         tonnage = 0.6;
         criticals = 0;
-        bv = 35;
+        bv = 34;
         // Per Herb all ProtoMek launcher use the ProtoMek Chassis progression.
         // But LRM Tech Base and Avail Ratings.
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)


### PR DESCRIPTION
LRM-3s should 34 BV instead of 35 (4 instead of 5 for ammo).

LRM-5s should have 55 BV instead of, uh, zero.

TMp318