### PR TITLE
Improvements to unit selection: Coolant Pods and HHWs

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/advancedsearch/EquipmentTableModel.java
+++ b/megamek/src/megamek/client/ui/dialogs/advancedsearch/EquipmentTableModel.java
@@ -18,13 +18,12 @@
  */
 package megamek.client.ui.dialogs.advancedsearch;
 
-import megamek.common.EquipmentType;
-import megamek.common.MiscType;
-import megamek.common.TechConstants;
-
-import javax.swing.table.AbstractTableModel;
 import java.util.ArrayList;
 import java.util.List;
+import javax.swing.table.AbstractTableModel;
+
+import megamek.common.EquipmentType;
+import megamek.common.TechConstants;
 
 /**
  * A table model for the advanced search weapon tab's equipment list
@@ -39,7 +38,7 @@ class EquipmentTableModel extends AbstractTableModel {
     static final int COL_INTERNAL_NAME = 5;
 
     private final TWAdvancedSearchPanel twAdvancedSearchPanel;
-    private final List<MiscType> equipment = new ArrayList<>();
+    private final List<EquipmentType> equipment = new ArrayList<>();
 
     EquipmentTableModel(TWAdvancedSearchPanel twAdvancedSearchPanel) {
         this.twAdvancedSearchPanel = twAdvancedSearchPanel;
@@ -81,13 +80,13 @@ class EquipmentTableModel extends AbstractTableModel {
         return getValueAt(0, c).getClass();
     }
 
-    void setData(List<MiscType> eq) {
+    void setData(List<EquipmentType> eq) {
         equipment.clear();
         equipment.addAll(eq);
         fireTableDataChanged();
     }
 
-    MiscType getEquipmentTypeAt(int row) {
+    EquipmentType getEquipmentTypeAt(int row) {
         return equipment.get(row);
     }
 

--- a/megamek/src/megamek/client/ui/dialogs/advancedsearch/WeaponSearchTab.java
+++ b/megamek/src/megamek/client/ui/dialogs/advancedsearch/WeaponSearchTab.java
@@ -490,8 +490,8 @@ class WeaponSearchTab extends JPanel implements KeyListener, DocumentListener, F
 
     private boolean matchUnitTypeToMisc(EquipmentType eq) {
         if (eq instanceof AmmoType at) {
-            if (!(at.getAmmoType() == AmmoType.AmmoTypeEnum.COOLANT_POD)) {
-                throw new IllegalArgumentException("The only support AmmoType here is the Coolant Pod");
+            if (at.getAmmoType() != AmmoType.AmmoTypeEnum.COOLANT_POD) {
+                throw new IllegalArgumentException("The only supported AmmoType here is the Coolant Pod");
             }
             // Check for coolant pods
             return btnUnitTypeMek.isSelected() || btnUnitTypeAero.isSelected();

--- a/megamek/src/megamek/common/UnitType.java
+++ b/megamek/src/megamek/common/UnitType.java
@@ -34,13 +34,16 @@ public class UnitType {
     public static final int JUMPSHIP = 12;
     public static final int WARSHIP = 13;
     public static final int SPACE_STATION = 14;
-    public static final int AERO = 15; // Non-differentiated Aerospace, like Escape Pods / Life Boats
-    public static final int HANDHELD_WEAPON = 16;
+    public static final int HANDHELD_WEAPON = 15;
+    // IMPORTANT: AERO must be the last unit type for advanced search to work,
+    // unless you are adding a new unit type which like Aero should be excluded from search.
+    // In that case add an exception for it in the definition of unitTypeModel in AbstractUnitSelectorDialog.java
+    public static final int AERO = 16; // Non-differentiated Aerospace, like Escape Pods / Life Boats
 
     private static String[] names = { "Mek", "Tank", "BattleArmor", "Infantry",
                                       "ProtoMek", "VTOL", "Naval", "Gun Emplacement", "Conventional Fighter",
                                       "AeroSpaceFighter", "Small Craft", "Dropship",
-                                      "Jumpship", "Warship", "Space Station", "Aero", "Handheld Weapon" };
+                                      "Jumpship", "Warship", "Space Station", "Handheld Weapon", "Aero" };
 
     public static final int SIZE = names.length;
     


### PR DESCRIPTION
Currently selecting the Handheld Weapon unit type doesn't actually work and shows 0 units, which this fixes.
Also, the equipment list in advanced search now includes the Coolant Pod, so you can search for units that have Coolant Pods.