### PR TITLE
Fix: #7296 Fixed Weapon Panel Jumping to the Bottom Right During Firing Phase

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitDisplay/WeaponPanel.java
@@ -1,20 +1,34 @@
 /*
- * Copyright (c) 2024 - The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
  * MegaMek is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
  *
  * MegaMek is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with MegaMek. If not, see <http://www.gnu.org/licenses/>.
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
  */
 package megamek.client.ui.dialogs.unitDisplay;
 
@@ -24,7 +38,6 @@ import java.awt.Dimension;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Image;
-import java.awt.Insets;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -45,12 +58,12 @@ import megamek.client.Client;
 import megamek.client.event.MekDisplayEvent;
 import megamek.client.ui.GBC;
 import megamek.client.ui.Messages;
-import megamek.client.ui.comboBoxes.MMComboBox;
 import megamek.client.ui.clientGUI.ClientGUI;
 import megamek.client.ui.clientGUI.GUIPreferences;
+import megamek.client.ui.clientGUI.tooltip.UnitToolTip;
+import megamek.client.ui.comboBoxes.MMComboBox;
 import megamek.client.ui.panels.phaseDisplay.FiringDisplay;
 import megamek.client.ui.panels.phaseDisplay.TargetingPhaseDisplay;
-import megamek.client.ui.clientGUI.tooltip.UnitToolTip;
 import megamek.client.ui.widget.BackGroundDrawer;
 import megamek.client.ui.widget.PMUtil;
 import megamek.client.ui.widget.PicMap;
@@ -1021,18 +1034,6 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         setContentMargins(dx, dy, dx, dy);
         revalidate();
         repaint();
-    }
-
-    @Override
-    public Dimension getPreferredSize() {
-        // Calculate preferred size based on the main split pane's preferred size
-        Dimension splitPanePrefSize = splitPane.getPreferredSize();
-        Insets insets = getInsets();
-        int height = splitPanePrefSize.height + insets.top + insets.bottom;
-
-        // Consider superclass preferred size as well
-        Dimension superPref = super.getPreferredSize();
-        return new Dimension(Math.max(splitPanePrefSize.width, superPref.width), Math.max(height, superPref.height));
     }
 
     private void setBackGround() {


### PR DESCRIPTION
Fix #7296

This PR fixes a really annoying issue where, during the firing phase, the weapon display would default to the bottom-right of the scroll bar/s. This meant that to fire weapons the player would need to scroll up, for every unit, every round.

The culprit is an override that was added when we implemented the scrollbars. This override causes the display to resize. This in turn runs us into a _awesome_ feature of Java Swing: if a JScrollPane is resized it jumps to the bottom right. Super useful. Well implemented. Thank you Java Swing, truly you are the gift that keeps on giving...

The solution is to remove the override. Now, removing code like this isn't something I'm overly inclined towards so I tested the heck out of it, and insofar as I can tell we're not introducing any new issues that players will notice. Now, in the event that this does break something it's effortless to restore the code. Though even if that does happen, I'm not convinced the cure will be worse than the sickness.