### PR TITLE
PR: Data updates - early Clan Mek availability (all weight classes) 2807-2900

### DIFF
--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2807-->
-<ratgen
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -477,7 +477,7 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>IS:2,FS:4,LA:3,DC:4,PP:5+,CLAN:4,CCC:3,CGS:3,CIH:2,CMG:3,CDS:3,CSV:3,CS:4-,NIOPS:4-,TC:1,MOC:1,OA:1,Periphery.Deep:0</availability>
+			<availability>IS:2,FS:4,LA:3,DC:4,CS:4-,PP:5+,CLAN:4,CCC:3,CGS:3,CIH:2,CMG:3,CDS:3,CSV:3,TC:1,MOC:1,OA:1,NIOPS:4-,Periphery.Deep:0</availability>
 			<model name='AS7-D'>
                 <roles>command</roles>
 				<availability>IS:8,PP:8,CLAN:8,Periphery:8</availability>
@@ -549,7 +549,7 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>IS:7,LA:8,FWL:8,CS:8-,PP:4,CLAN:6,CB:5,CCO:5,CGB:5,CIH:5,CSJ:4,CSA:5,CWI:5,NIOPS:8-,TC:6,MOC:5,PIR:6</availability>
+			<availability>IS:7,LA:8,FWL:8,CS:8-,PP:4,CLAN:6,CB:5,CCO:5,CGB:5,CIH:5,CSJ:4,CSA:5,CWI:5,TC:6,MOC:5,NIOPS:8-,PIR:6</availability>
 			<model name='BLR-1G'>
                 <roles>command</roles>
 				<availability>IS:8,PP:5,Periphery:8,Periphery.Deep:8,PIR:8</availability>
@@ -568,7 +568,7 @@
 			</model>
 			<model name='BLR-1Gc'>
                 <roles>command</roles>
-				<availability>FS:2+,LA:3+,DC:2+,FWL:3+,CC:3+,PP:2+,CLAN!Front Line:1,CFM:0,CIH:0,CSJ:0</availability>
+				<availability>FS:2+,LA:3+,DC:2+,FWL:3+,CC:3+,PP:2+,CLAN!Front Line:1,CFM:0,CIH:0,CSJ:0,CSA!Front Line:1!Second Line:1</availability>
 			</model>
 			<model name='BLR-1Gd'>
                 <roles>command</roles>
@@ -1578,10 +1578,10 @@
             </model>
         </chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>FS:6,CC:6,FWL:7,MERC:6,CS:7,PP:2+,CLAN:3+,NIOPS:7,TC:5,MOC:5,OA:5</availability>
+			<availability>FS:6,FWL:7,CC:6,MERC:6,CS:7,PP:2+,CLAN:3+,TC:5,MOC:5,OA:5,NIOPS:7</availability>
 			<model name='EMP-5A'>
                 <roles>command</roles>
-				<availability>IS:8,PP:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,Periphery:8,NIOPS:3-</availability>
 			</model>
 			<model name='EMP-6A'>
                 <roles>command</roles>
@@ -2886,7 +2886,7 @@
 			</model>
 			<model name='LGB-7Q'>
 				<roles>fire_support</roles>
-				<availability>IS:6,TC:6,MOC:6,OA:6,PP:8,CDS:8,CSR:8,CWOV:8</availability>
+				<availability>IS:6,PP:8,CDS:8,CSR:8,CWOV:8,TC:6,MOC:6,OA:6</availability>
 			</model>
 			<model name='LGB-8C'>
                 <roles>fire_support</roles>
@@ -4251,7 +4251,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>IS:8,FS:7,DC:7,CC:7,FWL:9,CS:6,PP:6,CLAN:5,CBS:6,CGB:6,CHH:6,CIH:4,CMG:4,CNC:6,CW:6,Periphery:9,NIOPS:6,Periphery.Deep:9</availability>
+			<availability>IS:8,FS:7,DC:7,FWL:9,CC:7,CS:6,PP:6,CLAN:5,CBS:6,CGB:6,CHH:6,CIH:4,CMG:4,CNC:6,CW:6,Periphery:9,NIOPS:6,Periphery.Deep:9</availability>
 			<model name='STK-3F'>
 				<availability>IS:8,PP:6,Periphery:8,Periphery.Deep:8</availability>
 			</model>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -800,7 +800,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cestus' unitType='Mek'>
-			<availability>IS:4+,FS:6,CS:4,PP:3+,CB:3+,CFM:2+,CJF:3+,CSJ:3+,NIOPS:4</availability>
+			<availability>IS:4+,FS:6,CS:4,PP:3+,CB:3+,CFM:2+,CJF:3+,CSJ:3+,NIOPS:4+</availability>
 			<model name='CTS-6Y'>
 				<availability>IS:8,PP:8,CB:8,CFM:8,CJF:8,CSJ:8,NIOPS:8</availability>
 			</model>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -353,6 +353,12 @@
 				<availability>IS:3,Periphery:3</availability>
 			</model>
 		</chassis>
+        <chassis name='Annihilator' unitType='Mek'>
+            <availability>CB:3+,CCO:3+,CGB:3+,CSA:3+,CWI:3+</availability>
+            <model name='ANH-1X'>
+                <availability>CB:8,CCO:8,CGB:8,CS:8,CWI:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Aquarius Escort' unitType='Small Craft'>
 			<availability>FWL:6</availability>
 			<model name=''>
@@ -460,25 +466,25 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas II' unitType='Mek'>
-			<availability>PP:3,CLAN:5</availability>
+			<availability>PP:2+,CLAN:3+</availability>
 			<model name='AS7-D-H'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>PP:8,CLAN:5</availability>
 			</model>
 			<model name='AS7-D-H2'>
                 <roles>command</roles>
-				<availability>General:4,CLAN:4</availability>
+				<availability>PP:2+,CLAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>PP:5,MOC:1,CS:4-,OA:1,LA:3,IS:2,NIOPS:4-,FS:4,TC:1,DC:4</availability>
+			<availability>IS:2,FS:4,LA:3,DC:4,PP:5+,CLAN:4,CCC:3,CGS:3,CIH:2,CMG:3,CDS:3,CSV:3,CS:4-,NIOPS:4-,TC:1,MOC:1,OA:1,Periphery.Deep:0</availability>
 			<model name='AS7-D'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,PP:8,CLAN:8,Periphery:8</availability>
 			</model>
 			<model name='AS7-D-DC'>
 				<roles>command</roles>
-				<availability>IS:1,MERC:0,DC:2</availability>
+				<availability>IS:1+,DC:2+,MERC:0,CLAN:1+,CFM:0,CSJ:0</availability>
 			</model>
 		</chassis>
 		<chassis name='Atreus Battleship' unitType='Warship'>
@@ -489,9 +495,9 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>PP:8,MOC:6,IS:7,Periphery.Deep:4,CIR:7,TC:6,Periphery:4,CS:8,OA:6,FWL:8,NIOPS:8</availability>
+			<availability>IS:7,FWL:8,CS:8,PP:5+,CSA:3,Periphery:4,TC:6,MOC:6,OA:6,CIR:7,NIOPS:8,Periphery.Deep:4+</availability>
 			<model name='AWS-8Q'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CSA:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='AWS-8R'>
 				<availability>CS:2,FWL:4</availability>
@@ -543,26 +549,26 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>PP:4,CS:8-,MOC:5,LA:8,PIR:6,IS:7,FWL:8,NIOPS:8-,TC:6</availability>
+			<availability>IS:7,LA:8,FWL:8,CS:8-,PP:4,CLAN:6,CB:5,CCO:5,CGB:5,CIH:5,CSJ:4,CSA:5,CWI:5,NIOPS:8-,TC:6,MOC:5,PIR:6</availability>
 			<model name='BLR-1G'>
                 <roles>command</roles>
-				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:5,Periphery:8,Periphery.Deep:8,PIR:8</availability>
 			</model>
             <model name='BLR-1G-DC'>
                 <roles>command</roles>
-                <availability>IS:2+,PP:2</availability>
+                <availability>IS:2+,PP!A:2!B:2!C:1</availability>
             </model>
 			<model name='BLR-1Gb'>
                 <roles>command</roles>
-				<availability>PP:4,CC:2+</availability>
+				<availability>CC:2+,PP:4+,CLAN:8</availability>
 			</model>
 			<model name='BLR-1Gbc'>
                 <roles>command</roles>
-				<availability>PP:2+</availability>
+				<availability>PP:1+,CLAN:1+,CFM:0,CIH:0,CSJ:0</availability>
 			</model>
 			<model name='BLR-1Gc'>
                 <roles>command</roles>
-				<availability>PP:4,CC:3+,LA:3+,FWL:3+,FS:2+,DC:2+</availability>
+				<availability>FS:2+,LA:3+,DC:2+,FWL:3+,CC:3+,PP:2+,CLAN!Front Line:1,CFM:0,CIH:0,CSJ:0</availability>
 			</model>
 			<model name='BLR-1Gd'>
                 <roles>command</roles>
@@ -1291,12 +1297,12 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>PP:10,CC:7,CS:8,LA:7,FWL:7,NIOPS:8,FS:7,DC:7</availability>
+			<availability>FS:7,LA:7,DC:7,FWL:7,CC:7,CS:8,PP:6,CLAN:4-,CBS:5-,CCO:5-,CFM:5-,CGB:5-,CHH:5-,CW:5-,NIOPS:8</availability>
 			<model name='CRK-5003-1'>
-				<availability>CS:8,General:8+,NIOPS:8</availability>
+				<availability>IS:8+,CS:8,PP:6,CLAN:8,CBS:4-,CB:4-,CCO:4-,CGB:4-,CHH:4-,CW:4-,NIOPS:8</availability>
 			</model>
 			<model name='CRK-5003-1b'>
-				<availability>PP:4</availability>
+				<availability>PP:3+,CBS:5,CB:5,CCO:5,CGB:5,CHH:5,CW:5</availability>
 			</model>
 		</chassis>
 		<chassis name='Crossbow' unitType='Mek'>
@@ -1361,18 +1367,18 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>PP:4,CC:5,CS:3,OA:3,LA:5,IS:3,FWL:4,NIOPS:3,FS:5,TC:3,DC:5</availability>
+			<availability>IS:3,FS:5,LA:5,DC:5,FWL:4,CC:5,CS:3,PP:3+,TC:3,OA:3,NIOPS:3</availability>
 			<model name='CP-10-HQ'>
                 <roles>command</roles>
-				<availability>IS:2</availability>
+				<availability>IS:2+,PP:1+</availability>
 			</model>
 			<model name='CP-10-Q'>
                 <roles>command</roles>
-				<availability>IS:3</availability>
+				<availability>IS:3+</availability>
 			</model>
 			<model name='CP-10-Z'>
                 <roles>command</roles>
-				<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+				<availability>IS:8,FS:8,DC:8,MERC:8,PP:8,TC:8,OA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
@@ -1572,14 +1578,14 @@
             </model>
         </chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>PP:3,CC:6,MOC:5,CS:7,OA:5,FWL:7,NIOPS:7,FS:6,MERC:6,TC:5</availability>
+			<availability>FS:6,CC:6,FWL:7,MERC:6,CS:7,PP:2+,CLAN:3+,NIOPS:7,TC:5,MOC:5,OA:5</availability>
 			<model name='EMP-5A'>
                 <roles>command</roles>
-				<availability>PP:2,General:8</availability>
+				<availability>IS:8,PP:8,Periphery:8</availability>
 			</model>
 			<model name='EMP-6A'>
                 <roles>command</roles>
-				<availability>PP:6,CC:6+,CS:8,LA:6+,NIOPS:8,FWL:6+,FS:6+</availability>
+				<availability>FS:6+,LA:6+,FWL:6+,CC:6+,CS:8,PP:3+,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Enforcer' unitType='Mek'>
@@ -2335,14 +2341,14 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>PP:9,CS:9,NIOPS:9,IS:5,MERC:5</availability>
+			<availability>IS:5,MERC:5,CS:9,PP:3+,CLAN:4+,NIOPS:9</availability>
 			<model name='HGN-732'>
                 <roles>command</roles>
-				<availability>PP:8,CS:8,FWL:8+,IS:8,NIOPS:8</availability>
+				<availability>IS:8,FWL:8+,CS:8,PP:8,CLAN:4-,NIOPS:8</availability>
 			</model>
 			<model name='HGN-732b'>
                 <roles>command</roles>
-				<availability>PP:4,FWL:4+</availability>
+				<availability>FWL:4+,PP:4+,CLAN:6,NIOPS:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
@@ -2414,10 +2420,10 @@
 			</model>
 		</chassis>
 		<chassis name='Imp' unitType='Mek'>
-			<availability>PP:2</availability>
+			<availability>PP:2+,CB:2+,CCO:2+,CGB:2+,CSJ:2+,CWI:2+,CW:2+</availability>
 			<model name='IMP-1A'>
                 <roles>command</roles>
-				<availability>PP:8</availability>
+				<availability>PP:8,CB:8,CCO:8,CGB:8,CSJ:8,CWI:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
@@ -2617,15 +2623,19 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>PP:5,CS:6,IS:2+,NIOPS:6,MERC:2+</availability>
+			<availability>IS:2+,MERC:2+,CS:6,PP:5,CLAN:4,CCC:2+,CFM:5,CGS:3,CHH:3,CIH:2,CMG:2,CDS:3,CSR:2,CSA:3,CSV:3,CWI:5,NIOPS:6</availability>
 			<model name='KGC-000'>
                 <roles>command</roles>
-				<availability>CS:8,General:6,NIOPS:8</availability>
+				<availability>IS:6,CS:8,PP:8,CLAN:3-,CCC:0,CIH:2-,NIOPS:8</availability>
 			</model>
 			<model name='KGC-000b'>
                 <roles>command</roles>
-				<availability>PP:4</availability>
+				<availability>PP:4+,CB:5,CFM:5,CGB:5,CGS:5,CWI:5,CW:5</availability>
 			</model>
+            <model name='KGC-010'>
+                <roles>command</roles>
+                <availability>CLAN:3+,CCC:8</availability>
+            </model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
 			<availability>FS:6,DC:5,FWL:5,MERC:3,CS:7,PP:8,CLAN:4,CCC:5,CIH:4-,CMG:3,CSR:3,CSV:3,CWOV:3,NIOPS:7</availability>
@@ -2865,7 +2875,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>PP:3,CLAN:3,CC:6,IS:7,Periphery.Deep:7,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:6</availability>
+			<availability>IS:7,FS:8,DC:6,CC:6,FWL:9,CS:4,PP:3,CDS:3,CSR:3,CWOV:3,Periphery:7,NIOPS:4,Periphery.Deep:7</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>IS:8,Periphery:8</availability>
@@ -2876,11 +2886,11 @@
 			</model>
 			<model name='LGB-7Q'>
 				<roles>fire_support</roles>
-				<availability>MOC:6,OA:6,IS:6,TC:6,CLAN:6</availability>
+				<availability>IS:6,TC:6,MOC:6,OA:6,PP:8,CDS:8,CSR:8,CWOV:8</availability>
 			</model>
 			<model name='LGB-8C'>
                 <roles>fire_support</roles>
-				<availability>MOC:4,CS:6,OA:4,IS:6,MERC:2,TC:4,CLAN:6</availability>
+				<availability>IS:6,MERC:2,PP:6,TC:4,MOC:4,CS:6,OA:4</availability>
 			</model>
 		</chassis>
         <chassis name='Luciano White Wolverine' unitType='Tank'>
@@ -2943,6 +2953,12 @@
                 <availability>CLAN:8,PP:8,IS:7,Periphery:7,Periphery.Deep:0,PIR:7</availability>
             </model>
 		</chassis>
+        <chassis name='Mackie' unitType='Mek'>
+            <availability>CSJ:2-,CSV:2-</availability>
+            <model name='MSK-7A'>
+                <availability>CSJ:8,CSV:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Magi Infantry Support Vehicle' unitType='Tank'>
 			<availability>PP:5,MOC:4,CS:5,OA:4,IS:3,NIOPS:5,TC:4</availability>
 			<model name=''>
@@ -3484,10 +3500,10 @@
 			</model>
 		</chassis>
 		<chassis name='Nightstar' unitType='Mek'>
-			<availability>PP:5,CS:4,NIOPS:4</availability>
+			<availability>CS:4,PP:1+,CCO:1+,CWI:1+,NIOPS:4+</availability>
 			<model name='NSR-9J'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CS:8,PP:8,CCO:8,CWI:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Olympus Recharge Station' unitType='Space Station'>
@@ -3684,9 +3700,9 @@
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
-			<availability>PP:5,CLAN:5,CC:7+,CS:5,LA:6+,FWL:6+,NIOPS:5,FS:6+</availability>
+			<availability>FS:6+,LA:6+,FWL:6+,CC:7+,CS:5,PP:2+,CLAN:3+,CBS:2+,CCC:2+,CFM:2+,CGB:2+,CHH:2+,CIH:2+,CMG:2+,CDS:2+,CSR:2+,CSA:2+,CSV:2+,CW:2+,NIOPS:5+</availability>
 			<model name='PLG-3Z'>
-				<availability>IS:8,CLAN:8,PP:8,NIOPS:8</availability>
+				<availability>IS:8,PP:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Pinto Corvette' unitType='Warship'>
@@ -3832,10 +3848,10 @@
             </model>
 		</chassis>
 		<chassis name='Rifleman II' unitType='Mek'>
-			<availability>CLAN:5</availability>
+			<availability>CGB:3+</availability>
 			<model name='RFL-3N-2'>
 				<roles>anti_aircraft</roles>
-				<availability>General:8</availability>
+				<availability>CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
@@ -4094,9 +4110,9 @@
 			</model>
 		</chassis>
 		<chassis name='Shogun' unitType='Mek'>
-			<availability>PP:1,FWL:2+</availability>
+			<availability>FWL:2+,PP:2,CBS:3+,CB:3+,CCC:3+,CCO:3+,CSA:3+</availability>
 			<model name='SHG-2H'>
-				<availability>General:8,CLAN:8</availability>
+				<availability>FWL:8,PP:8,CBS:8,CB:8,CCC:8,CCO:8,CSA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Sholagar' unitType='AeroSpaceFighter'>
@@ -4211,11 +4227,15 @@
 			</model>
 		</chassis>
 		<chassis name='Spartan' unitType='Mek'>
-			<availability>CS:5</availability>
+			<availability>CS:5,PP:1,CLAN:2,CCC:4+,CFM:4,CGS:3,CIH:6+,CMG:5,CDS:4,CSV:4,CWOV:4</availability>
 			<model name='SPT-N2'>
 				<roles>cavalry,spotter</roles>
-				<availability>IS:8</availability>
+				<availability>CS:8,PP:8,CFM:4-</availability>
 			</model>
+            <model name='SPT-NF'>
+                <roles>cavalry</roles>
+                <availability>PP:2+,CLAN:8,CFM:3+</availability>
+            </model>
 		</chassis>
 		<chassis name='Spector' unitType='Mek'>
 			<availability>CIH:1+,CMG:2+,PP:2+</availability>
@@ -4231,18 +4251,18 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>PP:9,CC:7,IS:8,Periphery.Deep:9,FS:7,Periphery:9,CS:6,FWL:9,NIOPS:6,DC:7</availability>
+			<availability>IS:8,FS:7,DC:7,CC:7,FWL:9,CS:6,PP:6,CLAN:5,CBS:6,CGB:6,CHH:6,CIH:4,CMG:4,CNC:6,CW:6,Periphery:9,NIOPS:6,Periphery.Deep:9</availability>
 			<model name='STK-3F'>
-				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:6,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='STK-3Fb'>
-				<availability>PP:4</availability>
+				<availability>PP:4+,CLAN:8</availability>
 			</model>
 			<model name='STK-3Fk'>
 				<availability>DC:2+</availability>
 			</model>
 			<model name='STK-3H'>
-				<availability>MOC:2,OA:2,IS:2,TC:2</availability>
+				<availability>IS:2,TC:2,MOC:2,OA:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -4308,9 +4328,9 @@
 			</model>
 		</chassis>
 		<chassis name='Striker' unitType='Mek'>
-			<availability>PP:6,CC:9,MOC:7,Periphery.Deep:4,FS:8,MERC:7,TC:7,CS:4,OA:7,LA:9,PIR:4,NIOPS:4,DC:8</availability>
+			<availability>FS:8,LA:9,DC:8,CC:9,MERC:7,CS:4,PP:4+,TC:7,MOC:7,OA:7,NIOPS:4,Periphery.Deep:4+,PIR:4</availability>
 			<model name='STC-2C'>
-				<availability>CC:8,General:8</availability>
+				<availability>IS:8,PP:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
@@ -4387,12 +4407,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>PP:8,CS:7,LA:6+,FWL:6+,NIOPS:7,IS:6+,FS:6+,TC:4+</availability>
+			<availability>IS:6+,FS:6+,LA:6+,FWL:6+,CS:7,PP:5+,CLAN:5,CIH:4,TC:4+,NIOPS:7</availability>
 			<model name='THG-11E'>
-				<availability>PP:8,CS:8,FWL:8+,IS:8+,NIOPS:8,FS:8+,DC:8+,TC:8</availability>
+				<availability>IS:8+,FS:8+,DC:8+,FWL:8+,CS:8,PP:8,CLAN:4-,TC:8,NIOPS:8</availability>
 			</model>
 			<model name='THG-11Eb'>
-				<availability>PP:4</availability>
+				<availability>PP:3+,CLAN:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -4403,10 +4423,10 @@
 			</model>
 		</chassis>
 		<chassis name='Thunder Hawk' unitType='Mek'>
-			<availability>PP:3,CS:2,LA:3+,NIOPS:2,DC:3+</availability>
+			<availability>LA:3+,DC:3+,CS:2,PP:1+,CB:1+,NIOPS:2+</availability>
 			<model name='TDK-7X'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,DC:8,CS:8,PP:8,CB:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
@@ -4645,15 +4665,15 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>PP:6,CC:8,MOC:6,IS:5,Periphery.Deep:5,FS:8,CIR:6,Periphery.OS:6,TC:6,Periphery:5,CS:5-,OA:6,LA:7,Periphery.HR:6,FWL:7,NIOPS:5-,DC:7</availability>
+			<availability>IS:5,FS:8,LA:7,DC:7,FWL:7,CC:8,CS:5-,PP:6+,CCO:2-,CIH:3,Periphery:5,Periphery.OS:6,Periphery.HR:6,TC:6,MOC:6,OA:6,CIR:6,NIOPS:5-,Periphery.Deep:5+</availability>
 			<model name='VTR-9A'>
-				<availability>CC:2,CS:2,IS:1,FS:2</availability>
+				<availability>IS:1,FS:2,CC:2,CS:2</availability>
 			</model>
 			<model name='VTR-9A1'>
-				<availability>CC:2,CS:2,IS:1,FS:2</availability>
+				<availability>IS:1,FS:2,CC:2,CS:2</availability>
 			</model>
 			<model name='VTR-9B'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CCO:8,CIH:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Vigilant Corvette' unitType='Warship'>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -4353,7 +4353,7 @@
 		<chassis name='Thorn' unitType='Mek'>
 			<availability>FS:4,CC:4,FWL:6,MERC:4,CS:6,CLAN:4,CGB:5,CHH:6,CIH:4-,CMG:3,CNC:5,CW:5,CWOV:3,PP:6,TC:4+,MOC:4+,OA:4+,NIOPS:6</availability>
 			<model name='THE-F'>
-				<availability>CC:2,FWL:2,FS:2</availability>
+				<availability>CC:2,FWL:2,FS:2,Periphery:8</availability>
 			</model>
 			<model name='THE-N'>
 				<availability>IS:6+,CS:8,CLAN:8,CB:7,CGB:7,CIH:7,CJF:7,CMG:7,CNC:7,CDS:7,CSR:7,CW:7,PP:6,NIOPS:8</availability>
@@ -4603,10 +4603,10 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>PP:5,CC:6-,IS:3-,Periphery:2-,CS:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
+			<availability>PP:5-,CC:6-,IS:3-,Periphery:2-,CS:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
-				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Valkyrie' unitType='Mek'>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -361,14 +361,14 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>PP:3,CC:7,CS:5-,LA:9,IS:6,FWL:9,NIOPS:5-,Periphery.Deep:6,FS:8,Periphery:6,DC:8</availability>
+			<availability>IS:6,FS:8,LA:9,DC:8,FWL:9,CC:7,CS:5-,PP:3,CLAN:4,CFM:3,CGS:3,CIH:4-,CMG:3,CSV:3,CWOV:3,Periphery:6,NIOPS:5-,Periphery.Deep:6</availability>
 			<model name='ARC-2R'>
 				<roles>command,fire_support</roles>
-				<availability>LA:8,IS:8,Periphery.Deep:8,DC:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CGB:2-,CW:2-,Periphery:8,NIOPS:4-,Periphery.Deep:8</availability>
 			</model>
 			<model name='ARC-2Rb'>
 				<roles>command,fire_support</roles>
-				<availability>PP:4</availability>
+				<availability>PP:4+,CLAN:8,NIOPS:5</availability>
 			</model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -591,22 +591,22 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>PP:10,CS:7,LA:4,FWL:6,NIOPS:7,FWL.OH:6,MERC:4,FS:6,DC:4</availability>
+			<availability>FS:6,LA:4,DC:4,FWL:6,MERC:4,CS:7,PP:5+,CLAN:3+,CGS:4+,CIH:2+,NIOPS:7</availability>
 			<model name='BL-6-KNT'>
                 <roles>command</roles>
-				<availability>PP:8,CS:8,FWL:6+,NIOPS:8,FS:6+</availability>
+				<availability>FS:6+,FWL:6+,CS:8,PP:8,CLAN:8,CBS:6-,CCO:6-,CGB:6-,CGS:6-,CNC:6-,CW:6-,NIOPS:8</availability>
 			</model>
 			<model name='BL-6b-KNT'>
                 <roles>command</roles>
-				<availability>PP:4,CS:4,NIOPS:4,FWL:2+</availability>
+				<availability>FWL:2+,CS:4,PP:4+,CBS:7,CCO:7,CGB:7,CGS:7,CNC:7,CW:7,NIOPS:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
                 <roles>command</roles>
-				<availability>LA:6-:2809,FWL:3-:2809,MERC:6-:2809,FS:6-:2809,DC:6-:2809</availability>
+				<availability>LA:6-,FWL:3-,MERC:6-,FS:6-,DC:6-</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
                 <roles>command</roles>
-				<availability>FWL:6-:2809</availability>
+				<availability>FWL:6-</availability>
 			</model>
 		</chassis>
 		<chassis name='Black Lion I Battlecruiser' unitType='Warship'>
@@ -637,10 +637,10 @@
 			</model>
 		</chassis>
 		<chassis name='Bombardier' unitType='Mek'>
-			<availability>PP:6,CLAN:5,CS:5,FWL:4,DC:4,NIOPS:5</availability>
+			<availability>DC:4,FWL:4,CS:5,PP:6+,CLAN:3-,CB:2-,CCO:2-,CIH:4,CMG:4-,CDS:4-,CSR:4-,CWI:2-,CWOV:2-,NIOPS:5</availability>
 			<model name='BMB-12D'>
 				<roles>fire_support</roles>
-				<availability>PP:8,CLAN:8,CS:8,FWL:8,DC:8,NIOPS:8</availability>
+				<availability>DC:8,FWL:8,CS:8,PP:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
         <chassis name='Brunel Dump Truck' unitType='Tank'>
@@ -761,18 +761,18 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>PP:2,CC:6,IS:4,MERC:3,CIR:1,TC:2,Periphery:2,CS:2,NIOPS:2,DC:6</availability>
+			<availability>IS:4,DC:6,CC:6,MERC:3,CS:2,PP:2,CFM:4+,CDS:3,CWI:3+,CW:3,CWOV:3+,Periphery:2,TC:2,CIR:1,NIOPS:2</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
-				<availability>CC:4,FWL:4,DC:4</availability>
+				<availability>DC:4,FWL:4,CC:4</availability>
 			</model>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
-				<availability>CC:8,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CDS:8,CW:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='CPLT-C1b'>
 				<roles>fire_support</roles>
-				<availability>PP:4,CC:2+,CLAN:6,DC:3+</availability>
+				<availability>CC:2+,DC:3+,PP:4+,CFM:8,CWI:8,CWOV:8,CLAN:6</availability>
 			</model>
 			<model name='CPLT-C4'>
 				<roles>fire_support</roles>
@@ -800,9 +800,9 @@
 			</model>
 		</chassis>
 		<chassis name='Cestus' unitType='Mek'>
-			<availability>PP:4,CS:4,LA:4+,NIOPS:4,IS:4+,FS:6</availability>
+			<availability>IS:4+,FS:6,PP:3+,CS:4,CB:3+,CFM:2+,CJF:3+,CSJ:3+,NIOPS:4</availability>
 			<model name='CTS-6Y'>
-				<availability>General:8</availability>
+				<availability>IS:8,PP:8,CB:8,CFM:8,CJF:8,CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chameleon' unitType='Mek'>
@@ -813,16 +813,16 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>PP:5,CC:7,CS:5,LA:7,IS:6,FWL:6,NIOPS:5,FS:6,MERC:6,DC:6</availability>
+			<availability>IS:6,FS:6,LA:7,DC:6,FWL:6,CC:7,MERC:6,CS:5,PP:5,CBS:4-,CCO:3-,CFM:4-,CGB:4+,CHH:4+,CIH:6+,CDS:4+,CSV:3+,NIOPS:5</availability>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
-				<availability>PP:8,CC:7+,CS:8,NIOPS:8</availability>
+				<availability>CC:7+,CS:8,PP:8,CBS:8,CCO:8,CGB:4-,CHH:4-,NIOPS:8</availability>
 			</model>
 			<model name='CHP-1N2'>
-				<availability>CC:4+,CS:4,LA:4+</availability>
+				<availability>LA:4+,CC:4+,CS:4,PP:4+,CFM:8,CGB:5,CHH:5,CIH:8,CDS:5,NIOPS:5</availability>
 			</model>
 			<model name='CHP-1Nb'>
-				<availability>PP:4</availability>
+				<availability>PP:3+,CDS:3+,CSV:8</availability>
 			</model>
 			<model name='CHP-2N'>
 				<availability>IS:4-,NIOPS:0</availability>
@@ -1342,9 +1342,9 @@
 			</model>
 		</chassis>
 		<chassis name='Crusader' unitType='Mek'>
-			<availability>PP:6,CS:6-,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:8,CS:6-,PP:6,CLAN:3,CDS:2,Periphery:6,NIOPS:6-,Periphery.Deep:6</availability>
 			<model name='CRD-2R'>
-				<availability>PP:4,IS:3+,Periphery:3+</availability>
+				<availability>IS:3+,MERC:3+,PP:4+,CLAN:8,Periphery:3+,NIOPS:5,Periphery.Deep:0</availability>
 			</model>
 			<model name='CRD-3D'>
 				<availability>FS:5</availability>
@@ -1357,7 +1357,7 @@
 				<availability>CC:9</availability>
 			</model>
 			<model name='CRD-3R'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CBS:2-,CFM:2-,CHH:2-,CWI:2-,Periphery:8,NIOPS:6-,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
@@ -1625,25 +1625,25 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>IS:4,Periphery:2,CS:5,NIOPS:5</availability>
+			<availability>IS:4,CS:5,Periphery:2,NIOPS:5</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Mek'>
-			<availability>PP:5,CS:5,LA:3+,NIOPS:5,FS:3+,DC:3+</availability>
+			<availability>FS:3+,LA:3+,DC:3+,CS:5,PP:5+,CLAN:3+,NIOPS:5</availability>
 			<model name='EXC-B1'>
 				<roles>cavalry,fire_support</roles>
-				<availability>LA:8</availability>
+				<availability>LA:8,CGS:4-,CDS:4-,CW:4-</availability>
 			</model>
 			<model name='EXC-B2'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CS:8,LA:0,General:8,NIOPS:8</availability>
+				<availability>FS:8,LA:0,DC:8,CS:8,PP:8,CLAN:8,NIOPS:8</availability>
 			</model>
 			<model name='EXC-B2b'>
 				<roles>cavalry,fire_support</roles>
-				<availability>PP:4</availability>
+				<availability>PP:4+,CLAN:2+,CJF:3+,CSJ:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -1658,14 +1658,18 @@
 			</model>
 		</chassis>
 		<chassis name='Exterminator' unitType='Mek'>
-			<availability>PP:7,CC:2,CS:4,LA:2,FWL:2,NIOPS:4,FS:2,DC:2</availability>
+			<availability>FS:2,DC:2,LA:2,FWL:2,CC:2,CS:4,PP:3+,CLAN:2+,CCC:3+,CFM:3+,CIH:4+,CMG:3+,CDS:3+,CSR:3+,CSV:3+,CWI:1+,CWOV:3+,NIOPS:4</availability>
+            <model name='EXT-4C'>
+                <roles>specops</roles>
+                <availability>CJF:1+,CW:2+,CWOV:3+</availability>
+            </model>
 			<model name='EXT-4D'>
                 <roles>cavalry</roles>
-				<availability>CS:8,General:8+,NIOPS:8</availability>
+				<availability>FS:8,DC:8,LA:8,FWL:8,CC:8,CS:8,PP:8,CLAN:8,CFM:4-,CIH:4-,CJF:4-,CDS:4-,CSR:4-,NIOPS:8</availability>
 			</model>
 			<model name='EXT-4Db'>
                 <roles>cavalry</roles>
-				<availability>PP:4</availability>
+				<availability>PP:2+,CFM:8,CIH:5,CJF:8,CDS:8,CSR:8,NIOPS:3+</availability>
 			</model>
 		</chassis>
 	    <chassis name='Factory' unitType='Space Station'>
@@ -1776,13 +1780,13 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>PP:8,CS:5,Periphery.R:4,LA:6,FWL:5,NIOPS:5</availability>
+			<availability>LA:6,FWL:5,PP:5+,CS:5,CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CJF!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CNC!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,Periphery.R:4,NIOPS:5</availability>
 			<model name='FLS-7K'>
 				<availability>LA:4-,Periphery.R:8</availability>
 			</model>
 			<model name='FLS-8K'>
                 <roles>cavalry</roles>
-				<availability>PP:8,CS:8,LA:8+,FWL:8+,NIOPS:8</availability>
+				<availability>LA:8+,FWL:8,CS:8,PP:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Flatbed Truck' unitType='Tank'>
@@ -1950,12 +1954,12 @@
 			</model>
 		</chassis>
 		<chassis name='Galahad' unitType='Mek'>
-			<availability>PP:4,CC:4+,LA:4+,FS:4+</availability>
+			<availability>FS:4+,LA:4+,CC:4+,PP:4+,CGB!Keshik:1!Front Line:1!Second Line:1,CHH!Keshik:1!Front Line:1!Second Line:1,CSR!Keshik:1!Front Line:1!Second Line:1,CWI!Keshik:1!Front Line:1!Second Line:1,CW!Keshik:1!Front Line:1!Second Line:1</availability>
 			<model name='GLH-1D'>
-				<availability>IS:8</availability>
+				<availability>FS:8,LA:8,CC:8</availability>
 			</model>
 			<model name='GLH-2D'>
-				<availability>PP:8</availability>
+				<availability>PP:8,CGB:8,CHH:8,CSR:8,CWI:8,CW:8</availability>
 			</model>
 		</chassis>
         <chassis name='Galaport Ground Trailer' unitType='Tank'>
@@ -2051,10 +2055,10 @@
             </model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>PP:9,CS:7,IS:8,NIOPS:7,FS:7,MERC:8</availability>
+			<availability>IS:8,FS:7,MERC:8,CS:7,PP:5,CHH:3+,CSR:3+,NIOPS:7</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
-				<availability>PP:8,CS:8,IS:8,NIOPS:8</availability>
+				<availability>IS:8,CS:8,PP:8,CHH:8,CSR:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Habitat' unitType='Space Station'>
@@ -2692,14 +2696,14 @@
 			</model>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>PP:6,MOC:4,CS:6,OA:4,IS:6,NIOPS:6,MERC:6,CIR:4,TC:4</availability>
+			<availability>IS:6,MERC:6,CS:6,PP:6+,CLAN:3+,CCC:4+,CCO:2+,CFM:4+,CHH:2+,CIH:4+,CMG:4+,CSV:4+,CWI:2+,TC:4,MOC:4,OA:4,CIR:4,NIOPS:6</availability>
 			<model name='LNC25-01'>
 				<roles>cavalry,anti_aircraft</roles>
-				<availability>PP:6,CS:8,IS:8,NIOPS:8</availability>
+				<availability>IS:8,CS:8,PP:8,CLAN:8,NIOPS:8</availability>
 			</model>
 			<model name='LNC25-05'>
 				<roles>cavalry,anti_infantry</roles>
-				<availability>CS:4,IS:4,NIOPS:4</availability>
+				<availability>IS:4,CS:4,NIOPS:4</availability>
 			</model>
 		</chassis>
 		<chassis name='League Destroyer' unitType='Warship'>
@@ -2991,14 +2995,14 @@
             </model>
         </chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>PP:8,CC:5,CS:8,MOC:2+,LA:6,FWL:6,IS:3,NIOPS:8,FS:6,DC:6,TC:2+</availability>
+			<availability>IS:3,FS:6,LA:6,DC:6,FWL:6,CC:5,CS:8,PP:5+,CLAN:4+,CIH:3+,CMG:3+,CSV:3+,TC:2+,MOC:2+,NIOPS:8</availability>
 			<model name='MAD-1R'>
                 <roles>command</roles>
-				<availability>PP:8,CS:8,MOC:8,IS:7+,NIOPS:8,MERC:0,TC:8+</availability>
+				<availability>IS:7+,MERC:0,CS:8,PP:8,CLAN:4-,TC:8,MOC:8,NIOPS:8</availability>
 			</model>
 			<model name='MAD-2R'>
                 <roles>command</roles>
-				<availability>PP:4,FS:4+</availability>
+				<availability>FS:4+,PP:4+,CLAN:5</availability>
 			</model>
 		</chassis>
         <chassis name='Marco' unitType='Mek'>
@@ -3494,12 +3498,15 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>PP:4,MOC:5,IS:5,Periphery.Deep:4,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,LA:6,FWL:6,NIOPS:5-</availability>
+			<availability>IS:5,LA:6,FWL:6,CS:5-,PP:4,CLAN:3+,CCC:2+,CGS:2+,CIH:2+,CMG:2+,CNC:2+,CSR:2+,CW:5+,CWOV:2+,Periphery:4,TC:5,MOC:5,OA:5,CIR:5,NIOPS:5-,Periphery.Deep:4</availability>
 			<model name='ON1-K'>
-				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CW:4-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
+            <model name='ON1-Kb'>
+                <availability>CLAN:8,CW:3+</availability>
+            </model>
 			<model name='ON1-V'>
-				<availability>OA:3,IS:3,TC:3</availability>
+				<availability>IS:3,PP:6,CW:3-,TC:3,OA:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Osprey' unitType='Mek'>
@@ -3510,14 +3517,14 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>PP:5,CS:4,LA:6,IS:6,Periphery.Deep:4,NIOPS:4,Periphery:4</availability>
+			<availability>IS:6,CS:4,PP:5,CLAN:4,CB:3,CCC:5,CCO:3,CIH:5,CJF:4,CMG!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,CWI:3,Periphery:4,NIOPS:4,Periphery.Deep:4</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
-				<availability>IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CCC:2-,CMG:2-,CDS:2-,CSR:2-,CSV:2-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='OSR-2Cb'>
 				<roles>urban</roles>
-				<availability>PP:4</availability>
+				<availability>PP:4+,CLAN:8</availability>
 			</model>
 			<model name='OSR-2M'>
 				<availability>FWL:6</availability>
@@ -3535,10 +3542,10 @@
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
-			<availability>PP:6,CLAN:6,CS:6,FWL:8,NIOPS:6,FS:8,MERC:8,Periphery:3</availability>
+			<availability>FS:8,FWL:8,MERC:8,CS:6,PP:6,CLAN:3-,CB:2-,CIH:4-,CWI:2-,Periphery:3,NIOPS:6</availability>
 			<model name='OTL-4D'>
                 <roles>raider</roles>
-				<availability>PP:8,CLAN:8,IS:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CLAN:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Overlord' unitType='Dropship'>
@@ -3832,10 +3839,10 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>PP:4,CS:6-,IS:6,NIOPS:6-,Periphery.Deep:5,CIR:4,Periphery:5</availability>
+			<availability>IS:6,PP:4,CS:6-,Periphery:5,CIR:4,NIOPS:6-,Periphery.Deep:5</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,MERC:8,PP:8,Peripher:8,NIOPS:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Riga II Destroyer-Carrier' unitType='Warship'>
@@ -4099,10 +4106,10 @@
 			</model>
 		</chassis>
 		<chassis name='Shootist' unitType='Mek'>
-			<availability>PP:4,CS:5,LA:4+,NIOPS:5</availability>
+			<availability>LA:4+,CS:5,PP:3+,CLAN:2+,CB:4+,CCO:3+,CGB:3+,CIH!Front Line:2!Second Line:1,CJF:3+,CMG:1+,CSJ:3+,CWI:3+,CW:3+,NIOPS:5</availability>
 			<model name='ST-8A'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,CS:8,PP:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
         <chassis name='Shugosha' unitType='Mek'>
@@ -4418,12 +4425,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>PP:5,CLAN:5,CC:8,CS:5-,LA:8,IS:6,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:6,Periphery:6,DC:8</availability>
+			<availability>IS:6,FS:7,LA:8,DC:8,CC:8,MERC:6,CS:5-,PP:5,CLAN:5,CB!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CCC:4,CIH:4,CSR:4,CSV:4,Periphery:6,NIOPS:5-,Periphery.Deep:6</availability>
 			<model name='TDR-5S'>
-				<availability>IS:8,PP:8,CLAN:6,Periphery:8</availability>
+				<availability>IS:8,PP:8,CLAN:3-,Periphery:8</availability>
 			</model>
 			<model name='TDR-5Sb'>
-				<availability>PP:4,CLAN:8</availability>
+				<availability>PP:4+,CLAN:4</availability>
 			</model>
 			<model name='TDR-5Sd'>
 				<availability>FS:2+</availability>
@@ -4717,19 +4724,19 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>PP:6,CS:6-,LA:9,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
+			<availability>IS:8,LA:9,FWL:9,CS:6-,PP:6,CLAN:6+,CB:5+,CCC:5+,CHH:5+,CIH:4-,CMG:5+,CNC:5+,CSR:5+,CSV:5+,Periphery:5,NIOPS:6-,Periphery.Deep:5</availability>
 			<model name='WHM-6R'>
-				<availability>General:8</availability>
+				<availability>IS:8,PP:8,CB:2-,CCO:2-,CGS:2-,CJF:2-,CNC:2-,CSJ:2-,CSA:2-,CWOV:2-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='WHM-6Rb'>
-				<availability>PP:4,CC:4+,LA:4+,FWL:4+,FS:4+</availability>
+				<availability>FS:4+,LA:4+,FWL:4+,CC:4+,PP:4+,CLAN:5</availability>
 			</model>
 			<model name='WHM-6Rk'>
                 <roles>cavalry</roles>
 				<availability>DC:2+</availability>
 			</model>
 			<model name='WHM-7A'>
-				<availability>PP:2</availability>
+				<availability>PP:2+,CLAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Wasp LAM Mk I' unitType='Mek'>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -2341,7 +2341,7 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>IS:5,MERC:5,CS:9,PP:3+,CLAN:4+,NIOPS:9</availability>
+			<availability>IS:5,MERC:5,CS:9,PP:3+,CLAN:4+,NIOPS:9+</availability>
 			<model name='HGN-732'>
                 <roles>command</roles>
 				<availability>IS:8,FWL:8+,CS:8,PP:8,CLAN:4-,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -591,7 +591,7 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>FS:6,LA:4,DC:4,FWL:6,MERC:4,CS:7,PP:5+,CLAN:3+,CGS:4+,CIH:2+,NIOPS:7</availability>
+			<availability>FS:6,LA:4,DC:4,FWL:6,MERC:4,CS:7,PP:5+,CLAN:3+,CGS:4+,CIH:2+,CWOV:4+,NIOPS:7</availability>
 			<model name='BL-6-KNT'>
                 <roles>command</roles>
 				<availability>FS:6+,FWL:6+,CS:8,PP:8,CLAN:8,CBS:6-,CCO:6-,CGB:6-,CGS:6-,CNC:6-,CW:6-,NIOPS:8</availability>
@@ -761,7 +761,7 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>IS:4,DC:6,CC:6,MERC:3,CS:2,PP:2,CFM:4+,CDS:3,CWI:3+,CW:3,CWOV:3+,Periphery:2,TC:2,CIR:1,NIOPS:2</availability>
+			<availability>IS:4,DC:6,CC:6,MERC:3,CS:2,PP:2,CFM:4+,CDS:3,CWI:3+,CW:3,CWOV:3+,Periphery:2,CIR:1,NIOPS:2</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>DC:4,FWL:4,CC:4</availability>
@@ -772,7 +772,7 @@
 			</model>
 			<model name='CPLT-C1b'>
 				<roles>fire_support</roles>
-				<availability>CC:2+,DC:3+,PP:4+,CFM:8,CWI:8,CWOV:8,CLAN:6</availability>
+				<availability>DC:3+,CC:2+,PP:4+,CFM:8,CWI:8,CWOV:8</availability>
 			</model>
 			<model name='CPLT-C4'>
 				<roles>fire_support</roles>
@@ -800,9 +800,9 @@
 			</model>
 		</chassis>
 		<chassis name='Cestus' unitType='Mek'>
-			<availability>IS:4+,FS:6,PP:3+,CS:4,CB:3+,CFM:2+,CJF:3+,CSJ:3+,NIOPS:4</availability>
+			<availability>IS:4+,FS:6,CS:4,PP:3+,CB:3+,CFM:2+,CJF:3+,CSJ:3+,NIOPS:4</availability>
 			<model name='CTS-6Y'>
-				<availability>IS:8,PP:8,CB:8,CFM:8,CJF:8,CSJ:8</availability>
+				<availability>IS:8,PP:8,CB:8,CFM:8,CJF:8,CSJ:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chameleon' unitType='Mek'>
@@ -813,7 +813,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>IS:6,FS:6,LA:7,DC:6,FWL:6,CC:7,MERC:6,CS:5,PP:5,CBS:4-,CCO:3-,CFM:4-,CGB:4+,CHH:4+,CIH:6+,CDS:4+,CSV:3+,NIOPS:5</availability>
+			<availability>IS:6,LA:7,CC:7,MERC:6,CS:5,PP:5,CBS:4-,CCO:3-,CFM:4+,CGB:4+,CHH:4+,CIH:6+,CDS:4+,CSV:3+,NIOPS:5</availability>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
 				<availability>CC:7+,CS:8,PP:8,CBS:8,CCO:8,CGB:4-,CHH:4-,NIOPS:8</availability>
@@ -825,7 +825,7 @@
 				<availability>PP:3+,CDS:3+,CSV:8</availability>
 			</model>
 			<model name='CHP-2N'>
-				<availability>IS:4-,NIOPS:0</availability>
+				<availability>IS:4-</availability>
 			</model>
 		</chassis>
 		<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1643,7 +1643,7 @@
 			</model>
 			<model name='EXC-B2b'>
 				<roles>cavalry,fire_support</roles>
-				<availability>PP:4+,CLAN:2+,CJF:3+,CSJ:3+</availability>
+				<availability>PP:4+,CLAN:2+,CGB:3+,CJF:3+,CSJ:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -1658,14 +1658,14 @@
 			</model>
 		</chassis>
 		<chassis name='Exterminator' unitType='Mek'>
-			<availability>FS:2,DC:2,LA:2,FWL:2,CC:2,CS:4,PP:3+,CLAN:2+,CCC:3+,CFM:3+,CIH:4+,CMG:3+,CDS:3+,CSR:3+,CSV:3+,CWI:1+,CWOV:3+,NIOPS:4</availability>
+			<availability>FS:2,LA:2,DC:2,FWL:2,CC:2,CS:4,PP:3+,CLAN:2+,CCC:3+,CFM:3+,CIH:4+,CMG:3+,CDS:3+,CSR:3+,CSV:3+,CWI:1+,CWOV:3+,NIOPS:4</availability>
             <model name='EXT-4C'>
                 <roles>specops</roles>
-                <availability>CJF:1+,CW:2+,CWOV:3+</availability>
+                <availability>CJF:1+,CW:2+,CWOV:2+</availability>
             </model>
 			<model name='EXT-4D'>
                 <roles>cavalry</roles>
-				<availability>FS:8,DC:8,LA:8,FWL:8,CC:8,CS:8,PP:8,CLAN:8,CFM:4-,CIH:4-,CJF:4-,CDS:4-,CSR:4-,NIOPS:8</availability>
+				<availability>FS:8,LA:8,DC:8,FWL:8,CC:8,CS:8,PP:8,CLAN:8,CFM:4-,CIH:4-,CJF:4-,CDS:4-,CSR:4-,NIOPS:8</availability>
 			</model>
 			<model name='EXT-4Db'>
                 <roles>cavalry</roles>
@@ -1780,7 +1780,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>LA:6,FWL:5,PP:5+,CS:5,CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CJF!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CNC!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,Periphery.R:4,NIOPS:5</availability>
+			<availability>LA:6,FWL:5,CS:5,PP:5+,CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CJF!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CNC!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,Periphery.R:4,NIOPS:5</availability>
 			<model name='FLS-7K'>
 				<availability>LA:4-,Periphery.R:8</availability>
 			</model>
@@ -2272,11 +2272,11 @@
             </model>
         </chassis>
 		<chassis name='Helepolis' unitType='Mek'>
-			<availability>PP:6</availability>
+			<availability>PP:3+</availability>
 			<model name='HEP-3H'>
 				<roles>mixed_artillery</roles>
 				<deployedWith>Helepolis</deployedWith>
-				<availability>General:8</availability>
+				<availability>PP:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
@@ -3517,7 +3517,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>IS:6,CS:4,PP:5,CLAN:4,CB:3,CCC:5,CCO:3,CIH:5,CJF:4,CMG!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,CWI:3,Periphery:4,NIOPS:4,Periphery.Deep:4</availability>
+			<availability>IS:6,CS:4,PP:5,CLAN:4,CB:3,CCC:5,CCO:3,CIH:5,CMG!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,CWI:3,Periphery:4,NIOPS:4,Periphery.Deep:4</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
 				<availability>IS:8,MERC:8,PP:8,CCC:2-,CMG:2-,CDS:2-,CSR:2-,CSV:2-,Periphery:8,Periphery.Deep:8</availability>
@@ -3842,7 +3842,7 @@
 			<availability>IS:6,PP:4,CS:6-,Periphery:5,CIR:4,NIOPS:6-,Periphery.Deep:5</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
-				<availability>IS:8,MERC:8,PP:8,Peripher:8,NIOPS:8,Periphery.Deep:8</availability>
+				<availability>IS:8,MERC:8,PP:8,Periphery:8,NIOPS:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Riga II Destroyer-Carrier' unitType='Warship'>
@@ -4425,7 +4425,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>IS:6,FS:7,LA:8,DC:8,CC:8,MERC:6,CS:5-,PP:5,CLAN:5,CB!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CCC:4,CIH:4,CSR:4,CSV:4,Periphery:6,NIOPS:5-,Periphery.Deep:6</availability>
+			<availability>IS:6,FS:7,LA:8,DC:8,CC:8,MERC:6,CS:5-,PP:5,CLAN:5,CB!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CCC:4,CIH:4,CMG:4,CSR:4,CSV:4,Periphery:6,NIOPS:5-,Periphery.Deep:6</availability>
 			<model name='TDR-5S'>
 				<availability>IS:8,PP:8,CLAN:3-,Periphery:8</availability>
 			</model>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -449,7 +449,7 @@
 		<chassis name='Assassin' unitType='Mek'>
 			<availability>CC:1,MOC:1,CS:3-,LA:4,FS.CMM:4,IS:4,MERC:3,FS:4,TC:1</availability>
 			<model name='ASN-21'>
-				<availability>General:8</availability>
+				<availability>IS:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Athena Cruiser' unitType='Warship'>
@@ -873,10 +873,10 @@
 			</model>
 		</chassis>
 		<chassis name='Cicada' unitType='Mek'>
-			<availability>CC:5,CS:4-,OA:3,LA:5,IS:5,FWL:5,FS:5,MERC:5,Periphery:3,DC:5</availability>
+			<availability>IS:5,MERC:5,CS:4-,CIH:3,CMG:3,Periphery:3</availability>
 			<model name='CDA-2A'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CIH:8,CMG:8,Periphery:8</availability>
 			</model>
 		</chassis>
         <chassis name='Clan Field Artillery Point' unitType='Infantry'>
@@ -1120,12 +1120,12 @@
             </model>
         </chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>PP:3,CC:7,MOC:4,CLAN:3-,IS:5,FS:7,MERC:5,CS:3-,OA:4,FWL:5,NIOPS:3-</availability>
+			<availability>IS:5,FS:7,CC:7,MERC:5,CS:3-,PP:3,CLAN:3-,CB:2-,CCO:2-,CGB:2-,CIH:4-,CMG:4-,CSJ:2-,CSA:2-,CWI:2-,CWOV:2-,MOC:4,OA:4,NIOPS:3-</availability>
 			<model name='CLNT-1-2R'>
-				<availability>CC:1,FS:1</availability>
+				<availability>FS:1,CC:1,CLAN:5+,CHH:4,</availability>
 			</model>
 			<model name='CLNT-2-3T'>
-				<availability>PP:8,CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CLAN:4,CHH:5+,Periphery:8,NIOPS:8</availability>
 			</model>
 			<model name='CLNT-2-4T'>
 				<availability>CC:4,FS:4</availability>
@@ -1272,22 +1272,22 @@
             </model>
         </chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>PP:5,CS:5,NIOPS:5,IS:3,MERC:3,Periphery:3</availability>
+			<availability>IS:3,MERC:3,CS:5,PP:5+,CLAN:5,CBS:4,CIH:4-,CWOV:4,Periphery:3,NIOPS:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
-				<availability>IS:4:2810,Periphery.Deep:4:2810,NIOPS:0,Periphery:4:2810</availability>
+				<availability>IS:4:2810,Periphery:4:2811,NIOPS:0,Periphery.Deep:4:2812</availability>
 			</model>
 			<model name='CRB-27'>
 				<roles>raider</roles>
-				<availability>PP:8,CS:8,CC:6+,LA:6+,NIOPS:8,FWL:6+,DC:6+</availability>
+				<availability>LA:6+,DC:6+,FWL:6+,CC:6+,CS:8,PP:8,CLAN:5-,NIOPS:8</availability>
 			</model>
 			<model name='CRB-27b'>
 				<roles>raider</roles>
-				<availability>PP:4,CC:3+,FWL:3+</availability>
+				<availability>CC:3+,FWL:3+,PP:4+,CLAN:5+,CBS:4+</availability>
 			</model>
 			<model name='CRB-27sl'>
                 <roles>raider</roles>
-				<availability>PP:4,LA:4+,DC:4+</availability>
+				<availability>LA:4+,DC:4+,PP:2+,CLAN:2+,CB:3+,CCC:3+,CCO:3+,CGB:3+,CGS:3+,CSJ:3+,CSA:3+,CSV:3+,CWI:3+,CWOV:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
@@ -1482,12 +1482,12 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>PP:2,CC:3,Periphery.HR:6,IS:6,Periphery.Deep:6,MERC:8,TC:6,DC:8</availability>
+			<availability>IS:6,CC:3,DC:8,MERC:8,PP:2,CBS:3+,CDS:3+,Periphery.HR:6,TC:6,Periphery.Deep:6</availability>
 			<model name='DV-6M'>
-				<availability>PP:4,IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:4,CBS:8,CDS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='DV-6Md'>
-				<availability>FS:6+</availability>
+				<availability>FS:6+,CBS:6,CDS:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Dictator' unitType='Dropship'>
@@ -2039,13 +2039,16 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>PP:4,CC:7,MOC:7,IS:9,Periphery.Deep:5,MERC:6,TC:7,Periphery:5,CS:4,OA:6,LA:9,NIOPS:4,DC:8</availability>
+			<availability>IS:9,LA:9,CC:7,DC:8,MERC:6,CS:4,PP:4,CLAN:6,CB:5,CHH:5,CIH:5+,CSR:5,CSA:5,CSV:5,CWI:5,CWOV:5,Periphery:5,TC:7,MOC:7,OA:6,NIOPS:4,Periphery.Deep:5</availability>
 			<model name='GRF-1N'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CCC:3-,CIH:3-,CJF:3-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='GRF-2N'>
-				<availability>PP:4,CC:4+,LA:4+,FWL:4+,FS:4+</availability>
+				<availability>FS:4+,LA:4+,FWL:4+,CC:4+,PP:4+,CLAN:8,CCC:6,CIH:6,CJF:6   </availability>
 			</model>
+            <model name='GRF-2N2'>
+                <availability>CIH:4,CMG:5-</availability>
+            </model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
 			<availability>PP:9,CS:7,IS:8,NIOPS:7,FS:7,MERC:8</availability>
@@ -2339,18 +2342,18 @@
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
-			<availability>PP:3,CC:6,MOC:4,OA:4,LA:6,FWL:6,FS:6,DC:4,TC:6</availability>
+			<availability>FS:6,DC:4,LA:6,FWL:6,CC:6,PP:3,CBS:4+,CGB:5+,CGS:5+,CHH:6+,CJF:4,CNC:3+,TC:6,MOC:4,OA:4</availability>
 			<model name='HOP-4B'>
                 <roles>inf_support,fire_support</roles>
 				<availability>CC:2</availability>
 			</model>
 			<model name='HOP-4Bb'>
                 <roles>fire_support</roles>
-				<availability>PP:6</availability>
+				<availability>PP:6+,CBS:3,CGB:6,CGS:5,CHH:6,CJF:4,CNC:6</availability>
 			</model>
 			<model name='HOP-4C'>
                 <roles>inf_support</roles>
-				<availability>MOC:8,OA:8,FS:8</availability>
+				<availability>FS:8,PP:8,CBS:4-,CGB:4-,CGS:4-,CHH:4-,CJF:3-,CNC:4-,MOC:8,OA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
@@ -2368,9 +2371,9 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>PP:5,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,NIOPS:5-</availability>
+			<availability>IS:5,CS:5-,PP:5,CB:4+,CCO:4+,CSJ:4,CSV:4+,Periphery:5,NIOPS:5-,Periphery.Deep:5</availability>
 			<model name='HBK-4G'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CB:8,CCO:8,CSJ:8,CSV:8,Periphery:8,NIOPS:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hurricane Conventional Fighter' unitType='Conventional Fighter'>
@@ -2621,15 +2624,15 @@
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
-			<availability>PP:8,CS:7,FWL:5,NIOPS:7,FS:6,MERC:3,DC:5</availability>
+			<availability>FS:6,DC:5,FWL:5,MERC:3,CS:7,PP:8,CLAN:4,CCC:5,CIH:4-,CMG:3,CSR:3,CSV:3,CWOV:3,NIOPS:7</availability>
 			<model name='KTO-18'>
 				<availability>FS:2</availability>
 			</model>
 			<model name='KTO-19'>
-				<availability>PP:8,CS:8,General:4,NIOPS:8,FS:4,MERC:4</availability>
+				<availability>IS:4,MERC:4,CS:8,PP:8,CLAN:4-,NIOPS:8</availability>
 			</model>
 			<model name='KTO-19b'>
-				<availability>PP:4</availability>
+				<availability>PP:4+,CLAN:5</availability>
 			</model>
 		</chassis>
 		<chassis name='Kiso' unitType='Mek'>
@@ -2675,10 +2678,10 @@
 			</model>
 		</chassis>
 		<chassis name='Kyudo' unitType='Mek'>
-			<availability>PP:4,CLAN:4,FWL:4+,FS:4+</availability>
+			<availability>FS:4+,FWL:4+,PP:4+,CBS:3+,CCC:3+,CMG:3+,CDS:3+</availability>
 			<model name='KY2-D-02'>
 				<roles>fire_support</roles>
-				<availability>PP:8,CLAN:8,IS:8</availability>
+				<availability>FS:8,FWL:8,PP:8,CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='LRM Carrier' unitType='Tank'>
@@ -2908,10 +2911,10 @@
 			</model>
 		</chassis>
 		<chassis name='Lynx' unitType='Mek'>
-			<availability>PP:4,LA:3+,FWL:3+,DC:3+</availability>
+			<availability>LA:3+,DC:3+,FWL:3+,PP:4+,CLAN:5+,CBS:4+,CCC:4+,CFM:4+,CGS:4+,CHH:4+,CMG:4+,CNC:3+,CDS:3+,CSR:4+,CSA:3+,CWI:4+,CWOV:3+</availability>
 			<model name='LNX-9Q'>
                 <roles>raider</roles>
-				<availability>PP:8,IS:8+</availability>
+				<availability>LA:8,DC:8,FWL:8,PP:8,CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -3643,10 +3646,10 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>PP:5,CS:7,IS:7,FWL:7,NIOPS:7,Periphery.Deep:5,Periphery:5</availability>
+			<availability>IS:7,FWL:7,CS:7,PP:5,CLAN:4+,CB:3+,CCO:3+,CGB:3+,CGS:6+,CIH:5,CWI:3+,Periphery:5,NIOPS:7,Periphery.Deep:5</availability>
 			<model name='PXH-1'>
 				<roles>command,recon</roles>
-				<availability>PP:6,General:8,Periphery:8</availability>
+				<availability>IS:8,PP:6,CGB:4-,CIH:3-,CJF!Second Line:3!Solahma:4!Provisional Garrison:5,Periphery:8,NIOPS:4-</availability>
 			</model>
 			<model name='PXH-1D'>
 				<roles>command,recon</roles>
@@ -3662,11 +3665,14 @@
 			</model>
 			<model name='PXH-1b &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>PP:3</availability>
+				<availability>PP:3,CLAN:8,CGB:5,CGS:4,CIH:6,NIOPS:4+</availability>
 			</model>
+            <model name='PXH-1c &apos;Special&apos;'>
+                <availability>CGS:3+</availability>
+            </model>
 			<model name='PXH-2'>
 				<roles>command,recon</roles>
-				<availability>PP:4,CC:4+,MOC:4+,OA:4+,FWL:4+</availability>
+				<availability>FWL:4+,CC:4+,PP:4+,CLAN:2+,CCC:3+,CIH:3+,CJF:3+,CMG:3+,CSA:3+,CW:3+,MOC:4+,OA:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
@@ -4006,9 +4012,9 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>PP:2-,CC:5-,CS:3-,LA:5-,FWL:5-,NIOPS:3-,Periphery.Deep:5-,MERC:5-,Periphery:5-,DC:5-</availability>
+			<availability>LA:5-,DC:5-,FWL:5-,CC:5-,MERC:5-,CS:3-,PP:2-,CGS:3-,Periphery:5-,NIOPS:3-,Periphery.Deep:5-</availability>
 			<model name='SCP-1N'>
-				<availability>LA:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CGS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Scout JumpShip' unitType='Jumpship'>
@@ -4025,15 +4031,15 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>PP:6,CC:1,CS:4,LA:6,FWL:3,NIOPS:4,FS:3,DC:3</availability>
+			<availability>FS:3,LA:6,FWL:3,CC:1,DC:3,CS:4,PP:6,CLAN:5-,CBS:6-,CB:4-,CCO:4-,CFM:6-,CGB:6-,CIH:6,CDS:3,CSJ:4-,CSR:6-,CSA:4-,CSV:4-,CWI:4-,CWOV:4-,NIOPS:4</availability>
 			<model name='STN-1S'>
 				<availability>LA:2,FWL:2,FS:2</availability>
 			</model>
 			<model name='STN-3L'>
-				<availability>PP:8,CS:8,LA:8+,NIOPS:8,FWL:8+,FS:8+,MERC:8+</availability>
+				<availability>FS:8+,LA:8+,FWL:8+,MERC:8+,CS:8,PP:8,CLAN:8,CBS:4-,CCC:4,CFM:3,CGB:4-,CHH:4-,CJF:4,CDS:4-,CSR:4-,NIOPS:8</availability>
 			</model>
 			<model name='STN-3Lb'>
-				<availability>PP:4</availability>
+				<availability>PP:4+,CBS:4+,CCC:4+,CFM:4+,CGB:4+,CHH:4+,CJF:4+,CDS:4+,CSR:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
@@ -4048,15 +4054,15 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>PP:4,CS:6-,LA:6,IS:7,NIOPS:6-,Periphery.Deep:4,Periphery:4</availability>
+			<availability>IS:7,LA:6,CS:6-,PP:4,CLAN:5,CIH:4,Periphery:4,NIOPS:6-,Periphery.Deep:4</availability>
 			<model name='SHD-2D'>
 				<availability>FS:8</availability>
 			</model>
 			<model name='SHD-2H'>
-				<availability>General:8</availability>
+				<availability>IS:8,MERC:8,PP:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='SHD-2Hb'>
-				<availability>PP:4,FS:3+</availability>
+				<availability>FS:3+,PP:4+,CLAN:8</availability>
 			</model>
 			<model name='SHD-2K'>
 				<availability>DC:9</availability>
@@ -4241,10 +4247,10 @@
 			</model>
 		</chassis>
 		<chassis name='Starslayer' unitType='Mek'>
-			<availability>LA:5+</availability>
+			<availability>LA:5+,CNC:4+,CSA:4+</availability>
 			<model name='STY-2C'>
 				<roles>raider</roles>
-				<availability>IS:8</availability>
+				<availability>LA:8,CNC:8,CSA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stinger LAM Mk I' unitType='Mek'>
@@ -4501,14 +4507,14 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:4,MOC:4,CS:5-,FWL:6,NIOPS:5-,MERC:4</availability>
+			<availability>FWL:6,CC:4,MERC:4,CS:5-,CDS:3+,MOC:4,NIOPS:5-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
-				<availability>CC:5+,CS:6,FWL:5+,NIOPS:6</availability>
+				<availability>FWL:5+,CC:5+,CS:6,CDS:8,NIOPS:6</availability>
 			</model>
 			<model name='TBT-5N'>
 				<roles>fire_support</roles>
-				<availability>CC:2,CS:2,MOC:2,FWL:2,NIOPS:2,MERC:2</availability>
+				<availability>FWL:2,CC:2,MERC:2,CS:2,MOC:8,NIOPS:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Trident' unitType='AeroSpaceFighter'>
@@ -4676,20 +4682,20 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='AeroSpaceFighter'>
-			<availability>MOC:5,OA:5,MERC:6,Periphery:3,TC:5</availability>
+			<availability>MERC:6,Periphery:3,TC:5,MOC:5,OA:5</availability>
 			<model name='VLC-5N'>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>PP:5,CC:4,CS:3,MOC:3,LA:7,FWL:7,IS:5,NIOPS:3,CIR:3,TC:3</availability>
+			<availability>IS:5,LA:7,FWL:7,CC:4,CS:3,PP:5,CWOV:3-,TC:3,MOC:3,CIR:3,NIOPS:3</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
-				<availability>General:8,FS:4</availability>
+				<availability>IS:8,FS:4,PP:6,CWOV:8,Periphery:8</availability>
 			</model>
 			<model name='VL-5T'>
 				<roles>anti_infantry</roles>
-				<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,TC:2</availability>
+				<availability>IS:2,FS:6,PP:4+,CWOV:5,TC:2,MOC:2,CIR:2,PIR:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Vulture' unitType='Dropship'>
@@ -4795,13 +4801,13 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>PP:4,MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+			<availability>FS.CMM:5,DC:6,MERC:3,CS:3-,PP:4,CB:3-,CWI:3-,Periphery.DD:2,Periphery.OS:2,TC:2,MOC:1,OA:1,NIOPS:3-</availability>
 			<model name='WTH-0'>
 				<availability>TC:6</availability>
 			</model>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
-				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CB:8,CWI:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='WTH-1S'>
 				<roles>fire_support</roles>
@@ -4809,14 +4815,14 @@
 			</model>
 		</chassis>
         <chassis name='Wolverine II' unitType='Mek'>
-            <availability>CWOV:8,CLAN:4</availability>
+            <availability>CMG:3+,CSR:3+,CW:2+,CWOV:6+</availability>
             <model name='WVR-7H'>
                 <roles>command,recon</roles>
-                <availability>General:8</availability>
+                <availability>CMG:8,CSR:8,CW:8,CWOV:8</availability>
             </model>
         </chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>PP:5,CS:5-,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,TC:5,DC:6</availability>
+			<availability>IS:7,DC:6,FWL:9,CS:5-,PP:5,CLAN:3-,CGS:2-,CIH:2-,CMG:2-,CWOV:4-,TC:5,NIOPS:5-,Periphery.Deep:6</availability>
 			<model name='WVR-1R'>
 				<availability>FS:2-</availability>
 			</model>
@@ -4826,21 +4832,21 @@
 			</model>
 			<model name='WVR-6R'>
 				<roles>command,recon</roles>
-				<availability>General:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CLAN:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>PP:6,CS:6,CC:6,NIOPS:6,FS:6,DC:6,TC:5</availability>
+			<availability>FS:6,DC:6,CC:6,CS:6,PP:6,CLAN:4,CCC:3,CGB:3,CGS:3,CHH:4,CIH:2-,CJF:3,CMG:4-,CDS:3,CSJ:2,CSR:3,CSV:3,CW:3,CWOV:3,NIOPS:6,TC:5</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
-				<availability>CS:8,CC:8,NIOPS:8,FS:8,DC:8,TC:8</availability>
+				<availability>FS:8,DC:8,CC:8,CS:8,PP:6,CBS:4-,CB:4-,CCO:4-,CFM:4-,TC:8,NIOPS:8</availability>
 			</model>
 			<model name='WVE-5Nb'>
 				<roles>urban</roles>
-				<availability>PP:4</availability>
+				<availability>PP:4+,CLAN:6</availability>
 			</model>
 			<model name='WVE-5Nsl'>
-				<availability>LA:4+,FWL:4+</availability>
+				<availability>LA:4+,FWL:4+,PP:2+,CLAN:3-,CBS:2-,CB:2-,CCO:2-,CFM:2-</availability>
 			</model>
 			<model name='WVE-6N'>
 				<roles>urban</roles>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -447,7 +447,7 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>CC:1,MOC:1,CS:3-,LA:4,FS.CMM:4,IS:4,MERC:3,FS:4,TC:1</availability>
+			<availability>IS:4,FS:4,FS.CMM:4,LA:4,CC:1,MERC:3,CS:3-,TC:1,MOC:1</availability>
 			<model name='ASN-21'>
 				<availability>IS:8,Periphery:8</availability>
 			</model>
@@ -1122,10 +1122,10 @@
 		<chassis name='Clint' unitType='Mek'>
 			<availability>IS:5,FS:7,CC:7,MERC:5,CS:3-,PP:3,CLAN:3-,CB:2-,CCO:2-,CGB:2-,CIH:4-,CMG:4-,CSJ:2-,CSA:2-,CWI:2-,CWOV:2-,MOC:4,OA:4,NIOPS:3-</availability>
 			<model name='CLNT-1-2R'>
-				<availability>FS:1,CC:1,CLAN:5+,CHH:4,</availability>
+				<availability>FS:1,CC:1,CLAN:5+</availability>
 			</model>
 			<model name='CLNT-2-3T'>
-				<availability>IS:8,PP:8,CLAN:4,CHH:5+,Periphery:8,NIOPS:8</availability>
+				<availability>IS:8,PP:8,CLAN:4,Periphery:8,NIOPS:8</availability>
 			</model>
 			<model name='CLNT-2-4T'>
 				<availability>CC:4,FS:4</availability>
@@ -1283,7 +1283,7 @@
 			</model>
 			<model name='CRB-27b'>
 				<roles>raider</roles>
-				<availability>CC:3+,FWL:3+,PP:4+,CLAN:5+,CBS:4+</availability>
+				<availability>FWL:3+,CC:3+,PP:4+,CLAN:5+,CBS:4+</availability>
 			</model>
 			<model name='CRB-27sl'>
                 <roles>raider</roles>
@@ -1484,7 +1484,7 @@
 		<chassis name='Dervish' unitType='Mek'>
 			<availability>IS:6,CC:3,DC:8,MERC:8,PP:2,CBS:3+,CDS:3+,Periphery.HR:6,TC:6,Periphery.Deep:6</availability>
 			<model name='DV-6M'>
-				<availability>IS:8,PP:4,CBS:8,CDS:8,Periphery:8,Periphery.Deep:8</availability>
+				<availability>IS:8,PP:8,CBS:8,CDS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='DV-6Md'>
 				<availability>FS:6+,CBS:6,CDS:6</availability>
@@ -2039,12 +2039,12 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>IS:9,LA:9,CC:7,DC:8,MERC:6,CS:4,PP:4,CLAN:6,CB:5,CHH:5,CIH:5+,CSR:5,CSA:5,CSV:5,CWI:5,CWOV:5,Periphery:5,TC:7,MOC:7,OA:6,NIOPS:4,Periphery.Deep:5</availability>
+			<availability>IS:9,LA:9,DC:8,CC:7,MERC:6,CS:4,PP:4,CLAN:6,CB:5,CHH:5,CIH:5+,CSR:5,CSA:5,CSV:5,CWI:5,CWOV:5,Periphery:5,TC:7,MOC:7,OA:6,NIOPS:4,Periphery.Deep:5</availability>
 			<model name='GRF-1N'>
 				<availability>IS:8,PP:8,CCC:3-,CIH:3-,CJF:3-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='GRF-2N'>
-				<availability>FS:4+,LA:4+,FWL:4+,CC:4+,PP:4+,CLAN:8,CCC:6,CIH:6,CJF:6   </availability>
+				<availability>FS:4+,LA:4+,FWL:4+,CC:4+,PP:4+,CLAN:8,CCC:6,CIH:6,CJF:6</availability>
 			</model>
             <model name='GRF-2N2'>
                 <availability>CIH:4,CMG:5-</availability>
@@ -2342,7 +2342,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
-			<availability>FS:6,DC:4,LA:6,FWL:6,CC:6,PP:3,CBS:4+,CGB:5+,CGS:5+,CHH:6+,CJF:4,CNC:3+,TC:6,MOC:4,OA:4</availability>
+			<availability>FS:6,LA:6,DC:4,FWL:6,CC:6,PP:3,CBS:4+,CGB:5+,CGS:5+,CHH:6+,CJF:4,CNC:3+,TC:6,MOC:4,OA:4</availability>
 			<model name='HOP-4B'>
                 <roles>inf_support,fire_support</roles>
 				<availability>CC:2</availability>
@@ -3665,9 +3665,10 @@
 			</model>
 			<model name='PXH-1b &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>PP:3,CLAN:8,CGB:5,CGS:4,CIH:6,NIOPS:4+</availability>
+				<availability>PP:3+,CLAN:8,CGB:5,CGS:4,CIH:6,NIOPS:4+</availability>
 			</model>
             <model name='PXH-1c &apos;Special&apos;'>
+                <roles>command,recon</roles>
                 <availability>CGS:3+</availability>
             </model>
 			<model name='PXH-2'>
@@ -4031,7 +4032,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>FS:3,LA:6,FWL:3,CC:1,DC:3,CS:4,PP:6,CLAN:5-,CBS:6-,CB:4-,CCO:4-,CFM:6-,CGB:6-,CIH:6,CDS:3,CSJ:4-,CSR:6-,CSA:4-,CSV:4-,CWI:4-,CWOV:4-,NIOPS:4</availability>
+			<availability>FS:3,LA:6,DC:3,FWL:3,CC:1,CS:4,PP:6,CLAN:5-,CBS:6-,CB:4-,CCO:4-,CFM:6-,CGB:6-,CIH:6,CDS:3,CSJ:4-,CSR:6-,CSA:4-,CSV:4-,CWI:4-,CWOV:4-,NIOPS:4</availability>
 			<model name='STN-1S'>
 				<availability>LA:2,FWL:2,FS:2</availability>
 			</model>
@@ -4695,7 +4696,7 @@
 			</model>
 			<model name='VL-5T'>
 				<roles>anti_infantry</roles>
-				<availability>IS:2,FS:6,PP:4+,CWOV:5,TC:2,MOC:2,CIR:2,PIR:2</availability>
+				<availability>IS:2,FS:6,PP:4+,CWOV:5+,TC:2,MOC:2,CIR:2,PIR:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Vulture' unitType='Dropship'>
@@ -4836,7 +4837,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>FS:6,DC:6,CC:6,CS:6,PP:6,CLAN:4,CCC:3,CGB:3,CGS:3,CHH:4,CIH:2-,CJF:3,CMG:4-,CDS:3,CSJ:2,CSR:3,CSV:3,CW:3,CWOV:3,NIOPS:6,TC:5</availability>
+			<availability>FS:6,DC:6,CC:6,CS:6,PP:6,CLAN:4,CCC:3,CGB:3,CGS:3,CIH:2-,CJF:3,CMG:4-,CDS:3,CSJ:2,CSR:3,CSV:3,CW:3,CWOV:3,NIOPS:6,TC:5</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>FS:8,DC:8,CC:8,CS:8,PP:6,CBS:4-,CB:4-,CCO:4-,CFM:4-,TC:8,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -1684,7 +1684,7 @@
             </model>
 		</chassis>
 		<chassis name='Falcon' unitType='Mek'>
-			<availability>CGS:6+,PP:4+,CC:5,LA:7,FWL:5,FS:5,MERC:5,TC:4,MOC:4,OA:4</availability>
+			<availability>FS:5,LA:7,FWL:5,CC:5,MERC:5,CGS:6+,PP:4+,TC:4,MOC:4,OA:4</availability>
 			<model name='FLC-4N'>
 				<availability>IS:8,CGS:4,PP:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
@@ -1739,10 +1739,10 @@
 			</model>
 		</chassis>
 		<chassis name='Firefly' unitType='Mek'>
-			<availability>CC:4,FS:4,CLAN:4+,CBS:3+,CB:5+,CCC:3+,CGB:7+,CGS:3+,CHH:5+,CIH:3-,CMG:3-,CDS:3,CSV:5-,CWOV:3+,PP:8+,OA:2+</availability>
+			<availability>FS:4,CC:4,CLAN:4+,CBS:3+,CB:5+,CCC:3+,CGB:7+,CGS:3+,CHH:5+,CIH:3-,CMG:3-,CDS:3,CSV:5-,CWOV:3+,PP:8+,OA:2+</availability>
 			<model name='FFL-3A'>
 				<roles>spotter</roles>
-				<availability>CC:8,FS:8,CFM:6,CHH:4,CSR:5,PP:4</availability>
+				<availability>FS:8,CC:8,CFM:6,CHH:4,CSR:5,PP:4</availability>
 			</model>
 			<model name='FFL-3PP'>
 				<availability>PP:2</availability>
@@ -1758,7 +1758,7 @@
 			</model>
 		</chassis>
 		<chassis name='Firestarter' unitType='Mek'>
-			<availability>IS:7,CS:3,LA:8,CFM:4-,CHH:3,PP:5,NIOPS:3,Periphery:7,Periphery.Deep:7</availability>
+			<availability>IS:7,CS:3,LA:8,CFM:4-,CHH:3,PP:5,Periphery:7,NIOPS:3,Periphery.Deep:7</availability>
 			<model name='FS9-A'>
                 <roles>anti_infantry,recon</roles>
 				<deployedWith>Vulcan</deployedWith>
@@ -2380,7 +2380,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hussar' unitType='Mek'>
-			<availability>FS:2,DC:1,CS:4,LA:2,CLAN:3+,CGB:2+,CIH:6+,CMG:4+,CDS:4+,CSV:4+,CWI:4+,PP:9+,NIOPS:4</availability>
+			<availability>FS:2,LA:2,DC:1,CS:4,CLAN:3+,CGB:2+,CIH:6+,CMG:4+,CDS:4+,CSV:4+,CWI:4+,PP:9+,NIOPS:4</availability>
 			<model name='HSR-200-D'>
 				<roles>recon</roles>
 				<availability>FS:8,DC:8,CS:8,LA:8,CLAN:5,PP:8,NIOPS:8</availability>
@@ -3459,7 +3459,7 @@
 			</model>
 		</chassis>
 		<chassis name='Night Hawk' unitType='Mek'>
-			<availability>LA:5+,FWL:5+,FS:5+,CLAN:4+,CBS:5+,CB:5+,CCO:5+,CGB:5+,CJF:5+,CNC:5+,CSJ:5+,CSR:3+,CSV:5+,CW:5+,PP:6+</availability>
+			<availability>FS:5+,LA:5+,FWL:5+,CLAN:4+,CBS:5+,CB:5+,CCO:5+,CGB:5+,CJF:5+,CNC:5+,CSJ:5+,CSR:3+,CSV:5+,CW:5+,PP:6+</availability>
 			<model name='NTK-2Q'>
 				<roles>raider</roles>
 				<availability>IS:8,CLAN:8,PP:8</availability>
@@ -3576,7 +3576,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>FS:3,FS.RR:3,FS.DMM:3,DC:8,FWL:3,CC:3,CS:2,LA:3,MERC:4,CSJ:4,PP:6,Periphery:3,Periphery.DD:4,Periphery.OS:4,NIOPS:2</availability>
+			<availability>FS:3,FS.RR:3,FS.DMM:3,LA:3,DC:8,FWL:3,CC:3,MERC:4,CS:2,CSJ:4,PP:6,Periphery:3,Periphery.DD:4,Periphery.OS:4,NIOPS:2</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,DC:1,TC:8</availability>
 			</model>
@@ -4211,7 +4211,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>IS:4,FS:6,DC:7,CC:5,MERC:4,CS:4,OA:2,FWL:7,CIH:3+,CMG:3+,PP:4+,TC:2,NIOPS:4</availability>
+			<availability>IS:4,FS:6,DC:7,FWL:7,CC:5,MERC:4,CS:4,CIH:3+,CMG:3+,PP:4+,TC:2,OA:2,NIOPS:4</availability>
 			<model name='SDR-5V'>
 				<availability>IS:8,CIH:8,CMG:8,PP:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
@@ -4262,7 +4262,7 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>IS:9,DC:6,MERC:5,CS:4-,CLAN:4,CB:5,CCO:5,CWOV:5,PP:5,NIOPS:4-,Periphery:5,Periphery.Deep:5</availability>
+			<availability>IS:9,DC:6,MERC:5,CS:4-,CLAN:4,CB:5,CCO:5,CWOV:5,PP:5,Periphery:5,NIOPS:4-,Periphery.Deep:5</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
 				<availability>IS:4,PP:4,Periphery:4,Periphery.Deep:4</availability>
@@ -4318,7 +4318,7 @@
 			</model>
 		</chassis>
 		<chassis name='Talon' unitType='Mek'>
-			<availability>LA:5+,FWL:5+,FS:5+,CLAN:5+,CB:4+,CFM:4+,CGS:3+,CIH:4+,CJF:7+,CNC:7+,CDS:7+,CSJ:6+,CSR:3+,CSV:6+,CW:8+,CWOV:6+,PP:7+</availability>
+			<availability>FS:5+,LA:5+,FWL:5+,CLAN:5+,CB:4+,CFM:4+,CGS:3+,CIH:4+,CJF:7+,CNC:7+,CDS:7+,CSJ:6+,CSR:3+,CSV:6+,CW:8+,CWOV:6+,PP:7+</availability>
 			<model name='TLN-5V'>
 				<availability>FWL:8,FS:8,CIH:6,CMG:6,CNC:6,CDS:6,CW:6,PP:8</availability>
 			</model>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -2272,11 +2272,11 @@
             </model>
         </chassis>
 		<chassis name='Helepolis' unitType='Mek'>
-			<availability>PP:3+</availability>
+			<availability>PP:3+,CLAN:2-,CHH:3-</availability>
 			<model name='HEP-3H'>
 				<roles>mixed_artillery</roles>
 				<deployedWith>Helepolis</deployedWith>
-				<availability>PP:8</availability>
+				<availability>PP:8,CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -447,9 +447,9 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>IS:4,FS:4,FS.CMM:4,LA:4,CC:1,MERC:3,CS:3-,TC:1,MOC:1</availability>
+			<availability>IS:4,FS:4,FS.CMM:4,LA:4,CC:1,MERC:3,CS:3-,CCC:1,CIH!Front Line:2!Second Line:1,TC:1,MOC:1</availability>
 			<model name='ASN-21'>
-				<availability>IS:8,Periphery:8</availability>
+				<availability>IS:8,CCC:8,CIH:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Athena Cruiser' unitType='Warship'>

--- a/megamek/data/forcegenerator/2807.xml
+++ b/megamek/data/forcegenerator/2807.xml
@@ -1158,7 +1158,7 @@
             </model>
         </chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>LA:9,CIR:4,MERC:4</availability>
+			<availability>LA:9,CGS:3-,CSJ:3,CIR:4,MERC:4</availability>
 			<model name='COM-1D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
@@ -1167,7 +1167,7 @@
 			<model name='COM-2D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
-				<availability>LA:8,General:8,Periphery.Deep:8</availability>
+				<availability>IS:8,MERC:8,CGS:8,CSJ:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Commonwealth Light Cruiser' unitType='Warship'>
@@ -1684,12 +1684,12 @@
             </model>
 		</chassis>
 		<chassis name='Falcon' unitType='Mek'>
-			<availability>PP:4,CC:5,MOC:4,OA:4,LA:7,FWL:5,FS:5,MERC:5,TC:4</availability>
+			<availability>CGS:6+,PP:4+,CC:5,LA:7,FWL:5,FS:5,MERC:5,TC:4,MOC:4,OA:4</availability>
 			<model name='FLC-4N'>
-				<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CGS:4,PP:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='FLC-4Nb'>
-				<availability>PP:2</availability>
+				<availability>CGS:3+,PP:2</availability>
 			</model>
 			<model name='FLC-4Nb-PP'>
 				<availability>PP:2</availability>
@@ -1739,10 +1739,10 @@
 			</model>
 		</chassis>
 		<chassis name='Firefly' unitType='Mek'>
-			<availability>PP:8,CC:4,OA:2+,FS:4</availability>
+			<availability>CC:4,FS:4,CLAN:4+,CBS:3+,CB:5+,CCC:3+,CGB:7+,CGS:3+,CHH:5+,CIH:3-,CMG:3-,CDS:3,CSV:5-,CWOV:3+,PP:8+,OA:2+</availability>
 			<model name='FFL-3A'>
 				<roles>spotter</roles>
-				<availability>PP:4,CC:8,FS:8</availability>
+				<availability>CC:8,FS:8,CFM:6,CHH:4,CSR:5,PP:4</availability>
 			</model>
 			<model name='FFL-3PP'>
 				<availability>PP:2</availability>
@@ -1754,11 +1754,11 @@
 				<availability>PP:2</availability>
 			</model>
 			<model name='FFL-3SLE'>
-				<availability>PP:4</availability>
+				<availability>CLAN:8,CFM:5+,CHH:5+,CSR:4+,PP:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Firestarter' unitType='Mek'>
-			<availability>PP:5,CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
+			<availability>IS:7,CS:3,LA:8,CFM:4-,CHH:3,PP:5,NIOPS:3,Periphery:7,Periphery.Deep:7</availability>
 			<model name='FS9-A'>
                 <roles>anti_infantry,recon</roles>
 				<deployedWith>Vulcan</deployedWith>
@@ -1767,7 +1767,7 @@
 			<model name='FS9-H'>
                 <roles>anti_infantry,recon</roles>
 				<deployedWith>Vulcan</deployedWith>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CFM:8,CHH:8,PP:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='FS9-K'>
                 <roles>anti_infantry,recon</roles>
@@ -2317,14 +2317,14 @@
 			</model>
 		</chassis>
 		<chassis name='Hermes' unitType='Mek'>
-			<availability>MOC:5,PP:4,CC:4,CS:3,OA:5,FWL:5,NIOPS:3,DC:4</availability>
+			<availability>DC:4,FWL:5,CC:4,CS:3,CLAN:2,CB:1,CCO:1,CGB:1,CIH:6+,CDS:3,CWI:1,PP:4+,MOC:5,OA:5,NIOPS:3</availability>
 			<model name='HER-1S'>
 				<roles>recon</roles>
-				<availability>PP:8,CS:8,General:8-,NIOPS:8</availability>
+				<availability>IS:8-,MERC:8-,CS:8,CLAN:4,PP:8,Periphery:8,NIOPS:8</availability>
 			</model>
 			<model name='HER-1Sb'>
 				<roles>recon</roles>
-				<availability>PP:4,FWL:4+</availability>
+				<availability>FWL:4+,CLAN:3+,PP:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
@@ -2380,13 +2380,13 @@
 			</model>
 		</chassis>
 		<chassis name='Hussar' unitType='Mek'>
-			<availability>PP:9,CS:4,LA:2,NIOPS:4,FS:2,DC:1</availability>
+			<availability>FS:2,DC:1,CS:4,LA:2,CLAN:3+,CGB:2+,CIH:6+,CMG:4+,CDS:4+,CSV:4+,CWI:4+,PP:9+,NIOPS:4</availability>
 			<model name='HSR-200-D'>
 				<roles>recon</roles>
-				<availability>PP:8,CS:8,General:8,NIOPS:8,DC:8</availability>
+				<availability>FS:8,DC:8,CS:8,LA:8,CLAN:5,PP:8,NIOPS:8</availability>
 			</model>
 			<model name='HSR-200-Db'>
-				<availability>PP:4</availability>
+				<availability>CLAN:4+,PP:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Icarus II' unitType='Mek'>
@@ -2807,10 +2807,10 @@
 			</model>
 		</chassis>
 		<chassis name='Locust' unitType='Mek'>
-			<availability>PP:5,CS:6-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:9,CS:6-,CLAN:5,CB:4,CCO:4,CJF:6,CWI:4,CW:6,PP:5,Periphery:6,NIOPS:6-,Periphery.Deep:6</availability>
 			<model name='LCT-1E'>
 				<roles>recon</roles>
-				<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
+				<availability>IS:4,Periphery:4,Periphery.Deep:4</availability>
 			</model>
 			<model name='LCT-1M'>
 				<roles>recon</roles>
@@ -2822,11 +2822,11 @@
 			</model>
 			<model name='LCT-1V'>
 				<roles>recon</roles>
-				<availability>LA:4,General:8,FS:7</availability>
+				<availability>IS:8,MERC:8,LA:4,FS:7,PP:8,Periphery:8</availability>
 			</model>
 			<model name='LCT-1Vb'>
 				<roles>recon</roles>
-				<availability>PP:4</availability>
+				<availability>CLAN:8,PP:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Lola I Destroyer' unitType='Warship'>
@@ -3241,14 +3241,14 @@
 			</model>
 		</chassis>
 		<chassis name='Mercury' unitType='Mek'>
-			<availability>PP:2,CS:8,CC:4+,LA:4+,NIOPS:8,IS:4+,MERC:3+</availability>
+			<availability>IS:4+,MERC:3+,CS:8,CLAN:3+,CB:2+,CCO:2+,CIH:5+,CSJ:1,CWI:2+,PP:2+,NIOPS:8</availability>
 			<model name='MCY-98'>
 				<roles>recon</roles>
 				<availability>CC:5</availability>
 			</model>
 			<model name='MCY-99'>
 				<roles>recon</roles>
-				<availability>CS:4,General:6,NIOPS:4</availability>
+				<availability>IS:8,CC:6,MERC:8,CS:4,CLAN:8,PP:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Mobile Headquarters' unitType='Tank'>
@@ -3326,14 +3326,14 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>PP:6,CS:6,MOC:4+,OA:4+,FWL:6+,NIOPS:6,FS:6+,MERC:4+,DC:6+,TC:4+</availability>
+			<availability>FS:6+,DC:6+,FWL:6+,MERC:4+,CS:6,CLAN:4+,CBS:3+,CGS:3+,CJF:5+,CMG:6+,CWI:3+,PP:6+,TC:4+,MOC:4+,OA:4+,NIOPS:6</availability>
 			<model name='MON-66'>
 				<roles>command,recon</roles>
-				<availability>PP:8,CS:8,NIOPS:8,IS:8,Periphery:8</availability>
+				<availability>IS:8,CS:8,CLAN:6,PP:8,Periphery:8,NIOPS:8</availability>
 			</model>
 			<model name='MON-66b'>
 				<roles>command,recon</roles>
-				<availability>PP:4</availability>
+				<availability>CLAN:5+,PP:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Monolith Jumpship' unitType='Jumpship'>
@@ -3459,10 +3459,10 @@
 			</model>
 		</chassis>
 		<chassis name='Night Hawk' unitType='Mek'>
-			<availability>PP:6,LA:5+,FWL:5+,FS:5+</availability>
+			<availability>LA:5+,FWL:5+,FS:5+,CLAN:4+,CBS:5+,CB:5+,CCO:5+,CGB:5+,CJF:5+,CNC:5+,CSJ:5+,CSR:3+,CSV:5+,CW:5+,PP:6+</availability>
 			<model name='NTK-2Q'>
 				<roles>raider</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CLAN:8,PP:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
@@ -3521,14 +3521,14 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>PP:5,CS:4,IS:5,Periphery.Deep:5,NIOPS:4,MERC:5,Periphery:5</availability>
+			<availability>IS:5,MERC:5,CS:4,CLAN:2,CB:1,CCO:1,CSJ:1,CWI:1,PP:5+,Periphery:5,NIOPS:4,Periphery.Deep:5</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,MERC:8,PP:8,Periphery:8</availability>
 			</model>
 			<model name='OTT-7Jb'>
 				<roles>recon</roles>
-				<availability>PP:4</availability>
+				<availability>CLAN:8,PP:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
@@ -3576,13 +3576,13 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>PP:6,CC:3,Periphery.DD:4,FS.RR:3,MERC:4,Periphery.OS:4,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:8</availability>
+			<availability>FS:3,FS.RR:3,FS.DMM:3,DC:8,FWL:3,CC:3,CS:2,LA:3,MERC:4,CSJ:4,PP:6,Periphery:3,Periphery.DD:4,Periphery.OS:4,NIOPS:2</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,DC:1,TC:8</availability>
 			</model>
 			<model name='PNT-9R'>
 				<roles>fire_support</roles>
-				<availability>PP:8,MERC:8,DC:8</availability>
+				<availability>DC:8,MERC:8,CSJ:8,PP:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -4146,14 +4146,14 @@
 			</model>
 		</chassis>
 		<chassis name='Sling' unitType='Mek'>
-			<availability>PP:3,CC:3+,LA:3+,CSJ:3</availability>
+			<availability>CC:3+,LA:3+,CSJ:5+,PP:3+</availability>
 			<model name='SL-1G'>
 				<roles>spotter</roles>
-				<availability>General:8</availability>
+				<availability>CC:8,LA:8,CSJ:8,PP:8</availability>
 			</model>
 			<model name='SL-1H'>
 				<roles>spotter</roles>
-				<availability>PP:4,LA:4</availability>
+				<availability>LA:4,CSJ:3+,PP:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Snowden Mining Station' unitType='Space Station'>
@@ -4204,16 +4204,16 @@
 			</model>
 		</chassis>
 		<chassis name='Spector' unitType='Mek'>
-			<availability>PP:2</availability>
+			<availability>CIH:1+,CMG:2+,PP:2+</availability>
 			<model name='SPR-4F'>
 			    <roles>specops,raider</roles>
-				<availability>General:8</availability>
+				<availability>CIH:8,CMG:8,PP:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>PP:4,CC:5,CS:4,OA:2,IS:4,FWL:7,NIOPS:4,FS:6,MERC:4,TC:2,DC:7</availability>
+			<availability>IS:4,FS:6,DC:7,CC:5,MERC:4,CS:4,OA:2,FWL:7,CIH:3+,CMG:3+,PP:4+,TC:2,NIOPS:4</availability>
 			<model name='SDR-5V'>
-				<availability>PP:8,CLAN:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
+				<availability>IS:8,CIH:8,CMG:8,PP:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
@@ -4262,18 +4262,18 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>PP:5,CS:4-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:5,Periphery:5,DC:6</availability>
+			<availability>IS:9,DC:6,MERC:5,CS:4-,CLAN:4,CB:5,CCO:5,CWOV:5,PP:5,NIOPS:4-,Periphery:5,Periphery.Deep:5</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
-				<availability>PP:4,IS:4,Periphery.Deep:4,Periphery:4</availability>
+				<availability>IS:4,PP:4,Periphery:4,Periphery.Deep:4</availability>
 			</model>
 			<model name='STG-3Gb'>
 				<roles>recon</roles>
-				<availability>PP:4</availability>
+				<availability>CLAN:8,PP:4+</availability>
 			</model>
 			<model name='STG-3R'>
 				<roles>recon</roles>
-				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:8-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
@@ -4318,12 +4318,12 @@
 			</model>
 		</chassis>
 		<chassis name='Talon' unitType='Mek'>
-			<availability>PP:9,LA:5+,FWL:5+,FS:5+</availability>
+			<availability>LA:5+,FWL:5+,FS:5+,CLAN:5+,CB:4+,CFM:4+,CGS:3+,CIH:4+,CJF:7+,CNC:7+,CDS:7+,CSJ:6+,CSR:3+,CSV:6+,CW:8+,CWOV:6+,PP:7+</availability>
 			<model name='TLN-5V'>
-				<availability>FWL:8,FS:8</availability>
+				<availability>FWL:8,FS:8,CIH:6,CMG:6,CNC:6,CDS:6,CW:6,PP:8</availability>
 			</model>
 			<model name='TLN-5W'>
-				<availability>PP:8,LA:8</availability>
+				<availability>LA:8,CLAN:8,CIH:6+,CMG:4+,CNC:6+,CDS:7+,CW:8+,PP:5+</availability>
 			</model>
 		</chassis>
 		<chassis name='Texas Battleship' unitType='Warship'>
@@ -4351,15 +4351,15 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>PP:6,CC:4,CS:6,MOC:4+,OA:4+,FWL:6,NIOPS:6,FS:4,MERC:4,TC:4+</availability>
+			<availability>FS:4,CC:4,FWL:6,MERC:4,CS:6,CLAN:4,CGB:5,CHH:6,CIH:4-,CMG:3,CNC:5,CW:5,CWOV:3,PP:6,TC:4+,MOC:4+,OA:4+,NIOPS:6</availability>
 			<model name='THE-F'>
 				<availability>CC:2,FWL:2,FS:2</availability>
 			</model>
 			<model name='THE-N'>
-				<availability>PP:6,CS:8,General:6+,NIOPS:8</availability>
+				<availability>IS:6+,CS:8,CLAN:8,CB:7,CGB:7,CIH:7,CJF:7,CMG:7,CNC:7,CDS:7,CSR:7,CW:7,PP:6,NIOPS:8</availability>
 			</model>
 			<model name='THE-Nb'>
-				<availability>PP:4</availability>
+				<availability>CB:6+,CGB:6+,CIH:6+,CJF:6+,CMG:6+,CNC:6+,CDS:6+,CSR:6+,CW:6+,PP:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
@@ -4748,10 +4748,10 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>PP:4,CS:4-,IS:10,NIOPS:4-,Periphery.Deep:5,Periphery:5</availability>
+			<availability>IS:10,CS:4-,PP:4,Periphery:5,NIOPS:4-,Periphery.Deep:5</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,MERC:8,PP:8,Periphery:8</availability>
 			</model>
 			<model name='WSP-1D'>
 				<roles>recon</roles>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -529,7 +529,7 @@
                 <availability>CGB!Keshik:5</availability>
             </model>
 			<model name='ANH-1X'>
-                <availability>CB:8,CCO:8,CGB:8,CS:8,CWI:8</availability>
+                <availability>CB:8,CCO:8,CGB:8,CSA:8,CWI:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aquarius Escort' unitType='Small Craft'>
@@ -1551,7 +1551,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>FS:7,LA:7,DC:7,FWL:7,CC:7,CS:8,PP:6,CLAN:4-,CBS:5-,CCO:5-,CFM:5-,CGB:5-,CHH:5-,CW:5-,NIOPS:8</availability>
+			<availability>FS:7,LA:7,DC:7,FWL:7,CC:7,CS:8,PP:6,CLAN:4-,CBS:5-,CCO:5-,CGB:5-,CHH:5-,CW:5-,NIOPS:8</availability>
 			<model name='CRK-5003-1'>
 				<availability>IS:7+,CS:8,PP:6,CLAN:8,CBS:4-,CB:4-,CCO:4-,CGB:4-,CHH:4-,CW:4-,NIOPS:8</availability>
 			</model>
@@ -1632,7 +1632,7 @@
 			</model>
 			<model name='CP-10-Z'>
                 <roles>command</roles>
-				<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+				<availability>IS:8,FS:8,DC:8,MERC:8,CLAN:8,TC:8,OA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
@@ -4771,7 +4771,7 @@
 		<chassis name='Thug' unitType='Mek'>
 			<availability>IS:6+,FS:6+,FWL:6+,CS:7,PP:3+,CLAN:5,CIH:4,TC:4+,NIOPS:7</availability>
 			<model name='THG-11E'>
-				<availability>IS:8+,FS:8+,DC:8+,FWL:8+,CS:8,PP:8,CLAN:4-,TC:8,NIOPS:8</availability>
+				<availability>IS:8+,CS:8,PP:8,CLAN:4-,TC:8,NIOPS:8</availability>
 			</model>
 			<model name='THG-11Eb'>
 				<availability>PP:1+,CLAN:6</availability>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -2620,7 +2620,7 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>IS:4,MERC:4,CS:9,PP:2+,CLAN:4+,CCC:3+,CIH:3+,CSV:3+,NIOPS:9</availability>
+			<availability>IS:4,MERC:4,CS:9,PP:2+,CLAN:4+,CCC:3+,CIH:3+,CSV:3+,NIOPS:9+</availability>
 			<model name='HGN-732'>
                 <roles>command</roles>
 				<availability>IS:8,FWL:7+,CS:8,PP:8,CLAN:4-,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -623,9 +623,9 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>IS:4,FS:4,LA:4,CC:1,MERC:3,CS:3-,CIH!Front Line:2!Second Line:1,TC:1,MOC:1</availability>
+			<availability>IS:4,FS:4,LA:4,CC:1,MERC:3,CS:3-,CCC:1,CIH!Front Line:2!Second Line:1,TC:1,MOC:1</availability>
 			<model name='ASN-21'>
-				<availability>IS:8,CIH:8,Periphery:8</availability>
+				<availability>IS:8,CCC:8,CIH:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Athena Cruiser' unitType='Warship'>
@@ -2317,7 +2317,7 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>IS:9,LA:9,DC:8,CC:7,MERC:6,CS:4,PP:4,CLAN:6,CB:5,CHH:5,CIH:5+,CSR:5,CSA:5,CSV:5,CWI:5,CWOV:5,Periphery:5,TC:7,MOC:7,OA:6,NIOPS:4,Periphery.Deep:5</availability>
+			<availability>IS:9,DC:8,CC:7,MERC:6,CS:4,PP:4,CLAN:6,CB:5,CHH:5,CIH:5+,CSR:5,CSA:5,CSV:5,CWI:5,CWOV:5,Periphery:5,TC:7,MOC:7,OA:6,NIOPS:4,Periphery.Deep:5</availability>
 			<model name='GRF-1N'>
 				<availability>IS:8,PP:8,CCC:3-,CIH:3-,CJF:3-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
@@ -2631,7 +2631,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
-			<availability>FS:5,LA:5,DC:4,FWL:5,CC:5,PP:3+,CBS:4+,CGB:5+,CGS:5+,CHH:6+,CJF:4+,CNC:3+,TC:5,MOC:4,OA:4</availability>
+			<availability>FS:5,LA:5,DC:4,FWL:5,CC:5,PP:3+,CBS:4+,CGB:5+,CGS:5+,CHH:6+,CJF:4,CNC:3+,TC:5,MOC:4,OA:4</availability>
 			<model name='HOP-4B'>
                 <roles>inf_support,fire_support</roles>
 				<availability>CC:2</availability>
@@ -5214,7 +5214,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>FS:6,DC:6,CC:6,MERC:5,CS:6,PP:6,CLAN:4,CCC:3,CGB:3,CGS:3,CIH:2-,CJF:3,CMG:4-,CDS:3,CSJ:2,CSR:3,CSV:3,CW:3,CWOV:3,NIOPS:6,TC:5</availability>
+			<availability>FS:6,DC:6,CC:6,MERC:5,CS:6,PP:6,CLAN:4,CCC:3,CGB:3,CGS:3,CIH:2-,CJF:3,CMG:4-,CDS:3,CSJ:2,CSR:3,CSV:3,CW:3,CWOV:3,TC:5,NIOPS:6</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
 				<availability>FS:8,DC:8,CC:8,CS:8,PP:6,CBS:4-,CB:4-,CCO:4-,CFM:4-,TC:8,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2815-->
-<ratgen
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -524,9 +524,12 @@
 			</model>
 		</chassis>
 		<chassis name='Annihilator' unitType='Mek'>
-			<availability>CSA:3,CHH:3,CSR:3,CLAN:3,CCO:3,CGB:3</availability>
+			<availability>CB:3+,CCO:3+,CGB:3+,CSA:3+,CWI:3+</availability>
+            <model name='ANH-1G'>
+                <availability>CGB!Keshik:5</availability>
+            </model>
 			<model name='ANH-1X'>
-				<availability>CSA:8,CLAN:8,CCO:8</availability>
+                <availability>CB:8,CCO:8,CGB:8,CS:8,CWI:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aquarius Escort' unitType='Small Craft'>
@@ -636,25 +639,25 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas II' unitType='Mek'>
-			<availability>PP:3,CLAN:5</availability>
+			<availability>PP:2+,CLAN:3+,CBS:2+,CCC:2+,CIH:2+,CMG:2+,CSA:2+,CWI:2+</availability>
 			<model name='AS7-D-H'>
                 <roles>command</roles>
-				<availability>PP:6,General:8</availability>
+				<availability>PP:8,CLAN:5</availability>
 			</model>
 			<model name='AS7-D-H2'>
                 <roles>command</roles>
-				<availability>PP:2,CLAN:4</availability>
+				<availability>PP:2+,CLAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>PP:5,MOC:1,CS:4-,OA:1,LA:3,IS:2,NIOPS:4-,FS:4,TC:1,DC:4</availability>
+			<availability>IS:2,FS:4,LA:3,DC:4,CS:4-,PP:5+,CLAN:4,CCC:3,CGS:3,CIH:2,CMG:3,CDS:3,CSV:3,TC:1,MOC:1,OA:1,NIOPS:4-</availability>
 			<model name='AS7-D'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,PP:8,CLAN:8,Periphery:8</availability>
 			</model>
 			<model name='AS7-D-DC'>
 				<roles>command</roles>
-				<availability>IS:1,MERC:0,DC:2</availability>
+				<availability>IS:1+,DC:2+,MERC:0,CLAN:1+,CFM:0,CSJ:0</availability>
 			</model>
 		</chassis>
 		<chassis name='Atreus Battleship' unitType='Warship'>
@@ -679,9 +682,9 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>PP:8,MOC:6,IS:7,Periphery.Deep:4,CIR:7,Periphery:4,TC:6,CS:8,OA:6,FWL:8,NIOPS:8</availability>
+			<availability>IS:7,FWL:8,CS:8,PP:5+,CSA:3,Periphery:4,TC:6,MOC:6,OA:6,CIR:7,NIOPS:8,Periphery.Deep:4+</availability>
 			<model name='AWS-8Q'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CSA:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='AWS-8R'>
 				<availability>CS:2,FWL:4</availability>
@@ -736,26 +739,26 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>PP:4,MOC:6,CLAN:4,IS:7,TC:6,CS:8-,LA:8,PIR:6,FWL:8,NIOPS:8-,CJF:4</availability>
+			<availability>IS:7,LA:8,FWL:8,CS:8-,PP:4,CLAN:6,CB:5,CCO:5,CGB:5,CIH:5,CSJ:4,CSA:5,CWI:5,TC:6,MOC:6,NIOPS:8-,PIR:6</availability>
 			<model name='BLR-1G'>
                 <roles>command</roles>
-				<availability>IS:8,Periphery:8</availability>
+				<availability>IS:8,PP:5,Periphery:8,Periphery.Deep:8,PIR:8</availability>
 			</model>
             <model name='BLR-1G-DC'>
                 <roles>command</roles>
-                <availability>IS:2+,PP:2+</availability>
+                <availability>IS:2+,PP!A:1!B:1</availability>
             </model>
 			<model name='BLR-1Gb'>
                 <roles>command</roles>
-				<availability>PP:2,CC:2+,CLAN:8</availability>
+				<availability>CC:2+,PP:3+,CLAN:8</availability>
 			</model>
 			<model name='BLR-1Gbc'>
                 <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>PP:1+,CLAN:1+,CFM:0,CIH:0,CSJ:0</availability>
 			</model>
 			<model name='BLR-1Gc'>
                 <roles>command</roles>
-				<availability>PP:4,CC:3+,LA:3+,CLAN:4,FWL:3+,FS:2+,DC:2+</availability>
+				<availability>FS:2+,LA:3+,DC:2+,FWL:3+,CC:3+,PP:2+,CLAN!Front Line:1,CFM:0,CIH:0,CSJ:0,CSA!Front Line:1!Second Line:1</availability>
 			</model>
 			<model name='BLR-1Gd'>
                 <roles>command</roles>
@@ -1548,12 +1551,12 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>PP:10,CC:7,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:7,CGS:8,CS:8,CDS:8,CW:10,LA:7,CBS:10,FWL:7,NIOPS:8,CJF:8,CGB:10,DC:7</availability>
+			<availability>FS:7,LA:7,DC:7,FWL:7,CC:7,CS:8,PP:6,CLAN:4-,CBS:5-,CCO:5-,CFM:5-,CGB:5-,CHH:5-,CW:5-,NIOPS:8</availability>
 			<model name='CRK-5003-1'>
-				<availability>CS:8,General:7+,NIOPS:8</availability>
+				<availability>IS:7+,CS:8,PP:6,CLAN:8,CBS:4-,CB:4-,CCO:4-,CGB:4-,CHH:4-,CW:4-,NIOPS:8</availability>
 			</model>
 			<model name='CRK-5003-1b'>
-				<availability>PP:2,CLAN:8,CGS:8</availability>
+				<availability>PP:2+,CBS:5,CB:5,CCO:5,CGB:5,CHH:5,CW:5</availability>
 			</model>
 		</chassis>
 		<chassis name='Crossbow' unitType='Mek'>
@@ -1618,7 +1621,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>PP:4,CC:5,CS:3,OA:3,LA:5,IS:3,FWL:4,NIOPS:3,FS:5,TC:3,DC:5</availability>
+			<availability>IS:3,FS:5,LA:5,DC:5,FWL:4,CC:5,CS:3,PP:2+,CLAN!Front Line:1,CFM!Second Line:1,CGB!Second Line:1,CJF!Second Line:1,CSJ!Second Line:1,CSA!Second Line:1,CSV!Second Line:1,CWI!Second Line:1,TC:3,OA:3,NIOPS:3</availability>
 			<model name='CP-10-HQ'>
                 <roles>command</roles>
 				<availability>IS:2</availability>
@@ -1836,14 +1839,14 @@
             </model>
         </chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>MOC:5,PP:3,CC:6,CS:7,OA:5,CLAN:3,FWL:7,NIOPS:7,FS:6,MERC:6,TC:5</availability>
+			<availability>FS:6,FWL:7,CC:6,MERC:6,CS:7,PP:1+,CLAN:3+,CSA:2+,TC:5,MOC:5,OA:5,NIOPS:7</availability>
 			<model name='EMP-5A'>
                 <roles>command</roles>
-				<availability>PP:2,General:8</availability>
+				<availability>IS:8,PP:8,Periphery:8,NIOPS:3-</availability>
 			</model>
 			<model name='EMP-6A'>
                 <roles>command</roles>
-				<availability>PP:6,CC:6+,CS:8,LA:6+,CLAN:8,NIOPS:8,FWL:6+,FS:6+</availability>
+				<availability>FS:6+,LA:6+,FWL:6+,CC:6+,CS:8,PP:3+,CLAN:8,NIOPS:8</availability>
 			</model>
 			<model name='EMP-6A-EC'>
 				<availability>CSA:4</availability>
@@ -2617,14 +2620,14 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>PP:9,CLAN:9,IS:4,CFM:10,MERC:4,CS:9,NIOPS:9,CJF:10</availability>
+			<availability>IS:4,MERC:4,CS:9,PP:2+,CLAN:4+,CCC:3+,CIH:3+,CSV:3+,NIOPS:9</availability>
 			<model name='HGN-732'>
                 <roles>command</roles>
-				<availability>PP:8,CS:8,FWL:7+,IS:8,NIOPS:8</availability>
+				<availability>IS:8,FWL:7+,CS:8,PP:8,CLAN:4-,NIOPS:8</availability>
 			</model>
 			<model name='HGN-732b'>
                 <roles>command</roles>
-				<availability>PP:2,CLAN:8,FWL:4+</availability>
+				<availability>FWL:4+,PP:2+,CLAN:6,CWOV:5,NIOPS:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
@@ -2696,14 +2699,14 @@
 			</model>
 		</chassis>
 		<chassis name='Imp' unitType='Mek'>
-			<availability>PP:2,CSA:2,CW:2,CLAN:2</availability>
+			<availability>PP:1+,CB:2+,CCO:2+,CGB:2+,CSJ:2+,CWI:2+,CW:2+</availability>
 			<model name='IMP-1A'>
                 <roles>command</roles>
-				<availability>PP:8,CLAN:8</availability>
+				<availability>PP:8,CB:8,CCO:8,CGB:8,CSJ:8,CWI:8,CW:8</availability>
 			</model>
 			<model name='IMP-1B'>
                 <roles>command</roles>
-				<availability>CLAN:2:2821</availability>
+				<availability>CB!Keshik:6!Front Line:1,CCO!Keshik:6!Front Line:1,CGB!Keshik:6!Front Line:1,CSJ!Keshik:6!Front Line:1,CW!Keshik:6!Front Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
@@ -2907,10 +2910,10 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>PP:5,CLAN:6,IS:2+,MERC:2+,CGS:7,CS:6,NIOPS:6,CGB:7</availability>
+			<availability>IS:2+,MERC:2+,CS:6,PP:4+,CLAN:4,CCC:2,CFM:5,CGS:3,CHH:3,CIH:2,CMG:2,CDS:3,CSR:2,CSA:3,CSV:3,CWI:5,NIOPS:6</availability>
 			<model name='KGC-000'>
                 <roles>command</roles>
-				<availability>CS:8,General:5,NIOPS:8</availability>
+				<availability>IS:5,CS:8,PP:8,CLAN:3-,CCC:2-,CIH:2-,NIOPS:8</availability>
 			</model>
 			<model name='KGC-0000'>
                 <roles>command</roles>
@@ -2918,11 +2921,11 @@
 			</model>
 			<model name='KGC-000b'>
                 <roles>command</roles>
-				<availability>PP:4,CLAN:8,CGS:8</availability>
+				<availability>PP:3+,CB:5,CFM:5,CGB:5,CGS:5,CWI:5,CW:5</availability>
 			</model>
 			<model name='KGC-010'>
                 <roles>command</roles>
-				<availability>CLAN:4</availability>
+				<availability>CLAN:3+,CCC:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
@@ -3157,22 +3160,22 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>PP:3,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:6</availability>
+			<availability>IS:7,FS:8,DC:6,FWL:9,CS:4,PP:3,CLAN:1-,CBS:2-,CB:2-,CCO:2-,CGB:2-,CHH:2-,CDS:3,CSR:3,CSA:2-,CWI:2-,CWOV:3,Periphery:7,NIOPS:4,Periphery.Deep:7</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
-				<availability>IS:8,Periphery:8,PP:8</availability>
+				<availability>IS:8,PP:8,Periphery:8</availability>
 			</model>
 			<model name='LGB-0W2'>
                 <roles>fire_support</roles>
-				<availability>IS:5,MERC:5,Periphery:3,PP:5</availability>
+				<availability>IS:5,MERC:5,PP:5,Periphery:3</availability>
 			</model>
 			<model name='LGB-7Q'>
 				<roles>fire_support</roles>
-				<availability>MOC:6,OA:6,IS:6,TC:6,CLAN:6,PP:6+</availability>
+				<availability>IS:6,PP:6+,CDS:8,CSR:8,CWOV:8,TC:6,MOC:6,OA:6</availability>
 			</model>
 			<model name='LGB-8C'>
                 <roles>fire_support</roles>
-				<availability>MOC:3,CS:6,OA:3,IS:6,MERC:2,TC:4,CLAN:6,PP:6+</availability>
+				<availability>IS:6,MERC:2,CS:6,PP:6+,CLAN:8,CDS:3-,CSR:2-,CWOV:2-,TC:4,MOC:3,OA:3</availability>
 			</model>
 		</chassis>
         <chassis name='Luciano White Wolverine' unitType='Tank'>
@@ -3235,6 +3238,12 @@
                 <availability>CLAN:8,PP:8,IS:6,CS:7,Periphery:6,Periphery.Deep:0,PIR:6</availability>
             </model>
 		</chassis>
+        <chassis name='Mackie' unitType='Mek'>
+            <availability>CSJ:2-,CSV:2-</availability>
+            <model name='MSK-7A'>
+                <availability>CSJ:8,CSV:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Magi Infantry Support Vehicle' unitType='Tank'>
 			<availability>PP:5,MOC:4,CS:5,CHH:6,OA:4,CLAN:5,IS:2,NIOPS:5,TC:4</availability>
 			<model name=''>
@@ -3774,10 +3783,10 @@
 			</model>
 		</chassis>
 		<chassis name='Nightstar' unitType='Mek'>
-			<availability>PP:5,CSA:6,CS:4,CLAN:5,NIOPS:4</availability>
+			<availability>CS:4,CCO:1+,CWI:1+,NIOPS:4+</availability>
 			<model name='NSR-9J'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CS:8,CCO:8,CWI:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Olympus Recharge Station' unitType='Space Station'>
@@ -3989,9 +3998,9 @@
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
-			<availability>PP:3+,CLAN:5,CC:6+,CS:5,LA:6+,FWL:6+,NIOPS:5,FS:6+</availability>
+			<availability>FS:6+,LA:6+,FWL:6+,CC:6,CS:5+,PP:1+,CLAN:3+,CBS:2+,CCC:2+,CFM:2+,CGB:2+,CHH:2+,CIH:2+,CMG:2+,CDS:2+,CSR:2+,CSA:2+,CSV:2+,CW:2+,NIOPS:5+</availability>
 			<model name='PLG-3Z'>
-				<availability>IS:8,CLAN:8,PP:8,NIOPS:8</availability>
+				<availability>IS:8,PP:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Pinto Corvette' unitType='Warship'>
@@ -4080,6 +4089,15 @@
 				<availability>General:4</availability>
 			</model>
 		</chassis>
+        <chassis name='Pulverizer' unitType='Mek'>
+            <availability>CWOV!Keshik:3</availability>
+            <model name='PUL-2V'>
+                <availability>CWOV:8</availability>
+            </model>
+            <model name='PUL-3R'>
+                <availability>CWOV:6</availability>
+            </model>
+        </chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
 			<availability>PP:8,CC:6,CLAN:8,Periphery.Deep:4,MERC:5,FS:6,CIR:5,Periphery:4,CS:8,LA:6,FWL:6,NIOPS:8,CJF:8,DC:6</availability>
 			<model name='PAT-005'>
@@ -4149,10 +4167,10 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman II' unitType='Mek'>
-			<availability>CLAN:5</availability>
+			<availability>CGB:3+</availability>
 			<model name='RFL-3N-2'>
 				<roles>anti_aircraft</roles>
-				<availability>General:8</availability>
+				<availability>CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
@@ -4427,9 +4445,9 @@
 			</model>
 		</chassis>
 		<chassis name='Shogun' unitType='Mek'>
-			<availability>PP:1,CSA:3,CIH:3,CBS:3,CLAN:3,FWL:2+,CCO:3,CB:3</availability>
+			<availability>FWL:2+,PP:1+,CBS:3+,CB:3+,CCC:3+,CCO:3+,CSA:3</availability>
 			<model name='SHG-2H'>
-				<availability>General:8,CLAN:8</availability>
+				<availability>FWL:8,PP:8,CBS:8,CB:8,CCC:8,CCO:8,CSA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Sholagar' unitType='AeroSpaceFighter'>
@@ -4544,11 +4562,15 @@
 			</model>
 		</chassis>
 		<chassis name='Spartan' unitType='Mek'>
-			<availability>CS:5</availability>
+			<availability>CS:5,CLAN:2,CCC:4+,CFM:4,CGS:3,CIH:6+,CMG:5,CDS:4,CSV:4,CWOV:4</availability>
 			<model name='SPT-N2'>
 				<roles>cavalry,spotter</roles>
-				<availability>IS:8</availability>
+				<availability>CS:8,CFM:4-</availability>
 			</model>
+            <model name='SPT-NF'>
+                <roles>cavalry</roles>
+                <availability>CLAN:8,CFM:3+</availability>
+            </model>
 		</chassis>
 		<chassis name='Spector' unitType='Mek'>
 			<availability>CIH:1+,CMG:2+,PP:1+</availability>
@@ -4576,18 +4598,18 @@
             </model>
         </chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>PP:9,CC:7,CLAN:7,IS:8,Periphery.Deep:9,FS:7,CIR:9,Periphery:9,CS:6,LA:8,FWL:9,NIOPS:6,DC:7</availability>
+			<availability>IS:8,FS:7,DC:7,FWL:9,CC:7,CS:6,PP:6,CLAN:5,CBS:6,CGB:6,CHH:6,CIH:4,CJF:6,CMG:4,CNC:6,CW:6,Periphery:9,CIR:9,NIOPS:6,Periphery.Deep:9</availability>
 			<model name='STK-3F'>
-				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CLAN:2-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='STK-3Fb'>
-				<availability>PP:2,CLAN:8</availability>
+				<availability>PP:2+,CLAN:8</availability>
 			</model>
 			<model name='STK-3Fk'>
 				<availability>DC:2+</availability>
 			</model>
 			<model name='STK-3H'>
-				<availability>MOC:2,OA:2,CLAN:2,IS:2,TC:2</availability>
+				<availability>IS:2,TC:2,MOC:2,OA:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -4657,9 +4679,9 @@
 			</model>
 		</chassis>
 		<chassis name='Striker' unitType='Mek'>
-			<availability>PP:6,CC:9,MOC:7,Periphery.Deep:4,FS:8,MERC:7,TC:7,CS:4,OA:7,LA:9,PIR:4,NIOPS:4,DC:8</availability>
+			<availability>FS:8,LA:9,DC:8,CC:9,MERC:7,CS:4,PP:2+,CLAN:1-,CCC:2-,CFM:2-,CGS:2-,CHH:2-,CIH:3-,CMG:3-,CDS:2-,CSR:2-,CSV:2-,CW:2-,CWOV:2-,TC:7,MOC:7,OA:7,NIOPS:4,Periphery.Deep:4+,PIR:4</availability>
 			<model name='STC-2C'>
-				<availability>CC:8,General:8</availability>
+				<availability>IS:8,PP:8,CLAN:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stuka' unitType='AeroSpaceFighter'>
@@ -4747,12 +4769,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>PP:8,CHH:7,CSV:9,CLAN:8,IS:6+,CFM:10,FS:6+,TC:4+,CS:7,CDS:7,CW:9,CBS:7,CNC:7,FWL:6+,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>IS:6+,FS:6+,FWL:6+,CS:7,PP:3+,CLAN:5,CIH:4,TC:4+,NIOPS:7</availability>
 			<model name='THG-11E'>
-				<availability>PP:8,CS:8,FWL:8+,IS:8+,NIOPS:8,FS:8+,DC:8+,TC:8</availability>
+				<availability>IS:8+,FS:8+,DC:8+,FWL:8+,CS:8,PP:8,CLAN:4-,TC:8,NIOPS:8</availability>
 			</model>
 			<model name='THG-11Eb'>
-				<availability>PP:2,CLAN:8</availability>
+				<availability>PP:1+,CLAN:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -4763,10 +4785,10 @@
 			</model>
 		</chassis>
 		<chassis name='Thunder Hawk' unitType='Mek'>
-			<availability>PP:1,CS:2,LA:3+,CLAN:4,NIOPS:2,DC:3+</availability>
+			<availability>LA:3+,DC:3+,CS:2,CB:1+,NIOPS:2+</availability>
 			<model name='TDK-7X'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,DC:8,CS:8,CB:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
@@ -5011,15 +5033,15 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>PP:6,CC:8,MOC:6,IS:5,Periphery.Deep:5,FS:8,CIR:6,Periphery.OS:6,Periphery:5,TC:6,CS:5-,OA:6,LA:7,Periphery.HR:6,FWL:7,NIOPS:5-,DC:7</availability>
+			<availability>IS:5,FS:8,LA:7,DC:7,FWL:7,CC:8,CS:5-,PP:6+,CCO:2-,CIH:3,Periphery:5,Periphery.OS:6,Periphery.HR:6,TC:6,MOC:6,OA:6,CIR:6,NIOPS:5-,Periphery.Deep:5+</availability>
 			<model name='VTR-9A'>
-				<availability>CC:2,CS:2,IS:1,FS:2</availability>
+				<availability>IS:1,FS:2,CC:2,CS:2</availability>
 			</model>
 			<model name='VTR-9A1'>
-				<availability>CC:2,CS:2,IS:1,FS:2</availability>
+				<availability>IS:1,FS:2,CC:2,CS:2</availability>
 			</model>
 			<model name='VTR-9B'>
-				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CCO:8,CIH:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Vigilant Corvette' unitType='Warship'>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2815-->
-<ratgen>
+<ratgen
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -1910,7 +1910,7 @@
 			</model>
 			<model name='EXC-B2b'>
 				<roles>cavalry,fire_support</roles>
-				<availability>PP:2+,CLAN:2+,CGB:3+,CJF:3+,CSJ:3+   </availability>
+				<availability>PP:2+,CLAN:2+,CGB:3+,CJF:3+,CSJ:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -3835,7 +3835,7 @@
 			<availability>FS:8,FWL:8,MERC:8,CS:6,PP:5,CLAN:3-,CB:2-,CIH:4-,CWI:2-,Periphery:3,NIOPS:6</availability>
 			<model name='OTL-4D'>
                 <roles>raider</roles>
-				<availability>IS:8,MERC:8,PP:8,CLAN:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CLAN:8,Periphery:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Overlord C' unitType='Dropship'>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -537,14 +537,14 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>PP:3,CC:7,CS:5-,LA:9,FWL:9,IS:6,NIOPS:5-,Periphery.Deep:6,FS:8,DC:8,Periphery:6</availability>
+			<availability>IS:6,FS:8,LA:9,DC:8,FWL:9,CC:7,CS:5-,PP:3,CLAN:4,CFM:3,CGS:3,CIH:4-,CMG:3,CSV:3,CWOV:3,Periphery:6,NIOPS:5-,Periphery.Deep:6</availability>
 			<model name='ARC-2R'>
 				<roles>command,fire_support</roles>
-				<availability>LA:8,IS:8,Periphery.Deep:8,DC:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CGB:2-,CW:2-,Periphery:8,NIOPS:4-,Periphery.Deep:8</availability>
 			</model>
 			<model name='ARC-2Rb'>
 				<roles>command,fire_support</roles>
-				<availability>PP:2,CLAN:8</availability>
+				<availability>PP:2+,CLAN:8,NIOPS:5</availability>
 			</model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -784,14 +784,14 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>PP:10,CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:6,FS:5,MERC:4,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:4,CNC:10,FWL:6,NIOPS:7,CJF:8,CGB:10,DC:4</availability>
+			<availability>FS:5,LA:4,DC:4,FWL:6,MERC:4,CS:7,PP:3+,CLAN:3+,CGS:4+,CIH:2+,CWOV:4+,NIOPS:7</availability>
 			<model name='BL-6-KNT'>
                 <roles>command</roles>
-				<availability>PP:8,CS:8,FWL:6+,NIOPS:8,FS:6+</availability>
+				<availability>FS:6+,FWL:6+,CS:8,PP:8,CLAN:8,CBS:6-,CCO:6-,CGB:6-,CGS:6-,CNC:6-,CW:6-,NIOPS:8</availability>
 			</model>
 			<model name='BL-6b-KNT'>
                 <roles>command</roles>
-				<availability>PP:2,CS:4,CLAN:8,NIOPS:4,FWL:2+,CGS:8</availability>
+				<availability>FWL:2+,CS:4,PP:2+,CBS:7,CCO:7,CGB:7,CGS:7,CNC:7,CW:7,NIOPS:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
                 <roles>command</roles>
@@ -830,10 +830,10 @@
 			</model>
 		</chassis>
 		<chassis name='Bombardier' unitType='Mek'>
-			<availability>PP:4,CLAN:4,CS:5,FWL:4,DC:4,NIOPS:5</availability>
+			<availability>DC:4,FWL:4,CS:5,PP:4+,CLAN:3-,CB:2-,CCO:2-,CIH:4,CMG:4-,CDS:4-,CSR:4-,CWI:2-,CWOV:2-,NIOPS:5</availability>
 			<model name='BMB-12D'>
 				<roles>fire_support</roles>
-				<availability>PP:8,CLAN:8,CS:8,FWL:8,DC:8,NIOPS:8</availability>
+				<availability>DC:8,FWL:8,CS:8,PP:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
         <chassis name='Brunel Dump Truck' unitType='Tank'>
@@ -954,18 +954,18 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>PP:2,CC:6,CLAN:2,IS:4,MERC:3,CIR:1,Periphery:2,CS:2,NIOPS:2,DC:6</availability>
+			<availability>IS:4,DC:6,CC:6,MERC:3,CS:2,PP:2,CFM:4+,CDS:3,CWI:3+,CW:3,CWOV:3+,Periphery:2,CIR:1,NIOPS:2</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
-				<availability>CC:4,FWL:4,DC:4</availability>
+				<availability>DC:4,FWL:4,CC:4</availability>
 			</model>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
-				<availability>CC:8,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CDS:8,CW:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='CPLT-C1b'>
 				<roles>fire_support</roles>
-				<availability>PP:2,CC:2+,CLAN:6,DC:3+</availability>
+				<availability>DC:3+,CC:2+,PP:2+,CFM:8,CWI:8,CWOV:8</availability>
 			</model>
 			<model name='CPLT-C4'>
 				<roles>fire_support</roles>
@@ -993,12 +993,9 @@
 			</model>
 		</chassis>
 		<chassis name='Cestus' unitType='Mek'>
-			<availability>PP:4,CS:4,LA:4+,CLAN:4,NIOPS:4,IS:4+,FS:6</availability>
+			<availability>IS:4+,FS:6,CS:4,PP:2+,CB:3+,CFM:2+,CJF:3+,CSJ:3+,NIOPS:4</availability>
 			<model name='CTS-6Y'>
-				<availability>General:8</availability>
-			</model>
-			<model name='CTS-6Y-EC'>
-				<availability>CFM:3</availability>
+				<availability>IS:8,PP:8,CB:8,CFM:8,CJF:8,CSJ:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chameleon' unitType='Mek'>
@@ -1009,19 +1006,19 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>PP:5,CC:7,CHH:6,CLAN:5,IS:6,MERC:6,FS:6,CS:5,LA:7,NIOPS:5,CGB:6</availability>
+			<availability>IS:6,LA:7,CC:7,MERC:6,CS:5,PP:5,CBS:4-,CCO:3-,CFM:4+,CGB:4+,CHH:4+,CIH:6+,CDS:4+,CSV:3+,NIOPS:5</availability>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
-				<availability>PP:8,CC:6+,CS:8,NIOPS:8</availability>
+				<availability>CC:6+,CS:8,PP:8,CBS:8,CCO:8,CGB:4-,CHH:4-,NIOPS:8</availability>
 			</model>
 			<model name='CHP-1N2'>
-				<availability>CC:4+,CS:4,LA:4+</availability>
+				<availability>LA:4+,CC:4+,CS:4,PP:2+,CFM:8,CGB:5,CHH:5,CIH:8,CDS:5,NIOPS:5</availability>
 			</model>
 			<model name='CHP-1Nb'>
-				<availability>PP:2,CLAN:8</availability>
+				<availability>PP:2+,CDS:3+,CSV:8</availability>
 			</model>
 			<model name='CHP-2N'>
-				<availability>IS:5-,NIOPS:0</availability>
+				<availability>IS:5-</availability>
 			</model>
 		</chassis>
 		<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1602,9 +1599,9 @@
 			</model>
 		</chassis>
 		<chassis name='Crusader' unitType='Mek'>
-			<availability>PP:6,CS:6-,CLAN:6,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:8,CS:6-,PP:6,CLAN:3,CDS:2,Periphery:6,NIOPS:6-,Periphery.Deep:6</availability>
 			<model name='CRD-2R'>
-				<availability>PP:4,CLAN:8,IS:3+,CGS:8,Periphery:3+</availability>
+				<availability>IS:3+,MERC:3+,PP:3+,CLAN:8,Periphery:3+,NIOPS:5,Periphery.Deep:0</availability>
 			</model>
 			<model name='CRD-3D'>
 				<availability>FS:5</availability>
@@ -1617,7 +1614,7 @@
 				<availability>CC:9</availability>
 			</model>
 			<model name='CRD-3R'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CBS:2-,CFM:2-,CHH:2-,CWI:2-,Periphery:8,NIOPS:6-,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
@@ -1895,25 +1892,25 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>IS:4,Periphery:2,CS:5,NIOPS:5</availability>
+			<availability>IS:4,CS:5,Periphery:2,NIOPS:5</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Mek'>
-			<availability>PP:5,CS:5,LA:3+,CLAN:5,NIOPS:5,FS:3+,DC:3+</availability>
+			<availability>FS:3+,LA:3+,DC:3+,CS:5,PP:3+,CLAN:3+,NIOPS:5</availability>
 			<model name='EXC-B1'>
 				<roles>cavalry,fire_support</roles>
-				<availability>LA:8</availability>
+				<availability>LA:8,CGS:4-,CDS:4-,CW:4-</availability>
 			</model>
 			<model name='EXC-B2'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CS:8,LA:0,General:8,CLAN:6,NIOPS:8</availability>
+				<availability>FS:8,LA:0,DC:8,CS:8,PP:8,CLAN:8,NIOPS:8</availability>
 			</model>
 			<model name='EXC-B2b'>
 				<roles>cavalry,fire_support</roles>
-				<availability>PP:2,CLAN:8,CGS:8</availability>
+				<availability>PP:2+,CLAN:2+,CGB:3+,CJF:3+,CSJ:3+   </availability>
 			</model>
 		</chassis>
 		<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -1928,22 +1925,22 @@
 			</model>
 		</chassis>
 		<chassis name='Exterminator' unitType='Mek'>
-			<availability>PP:7,CC:1,CS:4,LA:1,CLAN:6,FWL:1,NIOPS:4,FS:1,DC:1</availability>
+			<availability>FS:1,LA:1,DC:1,FWL:1,CC:1,CS:4,PP:2+,CLAN:2+,CCC:3+,CFM:3+,CIH:4+,CMG:3+,CDS:3+,CSR:3+,CSV:3+,CWI:1+,CWOV:3+,NIOPS:4</availability>
 			<model name='EXT-4C'>
                 <roles>specops</roles>
-				<availability>CLAN:2</availability>
+				<availability>CJF:1+,CW:1+,CWOV!Keshik:2</availability>
 			</model>
 			<model name='EXT-4D'>
                 <roles>cavalry</roles>
-				<availability>CS:8,General:8+,CLAN:4,NIOPS:8</availability>
+				<availability>FS:8,LA:8,DC:8,FWL:8,CC:8,CS:8,PP:8,CLAN:8,CFM:4-,CIH:4-,CJF:4-,CDS:4-,CSR:4-,NIOPS:8</availability>
 			</model>
 			<model name='EXT-4Db'>
                 <roles>cavalry</roles>
-				<availability>PP:2,CLAN:8</availability>
+				<availability>PP:1+,CFM:8,CIH:5,CJF:8,CDS:8,CSR:8,NIOPS:3+</availability>
 			</model>
 			<model name='EXT-4Db-EC'>
                 <roles>cavalry,raider</roles>
-				<availability>CJF:6:2819</availability>
+				<availability>CJF!Keshik:3</availability>
 			</model>
 		</chassis>
 	    <chassis name='Factory' unitType='Space Station'>
@@ -2054,13 +2051,13 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>PP:8,CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:4,CDS:5,LA:6,CBS:5,FWL:5,NIOPS:5,CJF:7,CGB:5</availability>
+			<availability>LA:6,FWL:5,CS:5,PP:4+,CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CJF!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CNC!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,Periphery.R:4,NIOPS:5</availability>
 			<model name='FLS-7K'>
 				<availability>LA:5-,Periphery.R:8</availability>
 			</model>
 			<model name='FLS-8K'>
                 <roles>cavalry</roles>
-				<availability>PP:8,CS:8,LA:8+,CLAN:8,FWL:8+,NIOPS:8</availability>
+				<availability>LA:8+,FWL:8,CS:8,PP:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Flatbed Truck' unitType='Tank'>
@@ -2228,12 +2225,12 @@
 			</model>
 		</chassis>
 		<chassis name='Galahad' unitType='Mek'>
-			<availability>PP:4,CC:4+,CWI:6,LA:4+,CLAN:4,FS:4+</availability>
+			<availability>FS:4+,LA:4+,CC:4+,PP:2+,CGB!Keshik:1!Front Line:1!Second Line:1,CHH!Keshik:1!Front Line:1!Second Line:1,CSR!Keshik:1!Front Line:1!Second Line:1,CWI!Keshik:1!Front Line:1!Second Line:1,CW!Keshik:1!Front Line:1!Second Line:1</availability>
 			<model name='GLH-1D'>
-				<availability>IS:8</availability>
+				<availability>FS:8,LA:8,CC:8</availability>
 			</model>
 			<model name='GLH-2D'>
-				<availability>PP:8,CLAN:8</availability>
+				<availability>PP:8,CGB:8,CHH:8,CSR:8,CWI:8,CW:8</availability>
 			</model>
 		</chassis>
         <chassis name='Galaport Ground Trailer' unitType='Tank'>
@@ -2329,10 +2326,10 @@
             </model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>PP:9,CS:7,CLAN:9,IS:8,NIOPS:7,FS:7,MERC:8</availability>
+			<availability>IS:8,FS:7,MERC:8,CS:7,PP:4,CHH:3+,CSR:3+,NIOPS:7</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
-				<availability>PP:8,CS:8,CLAN:8,IS:8,NIOPS:8</availability>
+				<availability>IS:8,CS:8,PP:8,CHH:8,CSR:8,NIOPS:8</availability>
 			</model>
 		</chassis>
         <chassis name='HMRV (Hazardous Materials Recovery Vehicle)' unitType='Tank'>
@@ -2557,7 +2554,7 @@
             </model>
         </chassis>
 		<chassis name='Helepolis' unitType='Mek'>
-			<availability>PP:6</availability>
+			<availability>PP:2+</availability>
 			<model name='HEP-3H'>
 				<roles>mixed_artillery</roles>
 				<deployedWith>Helepolis</deployedWith>
@@ -2997,14 +2994,14 @@
 			</model>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>MOC:4,PP:6,CLAN:6,IS:6,MERC:6,CIR:4,TC:4,CS:6,OA:4,NIOPS:6</availability>
+			<availability>IS:6,MERC:6,CS:6,PP:5+,CLAN:3+,CCC:4+,CCO:2+,CFM:4+,CHH:2+,CIH:4+,CMG:4+,CSV:4+,CWI:2+,TC:4,MOC:4,OA:4,CIR:4,NIOPS:6</availability>
 			<model name='LNC25-01'>
 				<roles>cavalry,anti_aircraft</roles>
-				<availability>PP:6,CS:8,CLAN:8,IS:7,NIOPS:8</availability>
+				<availability>IS:7,CS:8,PP:8,CLAN:8,NIOPS:8</availability>
 			</model>
 			<model name='LNC25-05'>
 				<roles>cavalry,anti_infantry</roles>
-				<availability>CS:4,IS:4,NIOPS:4</availability>
+				<availability>IS:4,CS:4,NIOPS:4</availability>
 			</model>
 		</chassis>
 		<chassis name='League Destroyer' unitType='Warship'>
@@ -3290,18 +3287,18 @@
             </model>
         </chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>PP:8,CC:5,MOC:2+,CLAN:8,IS:3,FS:6,TC:2+,CS:8,LA:6,FWL:6,NIOPS:8,DC:6</availability>
+			<availability>IS:3,FS:6,LA:6,DC:6,FWL:6,CC:5,CS:8,PP:4+,CLAN:4+,CIH:3+,CMG:3+,CSV:3+,TC:2+,MOC:2+,NIOPS:8</availability>
 			<model name='MAD-1R'>
                 <roles>command</roles>
-				<availability>PP:8,CS:8,MOC:8,IS:6+,NIOPS:8,MERC:0,TC:8+</availability>
+				<availability>IS:6+,MERC:0,CS:8,PP:8,CLAN:4-,TC:8+,MOC:8,NIOPS:8</availability>
 			</model>
 			<model name='MAD-2R'>
                 <roles>command</roles>
-				<availability>PP:2,CLAN:8,FS:4+</availability>
+				<availability>FS:4+,PP:2+,CLAN:5</availability>
 			</model>
 			<model name='MAD-3R'>
                 <roles>command</roles>
-				<availability>CS:4-:2819,IS:6:2819,TC:4:2819</availability>
+				<availability>IS:6,CS:4-,PP:3-,TC:4:2820</availability>
 			</model>
 		</chassis>
         <chassis name='Marco' unitType='Mek'>
@@ -3791,12 +3788,15 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>PP:4,MOC:5,IS:5,Periphery.Deep:4,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,LA:6,FWL:6,NIOPS:5-</availability>
+			<availability>IS:5,LA:6,FWL:6,CS:5-,PP:4,CLAN:3+,CCC:2+,CGS:2+,CIH:2+,CMG:2+,CNC:2+,CSR:2+,CW:5+,CWOV:2+,Periphery:4,TC:5,MOC:5,OA:5,CIR:5,NIOPS:5-,Periphery.Deep:4</availability>
 			<model name='ON1-K'>
-				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CW:4-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
+            <model name='ON1-Kb'>
+                <availability>CLAN:8,CW:3+</availability>
+            </model>
 			<model name='ON1-V'>
-				<availability>OA:3,IS:3,TC:3</availability>
+				<availability>IS:3,PP:6,CW:3-,TC:3,OA:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Osprey' unitType='Mek'>
@@ -3807,14 +3807,14 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>PP:5,CS:4,IS:6,NIOPS:4,Periphery.Deep:4,Periphery:4</availability>
+			<availability>IS:6,CS:4,PP:5,CLAN:4,CB:3,CCC:5,CCO:3,CIH:5,CMG!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,CWI:3,Periphery:4,NIOPS:4,Periphery.Deep:4</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
-				<availability>IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CCC:2-,CMG:2-,CDS:2-,CSR:2-,CSV:2-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='OSR-2Cb'>
 				<roles>urban</roles>
-				<availability>PP:4,CLAN:8</availability>
+				<availability>PP:3+,CLAN:8</availability>
 			</model>
 			<model name='OSR-2M'>
 				<availability>FWL:6</availability>
@@ -3832,10 +3832,10 @@
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
-			<availability>PP:5+,CLAN:6,CS:6,FWL:8,NIOPS:6,FS:8,MERC:8,Periphery:3</availability>
+			<availability>FS:8,FWL:8,MERC:8,CS:6,PP:5,CLAN:3-,CB:2-,CIH:4-,CWI:2-,Periphery:3,NIOPS:6</availability>
 			<model name='OTL-4D'>
                 <roles>raider</roles>
-				<availability>PP:8,CLAN:8,IS:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CLAN:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Overlord C' unitType='Dropship'>
@@ -4156,10 +4156,10 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>PP:4,CS:6-,IS:6,NIOPS:6-,Periphery.Deep:5,CIR:4,Periphery:5</availability>
+			<availability>IS:6,PP:4,CS:6-,Periphery:5,CIR:4,NIOPS:6-,Periphery.Deep:5</availability>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:8-,General:8</availability>
+				<availability>IS:8,MERC:8,PP:8,Periphery:8,NIOPS:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Riga II Destroyer-Carrier' unitType='Warship'>
@@ -4439,10 +4439,10 @@
 			</model>
 		</chassis>
 		<chassis name='Shootist' unitType='Mek'>
-			<availability>PP:4,CS:5,LA:3+,CLAN:6,NIOPS:5</availability>
+			<availability>LA:3+,CS:5,PP:2+,CLAN:2+,CB:4+,CCO:3+,CGB:3+,CIH!Front Line:2!Second Line:1,CJF:3+,CMG:1+,CSJ:3+,CWI:3+,CW:3+,NIOPS:5</availability>
 			<model name='ST-8A'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,CS:8,PP:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
         <chassis name='Shugosha' unitType='Mek'>
@@ -4785,12 +4785,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>PP:5,CC:8,CLAN:5,IS:6,Periphery.Deep:6,FS:7,MERC:6,Periphery:6,CS:5-,LA:8,NIOPS:5-,DC:8</availability>
+			<availability>IS:6,FS:7,LA:8,DC:8,CC:8,MERC:6,CS:5-,PP:5,CLAN:5,CB!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CCC:4,CIH:4,CMG:4,CSR:4,CSV:4,Periphery:6,NIOPS:5-,Periphery.Deep:6</availability>
 			<model name='TDR-5S'>
-				<availability>IS:8,PP:8,CLAN:6,Periphery:8</availability>
+				<availability>IS:8,PP:8,CLAN:3-,Periphery:8</availability>
 			</model>
 			<model name='TDR-5Sb'>
-				<availability>PP:2,CLAN:8</availability>
+				<availability>PP:2+,CLAN:4</availability>
 			</model>
 			<model name='TDR-5Sd'>
 				<availability>FS:2+</availability>
@@ -5090,19 +5090,19 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>PP:6,CS:6-,LA:9,CLAN:6,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:8,LA:9,FWL:9,CS:6-,PP:6,CLAN:6+,CB:5+,CCC:5+,CHH:5+,CIH:4-,CMG:5+,CNC:5+,CSR:5+,CSV:5+,Periphery:6,NIOPS:6-,Periphery.Deep:6</availability>
 			<model name='WHM-6R'>
-				<availability>General:8,CLAN:2</availability>
+				<availability>IS:8,PP:8,CB:2-,CCO:2-,CGS:2-,CJF:2-,CNC:2-,CSJ:2-,CSA:2-,CWOV:2-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='WHM-6Rb'>
-				<availability>PP:2,CC:4+,LA:4+,CLAN:4,FWL:4+,FS:4+</availability>
+				<availability>FS:4+,LA:4+,FWL:4+,CC:4+,PP:2+,CLAN:5</availability>
 			</model>
 			<model name='WHM-6Rk'>
                 <roles>cavalry</roles>
 				<availability>DC:2+</availability>
 			</model>
 			<model name='WHM-7A'>
-				<availability>PP:2,CLAN:8</availability>
+				<availability>PP:1+,CLAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Wasp LAM Mk I' unitType='Mek'>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -2554,11 +2554,11 @@
             </model>
         </chassis>
 		<chassis name='Helepolis' unitType='Mek'>
-			<availability>PP:2+</availability>
+			<availability>PP:2+,CLAN:2-,CHH:3-</availability>
 			<model name='HEP-3H'>
 				<roles>mixed_artillery</roles>
 				<deployedWith>Helepolis</deployedWith>
-				<availability>General:8</availability>
+				<availability>PP:8,CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -1418,7 +1418,7 @@
             </model>
         </chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>LA:9,CIR:4,MERC:4</availability>
+			<availability>LA:9,CGS:3-,CSJ:3,CIR:4,MERC:4</availability>
 			<model name='COM-1D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
@@ -1427,7 +1427,7 @@
 			<model name='COM-2D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
-				<availability>LA:8,General:8,Periphery.Deep:8</availability>
+				<availability>IS:8,MERC:8,CGS:8,CSJ:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Commonwealth Light Cruiser' unitType='Warship'>
@@ -1962,12 +1962,12 @@
             </model>
 		</chassis>
 		<chassis name='Falcon' unitType='Mek'>
-			<availability>PP:4,CC:5,MOC:4,OA:4,CIH:6,LA:7,CLAN:4,FWL:5,FS:5,MERC:5,CGS:5,TC:4</availability>
+			<availability>FS:5,LA:7,FWL:5,CC:5,MERC:5,CGS:6+,PP:4+,TC:4,MOC:4,OA:4</availability>
 			<model name='FLC-4N'>
-				<availability>PP:8,IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CGS:4,PP:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='FLC-4Nb'>
-				<availability>PP:1,CLAN:8</availability>
+				<availability>CGS:3+,PP:1+</availability>
 			</model>
 			<model name='FLC-4Nb-PP'>
 				<availability>PP:4</availability>
@@ -2017,10 +2017,10 @@
 			</model>
 		</chassis>
 		<chassis name='Firefly' unitType='Mek'>
-			<availability>PP:8,CC:3,OA:2+,FS:3</availability>
+			<availability>FS:3,CC:3,CLAN:4+,CBS:3+,CB:5+,CCC:3+,CGB:7+,CGS:3+,CHH:5+,CIH:3-,CMG:3-,CDS:3,CSV:5-,CWOV:3+,PP:8+,OA:2+</availability>
 			<model name='FFL-3A'>
 				<roles>spotter</roles>
-				<availability>PP:4,CC:8,FS:8</availability>
+				<availability>FS:8,CC:8,CFM:6,CHH:4,CSR:5,PP:4</availability>
 			</model>
 			<model name='FFL-3PP'>
 				<availability>PP:3</availability>
@@ -2032,11 +2032,11 @@
 				<availability>PP:3</availability>
 			</model>
 			<model name='FFL-3SLE'>
-				<availability>PP:4,CLAN:8</availability>
+				<availability>CLAN:8,CFM:5+,CHH:5+,CSR:4+,PP:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Firestarter' unitType='Mek'>
-			<availability>PP:5,CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
+			<availability>IS:7,CS:3,LA:8,CFM:4-,CHH:3,PP:5,Periphery:7,NIOPS:3,Periphery.Deep:7</availability>
 			<model name='FS9-A'>
                 <roles>anti_infantry,recon</roles>
 				<deployedWith>Vulcan</deployedWith>
@@ -2045,7 +2045,7 @@
 			<model name='FS9-H'>
                 <roles>anti_infantry,recon</roles>
 				<deployedWith>Vulcan</deployedWith>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CFM:8,CHH:8,PP:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='FS9-K'>
                 <roles>anti_infantry,recon</roles>
@@ -2606,14 +2606,14 @@
 			</model>
 		</chassis>
 		<chassis name='Hermes' unitType='Mek'>
-			<availability>MOC:5,PP:4,CC:4,CS:3,CHH:5,OA:5,CLAN:4,FWL:5,NIOPS:3,CGB:5,DC:4,CB:5</availability>
+			<availability>DC:4,FWL:5,CC:4,CS:3,CLAN:2,CB:1,CCO:1,CGB:1,CIH:6+,CDS:3,CWI:1,PP:4+,MOC:5,OA:5,NIOPS:3</availability>
 			<model name='HER-1S'>
 				<roles>recon</roles>
-				<availability>PP:8,CS:8,General:6-,CLAN:6,NIOPS:8</availability>
+				<availability>IS:6-,MERC:6-,CS:8,CLAN:4,PP:8,Periphery:6-,NIOPS:8</availability>
 			</model>
 			<model name='HER-1Sb'>
 				<roles>recon</roles>
-				<availability>PP:2,CLAN:8,FWL:4+</availability>
+				<availability>FWL:4+,CLAN:3+,PP:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
@@ -2669,13 +2669,13 @@
 			</model>
 		</chassis>
 		<chassis name='Hussar' unitType='Mek'>
-			<availability>PP:9,CS:4,CIH:9,LA:2,CSV:9,CLAN:8,NIOPS:4,FS:2,DC:1</availability>
+			<availability>FS:2,LA:2,DC:1,CS:4,CLAN:3+,CGB:2+,CIH:6+,CMG:4+,CDS:4+,CSV:4+,CWI:4+,PP:9+,NIOPS:4</availability>
 			<model name='HSR-200-D'>
 				<roles>recon</roles>
-				<availability>PP:8,CS:8,General:8,NIOPS:8,DC:8</availability>
+				<availability>IS:8,CS:8,CLAN:5,PP:8,NIOPS:8</availability>
 			</model>
 			<model name='HSR-200-Db'>
-				<availability>PP:2,CLAN:8</availability>
+				<availability>CLAN:4+,PP:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Icarus II' unitType='Mek'>
@@ -3106,10 +3106,10 @@
 			</model>
 		</chassis>
 		<chassis name='Locust' unitType='Mek'>
-			<availability>PP:5,CS:6-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:9,CS:6-,CLAN:5,CB:4,CCO:4,CJF:6,CWI:4,CW:6,PP:5,Periphery:6,NIOPS:6-,Periphery.Deep:6</availability>
 			<model name='LCT-1E'>
 				<roles>recon</roles>
-				<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
+				<availability>IS:4,Periphery:4,Periphery.Deep:4</availability>
 			</model>
 			<model name='LCT-1M'>
 				<roles>recon</roles>
@@ -3121,11 +3121,11 @@
 			</model>
 			<model name='LCT-1V'>
 				<roles>recon</roles>
-				<availability>LA:4,General:8,FS:7</availability>
+				<availability>IS:8,MERC:8,LA:4,FS:7,PP:8,Periphery:8</availability>
 			</model>
 			<model name='LCT-1Vb'>
 				<roles>recon</roles>
-				<availability>PP:2,CLAN:8</availability>
+				<availability>CLAN:8,PP:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Lola I Destroyer' unitType='Warship'>
@@ -3541,14 +3541,14 @@
 			</model>
 		</chassis>
 		<chassis name='Mercury' unitType='Mek'>
-			<availability>PP:2,CC:4+,CS:8,LA:4+,CLAN:4,IS:4+,NIOPS:8,MERC:4+</availability>
+			<availability>IS:4+,MERC:4+,CS:8,CLAN:3+,CB:2+,CCO:2+,CIH:5+,CSJ:1,CWI:2+,PP:2+,NIOPS:8</availability>
 			<model name='MCY-98'>
 				<roles>recon</roles>
 				<availability>CC:6</availability>
 			</model>
 			<model name='MCY-99'>
 				<roles>recon</roles>
-				<availability>CS:4,General:6,CLAN:8,NIOPS:4</availability>
+				<availability>IS:6,CS:4,CLAN:8,PP:8,NIOPS:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Mobile Headquarters' unitType='Tank'>
@@ -3602,14 +3602,14 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>PP:6,MOC:4+,CHH:5,CLAN:6,MERC:4+,FS:6+,TC:4+,CS:6,OA:4+,CDS:5,CBS:7,FWL:6+,NIOPS:6,CJF:7,CGB:5,DC:6+</availability>
+			<availability>FS:6+,DC:6+,FWL:6+,MERC:4+,CS:6,CLAN:4+,CBS:3+,CGS:3+,CJF:5+,CMG:6+,CWI:3+,PP:6+,TC:4+,MOC:4+,OA:4+,NIOPS:6</availability>
 			<model name='MON-66'>
 				<roles>command,recon</roles>
-				<availability>PP:8,CS:8,NIOPS:8,IS:6+,Periphery:6+</availability>
+				<availability>IS:6+,CS:8,CLAN:6,PP:8,Periphery:6+,NIOPS:8</availability>
 			</model>
 			<model name='MON-66b'>
 				<roles>command,recon</roles>
-				<availability>PP:2,CLAN:9,CGS:9</availability>
+				<availability>CLAN:5+,PP:2+</availability>
 			</model>
 			<model name='MON-69'>
 				<roles>command,recon</roles>
@@ -3743,13 +3743,13 @@
 			</model>
 		</chassis>
 		<chassis name='Night Hawk' unitType='Mek'>
-			<availability>PP:6,CW:7,LA:5+,CLAN:7,FWL:5+,FS:5+,CGS:7,CGB:7</availability>
+			<availability>FS:5+,LA:5+,FWL:5+,CLAN:4+,CBS:5+,CB:5+,CCO:5+,CGB:5+,CJF:5+,CNC:5+,CSJ:5+,CSR:3+,CSV:5+,CW:5+,PP:5+</availability>
 			<model name='NTK-2Q'>
 				<roles>raider</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CLAN:8,PP:8</availability>
 			</model>
 			<model name='NTK-2Q-EC'>
-				<availability>CSJ:4</availability>
+				<availability>CSJ:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
@@ -3812,14 +3812,14 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>PP:5,CLAN:4-,IS:5,Periphery.Deep:5,MERC:5,Periphery:5,CS:4,NIOPS:4</availability>
+			<availability>IS:5,MERC:5,CS:4,CLAN:2,CB:1,CCO:1,CSJ:1,CWI:1,PP:5+,Periphery:5,NIOPS:4,Periphery.Deep:5</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,MERC:8,PP:8,Periphery:8</availability>
 			</model>
 			<model name='OTT-7Jb'>
 				<roles>recon</roles>
-				<availability>PP:2,CLAN:8</availability>
+				<availability>CLAN:8+,PP:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
@@ -3878,13 +3878,13 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>PP:6,CC:3,Periphery.DD:4,FS.RR:3,MERC:4,Periphery.OS:4,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:8</availability>
+			<availability>FS:3,FS.RR:3,FS.DMM:3,LA:3,DC:8,FWL:3,CC:3,MERC:4,CS:2,CSJ:4,PP:6,Periphery:3,Periphery.DD:4,Periphery.OS:4,NIOPS:2</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,DC:1,TC:8</availability>
 			</model>
 			<model name='PNT-9R'>
 				<roles>fire_support</roles>
-				<availability>PP:8,CLAN:8,MERC:8,DC:8</availability>
+				<availability>DC:8,MERC:8,CSJ:8,PP:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -4484,14 +4484,14 @@
 			</model>
 		</chassis>
 		<chassis name='Sling' unitType='Mek'>
-			<availability>PP:3,CC:4+,LA:4+,CSJ:3</availability>
+			<availability>CC:4+,LA:4+,CSJ:5+,PP:2+</availability>
 			<model name='SL-1G'>
 				<roles>spotter</roles>
-				<availability>General:8</availability>
+				<availability>CC:8,LA:8,CSJ:8,PP:8</availability>
 			</model>
 			<model name='SL-1H'>
 				<roles>spotter</roles>
-				<availability>PP:4,LA:4</availability>
+				<availability>LA:4,CSJ:3+,PP:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Snowden Mining Station' unitType='Space Station'>
@@ -4542,16 +4542,16 @@
 			</model>
 		</chassis>
 		<chassis name='Spector' unitType='Mek'>
-			<availability>PP:1,CLAN:4</availability>
+			<availability>CIH:1+,CMG:2+,PP:1+</availability>
 			<model name='SPR-4F'>
                 <roles>specops,raider</roles>
-				<availability>General:8,CLAN:8</availability>
+				<availability>CIH:8,CMG:8,PP:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>PP:4,CC:5,CS:4,OA:2,IS:4,FWL:7,NIOPS:4,FS:6,MERC:4,TC:2,DC:7</availability>
+			<availability>IS:4,FS:6,DC:7,FWL:7,CC:5,MERC:4,CS:4,CIH:3+,CMG:3+,PP:4+,TC:2,OA:2,NIOPS:4</availability>
 			<model name='SDR-5V'>
-				<availability>PP:8,CLAN:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
+				<availability>IS:8,CIH:8,CMG:8,PP:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
@@ -4604,18 +4604,18 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>PP:5,CS:4-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:5,DC:6,Periphery:5</availability>
+			<availability>IS:9,DC:6,MERC:5,CS:4-,CLAN:4,CB:5,CCO:5,CWOV:5,PP:5,Periphery:5,NIOPS:4-,Periphery.Deep:5</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
-				<availability>PP:4,IS:4,Periphery.Deep:4,Periphery:4</availability>
+				<availability>IS:4,CLAN!Provisional Garrison:3,PP:4,Periphery:4,Periphery.Deep:4</availability>
 			</model>
 			<model name='STG-3Gb'>
 				<roles>recon</roles>
-				<availability>PP:2,CLAN:8</availability>
+				<availability>CLAN:8,PP:2+</availability>
 			</model>
 			<model name='STG-3R'>
 				<roles>recon</roles>
-				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CLAN:1-,PP:8-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
@@ -4668,15 +4668,15 @@
 			</model>
 		</chassis>
 		<chassis name='Talon' unitType='Mek'>
-			<availability>PP:9,LA:3+,CLAN:9,FWL:3+,FS:3+</availability>
+			<availability>FS:3+,LA:3+,FWL:3+,CLAN:5+,CB:4+,CFM:4+,CGS:3+,CIH:4+,CJF:7+,CNC:7+,CDS:7+,CSJ:6+,CSR:3+,CSV:6+,CW:8+,CWOV:6+,PP:5+</availability>
 			<model name='TLN-5V'>
-				<availability>FWL:8,FS:8</availability>
+				<availability>FWL:8,FS:8,CIH:6,CMG:6,CNC:6,CDS:6,CW:6,PP:8</availability>
 			</model>
 			<model name='TLN-5W'>
-				<availability>LA:8,CLAN:8</availability>
+				<availability>LA:8,CLAN:8,CIH:6+,CMG:4+,CNC:6+,CDS:7+,CW:8+,PP:3+</availability>
 			</model>
 			<model name='TLN-5W-EC'>
-				<availability>CIH:4</availability>
+				<availability>CIH:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Texas Battleship' unitType='Warship'>
@@ -4704,15 +4704,15 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>PP:6,CC:4,CS:6,MOC:4+,OA:4+,FWL:6,NIOPS:6,FS:4,MERC:4,TC:4+</availability>
+			<availability>FS:4,CC:4,FWL:6,MERC:4,CS:6,CLAN:4,CGB:5,CHH:6,CIH:4-,CMG:3,CNC:5,CW:5,CWOV:3,PP:6,TC:4+,MOC:4+,OA:4+,NIOPS:6</availability>
 			<model name='THE-F'>
 				<availability>CC:2,FWL:2,FS:2</availability>
 			</model>
 			<model name='THE-N'>
-				<availability>PP:6,CS:8,General:6+,NIOPS:8</availability>
+				<availability>IS:6+,CS:8,CLAN:8,CB:7,CGB:7,CIH:7,CJF:7,CMG:7,CNC:7,CDS:7,CSR:7,CW:7,PP:6,NIOPS:8</availability>
 			</model>
 			<model name='THE-Nb'>
-				<availability>PP:2,CLAN:8,CGS:8</availability>
+				<availability>CB:6+,CGB:6+,CIH:6+,CJF:6+,CMG:6+,CNC:6+,CDS:6+,CSR:6+,CW:6+,PP:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
@@ -5107,10 +5107,10 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>PP:4,CS:4-,IS:10,NIOPS:4-,Periphery.Deep:5,CIR:5,Periphery:5</availability>
+			<availability>IS:10,CS:4-,CLAN:1-,PP:4,Periphery:5,NIOPS:4-,Periphery.Deep:5</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,MERC:8,CLAN:8,PP:8,Periphery:8</availability>
 			</model>
 			<model name='WSP-1D'>
 				<roles>recon</roles>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -2036,7 +2036,7 @@
 			</model>
 		</chassis>
 		<chassis name='Firestarter' unitType='Mek'>
-			<availability>IS:7,CS:3,LA:8,CFM:4-,CHH:3,PP:5,Periphery:7,NIOPS:3,Periphery.Deep:7</availability>
+			<availability>IS:7,LA:8,CS:3,CFM:4-,CHH:3,PP:5,Periphery:7,NIOPS:3,Periphery.Deep:7</availability>
 			<model name='FS9-A'>
                 <roles>anti_infantry,recon</roles>
 				<deployedWith>Vulcan</deployedWith>
@@ -3121,7 +3121,7 @@
 			</model>
 			<model name='LCT-1V'>
 				<roles>recon</roles>
-				<availability>IS:8,MERC:8,LA:4,FS:7,PP:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,FS:7,LA:4,PP:8,Periphery:8</availability>
 			</model>
 			<model name='LCT-1Vb'>
 				<roles>recon</roles>
@@ -3819,7 +3819,7 @@
 			</model>
 			<model name='OTT-7Jb'>
 				<roles>recon</roles>
-				<availability>CLAN:8+,PP:2+</availability>
+				<availability>CLAN:8,PP:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
@@ -4484,10 +4484,10 @@
 			</model>
 		</chassis>
 		<chassis name='Sling' unitType='Mek'>
-			<availability>CC:4+,LA:4+,CSJ:5+,PP:2+</availability>
+			<availability>LA:4+,CC:4+,CSJ:5+,PP:2+</availability>
 			<model name='SL-1G'>
 				<roles>spotter</roles>
-				<availability>CC:8,LA:8,CSJ:8,PP:8</availability>
+				<availability>LA:8,CC:8,CSJ:8,PP:8</availability>
 			</model>
 			<model name='SL-1H'>
 				<roles>spotter</roles>
@@ -4676,7 +4676,7 @@
 				<availability>LA:8,CLAN:8,CIH:6+,CMG:4+,CNC:6+,CDS:7+,CW:8+,PP:3+</availability>
 			</model>
 			<model name='TLN-5W-EC'>
-				<availability>CIH:1+</availability>
+				<availability>CIH!Keshik:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Texas Battleship' unitType='Warship'>
@@ -4706,7 +4706,7 @@
 		<chassis name='Thorn' unitType='Mek'>
 			<availability>FS:4,CC:4,FWL:6,MERC:4,CS:6,CLAN:4,CGB:5,CHH:6,CIH:4-,CMG:3,CNC:5,CW:5,CWOV:3,PP:6,TC:4+,MOC:4+,OA:4+,NIOPS:6</availability>
 			<model name='THE-F'>
-				<availability>CC:2,FWL:2,FS:2</availability>
+				<availability>CC:2,FWL:2,FS:2,Periphery:8</availability>
 			</model>
 			<model name='THE-N'>
 				<availability>IS:6+,CS:8,CLAN:8,CB:7,CGB:7,CIH:7,CJF:7,CMG:7,CNC:7,CDS:7,CSR:7,CW:7,PP:6,NIOPS:8</availability>
@@ -4965,7 +4965,7 @@
 			<availability>PP:5,CC:6-,IS:3-,Periphery:2-,CS:4-,FS.CMM:5-,FWL:5-,NIOPS:4-,DC:5-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
-				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Valkyrie' unitType='Mek'>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -22,17 +22,17 @@
 			<weightDistribution era='2815' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 		</faction>
 		<faction key='CBS'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>CHH:5,CCC:5,CDS:1,CW:5,CSV:10,CNC:5,CCO:5,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CB'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>CCC:1,CHH:7,CSR:5,CIH:5,CSV:3,CFM:3,CCO:7,CGS:3,CSA:2,CDS:5,CW:3,CWI:2,CBS:3,CNC:10,CSJ:2,CMG:2,CJF:5</salvage>
@@ -40,17 +40,17 @@
 			<weightDistribution era='2815' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CCC'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>CHH:2,CSR:1,CIH:3,CWOV:2,CSV:3,CFM:3,CCO:10,CGS:2,CSA:3,CDS:1,CW:5,CBS:2,CNC:7,CJF:7,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CCO'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>CCC:8,CHH:1,CSR:5,CIH:8,CWOV:1,CSV:3,CFM:8,CGS:1,CSA:5,CDS:2,CW:1,CBS:1,CNC:5,CSJ:8,CJF:10,CB:5</salvage>
@@ -58,17 +58,17 @@
 			<weightDistribution era='2815' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CFM'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>CCC:1,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:3,CNC:1,CSJ:3,CMG:3,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CGB'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>CHH:10,CCC:3,CIH:5,CSR:1,CWOV:3,CSV:10,CFM:3,CGS:1,CCO:1,CSA:8,CDS:1,CW:8,CMG:3,CJF:5</salvage>
@@ -76,25 +76,25 @@
 			<weightDistribution era='2815' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CGS'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>CCC:1,CHH:3,CSR:1,CIH:6,CWOV:1,CSV:3,CFM:10,CCO:1,CSA:6,CDS:3,CW:1,CWI:2,CNC:2,CSJ:1,CMG:2,CJF:8,CB:2</salvage>
 		</faction>
 		<faction key='CHH'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>CCC:2,CSR:6,CIH:8,CWOV:2,CSV:4,CFM:8,CCO:2,CGS:6,CSA:4,CDS:10,CW:4,CWI:4,CBS:2,CNC:10,CSJ:6,CMG:2,CJF:10,CGB:8,CB:8</salvage>
 		</faction>
 		<faction key='CIH'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>CCC:2,CHH:3,CSR:4,CWOV:1,CSV:5,CFM:10,CCO:5,CGS:5,CSA:8,CDS:5,CW:4,CWI:1,CNC:2,CSJ:3,CMG:5,CJF:8,CGB:2,CB:2</salvage>
@@ -102,58 +102,58 @@
 			<weightDistribution era='2815' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
 		<faction key='CJF'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>CCC:3,CHH:4,CSR:4,CIH:8,CWOV:1,CSV:10,CFM:9,CCO:6,CGS:6,CSA:9,CDS:4,CW:10,CWI:1,CBS:1,CNC:2,CSJ:1,CMG:3,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CMG'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>CHH:3,CIH:10,CSR:3,CSV:8,CFM:8,CGS:5,CSA:8,CDS:3,CW:3,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
 		</faction>
 		<faction key='CNC'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>
 				CCC:7,CHH:8,CSR:5,CIH:3,CFM:3,CCO:7,CGS:3,CDS:2,CW:3,CWI:2,CBS:2,CSJ:5,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CDS'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>CCC:1,CHH:8,CSR:7,CIH:10,CWOV:2,CSV:8,CFM:5,CCO:3,CGS:5,CSA:10,CW:3,CWI:2,CNC:2,CSJ:5,CMG:2,CJF:8,CB:5</salvage>
 		</faction>
 		<faction key='CSJ'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
 		</faction>
 		<faction key='CSR'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>CCC:1,CHH:5,CIH:8,CWOV:7,CSV:7,CFM:7,CCO:7,CGS:1,CSA:2,CDS:7,CW:5,CWI:2,CNC:5,CSJ:2,CMG:3,CJF:10,CB:5</salvage>
 		</faction>
 		<faction key='CSA'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>CCC:1,CHH:1,CSR:1,CIH:8,CWOV:1,CSV:6,CFM:10,CCO:3,CGS:4,CDS:4,CW:4,CSJ:1,CMG:4,CJF:9,CGB:2,CB:1</salvage>
@@ -161,33 +161,33 @@
 			<weightDistribution era='2815' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CSV'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>CCC:1,CHH:1,CSR:3,CIH:4,CWOV:1,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:4,CBS:1,CSJ:1,CMG:2,CJF:10,CGB:3,CB:1</salvage>
 		</faction>
 		<faction key='CWI'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>CHH:10,CIH:5,CSR:5,CDS:5,CW:10,CNC:5,CGS:10,CJF:5,CB:5</salvage>
 		</faction>
 		<faction key='CW'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='5'>CCC:2,CHH:1,CSR:2,CIH:4,CWOV:3,CSV:4,CFM:3,CCO:1,CGS:1,CSA:4,CDS:1,CWI:1,CBS:1,CNC:1,CSJ:3,CMG:1,CJF:10,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CWOV'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CCC:3,CHH:3,CSR:10,CIH:3,CSV:3,CFM:3,CCO:3,CGS:3,CSA:5,CDS:3,CW:10,CJF:5,CGB:3</salvage>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -993,7 +993,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cestus' unitType='Mek'>
-			<availability>IS:4+,FS:6,CS:4,PP:2+,CB:3+,CFM:2+,CJF:3+,CSJ:3+,NIOPS:4</availability>
+			<availability>IS:4+,FS:6,CS:4,PP:2+,CB:3+,CFM:2+,CJF:3+,CSJ:3+,NIOPS:4+</availability>
 			<model name='CTS-6Y'>
 				<availability>IS:8,PP:8,CB:8,CFM:8,CJF:8,CSJ:8,NIOPS:8</availability>
 			</model>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -623,9 +623,9 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>CC:1,MOC:1,CS:3-,LA:4,FS.CMM:4,IS:4,FS:4,MERC:3,TC:1</availability>
+			<availability>IS:4,FS:4,LA:4,CC:1,MERC:3,CS:3-,CIH!Front Line:2!Second Line:1,TC:1,MOC:1</availability>
 			<model name='ASN-21'>
-				<availability>General:8</availability>
+				<availability>IS:8,CIH:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Athena Cruiser' unitType='Warship'>
@@ -1069,10 +1069,10 @@
 			</model>
 		</chassis>
 		<chassis name='Cicada' unitType='Mek'>
-			<availability>CC:5,CS:4-,OA:3,LA:5,IS:5,FWL:5,FS:5,MERC:5,Periphery:3,DC:5</availability>
+			<availability>IS:5,FS:5,LA:5,DC:5,FWL:5,CC:5,MERC:5,CIH:3,CMG:3,CS:4-,Periphery:3,OA:3</availability>
 			<model name='CDA-2A'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CIH:8,CMG:8,Periphery:8</availability>
 			</model>
 		</chassis>
         <chassis name='Clan Field Artillery Point' unitType='Infantry'>
@@ -1380,12 +1380,12 @@
             </model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>PP:3,CC:7,MOC:4,CLAN:3-,IS:5,FS:7,MERC:5,CS:3-,OA:4,FWL:5,NIOPS:3-</availability>
+			<availability>IS:5,FS:7,CC:7,MERC:5,CS:3-,PP:3,CLAN:3-,CB:2-,CCO:2-,CGB:2-,CIH:4-,CMG:4-,CSJ:2-,CSA:2-,CWI:2-,CWOV:2-,MOC:4,OA:4,NIOPS:3-</availability>
 			<model name='CLNT-1-2R'>
-				<availability>CC:1,FS:1</availability>
+				<availability>FS:1,CC:1,CLAN:5+</availability>
 			</model>
 			<model name='CLNT-2-3T'>
-				<availability>PP:8,CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CLAN:4,Periphery:8,NIOPS:8</availability>
 			</model>
 			<model name='CLNT-2-4T'>
 				<availability>CC:4,FS:4</availability>
@@ -1532,22 +1532,22 @@
             </model>
         </chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>PP:5,CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,CJF:4,CGB:4</availability>
+			<availability>IS:3,MERC:3,CS:5,PP:5+,CLAN:5,CBS:4,CIH:4-,CWOV:4,Periphery:3,NIOPS:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
-				<availability>IS:5,Periphery.Deep:5,NIOPS:0,Periphery:5</availability>
+				<availability>IS:5,Periphery:5,NIOPS:0,Periphery.Deep:5</availability>
 			</model>
 			<model name='CRB-27'>
 				<roles>raider</roles>
-				<availability>PP:8,CS:8,CC:5+,LA:5+,CLAN:4,NIOPS:8,FWL:5+,DC:5+</availability>
+				<availability>LA:5+,DC:5+,FWL:5+,CC:5+,CS:8,PP:8,CLAN:5-,NIOPS:8</availability>
 			</model>
 			<model name='CRB-27b'>
 				<roles>raider</roles>
-				<availability>PP:2,CC:3+,CLAN:8,FWL:3+,CGS:8</availability>
+				<availability>FWL:3+,CC:3+,PP:2+,CLAN:5+,CBS:4+</availability>
 			</model>
 			<model name='CRB-27sl'>
                 <roles>raider</roles>
-				<availability>PP:4,LA:4+,CLAN:4,DC:4+</availability>
+				<availability>LA:4+,DC:4+,PP:1+,CLAN:2+,CB:3+,CCC:3+,CCO:3+,CGB:3+,CGS:3+,CSJ:3+,CSA:3+,CSV:3+,CWI:3+,CWOV:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
@@ -1749,12 +1749,12 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>PP:2,CC:4,LA:6,Periphery.HR:6,CLAN:4,IS:8,Periphery.Deep:6,FS:6,MERC:8,TC:6</availability>
+			<availability>IS:8,FS:6,CC:4,LA:6,MERC:8,PP:2,CBS:3+,CDS:3+,Periphery.HR:6,TC:6,Periphery.Deep:6</availability>
 			<model name='DV-6M'>
-				<availability>PP:4,CLAN:4,IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CBS:8,CDS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='DV-6Md'>
-				<availability>FS:6+</availability>
+				<availability>FS:6+,CBS:6,CDS:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Dictator' unitType='Dropship'>
@@ -2317,13 +2317,16 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>PP:4,CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:5,MERC:6,TC:7,Periphery:5,CS:4,OA:6,LA:9,NIOPS:4,DC:8</availability>
+			<availability>IS:9,LA:9,DC:8,CC:7,MERC:6,CS:4,PP:4,CLAN:6,CB:5,CHH:5,CIH:5+,CSR:5,CSA:5,CSV:5,CWI:5,CWOV:5,Periphery:5,TC:7,MOC:7,OA:6,NIOPS:4,Periphery.Deep:5</availability>
 			<model name='GRF-1N'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CCC:3-,CIH:3-,CJF:3-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='GRF-2N'>
-				<availability>PP:2,CC:3+,LA:3+,CLAN:6,FWL:3+,FS:3+</availability>
+				<availability>FS:3+,LA:3+,FWL:3+,CC:3+,PP:2+,CLAN:8,CCC:6,CIH:6,CJF:6</availability>
 			</model>
+            <model name='GRF-2N2'>
+                <availability>CIH:4,CMG:5-</availability>
+            </model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
 			<availability>PP:9,CS:7,CLAN:9,IS:8,NIOPS:7,FS:7,MERC:8</availability>
@@ -2628,21 +2631,21 @@
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
-			<availability>PP:3,CC:5,MOC:4,CHH:4,CSR:0,CLAN:3,FS:5,CGS:5,TC:5,OA:4,LA:5,FWL:5,DC:4</availability>
+			<availability>FS:5,LA:5,DC:4,FWL:5,CC:5,PP:3+,CBS:4+,CGB:5+,CGS:5+,CHH:6+,CJF:4+,CNC:3+,TC:5,MOC:4,OA:4</availability>
 			<model name='HOP-4B'>
                 <roles>inf_support,fire_support</roles>
 				<availability>CC:2</availability>
 			</model>
 			<model name='HOP-4Bb'>
                 <roles>fire_support</roles>
-				<availability>PP:4,CLAN:6</availability>
+				<availability>PP:4+,CBS:3,CGB:6,CGS:5,CHH:5,CJF:4,CNC:6</availability>
 			</model>
 			<model name='HOP-4C'>
                 <roles>inf_support</roles>
-				<availability>MOC:8,OA:8,FS:8</availability>
+				<availability>FS:8,PP:8,CBS:4-,CGB:4-,CGS:4-,CHH:4-,CJF:3-,CNC:4-,MOC:8,OA:8</availability>
 			</model>
 			<model name='HOP-4Cb'>
-				<availability>CHH:8</availability>
+				<availability>CHH!Keshik:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
@@ -2660,9 +2663,9 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>PP:5,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,NIOPS:5-</availability>
+			<availability>IS:5,CS:5-,PP:5+,CB:4+,CCO:4+,CSJ:4,CSV:4+,Periphery:5,NIOPS:5-,Periphery.Deep:5</availability>
 			<model name='HBK-4G'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CB:8,CCO:8,CSJ:8,CSV:8,Periphery:8,NIOPS:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='HBK-4H'>
 				<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
@@ -2926,15 +2929,15 @@
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
-			<availability>PP:8,CS:7,CHH:8,CDS:8,CSV:8,CLAN:7,FWL:5,NIOPS:7,FS:6,MERC:3,DC:5</availability>
+			<availability>FS:6,DC:5,FWL:5,MERC:3,CS:7,PP:6+,CLAN:4,CCC:5,CIH:4-,CMG:3,CSR:3,CSV:3,CWOV:3,NIOPS:7</availability>
 			<model name='KTO-18'>
 				<availability>FS:2</availability>
 			</model>
 			<model name='KTO-19'>
-				<availability>PP:8,CS:8,General:4,NIOPS:8,FS:4,MERC:4</availability>
+				<availability>IS:4,MERC:4,CS:8,PP:8,CLAN:4-,NIOPS:8</availability>
 			</model>
 			<model name='KTO-19b'>
-				<availability>PP:2,CLAN:8,CGS:8</availability>
+				<availability>PP:2+,CLAN:5</availability>
 			</model>
 		</chassis>
 		<chassis name='Kiso' unitType='Mek'>
@@ -2980,10 +2983,10 @@
 			</model>
 		</chassis>
 		<chassis name='Kyudo' unitType='Mek'>
-			<availability>PP:4,CLAN:4,FWL:4+,FS:4+</availability>
+			<availability>FS:4+,FWL:4+,PP:3+,CBS:3+,CCC:3+,CMG:3+,CDS:3+</availability>
 			<model name='KY2-D-02'>
 				<roles>fire_support</roles>
-				<availability>PP:8,CLAN:8,IS:8</availability>
+				<availability>FS:8,FWL:8,PP:8,CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='LRM Carrier' unitType='Tank'>
@@ -3207,10 +3210,10 @@
 			</model>
 		</chassis>
 		<chassis name='Lynx' unitType='Mek'>
-			<availability>PP:4,CIH:4,LA:3+,CLAN:4,FWL:3+,CSJ:4,CJF:4,DC:3</availability>
+			<availability>LA:3+,DC:3,FWL:3+,PP:3+,CLAN:5+,CBS:4+,CCC:4+,CFM:4+,CGS:4+,CHH:4+,CMG:4+,CNC:3+,CDS:3+,CSR:4+,CSA:3+,CWI:4+,CWOV:3+</availability>
 			<model name='LNX-9Q'>
                 <roles>raider</roles>
-				<availability>PP:8,CLAN:8,IS:8+</availability>
+				<availability>LA:8,DC:8,FWL:8,PP:8,CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -3540,6 +3543,12 @@
 				<availability>General:3</availability>
 			</model>
 		</chassis>
+        <chassis name='Mercury II' unitType='Mek'>
+            <availability>CWOV!Keshik:3</availability>
+            <model name='MCY-100'>
+                <availability>CWOV:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Mercury' unitType='Mek'>
 			<availability>IS:4+,MERC:4+,CS:8,CLAN:3+,CB:2+,CCO:2+,CIH:5+,CSJ:1,CWI:2+,PP:2+,NIOPS:8</availability>
 			<model name='MCY-98'>
@@ -3945,14 +3954,14 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>PP:5,CS:7,IS:7,FWL:7,NIOPS:7,Periphery.Deep:5,Periphery:5</availability>
+			<availability>IS:7,FWL:7,PP:5,CS:7,PP:4,CLAN:4+,CB:3+,CCO:3+,CGB:3+,CGS:6+,CIH:5,CWI:3+,Periphery:5,NIOPS:7,Periphery.Deep:5</availability>
 			<model name='PXH-1'>
 				<roles>command,recon</roles>
-				<availability>PP:6,General:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CGB:4-,CIH:3-,CJF!Second Line:3!Solahma:4!Provisional Garrison:5,Periphery:8,NIOPS:4-</availability>
 			</model>
 			<model name='PXH-1-EC'>
                 <roles>command,recon</roles>
-				<availability>CGS:4</availability>
+				<availability>CGS!Keshik:3</availability>
 			</model>
 			<model name='PXH-1D'>
 				<roles>command,recon</roles>
@@ -3968,15 +3977,15 @@
 			</model>
 			<model name='PXH-1b &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>PP:2,CLAN:7</availability>
+				<availability>PP:2+,CLAN:8,CGB:5,CGS:4,CIH:6,NIOPS:4+</availability>
 			</model>
 			<model name='PXH-1c &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:4,CGS:5</availability>
+				<availability>CGS:3+</availability>
 			</model>
 			<model name='PXH-2'>
 				<roles>command,recon</roles>
-				<availability>PP:4,CC:4+,MOC:4+,OA:4+,FWL:4+</availability>
+				<availability>FWL:4+,CC:4+,PP:3+,CLAN:2+,CCC:3+,CIH:3+,CJF:3+,CMG:3+,CSA:3+,CW:3+,MOC:4+,OA:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
@@ -4337,9 +4346,9 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>PP:2-,CC:5-,CS:3-,LA:5-,FWL:5-,NIOPS:3-,Periphery.Deep:5-,MERC:5-,Periphery:5-,DC:5-</availability>
+			<availability>LA:5-,DC:5-,FWL:5-,CC:5-,MERC:5-,CS:3-,PP:2-,CGS:3-,Periphery:5-,NIOPS:3-,Periphery.Deep:5-</availability>
 			<model name='SCP-1N'>
-				<availability>LA:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CGS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Scout JumpShip' unitType='Jumpship'>
@@ -4363,15 +4372,15 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>PP:6,CC:1,CSV:5,CLAN:6,CFM:7,FS:3,CGS:5,CS:4,CDS:5,CW:5,LA:6,CBS:5,FWL:3,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
+			<availability>FS:3,LA:6,DC:3,FWL:3,CC:1,CS:4,PP:6,CLAN:5-,CBS:6-,CB:4-,CCO:4-,CFM:6-,CGB:6-,CIH:6,CDS:3,CSJ:4-,CSR:6-,CSA:4-,CSV:4-,CWI:4-,CWOV:4-,NIOPS:4</availability>
 			<model name='STN-1S'>
 				<availability>LA:2,FWL:2,FS:2</availability>
 			</model>
 			<model name='STN-3L'>
-				<availability>PP:8,CS:8,LA:8+,NIOPS:8,FWL:8+,FS:8+,MERC:8+</availability>
+				<availability>FS:8+,LA:8+,FWL:8+,MERC:8+,CS:8,PP:8,CLAN:8,CBS:4-,CCC:4,CFM:3,CGB:4-,CHH:4-,CJF:4,CDS:4-,CSR:4-,NIOPS:8</availability>
 			</model>
 			<model name='STN-3Lb'>
-				<availability>PP:2,CLAN:8</availability>
+				<availability>PP:2+,CBS:4+,CCC:4+,CFM:4+,CGB:4+,CHH:4+,CJF:4+,CDS:4+,CSR:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
@@ -4386,15 +4395,15 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>PP:4,CS:6-,LA:6,CLAN:4,IS:7,NIOPS:6-,Periphery.Deep:5,Periphery:5</availability>
+			<availability>IS:7,LA:6,CS:6-,PP:4,CLAN:5,CIH:4,Periphery:5,NIOPS:6-,Periphery.Deep:5</availability>
 			<model name='SHD-2D'>
 				<availability>FS:8</availability>
 			</model>
 			<model name='SHD-2H'>
-				<availability>General:8</availability>
+				<availability>IS:8,MERC:8,PP:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='SHD-2Hb'>
-				<availability>PP:2,CLAN:8,FS:3+</availability>
+				<availability>FS:3+,PP:3+,CLAN:8</availability>
 			</model>
 			<model name='SHD-2K'>
 				<availability>DC:9</availability>
@@ -4554,6 +4563,18 @@
 				<availability>IS:8,CIH:8,CMG:8,PP:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
+        <chassis name='Stag II' unitType='Mek'>
+            <availability>CWOV!Keshik:3</availability>
+            <model name='ST-24G'>
+                <availability>CWOV:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Stag' unitType='Mek'>
+            <availability>CWOV!Keshik:3</availability>
+            <model name='ST-14G'>
+                <availability>CWOV:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Stalker' unitType='Mek'>
 			<availability>PP:9,CC:7,CLAN:7,IS:8,Periphery.Deep:9,FS:7,CIR:9,Periphery:9,CS:6,LA:8,FWL:9,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
@@ -4579,14 +4600,14 @@
 			</model>
 		</chassis>
 		<chassis name='Starslayer' unitType='Mek'>
-			<availability>CSA:2,LA:5+,CNC:3</availability>
+			<availability>LA:5+,CNC:4+,CSA:4+</availability>
 			<model name='STY-2C'>
 				<roles>raider</roles>
-				<availability>IS:8</availability>
+				<availability>LA:8,CNC:8,CSA:8</availability>
 			</model>
 			<model name='STY-2C-EC'>
 			    <roles>raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CNC!Keshik:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Stinger LAM Mk I' unitType='Mek'>
@@ -4857,14 +4878,14 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:4,MOC:4,CS:5-,FWL:6,NIOPS:5-,MERC:4</availability>
+			<availability>FWL:6,CC:4,MERC:4,CS:5-,CDS:3+,MOC:4,NIOPS:5-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
-				<availability>CC:4+,CS:6,FWL:4+,NIOPS:6</availability>
+				<availability>FWL:4+,CC:4+,CS:6,CDS:8,NIOPS:6</availability>
 			</model>
 			<model name='TBT-5N'>
 				<roles>fire_support</roles>
-				<availability>CC:2,CS:2,MOC:2,FWL:2,NIOPS:2,MERC:2</availability>
+				<availability>FWL:2,CC:2,MERC:2,CS:2,MOC:8,NIOPS:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Trident' unitType='AeroSpaceFighter'>
@@ -5041,14 +5062,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>PP:5,CC:4,CS:3,MOC:4,LA:7,FWL:7,IS:5,NIOPS:3,CIR:4,TC:4</availability>
+			<availability>IS:5,LA:7,FWL:7,CC:4,CS:3,PP:5,CWOV:3-,TC:4,MOC:4,CIR:4,NIOPS:3</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
-				<availability>General:8,FS:4</availability>
+				<availability>IS:8,FS:4,PP:6,CWOV:8,Periphery:8</availability>
 			</model>
 			<model name='VL-5T'>
 				<roles>anti_infantry</roles>
-				<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,TC:2</availability>
+				<availability>IS:2,FS:6,PP:3+,CWOV:5+,TC:2,MOC:2,CIR:2,PIR:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Vulture' unitType='Dropship'>
@@ -5154,13 +5175,13 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>PP:4,MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+			<availability>FS.CMM:5,DC:6,MERC:3,CS:3-,PP:4,CB:3-,CWI:3-,Periphery.DD:2,Periphery.OS:2,TC:2,MOC:1,OA:1,NIOPS:3-</availability>
 			<model name='WTH-0'>
 				<availability>TC:6</availability>
 			</model>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
-				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CB:8,CWI:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='WTH-1S'>
 				<roles>fire_support</roles>
@@ -5168,14 +5189,14 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine II' unitType='Mek'>
-			<availability>CWOV:8,CLAN:4</availability>
+			<availability>CMG:3+,CSR:3+,CW:2+,CWOV:6+</availability>
 			<model name='WVR-7H'>
                 <roles>command,recon</roles>
-				<availability>General:8</availability>
+				<availability>CMG:8,CSR:8,CW:8,CWOV:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>PP:5,CWOV:6,CLAN:3,IS:7,Periphery.Deep:6,TC:5,CS:5-,FWL:9,NIOPS:5-,DC:6</availability>
+			<availability>IS:7,DC:6,FWL:9,CS:5-,PP:4+,CLAN:3-,CGS:2-,CIH:2-,CMG:2-,CWOV:4-,TC:5,NIOPS:5-,Periphery.Deep:6</availability>
 			<model name='WVR-1R'>
 				<availability>FS:2-</availability>
 			</model>
@@ -5189,21 +5210,21 @@
 			</model>
 			<model name='WVR-6R'>
 				<roles>command,recon</roles>
-				<availability>General:8,CLAN:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CLAN:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>PP:6,CS:6,CC:6,CIH:5,CLAN:6,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:5</availability>
+			<availability>FS:6,DC:6,CC:6,MERC:5,CS:6,PP:6,CLAN:4,CCC:3,CGB:3,CGS:3,CIH:2-,CJF:3,CMG:4-,CDS:3,CSJ:2,CSR:3,CSV:3,CW:3,CWOV:3,NIOPS:6,TC:5</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
-				<availability>CS:8,CC:8,NIOPS:8,FS:8,DC:8,TC:8</availability>
+				<availability>FS:8,DC:8,CC:8,CS:8,PP:6,CBS:4-,CB:4-,CCO:4-,CFM:4-,TC:8,NIOPS:8</availability>
 			</model>
 			<model name='WVE-5Nb'>
 				<roles>urban</roles>
-				<availability>PP:2,CLAN:8,CFM:8,CGS:8</availability>
+				<availability>PP:2+,CLAN:6</availability>
 			</model>
 			<model name='WVE-5Nsl'>
-				<availability>LA:4+,FWL:4+</availability>
+				<availability>LA:4+,FWL:4+,PP:2+,CLAN:3-,CBS:2-,CB:2-,CCO:2-,CFM:2-</availability>
 			</model>
 			<model name='WVE-6N'>
 				<roles>urban</roles>

--- a/megamek/data/forcegenerator/2815.xml
+++ b/megamek/data/forcegenerator/2815.xml
@@ -1418,7 +1418,7 @@
             </model>
         </chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>LA:9,CGS:3-,CSJ:3,CIR:4,MERC:4</availability>
+			<availability>LA:9,MERC:4,CGS:3-,CSJ:3,CIR:4</availability>
 			<model name='COM-1D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
@@ -2023,13 +2023,13 @@
 				<availability>FS:8,CC:8,CFM:6,CHH:4,CSR:5,PP:4</availability>
 			</model>
 			<model name='FFL-3PP'>
-				<availability>PP:3</availability>
+				<availability>PP:3+</availability>
 			</model>
 			<model name='FFL-3PP2'>
-				<availability>PP:3</availability>
+				<availability>PP:3+</availability>
 			</model>
 			<model name='FFL-3PP3'>
-				<availability>PP:3</availability>
+				<availability>PP:3+</availability>
 			</model>
 			<model name='FFL-3SLE'>
 				<availability>CLAN:8,CFM:5+,CHH:5+,CSR:4+,PP:4+</availability>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -1076,9 +1076,9 @@
 			</model>
 		</chassis>
 		<chassis name='Cestus' unitType='Mek'>
-			<availability>IS:3+,FS:6,CS:4,CB:3+,CFM:2+,CJF:3+,CSJ:3+,NIOPS:4</availability>
+			<availability>IS:3+,FS:6,CS:4,CB:3+,CFM:2+,CJF:3+,CSJ:3+,NIOPS:4+</availability>
 			<model name='CTS-6Y'>
-				<availability>IS:8,CB:8,CFM:5,CJF:8,CSJ:8</availability>
+				<availability>IS:8,CB:8,CFM:5,CJF:8,CSJ:8,NIOPS:8</availability>
 			</model>
 			<model name='CTS-6Y-EC'>
 				<availability>CFM!Keshik:3</availability>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2823-->
-<ratgen
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -2755,7 +2755,7 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>IS:4,MERC:4,CS:9,CLAN:4+,CCC:3+,CIH:3+,CSV:3+,NIOPS:9</availability>
+			<availability>IS:4,MERC:4,CS:9,CLAN:4+,CCC:3+,CIH:3+,CSV:3+,NIOPS:9+</availability>
 			<model name='HGN-732'>
                 <roles>command</roles>
 				<availability>IS:8,FWL:7+,CS:8,CLAN:4-,NIOPS:8</availability>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -22,17 +22,17 @@
 			<weightDistribution era='2823' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 		</faction>
 		<faction key='CBS'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CHH:5,CCC:5,CDS:1,CW:5,CSV:10,CNC:5,CCO:5,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CB'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CCC:1,CHH:7,CSR:5,CIH:5,CSV:3,CFM:3,CCO:7,CGS:3,CSA:2,CDS:5,CW:3,CWI:2,CBS:3,CNC:10,CSJ:2,CMG:2,CJF:5</salvage>
@@ -40,17 +40,17 @@
 			<weightDistribution era='2823' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CCC'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CHH:2,CSR:1,CIH:3,CWOV:2,CSV:3,CFM:3,CCO:10,CGS:2,CSA:3,CDS:1,CW:5,CBS:2,CNC:7,CJF:7,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CCO'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CCC:8,CHH:1,CSR:5,CIH:8,CWOV:1,CSV:3,CFM:8,CGS:1,CSA:5,CDS:2,CW:1,CBS:1,CNC:5,CSJ:8,CJF:10,CB:5</salvage>
@@ -58,17 +58,17 @@
 			<weightDistribution era='2823' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CFM'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:9,CWOV:1,CSV:6,CCO:4,CGS:7,CSA:10,CDS:2,CW:3,CNC:1,CSJ:3,CMG:3,CJF:9,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CGB'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CHH:10,CCC:3,CIH:5,CSR:1,CWOV:3,CSV:10,CFM:3,CGS:1,CCO:1,CSA:8,CDS:1,CW:8,CMG:3,CJF:5</salvage>
@@ -76,25 +76,25 @@
 			<weightDistribution era='2823' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CGS'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,5,10,15</pctClan>
-			<pctSL>100,100,95,90,85</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,5,10,15 -->
+            <!-- Star League percentages: 100,100,95,90,85 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CCC:1,CHH:3,CSR:1,CIH:6,CWOV:1,CSV:3,CFM:10,CCO:1,CSA:6,CDS:3,CW:1,CWI:2,CNC:2,CSJ:1,CMG:2,CJF:8,CB:2</salvage>
 		</faction>
 		<faction key='CHH'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CCC:2,CSR:6,CIH:8,CWOV:2,CSV:4,CFM:8,CCO:2,CGS:6,CSA:4,CDS:10,CW:4,CWI:4,CBS:2,CNC:10,CSJ:6,CMG:2,CJF:10,CGB:8,CB:8</salvage>
 		</faction>
 		<faction key='CIH'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,90,80</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,90,80 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CCC:2,CHH:3,CSR:4,CWOV:1,CSV:5,CFM:10,CCO:5,CGS:5,CSA:8,CDS:5,CW:4,CWI:1,CNC:2,CSJ:3,CMG:5,CJF:8,CGB:2,CB:2</salvage>
@@ -102,57 +102,57 @@
 			<weightDistribution era='2823' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
 		<faction key='CJF'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CCC:3,CHH:4,CSR:4,CIH:8,CWOV:1,CSV:10,CFM:9,CCO:6,CGS:6,CSA:9,CDS:4,CW:10,CWI:1,CBS:1,CNC:2,CSJ:1,CMG:3,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CMG'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CHH:3,CIH:10,CSR:3,CSV:8,CFM:8,CGS:5,CSA:8,CDS:3,CW:3,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
 		</faction>
 		<faction key='CNC'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CCC:7,CHH:8,CSR:5,CIH:3,CFM:3,CCO:7,CGS:3,CDS:2,CW:3,CWI:2,CBS:2,CSJ:5,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CDS'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='12'>CCC:1,CHH:8,CSR:7,CIH:10,CWOV:2,CSV:8,CFM:5,CCO:3,CGS:5,CSA:10,CW:3,CWI:2,CNC:2,CSJ:5,CMG:2,CJF:8,CB:5</salvage>
 		</faction>
 		<faction key='CSJ'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
 		</faction>
 		<faction key='CSR'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CCC:1,CHH:5,CIH:8,CWOV:7,CSV:7,CFM:7,CCO:7,CGS:1,CSA:2,CDS:7,CW:5,CWI:2,CNC:5,CSJ:2,CMG:3,CJF:10,CB:5</salvage>
 		</faction>
 		<faction key='CSA'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CCC:1,CHH:1,CSR:1,CIH:8,CWOV:1,CSV:6,CFM:10,CCO:3,CGS:4,CDS:4,CW:4,CSJ:1,CMG:4,CJF:9,CGB:2,CB:1</salvage>
@@ -160,33 +160,33 @@
 			<weightDistribution era='2823' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CSV'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CCC:1,CHH:1,CSR:3,CIH:4,CWOV:1,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:4,CBS:1,CSJ:1,CMG:2,CJF:10,CGB:3,CB:1</salvage>
 		</faction>
 		<faction key='CWI'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CHH:10,CIH:5,CSR:5,CDS:5,CW:10,CNC:5,CGS:10,CJF:5,CB:5</salvage>
 		</faction>
 		<faction key='CW'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CCC:2,CHH:1,CSR:2,CIH:4,CWOV:3,CSV:4,CFM:3,CCO:1,CGS:1,CSA:4,CDS:1,CWI:1,CBS:1,CNC:1,CSJ:3,CMG:1,CJF:10,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CWOV'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,0,0</pctClan>
-			<pctSL>100,100,100,100,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,0,0 -->
+            <!-- Star League percentages: 100,100,100,100,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,0,0</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,100,100</pctSL>
 			<salvage pct='10'>CCC:3,CHH:3,CSR:10,CIH:3,CSV:3,CFM:3,CCO:3,CGS:3,CSA:5,CDS:3,CW:10,CJF:5,CGB:3</salvage>
@@ -1495,7 +1495,7 @@
             </model>
         </chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>LA:9,CSJ:4,CIR:4,MERC:4,CGS:4</availability>
+			<availability>LA:9,MERC:4,CGS:3-,CSJ:3,CIR:4</availability>
 			<model name='COM-1D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
@@ -1504,7 +1504,7 @@
 			<model name='COM-2D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
-				<availability>LA:8,General:8,Periphery.Deep:8</availability>
+				<availability>IS:8,MERC:8,CGS:8,CSJ:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Commonwealth Light Cruiser' unitType='Warship'>
@@ -1872,9 +1872,9 @@
 			</model>
 		</chassis>
         <chassis name='Drift Shag' unitType='Mek'>
-            <availability>CIH:2:2827</availability>
+            <availability>CGS:1+:2828,CIH:3+,CMG:1+:2828</availability>
             <model name=''>
-                <availability>CLAN:8</availability>
+                <availability>CGS:8,CIH:8,CMG:8</availability>
             </model>
         </chassis>
 		<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -2056,13 +2056,19 @@
             </model>
 		</chassis>
 		<chassis name='Falcon' unitType='Mek'>
-			<availability>CC:3,MOC:2,OA:2,CIH:6,LA:4,CLAN:4,FWL:3,FS:3,MERC:3,CGS:5,TC:2</availability>
+			<availability>FS:3,LA:4,FWL:3,CC:3,MERC:3,CGS:6+,PP:4+,TC:2,MOC:2,OA:2</availability>
 			<model name='FLC-4N'>
-				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CGS:4,PP:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='FLC-4Nb'>
-				<availability>CLAN:8</availability>
+				<availability>CGS:3+</availability>
 			</model>
+            <model name='FLC-4Nb-PP'>
+                <availability>PP:4</availability>
+            </model>
+            <model name='FLC-4Nb-PP2'>
+                <availability>PP:4</availability>
+            </model>
 		</chassis>
 		<chassis name='Field Artillery' unitType='Infantry'>
 			<availability>IS:3,Periphery:3</availability>
@@ -2105,13 +2111,22 @@
 			</model>
 		</chassis>
 		<chassis name='Firefly' unitType='Mek'>
-			<availability>CC:3,OA:1+,CIH:7,CLAN:8,FS:3,CB:7</availability>
+			<availability>FS:3,CC:3,CLAN:4+,CBS:3+,CB:5+,CCC:3+,CGB:7+,CGS:3+,CHH:5+,CIH:3-,CMG:3-,CDS:3,CSV:5-,CWOV:3+,PP:3+,OA:1+</availability>
 			<model name='FFL-3A'>
 				<roles>spotter</roles>
-				<availability>CC:8,FS:8</availability>
+				<availability>FS:8,CC:8,CFM:6,CHH:4,CSR:5,PP:4</availability>
 			</model>
+            <model name='FFL-3PP'>
+                <availability>PP:3</availability>
+            </model>
+            <model name='FFL-3PP2'>
+                <availability>PP:2+</availability>
+            </model>
+            <model name='FFL-3PP3'>
+                <availability>PP:2+</availability>
+            </model>
 			<model name='FFL-3SLE'>
-				<availability>CLAN:8</availability>
+				<availability>CLAN:8,CFM:5+,CHH:5+,CSR:4+,PP:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Firestarter' unitType='Mek'>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -1504,7 +1504,7 @@
 			<model name='COM-2D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
-				<availability>IS:8,MERC:8,CGS:8,CSJ:8,Periphery:8,Periphery.Deep:8</availability>
+				<availability>LA:8,MERC:8,CGS:8,CSJ:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Commonwealth Light Cruiser' unitType='Warship'>
@@ -5259,7 +5259,7 @@
 			<availability>IS:3-,CC:5-,CLAN:1-,PP:4-,Periphery:2-,CS:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
-				<availability>IS:8,MERC:8,CLAN:8,PP:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CLAN:8,PP:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Valkyrie' unitType='Mek'>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -2673,6 +2673,14 @@
                 <availability>CLAN:3,PP:3,IS:3,FWL:3</availability>
             </model>
         </chassis>
+        <chassis name='Helepolis' unitType='Mek'>
+            <availability>CLAN:2-,CHH:3-</availability>
+            <model name='HEP-3H'>
+                <roles>mixed_artillery</roles>
+                <deployedWith>Helepolis</deployedWith>
+                <availability>CLAN:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 			<availability>CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,FWL:4,NIOPS:6,DC:4</availability>
 			<model name='HCT-213B'>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2823-->
-<ratgen>
+<ratgen
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BoS'>
 			<salvage pct='10'></salvage>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -3381,7 +3381,7 @@
 			<availability>LA:4+,DC:4+,FWL:4+,CLAN:5+,CBS:4+,CCC:4+,CFM:4+,CGS:4+,CHH:4+,CMG:4+,CNC:3+,CDS:3+,CSR:4+,CSA:3+,CWI:4+,CWOV:3+</availability>
 			<model name='LNX-9Q'>
                 <roles>raider</roles>
-				<availability>CLAN:8,IS:6+</availability>
+				<availability>IS:8,CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Lyonesse Escort' unitType='Small Craft'>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -587,18 +587,12 @@
 			</model>
 		</chassis>
 		<chassis name='Annihilator' unitType='Mek'>
-			<availability>CSA:3,CHH:3,CSR:3,CLAN:3,CCO:3,CGB:3</availability>
+			<availability>CB:3+,CCO:3+,CGB:3+,CSA:3+,CWI:3+</availability>
 			<model name='ANH-1G'>
-				<availability>CSA:6,CCO:6</availability>
+                <availability>CGB!Keshik:5!Front Line:1</availability>
 			</model>
 			<model name='ANH-1X'>
-				<availability>CSA:2,CLAN:6,CCO:2</availability>
-			</model>
-			<model name='C'>
-				<availability>CLAN:6</availability>
-			</model>
-			<model name='C 2'>
-				<availability>CLAN:3</availability>
+				<availability>CB:8,CCO:8,CGB:8,CSA:8,CWI:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aquarius Escort' unitType='Small Craft'>
@@ -712,26 +706,30 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas II' unitType='Mek'>
-			<availability>CLAN:5</availability>
+			<availability>CLAN:3+,CBS:2+,CCC:2+,CIH:2+,CMG:2+,CSA:2+,CWI:2+</availability>
 			<model name='AS7-D-H'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CLAN:5</availability>
 			</model>
 			<model name='AS7-D-H2'>
                 <roles>command</roles>
-				<availability>CLAN:4</availability>
+				<availability>CLAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>CC:3,MOC:1,CS:4-,OA:1,LA:4,IS:3,FWL:3,NIOPS:4-,FS:5,TC:1,DC:5</availability>
+			<availability>IS:3,FS:5,LA:4,DC:5,CS:4-,PP:4+,CLAN:4,CCC:3,CGS:3,CIH:2,CMG:3,CDS:3,CSV:3,TC:1,MOC:1,OA:1,NIOPS:4-</availability>
 			<model name='AS7-D'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,PP:8,CLAN:8,Periphery:8</availability>
 			</model>
 			<model name='AS7-D-DC'>
 				<roles>command</roles>
-				<availability>IS:1,MERC:0,DC:2</availability>
+				<availability>IS:1+,DC:2+,MERC:0,CLAN:1+,CCO:0,CFM:0,CIH:0,CSJ:0,CSV:0</availability>
 			</model>
+            <model name='C'>
+                <roles>command</roles>
+                <availability>CB!Keshik:3,CWI!Keshik:3</availability>
+            </model>
 		</chassis>
 		<chassis name='Atreus Battleship' unitType='Warship'>
 			<availability>FWL:4</availability>
@@ -755,9 +753,9 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:7,CLAN:4-,IS:7,Periphery.Deep:5,CIR:7,TC:7,Periphery:5,CS:8,OA:7,FWL:9,NIOPS:8</availability>
+			<availability>IS:7,FWL:9,CS:8,PP:3+,CSA:3,Periphery:5,TC:7,MOC:7,OA:7,CIR:7,NIOPS:8,Periphery.Deep:5+</availability>
 			<model name='AWS-8Q'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CSA:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='AWS-8R'>
 				<availability>CS:2,FWL:4</availability>
@@ -812,10 +810,10 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:7,MOC:6,CLAN:4,IS:6,TC:6,CS:8-,LA:8,PIR:6,FWL:8,NIOPS:8-,DC:7</availability>
+			<availability>IS:6,LA:8,DC:7,FWL:8,CC:7,CS:8-,PP:4,CLAN:6,CB:5,CCO:5,CGB:5,CIH:5,CSJ:4,CSA:5,CWI:5,CWOV:5,TC:6,MOC:6,NIOPS:8-,PIR:6</availability>
 			<model name='BLR-1G'>
                 <roles>command</roles>
-				<availability>IS:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,Periphery:8,Periphery.Deep:8,PIR:8</availability>
 			</model>
             <model name='BLR-1G-DC'>
                 <roles>command</roles>
@@ -823,15 +821,15 @@
             </model>
 			<model name='BLR-1Gb'>
                 <roles>command</roles>
-				<availability>CC:2+,CLAN:8</availability>
+				<availability>CC:2+,PP:1+,CLAN:8</availability>
 			</model>
 			<model name='BLR-1Gbc'>
                 <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>CLAN:1+,CCO:0,CFM:0,CIH:0,CSJ:0,CSV:0</availability>
 			</model>
 			<model name='BLR-1Gc'>
                 <roles>command</roles>
-				<availability>CC:3+,LA:3+,CLAN:4,FWL:3+,FS:2+,DC:2+</availability>
+				<availability>FS:2+,LA:3+,DC:2+,FWL:3+,CC:3+,CSA!Front Line:1</availability>
 			</model>
 			<model name='BLR-1Gd'>
                 <roles>command</roles>
@@ -1629,12 +1627,12 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>CC:6,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:6,CGS:8,CS:8,CDS:8,CW:10,LA:6,CBS:10,FWL:6,NIOPS:8,CJF:8,CGB:10,DC:6</availability>
+			<availability>FS:6,LA:6,DC:6,FWL:6,CC:6,CS:8,PP:2+,CLAN:4-,CBS:5-,CCO:5-,CGB:5-,CHH:5-,CW:5-,NIOPS:8</availability>
 			<model name='CRK-5003-1'>
-				<availability>CS:8,General:6+,CLAN:6,NIOPS:8</availability>
+				<availability>IS:6+,CS:8,PP:8,CLAN:8,CBS:4-,CB:4-,CCO:4-,CGB:4-,CHH:4-,CW:4-,NIOPS:8</availability>
 			</model>
 			<model name='CRK-5003-1b'>
-				<availability>CLAN:8,CGS:8</availability>
+				<availability>CBS:5,CB:5,CCO:5,CGB:5,CHH:5,CW:5</availability>
 			</model>
 		</chassis>
 		<chassis name='Crossbow' unitType='Mek'>
@@ -1699,7 +1697,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,CS:3,OA:3,LA:5,CLAN:5,IS:3,FWL:4,NIOPS:3,FS:5,TC:3,DC:5</availability>
+			<availability>IS:3,FS:5,LA:5,DC:5,FWL:4,CC:5,CS:3,CLAN!Front Line:1,CFM!Second Line:1,CGB!Second Line:1,CJF!Second Line:1,CSJ!Second Line:1,CSA!Second Line:1,CSV!Second Line:1,CWI!Second Line:1,TC:3,OA:3,NIOPS:3</availability>
 			<model name='CP-10-HQ'>
                 <roles>command</roles>
 				<availability>IS:2</availability>
@@ -1710,7 +1708,7 @@
 			</model>
 			<model name='CP-10-Z'>
                 <roles>command</roles>
-				<availability>OA:8,IS:8,FS:8,MERC:8,DC:8,TC:8</availability>
+				<availability>IS:8,FS:8,DC:8,MERC:8,CLAN:8,TC:8,OA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
@@ -1923,17 +1921,17 @@
             </model>
         </chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>MOC:5,CC:6,CS:7,OA:5,CLAN:3,CNC:3,FWL:7,NIOPS:7,FS:6,MERC:6,TC:5</availability>
+			<availability>FS:6,FWL:7,CC:6,MERC:6,CS:7,PP:1+,CLAN:3+,CSA:2+,TC:5,MOC:5,OA:5,NIOPS:7</availability>
 			<model name='EMP-5A'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,PP:8,Periphery:8,NIOPS:2-</availability>
 			</model>
 			<model name='EMP-6A'>
                 <roles>command</roles>
-				<availability>CC:4+,CS:8,LA:4+,CLAN:8,NIOPS:8,FWL:4+,FS:4+</availability>
+				<availability>FS:4+,LA:4+,FWL:4+,CC:4+,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 			<model name='EMP-6A-EC'>
-				<availability>CSA:6</availability>
+				<availability>CSA!Keshik:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Enfield' unitType='Mek'>
@@ -2751,14 +2749,14 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>CS:9,CLAN:9,NIOPS:9,IS:4,CFM:10,MERC:4,CJF:10</availability>
+			<availability>IS:4,MERC:4,CS:9,CLAN:4+,CCC:3+,CIH:3+,CSV:3+,NIOPS:9</availability>
 			<model name='HGN-732'>
                 <roles>command</roles>
-				<availability>CS:8,CLAN:6,FWL:7+,IS:8,NIOPS:8</availability>
+				<availability>IS:8,FWL:7+,CS:8,CLAN:4-,NIOPS:8</availability>
 			</model>
 			<model name='HGN-732b'>
                 <roles>command</roles>
-				<availability>CLAN:8,FWL:3+</availability>
+				<availability>FWL:3+,CLAN:6,CWOV:5,NIOPS:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
@@ -2837,18 +2835,18 @@
 			</model>
 		</chassis>
 		<chassis name='Imp' unitType='Mek'>
-			<availability>CSA:2,CW:2,CLAN:2</availability>
+			<availability>CB:2+,CCO:2+,CGB:2+,CSJ:2+,CWI:2+,CW:2+</availability>
 			<model name='IMP-1A'>
                 <roles>command</roles>
-				<availability>CLAN:8</availability>
+				<availability>CB:6,CCO:6,CGB:6,CSJ:6,CWI:6,CW:6</availability>
 			</model>
 			<model name='IMP-1B'>
                 <roles>command</roles>
-				<availability>CLAN:4</availability>
+				<availability>CB!Keshik:6!Front Line:1,CCO!Keshik:6!Front Line:1,CGB!Keshik:6!Front Line:1,CSJ!Keshik:6!Front Line:1,CW!Keshik:6!Front Line:1</availability>
 			</model>
 			<model name='IMP-1C'>
                 <roles>command</roles>
-				<availability>CHH:8:2825,CLAN:4:2825</availability>
+				<availability>CB!Keshik:3,CCO!Keshik:3,CGB!Keshik:3,CSJ!Keshik:3,CWI!Keshik:3,CW!Keshik:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
@@ -3069,10 +3067,10 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CS:6,CLAN:6,IS:2+,NIOPS:6,MERC:2+,CGS:7,CGB:7</availability>
+			<availability>IS:2+,MERC:2+,CS:6,PP:2+,CLAN:4,CCC:2,CFM:5,CGS:3,CHH:3,CIH:2,CMG:2,CDS:3,CSR:2,CSA:3,CSV:3,CWI:5,NIOPS:6</availability>
 			<model name='KGC-000'>
                 <roles>command</roles>
-				<availability>CS:8,CIH:5,General:5,CLAN:6,NIOPS:8,CB:5</availability>
+				<availability>IS:5,CS:8,PP:8,CLAN:3-,CCC:2-,CIH:2-,NIOPS:8</availability>
 			</model>
 			<model name='KGC-0000'>
                 <roles>command</roles>
@@ -3080,11 +3078,11 @@
 			</model>
 			<model name='KGC-000b'>
                 <roles>command</roles>
-				<availability>CLAN:8,CGS:8</availability>
+				<availability>CB:5,CFM:5,CGB:5,CGS:5,CWI:5,CW:5</availability>
 			</model>
 			<model name='KGC-010'>
                 <roles>command</roles>
-				<availability>CLAN:4</availability>
+				<availability>CLAN:3+,CCC:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
@@ -3139,9 +3137,9 @@
 			</model>
 		</chassis>
 		<chassis name='Kraken (Bane)' unitType='Mek'>
-			<availability>CLAN:6:2827</availability>
+			<availability>CJF!Keshik:3,CDS:1+:2828,CSR:1+:2828,CW:1+:2828</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CJF:8,CDS:8,CSR:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Kruger Combat Car' unitType='Tank'>
@@ -3329,22 +3327,22 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>CC:6,CLAN:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>IS:7,FS:8,DC:5,FWL:9,CC:6,CS:4,PP:3,CLAN:1-,CBS:2-,CB:2-,CCO:2-,CGB:2-,CHH:2-,CDS:3,CSR:3,CSA:2-,CWI:2-,CWOV:3,Periphery:7,NIOPS:4,Periphery.Deep:7</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
-				<availability>IS:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,Periphery:8</availability>
 			</model>
 			<model name='LGB-0W2'>
                 <roles>fire_support</roles>
-				<availability>IS:5,MERC:4,Periphery:3</availability>
+				<availability>IS:5,MERC:4,PP:5,Periphery:3</availability>
 			</model>
 			<model name='LGB-7Q'>
 				<roles>fire_support</roles>
-				<availability>MOC:6,OA:6,IS:6,TC:6,CLAN:6</availability>
+				<availability>IS:6,PP:6+,CDS:8,CSR:8,CWOV:8,TC:6,MOC:6,OA:6</availability>
 			</model>
 			<model name='LGB-8C'>
                 <roles>fire_support</roles>
-				<availability>MOC:3,CS:6,OA:3,IS:6,MERC:3,TC:3,CLAN:6</availability>
+				<availability>IS:6,MERC:3,CS:6,PP:6+,CLAN:8,CDS:3-,CSR:2-,CWOV:2-,TC:3,MOC:3,OA:3</availability>
 			</model>
 		</chassis>
         <chassis name='Luciano White Wolverine' unitType='Tank'>
@@ -3407,6 +3405,12 @@
                 <availability>CLAN:8,PP:8,IS:6,CS:7,Periphery:4,Periphery.Deep:0</availability>
             </model>
 		</chassis>
+        <chassis name='Mackie' unitType='Mek'>
+            <availability>CSJ:2-,CSV:2-</availability>
+            <model name='MSK-7A'>
+                <availability>CSJ:8,CSV:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Magi Infantry Support Vehicle' unitType='Tank'>
 			<availability>MOC:3,CS:5,CHH:6,OA:3,CLAN:5,IS:2,NIOPS:5,TC:3</availability>
 			<model name=''>
@@ -3457,9 +3461,9 @@
             </model>
         </chassis>
 		<chassis name='Marauder IIC' unitType='Mek'>
-			<availability>CSA:3,CSR:3,CW:3,CLAN:3,CNC:3,CJF:3,CGB:3</availability>
+			<availability>CLAN!Keshik:3,CBS:1+:2829,CB!Keshik:2,CFM:1+:2829,CGS:1+:2829,CIH!Keshik:2,CMG!Keshik:2,CSR!Keshik:2</availability>
 			<model name=''>
-				<availability>CLAN:8,CJF:8,CGB:8</availability>
+				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
@@ -3987,10 +3991,10 @@
 			</model>
 		</chassis>
 		<chassis name='Nightstar' unitType='Mek'>
-			<availability>CSA:6,CS:4,CLAN:5,NIOPS:4</availability>
+			<availability>CS:4,CCO:1+,CWI:1+,NIOPS:4+</availability>
 			<model name='NSR-9J'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CS:8,CCO:8,CWI:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Olympus Recharge Station' unitType='Space Station'>
@@ -4206,7 +4210,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
-			<availability>CLAN:5,CC:6+,CS:5,LA:6+,FWL:6+,NIOPS:5,FS:6+</availability>
+			<availability>FS:6+,LA:6+,FWL:6+,CC:6+,CS:5,CLAN:3+,CBS:2+,CCC:2+,CFM:2+,CGB:2+,CHH:2+,CIH:2+,CMG:2+,CDS:2+,CSR:2+,CSA:2+,CSV:2+,CW:2+,NIOPS:5+</availability>
 			<model name='PLG-3Z'>
 				<availability>IS:8,CLAN:8,NIOPS:8</availability>
 			</model>
@@ -4298,12 +4302,12 @@
 			</model>
 		</chassis>
 		<chassis name='Pulverizer' unitType='Mek'>
-			<availability>CSR:2,CWOV:3</availability>
+			<availability>CWOV:2+</availability>
 			<model name='PUL-2V'>
-				<availability>General:8</availability>
+				<availability>CWOV:8</availability>
 			</model>
 			<model name='PUL-3R'>
-				<availability>General:6</availability>
+				<availability>CWOV:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -4391,10 +4395,10 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman II' unitType='Mek'>
-			<availability>CLAN:5</availability>
+			<availability>CGB:3+</availability>
 			<model name='RFL-3N-2'>
 				<roles>anti_aircraft</roles>
-				<availability>General:8</availability>
+				<availability>CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
@@ -4683,9 +4687,9 @@
 			</model>
 		</chassis>
 		<chassis name='Shogun' unitType='Mek'>
-			<availability>CSA:3,CIH:3,CBS:3,CLAN:3,FWL:3+,CCO:3,CB:3</availability>
+			<availability>FWL:3+,CBS:3+,CB:3+,CCC:3+,CCO:3+,CSA:3</availability>
 			<model name='SHG-2H'>
-				<availability>General:8,CLAN:8</availability>
+				<availability>FWL:8,CBS:8,CB:8,CCC:8,CCO:8,CSA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Sholagar' unitType='AeroSpaceFighter'>
@@ -4800,11 +4804,15 @@
 			</model>
 		</chassis>
 		<chassis name='Spartan' unitType='Mek'>
-			<availability>CS:5</availability>
+			<availability>CS:5,CLAN:2,CCC:4+,CFM:4,CGS:3,CIH:6+,CMG:5,CDS:4,CSV:4,CWOV:4</availability>
 			<model name='SPT-N2'>
 				<roles>cavalry,spotter</roles>
-				<availability>IS:8</availability>
+				<availability>CS:8,CFM:4-</availability>
 			</model>
+            <model name='SPT-NF'>
+                <roles>cavalry</roles>
+                <availability>CLAN:8,CFM:3+</availability>
+            </model>
 		</chassis>
 		<chassis name='Spector' unitType='Mek'>
 			<availability>CIH:1+,CMG:2+</availability>
@@ -4840,18 +4848,18 @@
             </model>
         </chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>CC:7,CLAN:7,IS:8,Periphery.Deep:9,FS:7,Periphery:9,CS:6,FWL:9,NIOPS:6,DC:7</availability>
+			<availability>IS:8,FS:7,DC:7,FWL:9,CC:7,CS:6,PP:6,CLAN:5,CBS:6,CGB:6,CHH:6,CIH:4,CJF:6,CMG:4,CNC:6,CW:6,Periphery:9,NIOPS:6,Periphery.Deep:9</availability>
 			<model name='STK-3F'>
-				<availability>CLAN:2,IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CLAN:2-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='STK-3Fb'>
-				<availability>CLAN:8</availability>
+				<availability>PP:1+,CLAN:8</availability>
 			</model>
 			<model name='STK-3Fk'>
 				<availability>DC:1+</availability>
 			</model>
 			<model name='STK-3H'>
-				<availability>MOC:2,OA:2,CLAN:2,IS:2,TC:2</availability>
+				<availability>IS:2,TC:2,MOC:2,OA:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -4921,9 +4929,9 @@
 			</model>
 		</chassis>
 		<chassis name='Striker' unitType='Mek'>
-			<availability>CC:8,MOC:7,CS:4,OA:7,LA:8,PIR:4,Periphery.Deep:4,NIOPS:4,FS:7,MERC:7,TC:7,DC:7</availability>
+			<availability>FS:7,LA:8,DC:7,CC:8,MERC:7,CS:4,CLAN:1-,CCC:2-,CFM:2-,CGS:2-,CHH:2-,CIH:3-,CMG:3-,CDS:2-,CSR:2-,CSV:2-,CW:2-,CWOV:2-,TC:7,MOC:7,OA:7,NIOPS:4,Periphery.Deep:4+,PIR:4</availability>
 			<model name='STC-2C'>
-				<availability>CC:8,General:8</availability>
+				<availability>IS:8,CLAN:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='STC-2S'>
 				<availability>LA:4</availability>
@@ -5026,12 +5034,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>CHH:7,CSV:9,CLAN:8,IS:6+,CFM:10,FS:6+,TC:4+,CS:7,CDS:7,CW:9,CBS:7,LA:6+,CNC:7,FWL:6+,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>IS:6+,FS:6+,LA:6+,FWL:6+,CS:7,PP:2+,CLAN:5,CIH:4,TC:4+,NIOPS:7</availability>
 			<model name='THG-11E'>
-				<availability>CS:8,CLAN:6,FWL:6+,IS:6+,NIOPS:8,FS:6+,DC:6+,TC:8</availability>
+				<availability>IS:6+,CS:8,PP:8,CLAN:4-,TC:8,NIOPS:8</availability>
 			</model>
 			<model name='THG-11Eb'>
-				<availability>CLAN:8</availability>
+				<availability>CLAN:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -5042,10 +5050,10 @@
 			</model>
 		</chassis>
 		<chassis name='Thunder Hawk' unitType='Mek'>
-			<availability>CS:2,LA:3+,CLAN:4,NIOPS:2,DC:3+</availability>
+			<availability>LA:3+,DC:3+,CS:2,CB:1+,NIOPS:2+</availability>
 			<model name='TDK-7X'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,DC:8,CS:8,CB:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
@@ -5310,15 +5318,15 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>CC:6,MOC:6,CLAN:3-,IS:5,Periphery.Deep:5,FS:9,CIR:6,Periphery.OS:6,Periphery:5,TC:6,CS:5-,OA:6,LA:6,Periphery.HR:6,FWL:6,NIOPS:5-,CJF:3-,DC:6</availability>
+            <availability>IS:5,FS:9,LA:6,DC:6,FWL:6,CC:6,CS:5-,PP:5+,CCO:2-,CIH:3,Periphery:5,Periphery.OS:6,Periphery.HR:6,TC:6,MOC:6,OA:6,CIR:6,NIOPS:5-,Periphery.Deep:5+</availability>
 			<model name='VTR-9A'>
-				<availability>CC:2,CS:2,IS:1,FS:2</availability>
+				<availability>IS:1,FS:2,CC:2,CS:2</availability>
 			</model>
 			<model name='VTR-9A1'>
-				<availability>CC:2,CS:2,IS:1,FS:2</availability>
+				<availability>IS:1,FS:2,CC:2,CS:2</availability>
 			</model>
 			<model name='VTR-9B'>
-				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CCO:8,CIH:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Vigilant Corvette' unitType='Warship'>
@@ -5403,10 +5411,16 @@
 				<availability>General:8</availability>
 			</model>
 		</chassis>
+        <chassis name='Wakazashi' unitType='Mek'>
+            <availability>CJF!Keshik:3</availability>
+            <model name=''>
+                <availability>CJF:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Warhammer IIC' unitType='Mek'>
-			<availability>CLAN:3:2829</availability>
+			<availability>CGB!Keshik:3,CSA!Keshik:3</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CSA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -609,19 +609,23 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:7,CS:5-,LA:9,CLAN:2,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8</availability>
+			<availability>IS:6,FS:8,LA:9,DC:8,FWL:9,CC:7,CS:5-,PP:1,CLAN:4,CFM:3,CGS:3,CIH:4-,CMG:3,CSV:3,CWOV:3,Periphery:6,NIOPS:5-,Periphery.Deep:6</availability>
 			<model name='ARC-2K'>
 				<roles>command,fire_support</roles>
 				<availability>DC:6</availability>
 			</model>
 			<model name='ARC-2R'>
 				<roles>command,fire_support</roles>
-				<availability>LA:8,CLAN:5,IS:8,Periphery.Deep:8,DC:7,Periphery:8</availability>
+				<availability>IS:8,DC:7,PP:8,CLAN:1-,CGB:2-,CW:2-,Periphery:8,NIOPS:4-,Periphery.Deep:8</availability>
 			</model>
 			<model name='ARC-2Rb'>
 				<roles>command,fire_support</roles>
 				<availability>CLAN:8</availability>
 			</model>
+            <model name='C'>
+                <roles>command,fire_support</roles>
+                <availability>CLAN!Keshik:3</availability>
+            </model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
 			<availability>MOC:8,OA:8,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8</availability>
@@ -856,14 +860,14 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:5,FS:5,MERC:3,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:3,CNC:10,FWL:5,NIOPS:7,CJF:8,CGB:10,DC:3</availability>
+			<availability>FS:5,LA:3,DC:3,FWL:5,MERC:3,CS:7,CLAN:3+,CGS:4+,CIH:2+,CWOV:4+,NIOPS:7</availability>
 			<model name='BL-6-KNT'>
                 <roles>command</roles>
-				<availability>CS:8,CLAN:6,FWL:4+,NIOPS:8,FS:4+</availability>
+				<availability>FS:4+,FWL:4+,CS:8,CLAN:8,CBS:6-,CCO:6-,CGB:6-,CGS:6-,CNC:6-,CW:6-,NIOPS:8</availability>
 			</model>
 			<model name='BL-6b-KNT'>
                 <roles>command</roles>
-				<availability>CS:4,CLAN:8,NIOPS:4,FWL:2+,CGS:8</availability>
+				<availability>FWL:2+,CS:4,CBS:7,CCO:7,CGB:7,CGS:7,CNC:7,CW:7,NIOPS:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
                 <roles>command</roles>
@@ -902,14 +906,14 @@
 			</model>
 		</chassis>
 		<chassis name='Bombardier' unitType='Mek'>
-			<availability>CLAN:5,CS:5,FWL:3,DC:3,NIOPS:5</availability>
+			<availability>DC:3,FWL:3,CS:5,CLAN:3-,CB:2-,CCO:2-,CIH:4,CMG:4-,CDS:4-,CSR:4-,CWI:2-,CWOV:2-,NIOPS:5</availability>
 			<model name='BMB-10D'>
 				<roles>fire_support</roles>
-				<availability>CLAN:8,CS:8,FWL:8,DC:8,NIOPS:8</availability>
+				<availability>FWL:8,DC:8,CS:8,NIOPS:4-</availability>
 			</model>
 			<model name='BMB-12D'>
 				<roles>fire_support</roles>
-				<availability>CS:8,CLAN:8,NIOPS:8,FWL:7+,DC:7+</availability>
+				<availability>DC:7+,FWL:7+,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
         <chassis name='Brunel Dump Truck' unitType='Tank'>
@@ -1030,18 +1034,18 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>CC:5,CLAN:3,IS:3,MERC:2,Periphery:1,CS:2,NIOPS:2,DC:5</availability>
+			<availability>IS:3,DC:5,CC:5,MERC:2,CS:2,PP:2+,CFM:4+,CDS:3,CWI:3+,CW:3,CWOV:3+,Periphery:1,NIOPS:2</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
-				<availability>CC:4,FWL:4,DC:4</availability>
+				<availability>DC:4,FWL:4,CC:4</availability>
 			</model>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
-				<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CDS:8,CW:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='CPLT-C1b'>
 				<roles>fire_support</roles>
-				<availability>CC:2+,CLAN:6,DC:3+</availability>
+				<availability>DC:3+,CC:2+,CFM:8,CWI:8,CWOV:8</availability>
 			</model>
 			<model name='CPLT-C4'>
 				<roles>fire_support</roles>
@@ -1072,12 +1076,12 @@
 			</model>
 		</chassis>
 		<chassis name='Cestus' unitType='Mek'>
-			<availability>CS:4,LA:3+,CLAN:4,NIOPS:4,IS:3+,FS:6</availability>
+			<availability>IS:3+,FS:6,CS:4,CB:3+,CFM:2+,CJF:3+,CSJ:3+,NIOPS:4</availability>
 			<model name='CTS-6Y'>
-				<availability>General:8</availability>
+				<availability>IS:8,CB:8,CFM:5,CJF:8,CSJ:8</availability>
 			</model>
 			<model name='CTS-6Y-EC'>
-				<availability>CFM:3</availability>
+				<availability>CFM!Keshik:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Chameleon' unitType='Mek'>
@@ -1088,22 +1092,19 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:7,CS:5,CHH:6,LA:6,CLAN:5,IS:5,FWL:5,NIOPS:5,MERC:5,FS:5,CGB:6,DC:5</availability>
-			<model name='C'>
-				<availability>CHH:4,CLAN:6,CGB:4</availability>
-			</model>
+			<availability>IS:5,LA:6,CC:7,MERC:5,CS:5,CBS:4-,CCO:3-,CGB:4+,CHH:4+,CIH:6+,CDS:4+,CSV:3+,NIOPS:5</availability>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
-				<availability>CC:4+,CS:8,CHH:6,CLAN:6,NIOPS:8,CGB:6</availability>
+				<availability>CC:4+,CS:8,CBS:8,CCO:8,CGB:4-,CHH:4-,NIOPS:8</availability>
 			</model>
 			<model name='CHP-1N2'>
-				<availability>CC:2+,CS:4,LA:2+,CLAN:2,CGB:2</availability>
+				<availability>LA:2+,CC:2+,CS:4,CFM:8,CGB:5,CHH:5,CIH:8,CDS:5,NIOPS:5</availability>
 			</model>
 			<model name='CHP-1Nb'>
-				<availability>CLAN:8</availability>
+				<availability>CDS:3+,CSV:8</availability>
 			</model>
 			<model name='CHP-2N'>
-				<availability>IS:6-,NIOPS:0</availability>
+				<availability>IS:6-</availability>
 			</model>
 		</chassis>
 		<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1679,9 +1680,9 @@
 			</model>
 		</chassis>
 		<chassis name='Crusader' unitType='Mek'>
-			<availability>CS:6-,CLAN:6,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:8,CS:6-,PP:4+,CLAN:3,CDS:2,Periphery:6,NIOPS:6-,Periphery.Deep:6</availability>
 			<model name='CRD-2R'>
-				<availability>CLAN:8,IS:3+,CGS:8,Periphery:3+</availability>
+				<availability>IS:3+,MERC:3+,CLAN:8,Periphery:3+,NIOPS:5,Periphery.Deep:0</availability>
 			</model>
 			<model name='CRD-3D'>
 				<availability>FS:5</availability>
@@ -1694,7 +1695,7 @@
 				<availability>CC:9</availability>
 			</model>
 			<model name='CRD-3R'>
-				<availability>General:8,CLAN:4,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CLAN:1-,CBS:2-,CFM:2-,CHH:2-,CWI:2-,Periphery:8,NIOPS:6-,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
@@ -1985,29 +1986,29 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,IS:5,Periphery:2,TC:3,CS:5,NIOPS:5</availability>
+			<availability>IS:5,CS:5,Periphery:2,TC:3,MOC:3,NIOPS:5</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Mek'>
-			<availability>CS:5,LA:2+,CLAN:5,NIOPS:5,FS:2+,DC:2+</availability>
+			<availability>FS:2+,LA:2+,DC:2+,CS:5,CLAN:3+,NIOPS:5</availability>
 			<model name='EXC-B1'>
 				<roles>cavalry,fire_support</roles>
-				<availability>LA:8</availability>
+				<availability>LA:8,CGS:4-,CDS:4-,CW:4-</availability>
 			</model>
 			<model name='EXC-B2'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CS:8,LA:0,General:8,CLAN:6,NIOPS:8</availability>
+				<availability>FS:8,LA:0,DC:8,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 			<model name='EXC-B2b'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CLAN:8,CGS:8</availability>
+				<availability>CLAN:2+,CGB:3+,CJF:3+,CSJ:3+,</availability>
 			</model>
 			<model name='EXC-B2b-EC'>
                 <roles>cavalry,fire_support</roles>
-				<availability>CW:8:2825</availability>
+				<availability>CW!Keshik:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -2022,22 +2023,22 @@
 			</model>
 		</chassis>
 		<chassis name='Exterminator' unitType='Mek'>
-			<availability>CS:4,CLAN:6,NIOPS:4</availability>
+			<availability>CS:4,CLAN:2+,CCC:3+,CFM:3+,CIH:4+,CMG:3+,CDS:3+,CSR:3+,CSV:3+,CWI:1+,CWOV:3+,NIOPS:4</availability>
 			<model name='EXT-4C'>
 			    <roles>specops</roles>
-				<availability>CLAN:1</availability>
+				<availability>CJF:1+,CW:1+,CWOV!Keshik:2</availability>
 			</model>
 			<model name='EXT-4D'>
 			    <roles>cavalry</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8</availability>
+				<availability>CS:8,CLAN:8,CFM:4-,CIH:4-,CJF:4-,CDS:4-,CSR:4-,NIOPS:8</availability>
 			</model>
 			<model name='EXT-4Db'>
 			    <roles>cavalry</roles>
-				<availability>CLAN:8</availability>
+				<availability>CFM:8,CIH:5,CJF:8,CDS:8,CSR:8,NIOPS:3+</availability>
 			</model>
 			<model name='EXT-4Db-EC'>
 			    <roles>cavalry</roles>
-				<availability>CJF:8</availability>
+				<availability>CJF:1+</availability>
 			</model>
 		</chassis>
 	    <chassis name='Factory' unitType='Space Station'>
@@ -2148,13 +2149,13 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:4,CDS:5,LA:6,CBS:5,FWL:4,NIOPS:5,CJF:7,CGB:5</availability>
+			<availability>LA:6,FWL:4,CS:5,CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CJF!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CNC!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,Periphery.R:4,NIOPS:5</availability>
 			<model name='FLS-7K'>
 				<availability>LA:6-,FWL:6-,Periphery.R:8</availability>
 			</model>
 			<model name='FLS-8K'>
                 <roles>cavalry</roles>
-				<availability>CS:8,LA:6+,CLAN:8,FWL:5+,NIOPS:8</availability>
+				<availability>LA:6+,FWL:5+,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Flatbed Truck' unitType='Tank'>
@@ -2340,12 +2341,12 @@
 			</model>
 		</chassis>
 		<chassis name='Galahad' unitType='Mek'>
-			<availability>CC:4+,CWI:6,LA:4+,CLAN:4,FS:4+</availability>
+			<availability>FS:4+,LA:4+,CC:4+,CGB!Keshik:1!Front Line:1!Second Line:1,CHH!Keshik:1!Front Line:1!Second Line:1,CSR!Keshik:1!Front Line:1!Second Line:1,CWI!Keshik:1!Front Line:1!Second Line:1,CW!Keshik:1!Front Line:1!Second Line:1</availability>
 			<model name='GLH-1D'>
-				<availability>IS:8</availability>
+				<availability>FS:8,LA:8,CC:8</availability>
 			</model>
 			<model name='GLH-2D'>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CHH:8,CSR:8,CWI:8,CW:8</availability>
 			</model>
 		</chassis>
         <chassis name='Galaport Ground Trailer' unitType='Tank'>
@@ -2441,14 +2442,14 @@
             </model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>CS:7,CLAN:9,IS:7,NIOPS:7,FS:6,MERC:7</availability>
+			<availability>IS:7,FS:6,MERC:7,CS:7,CHH:3+,CSR:3+,NIOPS:7</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
-				<availability>CS:8,CLAN:8,IS:6+,NIOPS:8</availability>
+				<availability>IS:8,FWL:6+,MERC:6+,CS:8,CHH:8,CSR:8,NIOPS:8</availability>
 			</model>
 			<model name='GLT-4L'>
 				<roles>raider</roles>
-				<availability>FWL:5-,NIOPS:0,MERC:5-</availability>
+				<availability>FWL:5-,MERC:5-</availability>
 			</model>
 		</chassis>
         <chassis name='HMRV (Hazardous Materials Recovery Vehicle)' unitType='Tank'>
@@ -2672,14 +2673,6 @@
                 <availability>CLAN:3,PP:3,IS:3,FWL:3</availability>
             </model>
         </chassis>
-		<chassis name='Helepolis' unitType='Mek'>
-			<availability>CLAN:4</availability>
-			<model name='HEP-3H'>
-				<roles>mixed_artillery</roles>
-				<deployedWith>Helepolis</deployedWith>
-				<availability>General:8</availability>
-			</model>
-		</chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 			<availability>CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,FWL:4,NIOPS:6,DC:4</availability>
 			<model name='HCT-213B'>
@@ -3165,14 +3158,14 @@
 			</model>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>MOC:4,CLAN:6,IS:5,MERC:5,CIR:4,TC:4,CS:6,OA:4,NIOPS:6</availability>
+			<availability>IS:5,MERC:5,CS:6,CLAN:3+,CCC:4+,CCO:2+,CFM:4+,CHH:2+,CIH:4+,CMG:4+,CSV:4+,CWI:2+,TC:4,MOC:4,OA:4,CIR:4,NIOPS:6</availability>
 			<model name='LNC25-01'>
 				<roles>cavalry,anti_aircraft</roles>
-				<availability>CS:8,CLAN:8,IS:7,NIOPS:8</availability>
+				<availability>IS:7,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 			<model name='LNC25-05'>
 				<roles>cavalry,anti_infantry</roles>
-				<availability>CS:4,IS:3,NIOPS:4</availability>
+				<availability>IS:3,CS:4,NIOPS:4</availability>
 			</model>
 		</chassis>
 		<chassis name='League Destroyer' unitType='Warship'>
@@ -3462,18 +3455,18 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:5,CS:8,MOC:2+,LA:6,CLAN:8,FWL:5,IS:3,NIOPS:8,FS:6,DC:6,TC:3+,CGB:8</availability>
+			<availability>IS:3,FS:6,LA:6,DC:6,FWL:5,CC:5,CS:8,PP:2+,CLAN:4+,CIH:3+,CMG:3+,CSV:3+,TC:3+,MOC:2+,NIOPS:8</availability>
             <model name='C'>
                 <roles>command</roles>
-                <availability>CLAN:2+:2827</availability>
+                <availability>CLAN!Keshik:3</availability>
             </model>
 			<model name='MAD-1R'>
                 <roles>command</roles>
-				<availability>CS:8,MOC:6,CLAN:4,IS:6+,NIOPS:8,MERC:0,TC:6+</availability>
+				<availability>IS:6+,MERC:0,CS:8,CLAN:4-,MOC:6,NIOPS:8,TC:6+</availability>
 			</model>
 			<model name='MAD-2R'>
                 <roles>command</roles>
-				<availability>CLAN:8,FS:4+</availability>
+				<availability>FS:4+,CLAN:5</availability>
 			</model>
 			<model name='MAD-3D'>
                 <roles>command</roles>
@@ -3481,7 +3474,7 @@
 			</model>
 			<model name='MAD-3R'>
                 <roles>command</roles>
-				<availability>CS:4-,IS:8,TC:5</availability>
+				<availability>IS:8,CS:4-,PP:8,TC:5</availability>
 			</model>
 		</chassis>
         <chassis name='Marco' unitType='Mek'>
@@ -3737,6 +3730,13 @@
 				<availability>IS:3+,CS:4,CLAN:8,PP:8,NIOPS:4</availability>
 			</model>
 		</chassis>
+        <chassis name='Minsk' unitType='Mek'>
+            <availability>CGB!Keshik:3</availability>
+            <model name='MNK-101'>
+                <roles>command</roles>
+                <availability>CGB:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Mobile Headquarters' unitType='Tank'>
 			<availability>CLAN:1+,IS:2+,CS:3+,TC:1+</availability>
 			<model name=''>
@@ -3993,12 +3993,15 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CLAN:4,IS:5,Periphery.Deep:4,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,LA:6,FWL:8,NIOPS:5-</availability>
+			<availability>IS:5,LA:6,FWL:8,CS:5-,PP:3+,CLAN:3+,CCC:2+,CGS:2+,CIH:2+,CMG:2+,CNC:2+,CSR:2+,CW:5+,CWOV:2+,Periphery:4,TC:5,MOC:5,OA:5,CIR:5,NIOPS:5-,Periphery.Deep:4</availability>
 			<model name='ON1-K'>
-				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CW:4-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
+            <model name='ON1-Kb'>
+                <availability>CLAN:8,CW:3+</availability>
+            </model>
 			<model name='ON1-V'>
-				<availability>OA:3,IS:3,TC:3</availability>
+				<availability>IS:3,PP:6,CW:3-,TC:3,OA:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Osprey' unitType='Mek'>
@@ -4009,10 +4012,10 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CS:4,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,DC:6</availability>
+			<availability>IS:5,DC:6,CS:4,PP:4,CLAN:4,CB:3,CCC:5,CCO:3,CIH:5,CMG!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,CWI:3,Periphery:4,NIOPS:4,Periphery.Deep:4</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
-				<availability>CLAN:4,IS:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CLAN:1-,CCC:2-,CMG:2-,CDS:2-,CSR:2-,CSV:2-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='OSR-2Cb'>
 				<roles>urban</roles>
@@ -4034,10 +4037,10 @@
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
-			<availability>CLAN:5,CS:6,FWL:8,NIOPS:6,Periphery.Deep:4,FS:8,MERC:8,Periphery:4</availability>
+			<availability>FS:8,FWL:8,MERC:8,CS:6,PP:4,CLAN:3-,CB:2-,CIH:4-,CWI:2-,CW:2-,Periphery:4,NIOPS:6,Periphery.Deep:4</availability>
 			<model name='OTL-4D'>
                 <roles>raider</roles>
-				<availability>CLAN:8,IS:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CLAN:8,Periphery:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Overlord C' unitType='Dropship'>
@@ -4342,7 +4345,7 @@
 			</model>
 		</chassis>
 		<chassis name='Redback' unitType='Mek'>
-			<availability>CWI:3:2828</availability>
+			<availability>CWI!Keshik:3</availability>
 		    <model name=''>
                 <roles>cavalry</roles>
 			    <availability>CWI:8</availability>
@@ -4387,14 +4390,14 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CLAN:3,IS:7,Periphery.Deep:5,CIR:4,Periphery:5,CS:6-,NIOPS:6-</availability>
+			<availability>IS:7,CS:6-,PP:3,CLAN!Front Line:3!Provisional Garrison:1,CBS!Front Line:3!Solahma:1!Provisional Garrison:1,CFM!Front Line:3!Solahma:1!Provisional Garrison:1,CGS!Front Line:3!Solahma:1!Provisional Garrison:1,CSR!Keshik:3!Front Line:3!Solahma:1!Provisional Garrison:1,Periphery:5,CIR:4,NIOPS:6-,Periphery.Deep:5</availability>
             <model name='C'>
                 <roles>fire_support,anti_aircraft</roles>
-                <availability>CLAN:8:2826,BAN:4:2826</availability>
+                <availability>CLAN!Front Line:8,CSR!Keshik:8!Front Line:8</availability>
             </model>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:8-,General:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CLAN:1-,CBS:2-,CFM:2-,CGS:2-,CSR:2-,Periphery:8,NIOPS:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Riga II Destroyer-Carrier' unitType='Warship'>
@@ -4684,10 +4687,10 @@
 			</model>
 		</chassis>
 		<chassis name='Shootist' unitType='Mek'>
-			<availability>CS:5,LA:3+,CLAN:5,NIOPS:5</availability>
+			<availability>LA:3+,CS:5,CLAN:2+,CB:4+,CCO:3+,CGB:3+,CIH!Front Line:2!Second Line:1,CJF:3+,CMG:1+,CSJ:3+,CWI:3+,CW:3+,NIOPS:5</availability>
 			<model name='ST-8A'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
         <chassis name='Shugosha' unitType='Mek'>
@@ -5053,7 +5056,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:9,CS:5-,LA:8,CLAN:5,IS:6,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:6,Periphery:6,DC:8</availability>
+			<availability>IS:6,FS:7,LA:8,DC:8,CC:9,MERC:6,CS:5-,PP:4+,CLAN:5,CB!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CCC:4,CIH:4,CMG:4,CSR:4,CSV:4,Periphery:6,NIOPS:5-,Periphery.Deep:6</availability>
 			<model name='TDR-5D'>
 				<availability>FS:4,MERC:2</availability>
 			</model>
@@ -5061,10 +5064,10 @@
 				<availability>CC:1</availability>
 			</model>
 			<model name='TDR-5S'>
-				<availability>IS:8,CLAN:2-,Periphery:8</availability>
+				<availability>IS:8,PP:8,CLAN:3-,Periphery:8</availability>
 			</model>
 			<model name='TDR-5Sb'>
-				<availability>CLAN:8</availability>
+				<availability>CLAN:4</availability>
 			</model>
 			<model name='TDR-5Sd'>
 				<availability>FS:2+</availability>
@@ -5334,9 +5337,9 @@
 			</model>
 		</chassis>
 		<chassis name='Vision Quest' unitType='Mek'>
-			<availability>CNC:3</availability>
+			<availability>CNC!Keshik:3</availability>
 			<model name='VQ-1NC'>
-				<availability>CNC:6</availability>
+				<availability>CNC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Volga Transport' unitType='Warship'>
@@ -5399,25 +5402,25 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,LA:9,CLAN:6,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:8,LA:9,FWL:9,CS:6-,PP:3+,CLAN:6+,CB:5+,CCC:5+,CHH:5+,CIH:4-,CMG:5+,CNC:5+,CSR:5+,CSV:5+,Periphery:6,NIOPS:6-,Periphery.Deep:6</availability>
             <model name='C'>
-                <availability>CLAN:2:2825</availability>
+                <availability>CLAN!Keshik:3</availability>
             </model>
 			<model name='WHM-6L'>
-				<availability>CC:4:2825</availability>
+				<availability>CC:4</availability>
 			</model>
 			<model name='WHM-6R'>
-				<availability>General:8,CLAN:2</availability>
+				<availability>IS:8,PP:8,CLAN:1-,CBS:2-,CB:2-,CCO:2-,CGS:2-,CJF:2-,CNC:2-,CSJ:2-,CSA:2-,CWOV:2-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='WHM-6Rb'>
-				<availability>CC:4+,LA:4+,CLAN:4,FWL:4+,FS:4+</availability>
+				<availability>FS:4+,LA:4+,FWL:4+,CC:4+,CLAN:5</availability>
 			</model>
 			<model name='WHM-6Rk'>
                 <roles>cavalry</roles>
 				<availability>DC:2+</availability>
 			</model>
 			<model name='WHM-7A'>
-				<availability>CLAN:8</availability>
+				<availability>CLAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Wasp LAM Mk I' unitType='Mek'>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -695,9 +695,9 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>CC:1,MOC:1,CS:3-,LA:4,FS.CMM:4,IS:4,MERC:3,FS:4,TC:1</availability>
+			<availability>IS:4,FS:4,LA:4,CC:1,MERC:3,CS:3-,CCC:1,CIH!Front Line:2!Second Line:1,TC:1,MOC:1</availability>
 			<model name='ASN-21'>
-				<availability>General:8</availability>
+				<availability>IS:8,CCC:8,CIH:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Athena Cruiser' unitType='Warship'>
@@ -1154,10 +1154,10 @@
 			</model>
 		</chassis>
 		<chassis name='Cicada' unitType='Mek'>
-			<availability>CC:5,CS:4-,OA:3,LA:5,IS:5,FWL:5,FS:5,MERC:5,Periphery:3,DC:5</availability>
+			<availability>IS:5,FS:5,LA:5,DC:5,FWL:5,CC:5,MERC:5,CS:4-,CIH:3,CMG:3-,Periphery:3,OA:3</availability>
 			<model name='CDA-2A'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CIH:8,CMG:8,Periphery:8</availability>
 			</model>
 			<model name='CDA-2B'>
 				<roles>anti_infantry</roles>
@@ -1457,12 +1457,12 @@
             </model>
         </chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:6,MOC:4,CS:3-,OA:4,CLAN:3-,IS:5,NIOPS:3-,FS:6,MERC:5</availability>
+			<availability>IS:5,FS:6,CC:6,MERC:5,CS:3-,PP:1,CLAN:2-,CB:1-,CCO:1-,CGB:1-,CIH:3-,CMG:4-,CSJ:1-,CSR:3-,CSA:1-,CWI:1-,CWOV:1-,MOC:4,OA:4,NIOPS:3-</availability>
 			<model name='CLNT-1-2R'>
-				<availability>CC:1,FS:1</availability>
+				<availability>FS:1,CC:1,CLAN:5+</availability>
 			</model>
 			<model name='CLNT-2-3T'>
-				<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CLAN:4,Periphery:8,NIOPS:8</availability>
 			</model>
 			<model name='CLNT-2-4T'>
 				<availability>CC:4,FS:4</availability>
@@ -1609,22 +1609,22 @@
             </model>
         </chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:4,CSR:4,CLAN:5,IS:4,CFM:4,MERC:4,CGS:6,Periphery:4,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,CJF:4,CGB:4</availability>
+			<availability>IS:4,MERC:4,CS:5,PP:2+,CLAN:5,CBS:4,CIH:4-,CWOV:4,Periphery:4,NIOPS:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
-				<availability>IS:6,Periphery.Deep:6,NIOPS:0,Periphery:6</availability>
+				<availability>IS:6,PP:4-,Periphery:6,NIOPS:0,Periphery.Deep:6</availability>
 			</model>
 			<model name='CRB-27'>
 				<roles>raider</roles>
-				<availability>CS:8,CC:4+,LA:4+,CLAN:6,NIOPS:8,FWL:4+,DC:4+</availability>
+				<availability>LA:4+,DC:4+,FWL:4+,CC:4+,CS:8,PP:6,CLAN:5-,NIOPS:8</availability>
 			</model>
 			<model name='CRB-27b'>
 				<roles>raider</roles>
-				<availability>CC:3+,CLAN:8,FWL:3+,CGS:8</availability>
+				<availability>FWL:3+,CC:3+,PP:1+,CLAN:5+,CBS:4+</availability>
 			</model>
 			<model name='CRB-27sl'>
                 <roles>raider</roles>
-				<availability>LA:4+,CLAN:4,DC:4+</availability>
+				<availability>LA:4+,DC:4+,CLAN:2+,CB:3+,CCC:3+,CCO:3+,CGB:3+,CGS:3+,CSJ:3+,CSA:3+,CSV:3+,CWI:3+,CWOV:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
@@ -1826,12 +1826,12 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>CC:4,Periphery.HR:6,CLAN:4,IS:6,Periphery.Deep:6,FS:8,MERC:6,TC:6</availability>
+			<availability>IS:6,FS:8,CC:4,MERC:6,PP:1+,CBS:3+,CDS:3+,Periphery.HR:6,TC:6,Periphery.Deep:6</availability>
 			<model name='DV-6M'>
-				<availability>CLAN:4,IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CBS:8,CDS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='DV-6Md'>
-				<availability>FS:6+</availability>
+				<availability>FS:6+,CBS:6,CDS:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Dictator' unitType='Dropship'>
@@ -1936,7 +1936,7 @@
 			</model>
 		</chassis>
 		<chassis name='Enfield' unitType='Mek'>
-			<availability>CMG:4</availability>
+			<availability>CMG!Keshik:3</availability>
 			<model name='END-6J-EC'>
 				<roles>urban</roles>
 				<availability>CMG:8</availability>
@@ -2306,9 +2306,9 @@
 			</model>
 		</chassis>
 		<chassis name='Fox' unitType='Mek'>
-			<availability>CDS:3</availability>
+			<availability>CDS!Keshik:3,CSJ:1+:2826,CW:1+:2825</availability>
 			<model name='CS-1'>
-				<availability>General:8</availability>
+				<availability>CDS:8,CSJ:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Fury Command Tank' unitType='Tank'>
@@ -2426,16 +2426,19 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:6,MERC:6,TC:7,Periphery:6,CS:4,NIOPS:4,DC:8</availability>
+			<availability>IS:9,DC:8,CC:7,MERC:6,CS:4,PP:4+,CLAN:6,CB:5,CHH:5,CIH:5+,CSR:5,CSA:5,CSV:5,CWI:5,CWOV:5,Periphery:6,TC:7,MOC:7,NIOPS:4,Periphery.Deep:6</availability>
 			<model name='GRF-1N'>
-				<availability>General:8,CLAN:4-,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CCC:3-,CIH:3-,CJF:3-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='GRF-1S'>
 				<availability>LA:4</availability>
 			</model>
 			<model name='GRF-2N'>
-				<availability>CC:3+,LA:3+,CLAN:6,FWL:3+,FS:3+</availability>
+				<availability>FS:3+,LA:3+,FWL:3+,CC:3+,CLAN:8,CCC:6,CIH:6,CJF:6</availability>
 			</model>
+            <model name='GRF-2N2'>
+                <availability>CIH:4,CMG:5-</availability>
+            </model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
 			<availability>CS:7,CLAN:9,IS:7,NIOPS:7,FS:6,MERC:7</availability>
@@ -2706,6 +2709,12 @@
 				<availability>LA:6,FS:4</availability>
 			</model>
 		</chassis>
+        <chassis name='Hellhound (Conjurer)' unitType='Mek'>
+            <availability>CJF!Keshik:3</availability>
+            <model name=''>
+                <availability>CJF:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Hermes II' unitType='Mek'>
 			<availability>CC:2,MOC:2,FWL:10,MERC:2</availability>
 			<model name='HER-2M &apos;Mercury&apos;'>
@@ -2752,21 +2761,21 @@
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
-			<availability>CC:5,MOC:3,CHH:4,OA:3,LA:5,CLAN:3,FWL:5,FS:5,CGS:5,DC:3,TC:5</availability>
+			<availability>FS:5,LA:5,DC:3,FWL:5,CC:5,PP:2+,CBS:4+,CGB:5+,CGS:5+,CHH:6+,CJF:4,CNC:3+,TC:5,MOC:3,OA:3</availability>
 			<model name='HOP-4B'>
                 <roles>inf_support,fire_support</roles>
 				<availability>CC:1</availability>
 			</model>
 			<model name='HOP-4Bb'>
                 <roles>fire_support</roles>
-				<availability>CLAN:6</availability>
+				<availability>CBS:3,CGB:6,CGS:5,CHH:5,CJF:4,CNC:6</availability>
 			</model>
 			<model name='HOP-4C'>
                 <roles>inf_support</roles>
-				<availability>MOC:8,OA:8,FS:8</availability>
+				<availability>FS:8,PP:8,CBS:4-,CGB:4-,CGS:4-,CHH:4-,CJF:3-,CNC:4-,MOC:8,OA:8</availability>
 			</model>
 			<model name='HOP-4Cb'>
-				<availability>CHH:8,CLAN:2</availability>
+				<availability>CHH:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
@@ -2784,9 +2793,9 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>CLAN:2-,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,FWL:6,NIOPS:5-</availability>
+			<availability>IS:5,FWL:6,CS:5-,PP:3+,CB:4+,CCO:4+,CSJ:4,CSV:4+,Periphery:5,NIOPS:5-,Periphery.Deep:5</availability>
 			<model name='HBK-4G'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CB:8,CCO:8,CSJ:8,CSV:8,Periphery:8,NIOPS:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='HBK-4H'>
 				<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
@@ -3078,15 +3087,15 @@
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
-			<availability>CS:7,CHH:8,CDS:8,CSV:8,CLAN:7,FWL:4,NIOPS:7,FS:6,MERC:3,DC:4</availability>
+			<availability>FS:6,DC:4,FWL:4,MERC:3,CS:7,PP:4+,CLAN:4,CCC:5,CIH:4-,CMG:3,CSR:3,CSV:3,CWOV:3,NIOPS:7</availability>
 			<model name='KTO-18'>
-				<availability>FS:2</availability>
+				<availability>FS:2,PP:8</availability>
 			</model>
 			<model name='KTO-19'>
-				<availability>CS:8,General:2+,CLAN:6,NIOPS:8,FS:2+,MERC:2+</availability>
+				<availability>IS:2+,MERC:2+,CS:8,PP:1+,CLAN:4-,NIOPS:8</availability>
 			</model>
 			<model name='KTO-19b'>
-				<availability>CLAN:8,CGS:8</availability>
+				<availability>CLAN:5</availability>
 			</model>
 		</chassis>
 		<chassis name='Kiso' unitType='Mek'>
@@ -3142,10 +3151,10 @@
 			</model>
 		</chassis>
 		<chassis name='Kyudo' unitType='Mek'>
-			<availability>CLAN:2,FWL:4+,FS:4+</availability>
+			<availability>FS:4+,FWL:4+,CBS:3+,CCC:2+,CMG:3+,CDS:3+</availability>
 			<model name='KY2-D-02'>
 				<roles>fire_support</roles>
-				<availability>CLAN:8,IS:8</availability>
+				<availability>FS:8,FWL:8,CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='LRM Carrier' unitType='Tank'>
@@ -3369,7 +3378,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lynx' unitType='Mek'>
-			<availability>CIH:4,LA:4+,CLAN:4,FWL:4+,CSJ:4,CJF:4,DC:4+</availability>
+			<availability>LA:4+,DC:4+,FWL:4+,CLAN:5+,CBS:4+,CCC:4+,CFM:4+,CGS:4+,CHH:4+,CMG:4+,CNC:3+,CDS:3+,CSR:4+,CSA:3+,CWI:4+,CWOV:3+</availability>
 			<model name='LNX-9Q'>
                 <roles>raider</roles>
 				<availability>CLAN:8,IS:6+</availability>
@@ -3712,9 +3721,9 @@
 			</model>
 		</chassis>
 		<chassis name='Mercury II' unitType='Mek'>
-			<availability>CWOV:4</availability>
+			<availability>CCO:1+:2824,CWOV!Keshik:2</availability>
 			<model name='MCY-100'>
-				<availability>General:8</availability>
+				<availability>CCO:8,CWOV:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Mercury' unitType='Mek'>
@@ -3918,12 +3927,12 @@
 			</model>
 		</chassis>
 		<chassis name='Naja' unitType='Mek'>
-			<availability>CCC:5:2824,CLAN:3:2824</availability>
+			<availability>CCC!Keshik:3</availability>
             <model name=''>
-                <availability>CCC:8:2826,CLAN:6:2826</availability>
+                <availability>CCC:3+</availability>
             </model>
 			<model name='KTO-19b-EC'>
-				<availability>CCC:8,CBS:8,CSV:8,CMG:8</availability>
+				<availability>CCC:8-</availability>
 			</model>
 		</chassis>
 		<chassis name='Narukami Destroyer' unitType='Warship'>
@@ -4151,14 +4160,14 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:7,CLAN:3,IS:8,FWL:8,NIOPS:7,Periphery.Deep:5,Periphery:5,CGB:3</availability>
+			<availability>IS:8,CS:7,PP:4+,CLAN:4+,CB:3+,CCO:3+,CGB:3+,CGS:6+,CIH:5,CWI:3+,Periphery:5,NIOPS:7,Periphery.Deep:5</availability>
 			<model name='PXH-1'>
 				<roles>command,recon</roles>
-				<availability>General:8,Periphery:8</availability>
+				<availability>IS:8,PP:8,CGB:4-,CIH:3-,CJF!Second Line:3!Solahma:4!Provisional Garrison:5,Periphery:8,NIOPS:4-</availability>
 			</model>
 			<model name='PXH-1-EC'>
                 <roles>command,recon</roles>
-				<availability>CGS:6</availability>
+				<availability>CGS!Keshik:2</availability>
 			</model>
 			<model name='PXH-1D'>
 				<roles>command,recon</roles>
@@ -4174,15 +4183,15 @@
 			</model>
 			<model name='PXH-1b &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:7</availability>
+				<availability>CLAN:8,CGB:5,CGS:4,CIH:6,NIOPS:4+</availability>
 			</model>
 			<model name='PXH-1c &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:4,CGS:6</availability>
+				<availability>CGS:3+</availability>
 			</model>
 			<model name='PXH-2'>
 				<roles>command,recon</roles>
-				<availability>CC:3+,MOC:3+,OA:3+,CLAN:4,FWL:3+</availability>
+				<availability>FWL:3+,CC:3+,PP:1+,CLAN:2+,CCC:3+,CIH:3+,CJF:3+,CMG:3+,CSA:3+,CW:3+,MOC:3+,OA:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
@@ -4570,9 +4579,9 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>CC:5-,CS:3-,LA:5-,FWL:5-,NIOPS:3-,Periphery.Deep:5-,MERC:5-,Periphery:5-,DC:5-</availability>
+			<availability>LA:5-,DC:5-,FWL:5-,CC:5-,MERC:5-,CS:3-,PP:2-,CGS:3-,Periphery:5-,NIOPS:3-,Periphery.Deep:5-</availability>
 			<model name='SCP-1N'>
-				<availability>LA:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CGS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Scout JumpShip' unitType='Jumpship'>
@@ -4596,7 +4605,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>CC:1,CSV:5,CLAN:6,CFM:7,FS:3,CGS:5,CS:4,CDS:5,CW:5,LA:5,CBS:5,FWL:3,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
+			<availability>FS:3,LA:5,DC:3,FWL:3,CC:1,CS:4,PP:4+,CLAN:5-,CBS:6-,CB:4-,CCO:4-,CFM:6-,CGB:6-,CIH:6,CDS:3,CSJ:4-,CSR:6-,CSA:4-,CSV:4-,CWI:4-,CWOV:4-,NIOPS:4</availability>
 			<model name='STN-1S'>
 				<availability>LA:1,FWL:1,FS:1</availability>
 			</model>
@@ -4610,10 +4619,10 @@
 				<availability>LA:2</availability>
 			</model>
 			<model name='STN-3L'>
-				<availability>CS:8,LA:4+,CLAN:6,NIOPS:8,FWL:4+,FS:4+,MERC:4+</availability>
+				<availability>FS:4+,LA:4+,FWL:4+,MERC:4+,CS:8,PP:8,CLAN:8,CBS:4-,CCC:4,CFM:3,CGB:4-,CHH:4-,CJF:4,CDS:4-,CSR:4-,NIOPS:8</availability>
 			</model>
 			<model name='STN-3Lb'>
-				<availability>CLAN:8</availability>
+				<availability>CBS:4+,CCC:4+,CFM:4+,CGB:4+,CHH:4+,CJF:4+,CDS:4+,CSR:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
@@ -4628,18 +4637,18 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:6-,LA:6,CLAN:4,IS:7,NIOPS:6-,Periphery.Deep:5,Periphery:5,CGB:4</availability>
+			<availability>IS:7,LA:6,CS:6-,PP:4,CLAN:5,CIH:4,Periphery:5,NIOPS:6-,Periphery.Deep:5</availability>
             <model name='C'>
-                <availability>CSA:6,CCC:6,CSV:6,CFM:6,CGS:6</availability>
+                <availability>CLAN!Keshik:3</availability>
             </model>
 			<model name='SHD-2D'>
 				<availability>FS:10</availability>
 			</model>
 			<model name='SHD-2H'>
-				<availability>General:8,CLAN:6-</availability>
+				<availability>IS:8,MERC:8,PP:8,CLAN:2-,CIH:1-,CMG:1-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='SHD-2Hb'>
-				<availability>CLAN:8,FS:3+</availability>
+				<availability>FS:3+,PP:1+,CLAN:8+</availability>
 			</model>
 			<model name='SHD-2K'>
 				<availability>DC:9</availability>
@@ -4808,11 +4817,17 @@
 			</model>
 		</chassis>
 		<chassis name='Stag II' unitType='Mek'>
-			<availability>CWOV:4</availability>
+            <availability>CWOV!Keshik:2</availability>
 			<model name='ST-24G'>
-				<availability>General:8</availability>
+				<availability>CWOV:8</availability>
 			</model>
 		</chassis>
+        <chassis name='Stag' unitType='Mek'>
+            <availability>CWOV!Keshik:3</availability>
+            <model name='ST-14G'>
+                <availability>CWOV:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Stalker' unitType='Mek'>
 			<availability>CC:7,CLAN:7,IS:8,Periphery.Deep:9,FS:7,Periphery:9,CS:6,FWL:9,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
@@ -4838,14 +4853,14 @@
 			</model>
 		</chassis>
 		<chassis name='Starslayer' unitType='Mek'>
-			<availability>CSA:3,LA:5+,CNC:4</availability>
+			<availability>LA:5+,CNC:4+,CSA:4+</availability>
 			<model name='STY-2C'>
 				<roles>raider</roles>
-				<availability>IS:8</availability>
+				<availability>LA:8,CNC:8,CSA:8</availability>
 			</model>
 			<model name='STY-2C-EC'>
                 <roles>raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CNC!Keshik:2,CSA:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Stinger LAM Mk I' unitType='Mek'>
@@ -5137,10 +5152,10 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
+			<availability>FWL:8,CC:5,MERC:5,CS:5-,CDS:3+,MOC:5,NIOPS:5-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
-				<availability>CC:3+,CS:6,FWL:3+,NIOPS:6</availability>
+				<availability>FWL:3+,CC:3+,CS:6,CDS:8,NIOPS:6</availability>
 			</model>
 			<model name='TBT-5J'>
 				<availability>FWL:4</availability>
@@ -5350,14 +5365,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:4,CS:3,MOC:4,LA:7,CLAN:4-,FWL:7,IS:5,NIOPS:3,CIR:4,TC:4</availability>
+			<availability>IS:5,LA:7,FWL:7,CC:4,CS:3,PP:4,CWOV:3-,TC:4,MOC:4,CIR:4,NIOPS:3</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
-				<availability>General:8,FS:4</availability>
+				<availability>IS:8,FS:4,PP:8,CWOV:8,Periphery:8</availability>
 			</model>
 			<model name='VL-5T'>
 				<roles>anti_infantry</roles>
-				<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,TC:2</availability>
+				<availability>IS:2,FS:6,CWOV:5+,TC:2,MOC:2,CIR:2,PIR:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Vulture' unitType='Dropship'>
@@ -5471,13 +5486,13 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:3-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+			<availability>FS.CMM:5,DC:6,MERC:3,CS:3-,CB:2-,CWI:2-,Periphery.DD:2,Periphery.OS:2,TC:2,MOC:1,OA:1,NIOPS:3-</availability>
 			<model name='WTH-0'>
 				<availability>TC:6</availability>
 			</model>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
-				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CB:8,CWI:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='WTH-1S'>
 				<roles>fire_support</roles>
@@ -5485,14 +5500,14 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine II' unitType='Mek'>
-			<availability>CWOV:8</availability>
+			<availability>CMG:3+,CSR:3+,CW:2+,CWOV:6+</availability>
 			<model name='WVR-7H'>
                 <roles>command,recon</roles>
-				<availability>General:8</availability>
+				<availability>CMG:8,CSR:8,CW:8,CWOV:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CS:5-,CWOV:6,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,TC:5</availability>
+			<availability>IS:7,FS:8,FWL:9,CS:5-,PP:3+,CLAN:3-,CGS:2-,CIH:2-,CMG:2-,CWOV:4-,TC:5,NIOPS:5-,Periphery.Deep:6</availability>
 			<model name='WVR-1R'>
 				<availability>FS:2-</availability>
 			</model>
@@ -5506,21 +5521,21 @@
 			</model>
 			<model name='WVR-6R'>
 				<roles>command,recon</roles>
-				<availability>General:8,CLAN:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,PP:8,CLAN:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CS:6,CC:6,CIH:5,CLAN:6,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:5</availability>
+			<availability>FS:6,DC:6,CC:6,MERC:5,CS:6,PP:4+,CLAN:4,CCC:3,CGB:3,CGS:3,CIH:2-,CJF:3,CMG:4-,CDS:3,CSJ:2,CSR:3,CSV:3,CW:3,CWOV:3,TC:5,NIOPS:6</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
-				<availability>CS:8,CC:5+,CLAN:6,NIOPS:8,CFM:6,FS:5+,DC:5+,TC:8</availability>
+				<availability>FS:5+,DC:5+,CC:5+,CS:8,PP:8,CBS:4-,CB:4-,CCO:4-,CFM:4-,TC:8,NIOPS:8</availability>
 			</model>
 			<model name='WVE-5Nb'>
 				<roles>urban</roles>
-				<availability>CLAN:8,CFM:8,CGS:8</availability>
+				<availability>CLAN:6</availability>
 			</model>
 			<model name='WVE-5Nsl'>
-				<availability>LA:3+,FWL:3+</availability>
+				<availability>LA:3+,FWL:3+,CLAN:3-,CBS:2-,CB:2-,CCO:2-,CFM:2-</availability>
 			</model>
 			<model name='WVE-6N'>
 				<roles>urban</roles>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -620,7 +620,7 @@
 			</model>
 			<model name='ARC-2Rb'>
 				<roles>command,fire_support</roles>
-				<availability>CLAN:8</availability>
+				<availability>CLAN:8,NIOPS:5</availability>
 			</model>
             <model name='C'>
                 <roles>command,fire_support</roles>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -2130,7 +2130,7 @@
 			</model>
 		</chassis>
 		<chassis name='Firestarter' unitType='Mek'>
-			<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
+			<availability>IS:7,LA:8,CS:3,CFM:4-,CHH:3,PP:4,Periphery:7,NIOPS:3,Periphery.Deep:7</availability>
 			<model name='FS9-A'>
                 <roles>anti_infantry,recon</roles>
 				<deployedWith>Vulcan</deployedWith>
@@ -2139,7 +2139,7 @@
 			<model name='FS9-H'>
                 <roles>anti_infantry,recon</roles>
 				<deployedWith>Vulcan</deployedWith>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CFM:8,CHH:8,PP:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='FS9-K'>
                 <roles>anti_infantry,recon</roles>
@@ -2722,7 +2722,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hermes' unitType='Mek'>
-			<availability>MOC:4,CC:3,CS:3,CHH:5,OA:4,CLAN:4,FWL:5,NIOPS:3,CGB:5,DC:3,CB:5</availability>
+			<availability>DC:3,FWL:5,CC:3,CS:3,CLAN:2,CB:1,CCO:1,CGB:1,CIH:6+,CDS:3,CWI:1,PP:4+,MOC:4,OA:4,NIOPS:3</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
 				<availability>FWL:6</availability>
@@ -2733,11 +2733,11 @@
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
-				<availability>CS:8,General:5,CLAN:6,NIOPS:8</availability>
+				<availability>IS:5,MERC:5,CS:8,CLAN:4,PP:8,Periphery:5,NIOPS:8</availability>
 			</model>
 			<model name='HER-1Sb'>
 				<roles>recon</roles>
-				<availability>CLAN:8,FWL:3+</availability>
+				<availability>FWL:3+,CLAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
@@ -2793,13 +2793,13 @@
 			</model>
 		</chassis>
 		<chassis name='Hussar' unitType='Mek'>
-			<availability>CS:4,CIH:9,LA:1+,CSV:9,CLAN:8,NIOPS:4,FS:1+</availability>
+			<availability>FS:1+,LA:1+,CS:4,CLAN:3+,CGB:2+,CIH:6+,CMG:4+,CDS:4+,CSV:4+,CWI:4+,PP:5+,NIOPS:4</availability>
 			<model name='HSR-200-D'>
 				<roles>recon</roles>
-				<availability>CS:8,General:8,CLAN:6,NIOPS:8,DC:8</availability>
+				<availability>IS:8,CS:8,CLAN:5,PP:8,NIOPS:8</availability>
 			</model>
 			<model name='HSR-200-Db'>
-				<availability>CLAN:8</availability>
+				<availability>CLAN:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Icarus II' unitType='Mek'>
@@ -2808,6 +2808,13 @@
 				<availability>General:8</availability>
 			</model>
 		</chassis>
+        <chassis name='Icestorm' unitType='Mek'>
+            <availability>CIH!Keshik:3</availability>
+            <model name=''>
+                <roles>spotter</roles>
+                <availability>CIH:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
 			<availability>IS:2</availability>
 			<model name=''>
@@ -3261,10 +3268,10 @@
 			</model>
 		</chassis>
 		<chassis name='Locust' unitType='Mek'>
-			<availability>CS:6-,CLAN:3-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:9,CS:6-,CLAN:5,CB:4,CCO:4,CJF:6,CWI:4,CW:6,PP:5,Periphery:6,NIOPS:6-,Periphery.Deep:6</availability>
 			<model name='LCT-1E'>
 				<roles>recon</roles>
-				<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
+				<availability>IS:4,Periphery:4,Periphery.Deep:4</availability>
 			</model>
 			<model name='LCT-1M'>
 				<roles>recon</roles>
@@ -3276,7 +3283,7 @@
 			</model>
 			<model name='LCT-1V'>
 				<roles>recon</roles>
-				<availability>LA:4,General:8,CLAN:4-,FS:7</availability>
+				<availability>IS:8,MERC:8,FS:7,LA:4,PP:8,Periphery:8</availability>
 			</model>
 			<model name='LCT-1Vb'>
 				<roles>recon</roles>
@@ -3411,9 +3418,9 @@
 			</model>
 		</chassis>
 		<chassis name='Mandrill' unitType='Mek'>
-			<availability>CFM:4</availability>
+			<availability>CFM!Keshik:3</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CFM:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
@@ -3711,14 +3718,14 @@
 			</model>
 		</chassis>
 		<chassis name='Mercury' unitType='Mek'>
-			<availability>CS:8,CC:4+,LA:4+,CLAN:4,NIOPS:8,IS:4+,MERC:4+</availability>
+			<availability>IS:4+,MERC:4+,CS:8,CLAN:3+,CB:2+,CCO:2+,CIH:5+,CSJ:1,CWI:2+,PP:1+,NIOPS:8</availability>
 			<model name='MCY-98'>
 				<roles>recon</roles>
 				<availability>CC:8</availability>
 			</model>
 			<model name='MCY-99'>
 				<roles>recon</roles>
-				<availability>CS:4,General:3+,CLAN:8,NIOPS:4</availability>
+				<availability>IS:3+,CS:4,CLAN:8,PP:8,NIOPS:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Mobile Headquarters' unitType='Tank'>
@@ -3772,14 +3779,14 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>MOC:4+,CHH:5,CLAN:6,MERC:4+,FS:6+,TC:4+,CS:6,OA:4+,CDS:5,CBS:7,FWL:5+,NIOPS:6,CMG:6,CJF:7,CGB:5,DC:5+</availability>
+			<availability>FS:6+,DC:5+,FWL:5+,MERC:4+,CS:6,CLAN:4+,CBS:3+,CGS:3+,CJF:5+,CMG:6+,CWI:3+,PP:1+,TC:4+,MOC:4+,OA:4+,NIOPS:6</availability>
 			<model name='MON-66'>
 				<roles>command,recon</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,IS:6+,Periphery:6+</availability>
+				<availability>IS:6+,CS:8,CLAN:6,PP:8,Periphery:6+,NIOPS:8</availability>
 			</model>
 			<model name='MON-66b'>
 				<roles>command,recon</roles>
-				<availability>CLAN:9,CGS:9</availability>
+				<availability>CLAN:5+</availability>
 			</model>
 			<model name='MON-69'>
 				<roles>command,recon</roles>
@@ -3938,13 +3945,13 @@
 			</model>
 		</chassis>
 		<chassis name='Night Hawk' unitType='Mek'>
-			<availability>CW:7,LA:4+,CLAN:7,FWL:4+,FS:4+,CGS:7,CGB:7</availability>
+			<availability>FS:4+,LA:4+,FWL:4+,CLAN:4+,CBS:5+,CB:5+,CCO:5+,CGB:5+,CJF:5+,CNC:5+,CSJ:5+,CSR:3+,CSV:5+,CW:5+,PP:1+</availability>
 			<model name='NTK-2Q'>
 				<roles>raider</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CLAN:8,PP:8</availability>
 			</model>
 			<model name='NTK-2Q-EC'>
-				<availability>CSJ:6</availability>
+				<availability>CSJ!Keshik:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
@@ -4007,10 +4014,10 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CS:4,CLAN:4-,IS:5,Periphery.Deep:5,NIOPS:4,MERC:5,Periphery:5</availability>
+			<availability>IS:5,MERC:5,CS:4,CLAN:2,CB:1,CCO:1,CSJ:1,CWI:1,Periphery:5,NIOPS:4,Periphery.Deep:5</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
-				<availability>General:8,CLAN:6-</availability>
+				<availability>IS:8,MERC:8,Periphery:8</availability>
 			</model>
 			<model name='OTT-7Jb'>
 				<roles>recon</roles>
@@ -4077,13 +4084,13 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>CC:3,Periphery.DD:5,FS.RR:3,CLAN:4-,MERC:5,Periphery.OS:5,FS:3,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>FS:3,FS.RR:3,FS.DMM:3,LA:3,DC:10,FWL:3,CC:3,MERC:5,CS:2,CSJ:4,PP:4,Periphery:3,Periphery.DD:5,Periphery.OS:5,NIOPS:2</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,TC:8</availability>
 			</model>
 			<model name='PNT-9R'>
 				<roles>fire_support</roles>
-				<availability>CLAN:8,MERC:8,DC:8</availability>
+				<availability>DC:8,MERC:8,CSJ:8,PP:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -4722,14 +4729,14 @@
 			</model>
 		</chassis>
 		<chassis name='Sling' unitType='Mek'>
-			<availability>CC:4+,LA:4+,CLAN:1,CSJ:2</availability>
+			<availability>LA:4+,CC:4+,CSJ:5+</availability>
 			<model name='SL-1G'>
 				<roles>spotter</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,CC:8,CSJ:8</availability>
 			</model>
 			<model name='SL-1H'>
 				<roles>spotter</roles>
-				<availability>LA:4</availability>
+				<availability>LA:4,CSJ:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Snowden Mining Station' unitType='Space Station'>
@@ -4780,14 +4787,14 @@
 			</model>
 		</chassis>
 		<chassis name='Spector' unitType='Mek'>
-			<availability>CLAN:4</availability>
+			<availability>CIH:1+,CMG:2+</availability>
 			<model name='SPR-4F'>
                 <roles>specops,raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CIH:8,CMG:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>CC:5,CS:4,OA:2,LA:4,CLAN:2-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
+			<availability>IS:4,FS:5,DC:6,FWL:7,CC:5,MERC:4,CS:4,CIH:3+,CMG:3+,TC:2,OA:2,NIOPS:4</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -4797,7 +4804,7 @@
 				<availability>DC:8</availability>
 			</model>
 			<model name='SDR-5V'>
-				<availability>CLAN:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
+				<availability>IS:8,CIH:8,CMG:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stag II' unitType='Mek'>
@@ -4856,10 +4863,10 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>CS:4-,CLAN:3-,IS:9,NIOPS:4-,Periphery.Deep:5,MERC:5,Periphery:5,DC:6,CGB:3-</availability>
+			<availability>IS:9,DC:6,MERC:5,CS:4-,CLAN:4,CB:5,CCO:5,CWOV:5,PP:4,Periphery:5,NIOPS:4-,Periphery.Deep:5</availability>
 			<model name='STG-3G'>
 				<roles>recon</roles>
-				<availability>CLAN:2-,IS:4,Periphery.Deep:4,Periphery:4</availability>
+				<availability>IS:4,CLAN!Solahma:2!Provisional Garrison:3,PP:4,Periphery:4,Periphery.Deep:4</availability>
 			</model>
 			<model name='STG-3Gb'>
 				<roles>recon</roles>
@@ -4867,7 +4874,7 @@
 			</model>
 			<model name='STG-3R'>
 				<roles>recon</roles>
-				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CLAN:2-,PP:8-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
@@ -4938,15 +4945,15 @@
 			</model>
 		</chassis>
 		<chassis name='Talon' unitType='Mek'>
-			<availability>CLAN:8</availability>
+			<availability>CLAN:5+,CB:4+,CFM:4+,CGS:3+,CIH:4+,CJF:7+,CNC:7+,CDS:7+,CSJ:6+,CSR:3+,CSV:6+,CW:8+,CWOV:6+</availability>
 			<model name='TLN-5V'>
-				<availability>FWL:8,FS:8</availability>
+				<availability>CIH:6,CMG:6,CNC:6,CDS:6,CW:6</availability>
 			</model>
 			<model name='TLN-5W'>
-				<availability>LA:8,CLAN:8</availability>
+				<availability>CLAN:8,CIH:6+,CMG:4+,CNC:6+,CDS:7+,CW:8+</availability>
 			</model>
 			<model name='TLN-5W-EC'>
-				<availability>CIH:6</availability>
+				<availability>CIH!Keshik:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Texas Battleship' unitType='Warship'>
@@ -4971,15 +4978,15 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>CC:2,MOC:2+,CLAN:4,MERC:2,FS:2,CCO:2,TC:2+,CSA:2,CS:6,OA:2+,CDS:5,FWL:4,NIOPS:6,CJF:5,CGB:5</availability>
+			<availability>FS:2,CC:2,FWL:4,MERC:2,CS:6,CLAN:4,CGB:5,CHH:6,CIH:4-,CMG:3,CNC:5,CW:5,CWOV:3,TC:2+,MOC:2+,OA:2+,NIOPS:6</availability>
 			<model name='THE-F'>
-				<availability>CC:2+,FWL:2+,FS:2+</availability>
+				<availability>CC:2+,FWL:2+,FS:2+,Periphery:8</availability>
 			</model>
 			<model name='THE-N'>
-				<availability>CS:8,General:5+,CLAN:6,NIOPS:8</availability>
+				<availability>IS:5+,CS:8,CLAN:8,CB:7,CGB:7,CIH:7,CJF:7,CMG:7,CNC:7,CDS:7,CSR:7,CW:7,NIOPS:8</availability>
 			</model>
 			<model name='THE-Nb'>
-				<availability>CLAN:8,CGS:8</availability>
+				<availability>CB:6+,CGB:6+,CIH:6+,CJF:6+,CMG:6+,CNC:6+,CDS:6+,CSR:6+,CW:6+</availability>
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
@@ -5249,10 +5256,10 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>CC:5-,CLAN:2-,IS:3-,Periphery:2-,CS:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
+			<availability>IS:3-,CC:5-,CLAN:1-,PP:4-,Periphery:2-,CS:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
-				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CLAN:8,PP:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Valkyrie' unitType='Mek'>
@@ -5417,10 +5424,10 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>CS:4-,CW:2-,CLAN:2-,IS:10,NIOPS:4-,Periphery.Deep:5,Periphery:5</availability>
+			<availability>IS:10,CS:4-,CLAN:1-,PP:4,Periphery:5,NIOPS:4-,Periphery.Deep:5</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,MERC:8,CLAN:8,PP:8,Periphery:8</availability>
 			</model>
 			<model name='WSP-1D'>
 				<roles>recon</roles>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -1937,6 +1937,7 @@
 				<availability>FS:4+,LA:4+,FWL:4+,CC:4+,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 			<model name='EMP-6A-EC'>
+                <roles>command</roles>
 				<availability>CSA!Keshik:3</availability>
 			</model>
 		</chassis>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -5418,10 +5418,10 @@
 				<availability>CC:4</availability>
 			</model>
 			<model name='WHM-6R'>
-				<availability>IS:8,PP:8,CLAN:1-,CBS:2-,CB:2-,CCO:2-,CGS:2-,CJF:2-,CNC:2-,CSJ:2-,CSA:2-,CWOV:2-,Periphery:8,Periphery.Deep:8</availability>
+				<availability>IS:8,PP:8,CLAN:1-,CBS:2-,CB:2-,CCO:2-,CGS:2-,CJF:2-,CNC:2-,CSJ:2-,CSA:2-,CWOV:2-,Periphery:8,NIOPS:3-,Periphery.Deep:8</availability>
 			</model>
 			<model name='WHM-6Rb'>
-				<availability>FS:4+,LA:4+,FWL:4+,CC:4+,CLAN:5</availability>
+				<availability>FS:4+,LA:4+,FWL:4+,CC:4+,CLAN:5,NIOPS:6</availability>
 			</model>
 			<model name='WHM-6Rk'>
                 <roles>cavalry</roles>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -1092,7 +1092,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>IS:5,LA:6,CC:7,MERC:5,CS:5,CBS:4-,CCO:3-,CGB:4+,CHH:4+,CIH:6+,CDS:4+,CSV:3+,NIOPS:5</availability>
+			<availability>IS:5,LA:6,CC:7,MERC:5,CS:5,CBS:4-,CCO:3-,CFM:4+,CGB:4+,CHH:4+,CIH:6+,CDS:4+,CSV:3+,NIOPS:5</availability>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
 				<availability>CC:4+,CS:8,CBS:8,CCO:8,CGB:4-,CHH:4-,NIOPS:8</availability>
@@ -2004,7 +2004,7 @@
 			</model>
 			<model name='EXC-B2b'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CLAN:2+,CGB:3+,CJF:3+,CSJ:3+,</availability>
+				<availability>CLAN:2+,CGB:3+,CJF:3+,CSJ:3+</availability>
 			</model>
 			<model name='EXC-B2b-EC'>
                 <roles>cavalry,fire_support</roles>
@@ -3474,7 +3474,7 @@
 			</model>
 			<model name='MAD-3R'>
                 <roles>command</roles>
-				<availability>IS:8,CS:4-,PP:8,TC:5</availability>
+				<availability>IS:8,CS:4-,PP:8,TC:5,MOC:8</availability>
 			</model>
 		</chassis>
         <chassis name='Marco' unitType='Mek'>

--- a/megamek/data/forcegenerator/2823.xml
+++ b/megamek/data/forcegenerator/2823.xml
@@ -1833,6 +1833,12 @@
 				<availability>FS:6+,CBS:6,CDS:6</availability>
 			</model>
 		</chassis>
+        <chassis name='Devastator' unitType='Mek'>
+            <availability>CSJ!Keshik:3</availability>
+            <model name='DVS-2-EC'>
+                <availability>CSJ:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Dictator' unitType='Dropship'>
 			<availability>IS:4</availability>
 			<model name=''>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2830-->
-<ratgen>
+<ratgen
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2830-->
-<ratgen
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
             <!-- Omni percentages: 0,0 -->

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -623,7 +623,7 @@
 			</model>
 			<model name='ARC-2Rb'>
 				<roles>command,fire_support</roles>
-				<availability>CLAN:8,BAN:2+</availability>
+				<availability>CLAN:8,NIOPS:5,BAN:2+</availability>
 			</model>
             <model name='C'>
                 <roles>command,fire_support</roles>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -1947,6 +1947,7 @@
 				<availability>FS:4+,LA:4+,FWL:4+,CC:4+,CS:8,CLAN:8,CSA:4-,NIOPS:8</availability>
 			</model>
 			<model name='EMP-6A-EC'>
+                <roles>command</roles>
 				<availability>CSA:1+</availability>
 			</model>
 		</chassis>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -28,17 +28,17 @@
 			<weightDistribution era='2830' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 		</faction>
 		<faction key='CBS'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,5,0</pctClan>
-			<pctSL>100,100,100,95,100</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,5,0 -->
+            <!-- Star League percentages: 100,100,100,95,100 -->
 			<pctClan unitType='Vehicle'>0,0,0,5,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,95,90</pctSL>
 			<salvage pct='10'>CHH:5,CCC:5,CDS:1,CW:5,CSV:10,CNC:5,CCO:5,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CB'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,15,30</pctClan>
-			<pctSL>100,100,100,85,70</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,15,30 -->
+            <!-- Star League percentages: 100,100,100,85,70 -->
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 			<salvage pct='10'>CCC:1,CHH:7,CSR:5,CIH:5,CSV:3,CFM:3,CCO:7,CGS:3,CSA:2,CDS:5,CW:3,CWI:2,CBS:3,CNC:10,CSJ:2,CMG:2,CJF:5</salvage>
@@ -46,17 +46,17 @@
 			<weightDistribution era='2830' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CCC'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,5,15,25</pctClan>
-			<pctSL>100,100,95,85,75</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,5,15,25 -->
+            <!-- Star League percentages: 100,100,95,85,75 -->
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 			<salvage pct='10'>CHH:2,CSR:1,CIH:5,CSV:3,CFM:3,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CCO'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,15,20</pctClan>
-			<pctSL>100,100,100,85,80</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,15,20 -->
+            <!-- Star League percentages: 100,100,100,85,80 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CCC:7,CHH:1,CSR:3,CIH:10,CSV:3,CFM:7,CGS:1,CSA:5,CDS:1,CW:1,CBS:1,CNC:3,CSJ:7,CJF:3,CB:3</salvage>
@@ -64,17 +64,17 @@
 			<weightDistribution era='2830' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CFM'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,15,20</pctClan>
-			<pctSL>100,100,100,85,80</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,15,20 -->
+            <!-- Star League percentages: 100,100,100,85,80 -->
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CIH:10,CSV:5,CCO:6,CGS:7,CSA:10,CDS:3,CW:1,CNC:2,CSJ:4,CMG:1,CJF:4,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CGB'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,10,15,20</pctClan>
-			<pctSL>100,100,90,85,80</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,10,15,20 -->
+            <!-- Star League percentages: 100,100,90,85,80 -->
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 			<salvage pct='10'>CHH:10,CCC:3,CIH:5,CSR:1,CSV:10,CFM:3,CGS:1,CCO:1,CSA:8,CDS:1,CW:8,CMG:3,CJF:5</salvage>
@@ -82,25 +82,25 @@
 			<weightDistribution era='2830' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CGS'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,5,10,15</pctClan>
-			<pctSL>100,100,95,90,85</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,5,10,15 -->
+            <!-- Star League percentages: 100,100,95,90,85 -->
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 			<salvage pct='10'>CCC:1,CHH:4,CSR:1,CIH:6,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:1,CWI:3,CNC:3,CSJ:1,CMG:3,CJF:10,CB:3</salvage>
 		</faction>
 		<faction key='CHH'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,15,20</pctClan>
-			<pctSL>100,100,100,85,80</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,15,20 -->
+            <!-- Star League percentages: 100,100,100,85,80 -->
 			<pctClan unitType='Vehicle'>0,0,5,10,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,90,85</pctSL>
 			<salvage pct='10'>CCC:2,CSR:7,CIH:10,CSV:4,CFM:7,CCO:1,CGS:6,CSA:4,CDS:7,CW:3,CWI:4,CBS:2,CNC:10,CSJ:3,CMG:3,CJF:3,CGB:8,CB:7</salvage>
 		</faction>
 		<faction key='CIH'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,15,20</pctClan>
-			<pctSL>100,100,100,85,80</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,15,20 -->
+            <!-- Star League percentages: 100,100,100,85,80 -->
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 			<salvage pct='10'>CCC:3,CHH:4,CSR:3,CSV:1,CFM:10,CCO:9,CGS:5,CSA:1,CDS:4,CW:4,CWI:1,CNC:3,CSJ:3,CMG:3,CJF:3,CGB:2,CB:3</salvage>
@@ -108,57 +108,57 @@
 			<weightDistribution era='2830' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
 		<faction key='CJF'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,5,15,20</pctClan>
-			<pctSL>100,100,95,85,80</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,5,15,20 -->
+            <!-- Star League percentages: 100,100,95,85,80 -->
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 			<salvage pct='10'>CCC:2,CHH:3,CSR:7,CIH:7,CSV:7,CFM:10,CCO:7,CGS:6,CSA:3,CDS:4,CW:7,CWI:1,CBS:1,CNC:2,CSJ:3,CMG:3,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CMG'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,15,25</pctClan>
-			<pctSL>100,100,100,85,75</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,15,25 -->
+            <!-- Star League percentages: 100,100,100,85,75 -->
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 			<salvage pct='10'>CHH:3,CIH:10,CSR:3,CSV:8,CFM:8,CGS:5,CSA:8,CDS:3,CW:3,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
 		</faction>
 		<faction key='CNC'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,20,30</pctClan>
-			<pctSL>100,100,100,80,70</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,20,30 -->
+            <!-- Star League percentages: 100,100,100,80,70 -->
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 			<salvage pct='10'>CCC:5,CHH:10,CSR:3,CIH:7,CFM:3,CCO:7,CGS:3,CDS:3,CW:7,CWI:2,CBS:2,CSJ:3,CJF:5,CB:7</salvage>
 		</faction>
 		<faction key='CDS'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,15,20</pctClan>
-			<pctSL>100,100,100,85,80</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,15,20 -->
+            <!-- Star League percentages: 100,100,100,85,80 -->
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 			<salvage pct='12'>CCC:2,CHH:7,CSR:3,CIH:10,CSV:3,CFM:4,CCO:3,CGS:4,CSA:8,CW:3,CWI:1,CNC:3,CSJ:7,CMG:1,CJF:6,CB:3</salvage>
 		</faction>
 		<faction key='CSJ'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,15,20</pctClan>
-			<pctSL>100,100,100,85,80</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,15,20 -->
+            <!-- Star League percentages: 100,100,100,85,80 -->
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 			<salvage pct='10'>CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
 		</faction>
 		<faction key='CSR'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,5,20,30</pctClan>
-			<pctSL>100,100,95,80,70</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,5,20,30 -->
+            <!-- Star League percentages: 100,100,95,80,70 -->
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 			<salvage pct='10'>CCC:1,CHH:7,CIH:7,CSV:5,CFM:7,CCO:7,CGS:1,CSA:1,CDS:3,CW:3,CWI:1,CNC:3,CSJ:3,CMG:1,CJF:7,CB:10</salvage>
 		</faction>
 		<faction key='CSA'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,25,20</pctClan>
-			<pctSL>100,100,100,75,80</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,25,20 -->
+            <!-- Star League percentages: 100,100,100,75,80 -->
 			<pctClan unitType='Vehicle'>0,0,5,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,90,90</pctSL>
 			<salvage pct='10'>CCC:2,CHH:2,CSR:1,CIH:10,CSV:10,CFM:10,CCO:3,CGS:5,CDS:5,CW:10,CSJ:1,CMG:3,CJF:10,CGB:3,CB:1</salvage>
@@ -166,25 +166,25 @@
 			<weightDistribution era='2830' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CSV'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,10,20,30</pctClan>
-			<pctSL>100,100,90,80,70</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,10,20,30 -->
+            <!-- Star League percentages: 100,100,90,80,70 -->
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 			<salvage pct='10'>CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:4,CBS:1,CSJ:1,CMG:2,CJF:10,CGB:3,CB:1</salvage>
 		</faction>
 		<faction key='CWI'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,10,20</pctClan>
-			<pctSL>100,100,100,90,80</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,10,20 -->
+            <!-- Star League percentages: 100,100,100,90,80 -->
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 			<salvage pct='10'>CHH:10,CIH:5,CSR:5,CDS:5,CW:10,CNC:5,CGS:10,CJF:5,CB:5</salvage>
 		</faction>
 		<faction key='CW'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,5,15,25</pctClan>
-			<pctSL>100,100,95,85,75</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,5,15,25 -->
+            <!-- Star League percentages: 100,100,95,85,75 -->
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 			<salvage pct='10'>CCC:3,CHH:2,CSR:3,CIH:8,CSV:10,CFM:3,CCO:1,CGS:1,CSA:3,CDS:2,CWI:1,CBS:1,CNC:5,CSJ:10,CMG:3,CJF:5,CGB:2,CB:5</salvage>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -4093,7 +4093,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>IS:5,MERC:5,CS:4,CLAN!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CB!Front Line:1!Second Line:1!Solahma:1!Provisional Garrison:1,CCO!Front Line:1!Second Line:1!Solahma:1!Provisional Garrison:1,CSJ!Second Line:1!Solahma:1,Provisional Garrison:1,CWI!Second Line:1!Solahma:1,Provisional Garrison:1,CW!Front Line:1!Second Line:1!Solahma:2!Provisional Garrison:2,Periphery:5,NIOPS:4,Periphery.Deep:5,BAN:1</availability>
+			<availability>IS:5,MERC:5,CS:4,CLAN!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CB!Front Line:1!Second Line:1!Solahma:1!Provisional Garrison:1,CCO!Front Line:1!Second Line:1!Solahma:1!Provisional Garrison:1,CSJ!Second Line:1!Solahma:1!Provisional Garrison:1,CWI!Second Line:1!Solahma:1!Provisional Garrison:1,CW!Front Line:1!Second Line:1!Solahma:2!Provisional Garrison:2,Periphery:5,NIOPS:4,Periphery.Deep:5,BAN:1</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
 				<availability>IS:8,MERC:8,Periphery:8</availability>
@@ -5075,10 +5075,10 @@
 				<availability>CC:2+,FWL:2+,FS:2+,Periphery:8</availability>
 			</model>
 			<model name='THE-N'>
-				<availability>IS:5+,CS:8,CLAN:8,CB:7, CGB:7,CIH:7,CJF:7,CMG:7,CNC:7,CDS:7,CSR:7,CW:7,NIOPS:8,BAN:8</availability>
+				<availability>IS:5+,CS:8,CLAN:8,CB:7,CGB:7,CIH:7,CJF:7,CMG:7,CNC:7,CDS:7,CSR:7,CW:7,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='THE-Nb'>
-				<availability>CB:6+,CGB:6+,CIH:6+,CJF:6+,CMG:6+,CNC:6+,CDS:6+,CSR:6+,CW:6+,BAN!Second Line:1</availability>
+				<availability>CB:6+,CGB:6+,CIH:6+,CJF:6+,CMG:6+,CNC:6+,CDS:6+,CSR:6+,CW:6+,BAN:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
@@ -5535,7 +5535,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>IS:10,CS:4-,CLAN:1-,Periphery:6,NIOPS:4-,CIR:5,Periphery.Deep:6,BAN:1-</availability>
+			<availability>IS:10,CS:4-,CLAN:1-,Periphery:6,CIR:5,NIOPS:4-,Periphery.Deep:6,BAN:1-</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
 				<availability>IS:8,MERC:8,CLAN:8,Periphery:8,BAN:8</availability>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -612,19 +612,23 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:7,CS:5-,LA:9,CLAN:2,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8,CGB:2</availability>
+			<availability>IS:6,FS:8,LA:9,DC:8,FWL:9,CC:7,CS:5-,CLAN:4,CFM:3,CGS:3,CIH:4-,CMG:3,CSV:3,Periphery:6,NIOPS:5-,Periphery.Deep:6,BAN:4</availability>
 			<model name='ARC-2K'>
 				<roles>command,fire_support</roles>
 				<availability>DC:6</availability>
 			</model>
 			<model name='ARC-2R'>
 				<roles>command,fire_support</roles>
-				<availability>LA:8,CLAN:5,IS:8,Periphery.Deep:8,BAN:8,DC:7,Periphery:8</availability>
+				<availability>IS:8,DC:7,CLAN:1-,CGB:2-,CW:2-,Periphery:8,NIOPS:4-,Periphery.Deep:8,BAN:8</availability>
 			</model>
 			<model name='ARC-2Rb'>
 				<roles>command,fire_support</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,BAN:2+</availability>
 			</model>
+            <model name='C'>
+                <roles>command,fire_support</roles>
+                <availability>CLAN:2+,CBS:1+,CFM:1+</availability>
+            </model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
 			<availability>MOC:8,OA:8,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8,BAN:3</availability>
@@ -870,14 +874,14 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:5,FS:4,MERC:3,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:3,CNC:10,FWL:5,NIOPS:7,CJF:8,CGB:10,DC:3</availability>
+			<availability>FS:4,LA:3,DC:3,FWL:5,MERC:3,CS:7,CLAN:3+,CGS:4+,CIH:2+,NIOPS:7,BAN:2+</availability>
 			<model name='BL-6-KNT'>
                 <roles>command</roles>
-				<availability>CS:8,CLAN:6,FWL:4+,NIOPS:8,FS:4+,BAN:6</availability>
+				<availability>FS:4+,FWL:4+,CS:8,CLAN:8,CBS:6-,CCO:5-,CGB:6-,CGS:5-,CNC:6-,CW:5-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='BL-6b-KNT'>
                 <roles>command</roles>
-				<availability>CS:4,CLAN:8,NIOPS:4,FWL:2+,CGS:8,BAN:4</availability>
+				<availability>FWL:2+,CS:4,CBS:7,CCO:7,CGB:7,CGS:7,CNC:7,CW:7,NIOPS:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
                 <roles>command</roles>
@@ -916,14 +920,14 @@
 			</model>
 		</chassis>
 		<chassis name='Bombardier' unitType='Mek'>
-			<availability>CLAN:5,CS:5,FWL:3,DC:3,NIOPS:5,BAN:3</availability>
+			<availability>DC:3,FWL:3,CS:5,CLAN:3-,CB:2-,CCO:2-,CIH:4,CMG:4-,CDS:4-,CSR:4-,CWI:2-,NIOPS:5,BAN:0</availability>
 			<model name='BMB-10D'>
 				<roles>fire_support</roles>
-				<availability>CLAN:8,CS:8,FWL:8,DC:8,NIOPS:8,BAN:8</availability>
+				<availability>DC:8,FWL:8,CS:8,NIOPS:8</availability>
 			</model>
 			<model name='BMB-12D'>
 				<roles>fire_support</roles>
-				<availability>CS:8,CLAN:8,NIOPS:8,FWL:6+,BAN:8,DC:6+</availability>
+				<availability>DC:6+,FWL:6+,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
         <chassis name='Brunel Dump Truck' unitType='Tank'>
@@ -1040,18 +1044,18 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>CC:5,CLAN:3,IS:3,MERC:2,Periphery:1,CS:2,NIOPS:2,DC:5</availability>
+			<availability>IS:3,DC:5,CC:5,MERC:2,CS:2,CFM:4+,CDS:3,CWI:3+,CW:4-,Periphery:1,NIOPS:2</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:3,DC:3</availability>
 			</model>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
-				<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CDS:8,CW:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='CPLT-C1b'>
 				<roles>fire_support</roles>
-				<availability>CC:2+,CLAN:6,DC:2+</availability>
+				<availability>CC:2+,DC:2+,CFM:8,CWI:8</availability>
 			</model>
 			<model name='CPLT-C4'>
 				<roles>fire_support</roles>
@@ -1082,12 +1086,12 @@
 			</model>
 		</chassis>
 		<chassis name='Cestus' unitType='Mek'>
-			<availability>CS:4,LA:3+,CLAN:4,NIOPS:4,IS:3+,FS:6</availability>
+			<availability>IS:3+,FS:6,CS:4,CB:3+,CFM:2+,CJF:3+,CSJ:3+,NIOPS:4</availability>
 			<model name='CTS-6Y'>
-				<availability>General:8</availability>
+				<availability>IS:8,CB:8,CFM:5,CJF:8,CSJ:8</availability>
 			</model>
 			<model name='CTS-6Y-EC'>
-				<availability>CFM:3</availability>
+				<availability>CFM!Keshik:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chameleon' unitType='Mek'>
@@ -1098,22 +1102,19 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:7,CS:5,CHH:6,LA:6,CLAN:5,IS:5,NIOPS:5,MERC:5,CGB:6</availability>
-			<model name='C'>
-				<availability>CHH:4,CLAN:6,CGB:4</availability>
-			</model>
+			<availability>IS:5,LA:6,CC:7,MERC:5,CS:5,CBS:4-,CCO:3-,CFM:4+,CGB!Front Line:3!Second Line:2!Solahma:1,CHH:4+,CIH:6+,CDS:4+,CSV:3+,NIOPS:5</availability>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
-				<availability>CC:3+,CS:8,CHH:6,CLAN:6,NIOPS:8,BAN:8,CGB:6</availability>
+				<availability>CC:3+,CS:8,CBS:8,CCO:8,CGB:4-,CHH:4-,NIOPS:8</availability>
 			</model>
 			<model name='CHP-1N2'>
-				<availability>CC:2+,CS:4,LA:2+,CLAN:2,BAN:2,CGB:2</availability>
+				<availability>LA:2+,CC:2+,CS:4,CFM:8,CGB:5,CHH:5,CIH:8,CDS:5,NIOPS:5</availability>
 			</model>
 			<model name='CHP-1Nb'>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CDS:3+,CSV:8</availability>
 			</model>
 			<model name='CHP-2N'>
-				<availability>IS:7,NIOPS:0</availability>
+				<availability>IS:7</availability>
 			</model>
 		</chassis>
 		<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1693,9 +1694,9 @@
 			</model>
 		</chassis>
 		<chassis name='Crusader' unitType='Mek'>
-			<availability>CS:6-,CLAN:6,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:8,CS:6-,CLAN:3,CDS:2,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:4</availability>
 			<model name='CRD-2R'>
-				<availability>CLAN:8,IS:3+,CGS:8,BAN:4,Periphery:3+</availability>
+				<availability>IS:3+,CLAN:8,Periphery:3+,NIOPS:5,Periphery.Deep:0,BAN:4</availability>
 			</model>
 			<model name='CRD-3D'>
 				<availability>FS:5</availability>
@@ -1708,7 +1709,7 @@
 				<availability>CC:9</availability>
 			</model>
 			<model name='CRD-3R'>
-				<availability>General:8,CLAN:4,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CLAN:1-,Periphery:8,NIOPS:6-,Periphery.Deep:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
@@ -1992,29 +1993,29 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,IS:5,Periphery:2,TC:3,CS:5,NIOPS:5</availability>
+			<availability>IS:5,CS:5,Periphery:2,TC:3,MOC:3,NIOPS:5</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Mek'>
-			<availability>CS:5,LA:2+,CLAN:5,NIOPS:5,FS:2+,DC:2+</availability>
+			<availability>FS:2+,LA:2+,DC:2+,CS:5,CLAN:3+,NIOPS:5,BAN:0</availability>
 			<model name='EXC-B1'>
 				<roles>cavalry,fire_support</roles>
 				<availability>LA:8</availability>
 			</model>
 			<model name='EXC-B2'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CS:8,LA:0,General:8,CLAN:6,NIOPS:8</availability>
+				<availability>FS:8,LA:0,DC:8,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 			<model name='EXC-B2b'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CLAN:8,CGS:8,BAN:4</availability>
+				<availability>CLAN:2+,CGB:3+,CJF:3+,CSJ:3+</availability>
 			</model>
 			<model name='EXC-B2b-EC'>
                 <roles>cavalry,fire_support</roles>
-				<availability>CW:8</availability>
+				<availability>CW:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -2029,22 +2030,22 @@
 			</model>
 		</chassis>
 		<chassis name='Exterminator' unitType='Mek'>
-			<availability>CS:4,CLAN:6,NIOPS:4</availability>
+			<availability>CS:4,CLAN!Front Line:2!Second Line:1,CCO!Front Line:1,CIH:4+,CJF:2+,CMG:3+,CNC:2+,CDS:3+,CSJ:2+,CSR:3+,CWI!Front Line:1,NIOPS:4,BAN:2+</availability>
 			<model name='EXT-4C'>
 			    <roles>specops</roles>
-				<availability>CLAN:1</availability>
+				<availability>BAN:8</availability>
 			</model>
 			<model name='EXT-4D'>
 			    <roles>cavalry</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:4</availability>
+				<availability>CS:8,CLAN:8,CFM:4-,CIH:4-,CJF:3-,CDS:4-,CSR:4-,NIOPS:8,BAN:0</availability>
 			</model>
 			<model name='EXT-4Db'>
 			    <roles>cavalry</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CFM:8,CIH:5,CJF:4-,CDS:8,CSR:8,NIOPS:3+</availability>
 			</model>
 			<model name='EXT-4Db-EC'>
                 <roles>cavalry</roles>
-				<availability>CJF:8</availability>
+				<availability>CJF:1+</availability>
 			</model>
 		</chassis>
 	    <chassis name='Factory' unitType='Space Station'>
@@ -2155,13 +2156,13 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:4,CDS:5,LA:6,CBS:5,FWL:4,NIOPS:5,CJF:7,CGB:5</availability>
+			<availability>LA:6,FWL:4,CS:5,CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CJF!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CNC!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,Periphery.R:4,NIOPS:5,BAN:3+</availability>
 			<model name='FLS-7K'>
 				<availability>LA:6-,FWL:6-,Periphery.R:8</availability>
 			</model>
 			<model name='FLS-8K'>
                 <roles>cavalry</roles>
-				<availability>CS:8,LA:6+,CLAN:8,FWL:5+,NIOPS:8,BAN:8</availability>
+				<availability>LA:6+,FWL:5+,CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Flatbed Truck' unitType='Tank'>
@@ -2350,19 +2351,19 @@
 			</model>
 		</chassis>
 		<chassis name='Galahad (Glass Spider)' unitType='Mek'>
-			<availability>CSR:6,CWI:8,CW:6,CLAN:6</availability>
+			<availability>CW!Keshik:3</availability>
 			<model name=''>
                 <roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:8</availability>
+				<availability>CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Galahad' unitType='Mek'>
-			<availability>CC:3+,CWI:6,LA:3+,CLAN:3,FS:3+</availability>
+			<availability>FS:3+,LA:3+,CC:3+,CGB!Front Line:1!Second Line:1,CHH!Keshik:1!Front Line:1!Second Line:1,CSR!Keshik:1!Front Line:1!Second Line:1,CWI!Front Line:1!Second Line:1,CW!Front Line:1!Second Line:1</availability>
 			<model name='GLH-1D'>
-				<availability>IS:8</availability>
+				<availability>FS:8,LA:8,CC:8</availability>
 			</model>
 			<model name='GLH-2D'>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CHH:8,CSR:8,CWI:8,CW:8</availability>
 			</model>
 		</chassis>
         <chassis name='Galaport Ground Trailer' unitType='Tank'>
@@ -2465,14 +2466,14 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>CS:7,CLAN:9,IS:7,NIOPS:7,FS:6,MERC:7</availability>
+			<availability>IS:7,FS:6,MERC:7,CS:7,CHH:3+,CSR:3+,NIOPS:7</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
-				<availability>CS:8,CLAN:8,IS:6+,NIOPS:8,BAN:8</availability>
+				<availability>IS:6+,CS:8,CHH:8,CSR:8,NIOPS:8</availability>
 			</model>
 			<model name='GLT-4L'>
 				<roles>raider</roles>
-				<availability>FWL:6-,NIOPS:0,MERC:6-</availability>
+				<availability>FWL:6-,MERC:6-</availability>
 			</model>
 			<model name='GLT-4P'>
 				<roles>raider</roles>
@@ -2700,14 +2701,6 @@
                 <availability>CLAN:3,BAN:3,IS:3,FWL:3</availability>
             </model>
         </chassis>
-		<chassis name='Helepolis' unitType='Mek'>
-			<availability>CLAN:3</availability>
-			<model name='HEP-3H'>
-				<roles>mixed_artillery</roles>
-				<deployedWith>Helepolis</deployedWith>
-				<availability>General:8</availability>
-			</model>
-		</chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 			<availability>CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,FWL:4,NIOPS:6,DC:4</availability>
 			<model name='HCT-213B'>
@@ -3203,18 +3196,18 @@
 			</model>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>MOC:4,CLAN:6,IS:5,MERC:5,CIR:4,BAN:6,TC:4,CS:6,OA:4,NIOPS:6</availability>
+			<availability>IS:5,MERC:5,CS:6,CLAN:3+,CCC:4+,CCO:2+,CFM:4+,CHH:2+,CIH:4+,CMG:4+,CSV:4+,CWI:2+,TC:4,MOC:4,OA:4,CIR:4,NIOPS:6,BAN:0</availability>
             <model name='C'>
                 <roles>cavalry,anti_aircraft</roles>
-                <availability>CIH:2,CFM:2,CFM.SmJ:6,CB:4,CGB:2</availability>
+                <availability>CB!Keshik:3,CFM!Keshik:3,CGB!Keshik:3,CIH!Keshik:3</availability>
             </model>
 			<model name='LNC25-01'>
 				<roles>cavalry,anti_aircraft</roles>
-				<availability>CS:8,CLAN:8,IS:6,NIOPS:8</availability>
+				<availability>IS:6,CS:8,CLAN:8,CIH:4-,NIOPS:8</availability>
 			</model>
 			<model name='LNC25-05'>
 				<roles>cavalry,anti_infantry</roles>
-				<availability>CS:4,IS:2,NIOPS:4</availability>
+				<availability>IS:2,CS:4,NIOPS:4</availability>
 			</model>
 		</chassis>
 		<chassis name='League Destroyer' unitType='Warship'>
@@ -3513,18 +3506,18 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>CC:5,MOC:2+,CLAN:8,IS:3,FS:6,TC:3+,Periphery:2,CS:8,LA:6,FWL:5,NIOPS:8,DC:6,CGB:8</availability>
+			<availability>IS:3,FS:6,LA:6,DC:6,FWL:5,CC:5,CS:8,CLAN:4+,CIH:3+,CMG:3+,CSV:3+,Periphery:2,TC:3+,MOC:2+,NIOPS:8,BAN:2+</availability>
             <model name='C'>
                 <roles>command</roles>
-                <availability>CLAN:2+</availability>
+                <availability>CLAN:2+,CBS:1+,CFM:1+,CGS:1+,CHH:1+,CIH:1+,CMG:1+,CWI:1+,BAN:0</availability>
             </model>
 			<model name='MAD-1R'>
                 <roles>command</roles>
-				<availability>CS:8,MOC:5,CLAN:4,IS:5+,NIOPS:8,MERC:0,BAN:4,TC:5+</availability>
+				<availability>IS:5+,MERC:0,CS:8,CLAN:3-,CBS:4-,TC:5+,MOC:5,NIOPS:8,BAN:2+</availability>
 			</model>
 			<model name='MAD-2R'>
                 <roles>command</roles>
-				<availability>CLAN:8,FS:3+,BAN:8</availability>
+				<availability>FS:3+,CLAN:5,BAN:0</availability>
 			</model>
 			<model name='MAD-3D'>
                 <roles>command</roles>
@@ -3532,7 +3525,7 @@
 			</model>
 			<model name='MAD-3R'>
                 <roles>command</roles>
-				<availability>CS:4-,IS:8,TC:6</availability>
+				<availability>IS:8,CS:4-,TC:6,Periphery:8,BAN:8</availability>
 			</model>
 		</chassis>
         <chassis name='Marco' unitType='Mek'>
@@ -3573,9 +3566,9 @@
 			</model>
 		</chassis>
         <chassis name='Masauwu' unitType='Mek'>
-            <availability>CCO:3:2832</availability>
+            <availability>CCO!Keshik:3</availability>
             <model name=''>
-                <availability>General:8</availability>
+                <availability>CCO:8</availability>
             </model>
         </chassis>
 		<chassis name='Maultier Hover APC' unitType='Tank'>
@@ -3793,10 +3786,10 @@
 			</model>
 		</chassis>
 		<chassis name='Minsk' unitType='Mek'>
-			<availability>CGB:4</availability>
+			<availability>CGB!Front Line:1</availability>
 			<model name='MNK-101'>
 				<roles>command</roles>
-				<availability>CLAN:6</availability>
+				<availability>CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Mobile Headquarters' unitType='Tank'>
@@ -4069,12 +4062,15 @@
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CLAN:4,IS:5,Periphery.Deep:4,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,LA:6,FWL:8,NIOPS:5-</availability>
+			<availability>IS:5,LA:6,FWL:8,CS:5-,CLAN:3+,CCC:2+,CGS:2+,CIH:2+,CMG:2+,CNC:2+,CSR:2+,CW:5+,Periphery:4,TC:5,MOC:5,OA:5,CIR:5,NIOPS:5-,Periphery.Deep:4,BAN:2</availability>
 			<model name='ON1-K'>
-				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
+            <model name='ON1-Kb'>
+                <availability>CLAN:8,CW:3+,BAN:0</availability>
+            </model>
 			<model name='ON1-V'>
-				<availability>OA:3,IS:3,TC:3</availability>
+				<availability>IS:3,CW:2-,TC:3,OA:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Osprey' unitType='Mek'>
@@ -4085,14 +4081,14 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CS:4,LA:5,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,DC:6</availability>
+			<availability>IS:5,DC:6,CS:4,CLAN:4,CB:3,CCC:5,CCO:3,CIH:5,CMG!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,CWI:3,Periphery:4,NIOPS:4,Periphery.Deep:4,BAN:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
-				<availability>CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CLAN:1-,CCC:2-,Periphery:8,Periphery.Deep:8,BAN:4-</availability>
 			</model>
 			<model name='OSR-2Cb'>
 				<roles>urban</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,BAN:3</availability>
 			</model>
 			<model name='OSR-2M'>
 				<availability>FWL:6</availability>
@@ -4110,10 +4106,10 @@
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
-			<availability>CLAN:4,CS:6,FWL:8,NIOPS:6,Periphery.Deep:4,FS:8,MERC:8,Periphery:4,BAN:5</availability>
+			<availability>FS:8,FWL:8,MERC:8,CS:6,CLAN:2-,CB:1-,CGS:1-,CIH:3-,CWI:1-,CW:1-,Periphery:4,NIOPS:6,Periphery.Deep:4,BAN:3-</availability>
 			<model name='OTL-4D'>
                 <roles>raider</roles>
-				<availability>CLAN:8,IS:8,Periphery:8,BAN:8</availability>
+				<availability>IS:8,MERC:8,CLAN:8,Periphery:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Overlord C' unitType='Dropship'>
@@ -4429,7 +4425,7 @@
 			</model>
 		</chassis>
 		<chassis name='Redback' unitType='Mek'>
-			<availability>CWI:4</availability>
+			<availability>CWI:1+</availability>
 		    <model name=''>
                 <roles>cavalry</roles>
 			    <availability>CWI:8</availability>
@@ -4474,14 +4470,14 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CLAN:3,IS:7,Periphery.Deep:5,CIR:3,Periphery:5,CS:6-,NIOPS:6-</availability>
+			<availability>IS:7,CS:6-,CLAN!Front Line:1!Provisional Garrison:1,CBS!Front Line:1!Solahma:1!Provisional Garrison:1,CFM!Front Line:1!Solahma:1!Provisional Garrison:1,CGS!Front Line:1!Solahma:1!Provisional Garrison:1,CSR!Front Line:1!Solahma:1!Provisional Garrison:1,Periphery:5,CIR:3,NIOPS:6-,Periphery.Deep:5,BAN:3-</availability>
             <model name='C'>
                 <roles>fire_support,anti_aircraft</roles>
-                <availability>CLAN:8,BAN:4</availability>
+                <availability>CLAN!Front Line:1,BAN:0</availability>
             </model>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:7-,General:8</availability>
+				<availability>IS:8,MERC:8,CLAN:1-,CBS:2-,CFM:2-,CGS:2-,CSR:2-,Periphery:8,NIOPS:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Riga II Destroyer-Carrier' unitType='Warship'>
@@ -4780,10 +4776,10 @@
 			</model>
 		</chassis>
 		<chassis name='Shootist' unitType='Mek'>
-			<availability>CS:5,LA:2+,CLAN:5,NIOPS:5</availability>
+			<availability>LA:2+,CS:5,CLAN:2+,CB!Front Line:3!Second Line:2!Solahma:1,CCO:3+,CGB:3+,CIH!Front Line:2!Second Line:1,CJF:3+,CMG:1+,CSJ:3+,CWI:3+,CW:3+,NIOPS:5,BAN:0</availability>
 			<model name='ST-8A'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
         <chassis name='Shugosha' unitType='Mek'>
@@ -5143,9 +5139,9 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:9,CS:5-,LA:8,CLAN:5,IS:7,Periphery.Deep:6,NIOPS:5-,MERC:7,Periphery:6,DC:8</availability>
+			<availability>IS:7,LA:8,DC:8,CC:9,MERC:7,CS:5-,CLAN:5,CB!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CCC:4,CIH:4,CMG:4,CSR:4,CSV:4,Periphery:6,NIOPS:5-,Periphery.Deep:6,BAN:5</availability>
 			<model name='C'>
-				<availability>CLAN:3:2832</availability>
+				<availability>CLAN!Keshik:3,BAN:0</availability>
 			</model>
 			<model name='TDR-5D'>
 				<availability>FS:4,MERC:2</availability>
@@ -5154,10 +5150,10 @@
 				<availability>CC:2</availability>
 			</model>
 			<model name='TDR-5S'>
-				<availability>IS:8,CLAN:2-,BAN:6,Periphery:8</availability>
+				<availability>IS:8,CLAN:3-,Periphery:8,BAN:6-</availability>
 			</model>
 			<model name='TDR-5Sb'>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CLAN:4,BAN:5</availability>
 			</model>
 			<model name='TDR-5Sd'>
 				<availability>FS:2+</availability>
@@ -5431,9 +5427,9 @@
 			</model>
 		</chassis>
 		<chassis name='Vision Quest' unitType='Mek'>
-			<availability>CSR:3,CNC:5,CB:3</availability>
+			<availability>CNC!Keshik:3</availability>
 			<model name='VQ-1NC'>
-				<availability>CNC:5</availability>
+				<availability>CNC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Volga Transport' unitType='Warship'>
@@ -5502,9 +5498,9 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,LA:9,CLAN:6,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:8,LA:9,FWL:9,CS:6-,CLAN:6+,CB:5+,CCC:5+,CHH:5+,CIH:4-,CMG:5+,CNC:5+,CSR:5+,CSV:5+,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:5+</availability>
             <model name='C'>
-                <availability>CLAN:2</availability>
+                <availability>CLAN:2+</availability>
             </model>
 			<model name='WHM-6D'>
 				<availability>FS:4:2835</availability>
@@ -5516,17 +5512,17 @@
 				<availability>CC:4</availability>
 			</model>
 			<model name='WHM-6R'>
-				<availability>General:8,CLAN:2</availability>
+				<availability>IS:8,CLAN:1-,Periphery:8,Periphery.Deep:8,BAN:6-</availability>
 			</model>
 			<model name='WHM-6Rb'>
-				<availability>CC:3+,LA:3+,CLAN:4,FWL:3+,FS:3+,BAN:4</availability>
+				<availability>FS:3+,LA:3+,FWL:3+,CC:3+,CLAN:5,BAN:5</availability>
 			</model>
 			<model name='WHM-6Rk'>
                 <roles>cavalry</roles>
 				<availability>DC:2+</availability>
 			</model>
 			<model name='WHM-7A'>
-				<availability>CLAN:7</availability>
+				<availability>CLAN:3+,BAN:0</availability>
 			</model>
 		</chassis>
 		<chassis name='Wasp LAM Mk I' unitType='Mek'>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -3192,7 +3192,7 @@
 			<availability>FS:3+,FWL:3+,CBS:3+,CCC:2+,CMG:3+,CDS!Front Line:2!Second Line:1</availability>
 			<model name='KY2-D-02'>
 				<roles>fire_support</roles>
-				<availability>FS:8,FWL:8,CLAN:8</availability>
+				<availability>FS:8,FWL:8,CBS:8,CCC:8,CMG:8,CDS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='LRM Carrier' unitType='Tank'>
@@ -4666,7 +4666,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>LA:5-,DC:5-,FWL:5-,CC:5-,MERC:5-,CS:3-,CGS:2-,Periphery:5-,NIOPS:3-,Periphery.Deep:5-,BAN:2-</availability>
+			<availability>LA:5-,DC:5-,FWL:5-,CC:5-,MERC:5-,CS:3-,CGS:2-,Periphery:5-,NIOPS:3-,Periphery.Deep:5-</availability>
 			<model name='SCP-1N'>
 				<availability>IS:8,MERC:8,CGS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
@@ -4692,7 +4692,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>FS:3,LA:5,DC:3,FWL:3,CC:1,CS:4,CLAN:5-,CBS:6-,CB:4-,CCO:4-,CFM:6-,CGB:5-,CHH:4-,CJF:4-,CNC:4-,CDS:3,CSJ:4-,CSR:6-,CSA:4-,CSV:4-,CWI:4-,CLAN:6,NIOPS:4,BAN:2</availability>
+			<availability>FS:3,LA:5,DC:3,FWL:3,CC:1,CS:4,CLAN:5-,CBS:6-,CB:4-,CCO:4-,CFM:6-,CGB:5-,CHH:4-,CJF:4-,CNC:4-,CDS:3,CSJ:4-,CSR:6-,CSA:4-,CSV:4-,CWI:4-,NIOPS:4,BAN:2</availability>
 			<model name='STN-1S'>
 				<availability>LA:1,FWL:1,FS:1</availability>
 			</model>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -6,9 +6,9 @@
 >
 	<factions>
 		<faction key='BAN'>
-			<pctOmni>0,0</pctOmni>
-			<pctClan>0,0</pctClan>
-			<pctSL>90,90</pctSL>
+            <!-- Omni percentages: 0,0 -->
+            <!-- Clan percentages: 0,0 -->
+            <!-- Star League percentages: 90,90 -->
 			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CWI:2,CBS:1,CNC:2,CSJ:2,CMG:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS'>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -590,18 +590,12 @@
 			</model>
 		</chassis>
 		<chassis name='Annihilator' unitType='Mek'>
-			<availability>CSA:3,CHH:3,CSR:3,CLAN:3,CCO:3,BAN:1,CGB:3</availability>
+			<availability>CB:3+,CCO:3+,CGB:3+,CSA:3+,CWI:3+</availability>
 			<model name='ANH-1G'>
-				<availability>CSA:6,CCO:6,BAN:1</availability>
+				<availability>CCO:3+,CGB:3+,CSA:3+</availability>
 			</model>
 			<model name='ANH-1X'>
-				<availability>CSA:2,CLAN:6,CCO:2,BAN:8</availability>
-			</model>
-			<model name='C'>
-				<availability>CLAN:6,BAN:1</availability>
-			</model>
-			<model name='C 2'>
-				<availability>CLAN:4,BAN:1</availability>
+				<availability>CB:8,CCO:4,CGB:4,CSA:4,CWI:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Aquarius Escort' unitType='Small Craft'>
@@ -722,29 +716,29 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas II' unitType='Mek'>
-			<availability>CLAN:5</availability>
+			<availability>CLAN:3+,CBS:2+,CCC:2+,CIH:2+,CMG:2+,CSA:2+,CWI:2+,BAN:0</availability>
 			<model name='AS7-D-H'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CLAN:5</availability>
 			</model>
 			<model name='AS7-D-H2'>
                 <roles>command</roles>
-				<availability>CLAN:4</availability>
+				<availability>CLAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CWI:2,CW:2,LA:4,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
+			<availability>IS:3,FS:5,LA:4,DC:5,CS:4-,CLAN:4,CCC:3,CGS:3,CIH:2,CMG:3,CDS:3,CSV:3,TC:1,MOC:1,OA:1,NIOPS:4-,BAN:4-</availability>
 			<model name='AS7-D'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CLAN:8,CB:4-,CSJ:4-,CSV:4-,CWI:4-,CW:4-,Periphery:8,BAN:8</availability>
 			</model>
 			<model name='AS7-D-DC'>
 				<roles>command</roles>
-				<availability>IS:1,MERC:0,DC:2</availability>
+				<availability>IS:1+,DC:2+,MERC:0,CLAN!Front Line:1,CCO:0,CFM:0,CIH:0,CSJ:0,CSV:0,BAN:1+</availability>
 			</model>
 			<model name='C'>
                 <roles>command</roles>
-				<availability>CW:2+,CWI:2+,CSV:2+,CSJ:2+,CB:2+</availability>
+				<availability>CB:1+,CSJ:1+,CSV:1+,CWI:1+,CW:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Atreus Battleship' unitType='Warship'>
@@ -769,9 +763,9 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:7,CLAN:4-,IS:7,Periphery.Deep:5,CIR:7,TC:7,Periphery:5,CS:8,OA:7,FWL:9,NIOPS:8</availability>
+			<availability>IS:7,FWL:9,CS:8,CSA:3,Periphery:5,TC:7,MOC:7,OA:7,CIR:7,NIOPS:8,Periphery.Deep:5+,BAN:3</availability>
 			<model name='AWS-8Q'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CSA:8,Periphery:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
 			<model name='AWS-8R'>
 				<availability>CS:2,FWL:4</availability>
@@ -826,10 +820,10 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:7,MOC:6,CLAN:4,IS:6,TC:6,CS:8-,LA:8,PIR:6,FWL:8,NIOPS:8-,DC:7</availability>
+			<availability>IS:6,LA:8,DC:7,FWL:8,CC:7,CS:8-,CLAN:6,CB:5,CCC:5,CCO:5,CGB:5,CIH:5,CMG:5,CSJ:4,CSA:5,CSV:5,CWI:5,TC:6,MOC:6,NIOPS:8-,BAN:5,PIR:6</availability>
 			<model name='BLR-1G'>
                 <roles>command</roles>
-				<availability>IS:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:8,BAN:5,PIR:8</availability>
 			</model>
             <model name='BLR-1G-DC'>
                 <roles>command</roles>
@@ -837,15 +831,15 @@
             </model>
 			<model name='BLR-1Gb'>
                 <roles>command</roles>
-				<availability>CC:2+,CLAN:8,BAN:4</availability>
+				<availability>CC:2+,CLAN:8,BAN:6+</availability>
 			</model>
 			<model name='BLR-1Gbc'>
                 <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>CLAN!Front Line:1,CBS:0,CCO:0,CFM:0,CIH:0,CJF!Second Line:1,CMG:1+,CSJ:0,CSA:1+,CSV:0,CWI!Second Line:1,BAN:0</availability>
 			</model>
 			<model name='BLR-1Gc'>
                 <roles>command</roles>
-				<availability>CC:2+,LA:2+,CLAN:4,FWL:2+,FS:2+,DC:2+</availability>
+				<availability>FS:2+,LA:2+,DC:2+,FWL:2+,CC:2+,BAN:1+</availability>
 			</model>
 			<model name='BLR-1Gd'>
                 <roles>command</roles>
@@ -1643,12 +1637,12 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>CC:6,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:6,CGS:8,CS:8,CDS:8,CW:10,LA:6,CBS:10,FWL:6,NIOPS:8,CJF:8,CGB:10,DC:6</availability>
+			<availability>FS:6,LA:6,DC:6,FWL:6,CC:6,CS:8,CLAN:4-,CBS:5-,CFM:5-,CHH:5-,CW:5-,NIOPS:8,BAN:4-</availability>
 			<model name='CRK-5003-1'>
-				<availability>CS:8,General:5+,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>IS:5+,CS:8,CLAN:8,CBS:4-,CB:4-,CCO:4-,CGB:4-,CHH:4-,CW:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='CRK-5003-1b'>
-				<availability>CLAN:8,CGS:8,BAN:4</availability>
+				<availability>CBS:5,CB:5,CCO:5,CGB:5,CHH:5,CW:5,BAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Crossbow' unitType='Mek'>
@@ -1713,7 +1707,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,CS:3,OA:3,LA:5,CLAN:5,IS:3,FWL:4,NIOPS:3,FS:5,TC:3,DC:5</availability>
+			<availability>IS:3,FS:5,LA:5,DC:5,FWL:4,CC:5,CS:3,CLAN!Second Line:1,CGS!Front Line:1,CIH!Front Line:1,CDS!Front Line:1,TC:3,OA:3,NIOPS:3,BAN:1</availability>
 			<model name='CP-10-HQ'>
                 <roles>command</roles>
 				<availability>IS:2</availability>
@@ -1724,7 +1718,7 @@
 			</model>
 			<model name='CP-10-Z'>
                 <roles>command</roles>
-				<availability>OA:8,IS:8,MERC:8,TC:8</availability>
+				<availability>IS:8,MERC:8,CLAN:8,TC:8,OA:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
@@ -1849,6 +1843,12 @@
 				<availability>FS:5+,CBS:6,CDS:6</availability>
 			</model>
 		</chassis>
+        <chassis name='Devastator' unitType='Mek'>
+            <availability>CSJ:1+</availability>
+            <model name='DVS-2-EC'>
+                <availability>CSJ:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Dictator' unitType='Dropship'>
 			<availability>IS:4</availability>
 			<model name=''>
@@ -1937,17 +1937,17 @@
             </model>
         </chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>MOC:4,CC:5,CS:7,OA:5,CLAN:3,CNC:3,FWL:6,NIOPS:7,FS:5,MERC:5,TC:5</availability>
+			<availability>FS:5,FWL:6,CC:5,MERC:5,CS:7,CLAN:3+,CSA:2+,TC:5,MOC:4,OA:5,NIOPS:7,BAN:0</availability>
 			<model name='EMP-5A'>
                 <roles>command</roles>
-				<availability>General:8,BAN:2</availability>
+				<availability>IS:8,Periphery:8,NIOPS:1-</availability>
 			</model>
 			<model name='EMP-6A'>
                 <roles>command</roles>
-				<availability>CC:4+,CS:8,LA:4+,CLAN:8,NIOPS:8,FWL:4+,FS:4+,BAN:6</availability>
+				<availability>FS:4+,LA:4+,FWL:4+,CC:4+,CS:8,CLAN:8,CSA:4-,NIOPS:8</availability>
 			</model>
 			<model name='EMP-6A-EC'>
-				<availability>CSA:6</availability>
+				<availability>CSA:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Enfield' unitType='Mek'>
@@ -2779,12 +2779,14 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>CS:9,CLAN:9,NIOPS:9,IS:3,CFM:10,MERC:3,CJF:10</availability>
+			<availability>IS:3,MERC:3,CS:9,CLAN:4+,CCC:3+,CIH:3+,CSV:3+,NIOPS:9,BAN:2+</availability>
 			<model name='HGN-732'>
-				<availability>CS:8,CLAN:6,FWL:6+,IS:8,NIOPS:8,BAN:8</availability>
+                <roles>command</roles>
+				<availability>IS:8,FWL:6+,CS:8,CLAN:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='HGN-732b'>
-				<availability>CLAN:8,FWL:3+,BAN:4</availability>
+                <roles>command</roles>
+				<availability>FWL:3+,CLAN:6,BAN:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
@@ -2869,18 +2871,18 @@
 			</model>
 		</chassis>
 		<chassis name='Imp' unitType='Mek'>
-			<availability>CSA:2,CW:2,CLAN:2</availability>
+			<availability>CB:2+,CCO!Keshik:3!Front Line:1,CGB:2+,CSJ:2+,CWI:2+,CW!Keshik:3!Front Line:1</availability>
 			<model name='IMP-1A'>
                 <roles>command</roles>
-				<availability>CLAN:8</availability>
+				<availability>CB:6,CCO:6,CGB:6,CSJ:6,CWI:6,CW:6</availability>
 			</model>
 			<model name='IMP-1B'>
                 <roles>command</roles>
-				<availability>CLAN:4</availability>
+				<availability>CB!Keshik:6!Front Line:1,CCO!Keshik:6!Front Line:1,CGB!Keshik:6!Front Line:1,CSJ!Keshik:6!Front Line:1,CW!Keshik:6!Front Line:1</availability>
 			</model>
 			<model name='IMP-1C'>
                 <roles>command</roles>
-				<availability>CHH:8,CLAN:4</availability>
+				<availability>CB:1+,CCO:1+,CGB:1+,CSJ:1+,CWI!Keshik:4!Front Line:1,CW:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Intruder' unitType='Dropship'>
@@ -3107,10 +3109,10 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CS:6,CLAN:6,IS:2+,NIOPS:6,MERC:2+,CGS:7,CGB:7</availability>
+			<availability>IS:2+,MERC:2+,CS:6,CLAN:4-,CB:5-,CCC:3-,CCO:5-,CFM:5-,CGB:5-,CIH:3-,CJF:4,CMG:2,CNC:5-,CDS:3-,CSR:3-,CSV:3-,CWI:5-,CW:5-,NIOPS:6,BAN:1</availability>
 			<model name='KGC-000'>
                 <roles>command</roles>
-				<availability>CS:8,CIH:5,General:4,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
+				<availability>IS:4,CS:8,CLAN:2-,CGB:3-,NIOPS:8,BAN:5</availability>
 			</model>
 			<model name='KGC-0000'>
                 <roles>command</roles>
@@ -3118,11 +3120,11 @@
 			</model>
 			<model name='KGC-000b'>
                 <roles>command</roles>
-				<availability>CLAN:8,CGS:8,BAN:4</availability>
+				<availability>CB:4-,CFM:4-,CGB:5,CGS:4-,CWI:5,CW:4-,BAN:2+</availability>
 			</model>
 			<model name='KGC-010'>
                 <roles>command</roles>
-				<availability>CLAN:4</availability>
+				<availability>CLAN:3+,CIH:4+,CDS:4+,CSR:4+,BAN:0</availability>
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
@@ -3177,9 +3179,9 @@
 			</model>
 		</chassis>
 		<chassis name='Kraken (Bane)' unitType='Mek'>
-			<availability>CSR:6,CLAN:6,CJF:6</availability>
+			<availability>CJF:2+,CDS:1+,CSR:1+,CW:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CJF:8,CDS:8,CSR:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Kruger Combat Car' unitType='Tank'>
@@ -3377,7 +3379,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>CC:6,CDS:3,CSR:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>IS:7,FS:8,DC:5,FWL:9,CC:6,CS:4,CLAN:1-,CDS:3,CSR:3,Periphery:7,NIOPS:4,Periphery.Deep:7,BAN:0</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>IS:8,Periphery:8</availability>
@@ -3388,11 +3390,11 @@
 			</model>
 			<model name='LGB-7Q'>
 				<roles>fire_support</roles>
-				<availability>MOC:6,OA:6,IS:6,TC:6,CLAN:6</availability>
+				<availability>IS:6,CDS:8,CSR:8,TC:6,MOC:6,OA:6</availability>
 			</model>
 			<model name='LGB-8C'>
                 <roles>fire_support</roles>
-				<availability>MOC:3,CS:6,OA:3,IS:6,MERC:3,TC:3,CLAN:6</availability>
+				<availability>IS:6,MERC:3,CS:6,CLAN:8,CDS:2-,CSR:1-,TC:3,MOC:3,OA:3</availability>
 			</model>
 		</chassis>
         <chassis name='Luciano White Wolverine' unitType='Tank'>
@@ -3455,6 +3457,12 @@
                 <availability>CLAN:8,BAN:8,IS:5,CS:7,Periphery:3,Periphery.Deep:0</availability>
             </model>
 		</chassis>
+        <chassis name='Mackie' unitType='Mek'>
+            <availability>CSJ:1-</availability>
+            <model name='MSK-7A'>
+                <availability>CSJ:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Magi Infantry Support Vehicle' unitType='Tank'>
 			<availability>MOC:2,CS:5,CHH:6,OA:2,CLAN:5,IS:1,NIOPS:5,TC:2</availability>
 			<model name=''>
@@ -3505,12 +3513,12 @@
             </model>
         </chassis>
 		<chassis name='Marauder IIC' unitType='Mek'>
-			<availability>CSA:4,CSR:4,CW:4,CLAN:4,CNC:4,CJF:4,CGB:4</availability>
+			<availability>CLAN:2+,CBS:1+,CCC!Keshik:3!Front Line:1,CMG!Keshik:3!Front Line:1,CDS!Keshik:3!Front Line:1,BAN:0</availability>
 			<model name=''>
-				<availability>CLAN:8,CJF:8,CGB:8</availability>
+				<availability>CLAN:8,CJF:4,CW:4</availability>
 			</model>
 			<model name='9'>
-				<availability>CSA:4,CSV:4,CLAN:4,CJF:4</availability>
+				<availability>CJF:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
@@ -4050,10 +4058,10 @@
 			</model>
 		</chassis>
 		<chassis name='Nightstar' unitType='Mek'>
-			<availability>CSA:6,CS:4,CLAN:5,NIOPS:4</availability>
+			<availability>CS:4,CCO:1+,CWI:1+,NIOPS:4+</availability>
 			<model name='NSR-9J'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CS:8,CCO:8,CWI:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Olympus Recharge Station' unitType='Space Station'>
@@ -4289,7 +4297,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
-			<availability>CLAN:5,CC:6+,CS:5,LA:5+,FWL:5+,NIOPS:5,FS:5+,BAN:0</availability>
+			<availability>FS:5+,LA:5+,FWL:5+,CC:6+,CS:5,CLAN:2+,CB:3+,CCC:1+,CWI:3+,NIOPS:5+,BAN:0</availability>
 			<model name='PLG-3Z'>
 				<availability>IS:8,CLAN:8,NIOPS:8</availability>
 			</model>
@@ -4381,12 +4389,12 @@
 			</model>
 		</chassis>
 		<chassis name='Pulverizer' unitType='Mek'>
-			<availability>CSR:3</availability>
+			<availability>CSR:2+</availability>
 			<model name='PUL-2V'>
-				<availability>General:8</availability>
+				<availability>CSR:3+</availability>
 			</model>
 			<model name='PUL-3R'>
-				<availability>General:6</availability>
+				<availability>CSR:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -4471,10 +4479,10 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman II' unitType='Mek'>
-			<availability>CLAN:5</availability>
+			<availability>CGB:3+</availability>
 			<model name='RFL-3N-2'>
 				<roles>anti_aircraft</roles>
-				<availability>General:8</availability>
+				<availability>CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
@@ -4772,9 +4780,9 @@
 			</model>
 		</chassis>
 		<chassis name='Shogun' unitType='Mek'>
-			<availability>CSA:3,CIH:3,CBS:3,CLAN:3,FWL:3+,CCO:3,CB:3</availability>
+			<availability>FWL:3+,CBS:3+,CB!Front Line:3!Second Line:2!Solahma:1,CCC!Front Line:3!Second Line:2!Solahma:1,CCO!Front Line:3!Second Line:2!Solahma:1,CSA:2</availability>
 			<model name='SHG-2H'>
-				<availability>General:8,CLAN:8,BAN:8</availability>
+				<availability>FWL:8,CBS:8,CB:8,CCC:8,CCO:8,CSA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Sholagar' unitType='AeroSpaceFighter'>
@@ -4889,11 +4897,15 @@
 			</model>
 		</chassis>
 		<chassis name='Spartan' unitType='Mek'>
-			<availability>CS:5</availability>
+			<availability>CS:5,CCC!Front Line:3!Second Line:2!Solahma:1,CFM:4-,CIH:6+,CMG:4,CDS:4-,CSV:4-,BAN:4+</availability>
 			<model name='SPT-N2'>
 				<roles>cavalry,spotter</roles>
-				<availability>IS:8</availability>
+				<availability>CS:8,CFM:8,BAN:3-</availability>
 			</model>
+            <model name='SPT-NF'>
+                <roles>cavalry</roles>
+                <availability>CCC:8,CIH:8,CMG:8,CDS:8,CSV:8,BAN:5</availability>
+            </model>
 		</chassis>
 		<chassis name='Spector' unitType='Mek'>
 			<availability>CIH:1+,CMG:2+</availability>
@@ -4917,18 +4929,18 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>CC:7,CLAN:7,IS:8,Periphery.Deep:9,FS:7,Periphery:9,CS:6,FWL:9,NIOPS:6,DC:7</availability>
+			<availability>IS:8,FS:7,DC:7,FWL:9,CC:7,CS:6,CLAN:5,CBS:6,CCC:5-,CGB:6,CHH:6,CIH:4,CJF:6,CMG:4,CNC:6,CW:6,Periphery:9,NIOPS:6,Periphery.Deep:9,BAN:3</availability>
 			<model name='STK-3F'>
-				<availability>CLAN:1,IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CLAN:1-,Periphery:8,Periphery.Deep:8,BAN:5</availability>
 			</model>
 			<model name='STK-3Fb'>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,BAN:3+</availability>
 			</model>
 			<model name='STK-3Fk'>
 				<availability>DC:1+</availability>
 			</model>
 			<model name='STK-3H'>
-				<availability>MOC:2,OA:2,CLAN:1,IS:2,TC:2</availability>
+				<availability>IS:2,TC:2,MOC:2,OA:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -5001,9 +5013,9 @@
 			</model>
 		</chassis>
 		<chassis name='Striker' unitType='Mek'>
-			<availability>MOC:6,CC:8,CS:4,OA:7,LA:8,PIR:4,Periphery.Deep:4,NIOPS:4,MERC:7,FS:6,TC:7,DC:6</availability>
+			<availability>FS:6,LA:8,DC:6,CC:8,MERC:7,CS:4,CLAN:1-,CIH:2-,CMG:2-,TC:7,MOC:6,OA:7,NIOPS:4,Periphery.Deep:4+,PIR:4,BAN:0</availability>
 			<model name='STC-2C'>
-				<availability>CC:8,General:8</availability>
+				<availability>IS:8,CLAN:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='STC-2S'>
 				<availability>LA:4</availability>
@@ -5109,12 +5121,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>CHH:7,CSV:9,CLAN:8,IS:6+,CFM:10,TC:3+,CS:7,CDS:7,CW:9,CBS:7,CNC:7,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>IS:6+,CS:7,CLAN:5,CIH:4,TC:3+,NIOPS:7,BAN:4+</availability>
 			<model name='THG-11E'>
-				<availability>CS:8,CLAN:6,FWL:6+,IS:6+,NIOPS:8,FS:6+,BAN:8,DC:6+,TC:8</availability>
+				<availability>IS:6+,CS:8,CLAN:4-,TC:8,NIOPS:8,BAN:5</availability>
 			</model>
 			<model name='THG-11Eb'>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:6,BAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -5125,10 +5137,10 @@
 			</model>
 		</chassis>
 		<chassis name='Thunder Hawk' unitType='Mek'>
-			<availability>CS:2,LA:3+,CLAN:4,NIOPS:2,DC:3+</availability>
+			<availability>LA:3+,DC:3+,CS:2,CB:1+,NIOPS:2+</availability>
 			<model name='TDK-7X'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,DC:8,CS:8,CB:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
@@ -5400,7 +5412,7 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:6,CC:6,CLAN:3-,IS:5,Periphery.Deep:5,FS:9,CIR:6,Periphery.OS:6,TC:6,Periphery:5,CS:5-,OA:6,LA:6,Periphery.HR:6,FWL:6,NIOPS:5-,DC:6</availability>
+			<availability>IS:5,FS:9,LA:6,DC:6,FWL:6,CC:6,CS:5-,CCO:2-,Periphery:5,Periphery.OS:6,Periphery.HR:6,TC:6,MOC:6,OA:6,CIR:6,NIOPS:5-,Periphery.Deep:5+</availability>
 			<model name='VTR-9A'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
@@ -5494,15 +5506,15 @@
 			</model>
 		</chassis>
 		<chassis name='Wakazashi' unitType='Mek'>
-			<availability>CJF:4</availability>
+			<availability>CJF:2+</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CJF:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Warhammer IIC' unitType='Mek'>
-			<availability>CLAN:4</availability>
+			<availability>CGB:1+,CSA:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CSA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -627,7 +627,7 @@
 			</model>
             <model name='C'>
                 <roles>command,fire_support</roles>
-                <availability>CLAN:2+,CBS:1+,CFM:1+</availability>
+                <availability>CLAN:2+,CBS:1+,CFM:1+,BAN:0</availability>
             </model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -885,7 +885,7 @@
 			</model>
 			<model name='BL-7-KNT'>
                 <roles>command</roles>
-				<availability>LA:8-,FWL:4-,MERC:8-,FS:8-,DC:8-</availability>
+				<availability>FS:8-,LA:8-,DC:8-,FWL:4-,MERC:8-</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
                 <roles>command</roles>
@@ -1055,7 +1055,7 @@
 			</model>
 			<model name='CPLT-C1b'>
 				<roles>fire_support</roles>
-				<availability>CC:2+,DC:2+,CFM:8,CWI:8</availability>
+				<availability>DC:2+,CC:2+,CFM:8,CWI:8</availability>
 			</model>
 			<model name='CPLT-C4'>
 				<roles>fire_support</roles>
@@ -1086,9 +1086,9 @@
 			</model>
 		</chassis>
 		<chassis name='Cestus' unitType='Mek'>
-			<availability>IS:3+,FS:6,CS:4,CB:3+,CFM:2+,CJF:3+,CSJ:3+,NIOPS:4</availability>
+			<availability>IS:3+,FS:6,CS:4,CB:3+,CFM:2+,CJF:3+,CSJ:3+,NIOPS:4+</availability>
 			<model name='CTS-6Y'>
-				<availability>IS:8,CB:8,CFM:5,CJF:8,CSJ:8</availability>
+				<availability>IS:8,CB:8,CFM:5,CJF:8,CSJ:8,NIOPS:8</availability>
 			</model>
 			<model name='CTS-6Y-EC'>
 				<availability>CFM!Keshik:8</availability>
@@ -1696,7 +1696,7 @@
 		<chassis name='Crusader' unitType='Mek'>
 			<availability>IS:8,CS:6-,CLAN:3,CDS:2,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:4</availability>
 			<model name='CRD-2R'>
-				<availability>IS:3+,CLAN:8,Periphery:3+,NIOPS:5,Periphery.Deep:0,BAN:4</availability>
+				<availability>IS:3+,CLAN:8,Periphery:3+,NIOPS:5,Periphery.Deep:0,BAN:2+</availability>
 			</model>
 			<model name='CRD-3D'>
 				<availability>FS:5</availability>
@@ -2003,7 +2003,7 @@
 			<availability>FS:2+,LA:2+,DC:2+,CS:5,CLAN:3+,NIOPS:5,BAN:0</availability>
 			<model name='EXC-B1'>
 				<roles>cavalry,fire_support</roles>
-				<availability>LA:8</availability>
+				<availability>LA:8,CGS:4-,CDS:4-,CW:4-</availability>
 			</model>
 			<model name='EXC-B2'>
 				<roles>cavalry,fire_support</roles>
@@ -3525,7 +3525,7 @@
 			</model>
 			<model name='MAD-3R'>
                 <roles>command</roles>
-				<availability>IS:8,CS:4-,TC:6,Periphery:8,BAN:8</availability>
+				<availability>IS:8,CS:4-,Periphery:8,TC:6,BAN:8</availability>
 			</model>
 		</chassis>
         <chassis name='Marco' unitType='Mek'>
@@ -5500,7 +5500,7 @@
 		<chassis name='Warhammer' unitType='Mek'>
 			<availability>IS:8,LA:9,FWL:9,CS:6-,CLAN:6+,CB:5+,CCC:5+,CHH:5+,CIH:4-,CMG:5+,CNC:5+,CSR:5+,CSV:5+,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:5+</availability>
             <model name='C'>
-                <availability>CLAN:2+</availability>
+                <availability>CLAN:2+,BAN:0</availability>
             </model>
 			<model name='WHM-6D'>
 				<availability>FS:4:2835</availability>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -835,7 +835,7 @@
 			</model>
 			<model name='BLR-1Gbc'>
                 <roles>command</roles>
-				<availability>CLAN!Front Line:1,CBS:0,CCO:0,CFM:0,CIH:0,CJF!Second Line:1,CMG:1+,CSJ:0,CSA:1+,CSV:0,CWI!Second Line:1,BAN:0</availability>
+				<availability>CLAN!Front Line:1,CCO:0,CFM:0,CIH:0,CJF!Second Line:1,CMG:1+,CSJ:0,CSA:1+,CSV:0,CWI!Second Line:1,BAN:0</availability>
 			</model>
 			<model name='BLR-1Gc'>
                 <roles>command</roles>
@@ -2779,7 +2779,7 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>IS:3,MERC:3,CS:9,CLAN:4+,CCC:3+,CIH:3+,CSV:3+,NIOPS:9,BAN:2+</availability>
+			<availability>IS:3,MERC:3,CS:9,CLAN:4+,CCC:3+,CIH:3+,CSV:3+,NIOPS:9+,BAN:2+</availability>
 			<model name='HGN-732'>
                 <roles>command</roles>
 				<availability>IS:8,FWL:6+,CS:8,CLAN:4-,NIOPS:8,BAN:8</availability>
@@ -5420,7 +5420,7 @@
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
 			<model name='VTR-9B'>
-				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CCO:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Vigilant Corvette' unitType='Warship'>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -5520,10 +5520,10 @@
 				<availability>CC:4</availability>
 			</model>
 			<model name='WHM-6R'>
-				<availability>IS:8,CLAN:1-,Periphery:8,Periphery.Deep:8,BAN:6-</availability>
+				<availability>IS:8,CLAN:1-,Periphery:8,NIOPS:3-,Periphery.Deep:8,BAN:6-</availability>
 			</model>
 			<model name='WHM-6Rb'>
-				<availability>FS:3+,LA:3+,FWL:3+,CC:3+,CLAN:5,BAN:5</availability>
+				<availability>FS:3+,LA:3+,FWL:3+,CC:3+,CLAN:5,NIOPS:6,BAN:5</availability>
 			</model>
 			<model name='WHM-6Rk'>
                 <roles>cavalry</roles>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -1505,7 +1505,7 @@
             </model>
         </chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>LA:9,CSJ:3,CIR:4,MERC:4,CGS:3</availability>
+			<availability>LA:9,MERC:4,CGS:3-,CSJ:3-,CIR:4</availability>
 			<model name='COM-1D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
@@ -1514,7 +1514,7 @@
 			<model name='COM-2D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
-				<availability>LA:8,General:8,Periphery.Deep:8</availability>
+				<availability>LA:8,MERC:8,CGS:8,CSJ:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Commonwealth Light Cruiser' unitType='Warship'>
@@ -1886,9 +1886,9 @@
 			</model>
 		</chassis>
 		<chassis name='Drift Shag' unitType='Mek'>
-			<availability>CIH:2,CMG:1,CGS:1</availability>
+			<availability>CGS:2+,CIH:2+,CMG:1+</availability>
             <model name=''>
-                <availability>CLAN:8</availability>
+                <availability>CGS:8,CIH:8,CMG:8</availability>
             </model>
 		</chassis>
 		<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -2063,12 +2063,12 @@
             </model>
 		</chassis>
 		<chassis name='Falcon' unitType='Mek'>
-			<availability>CC:3,MOC:2,OA:2,CIH:6,LA:4,CLAN:4,FWL:3,FS:3,MERC:3,CGS:5,TC:2</availability>
+			<availability>FS:3,LA:4,FWL:3,CC:3,MERC:3,CGS:6+,TC:2,MOC:2,OA:2,BAN:2</availability>
 			<model name='FLC-4N'>
-				<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,CGS:4-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='FLC-4Nb'>
-				<availability>CLAN:8,BAN:2</availability>
+				<availability>CGS:2</availability>
 			</model>
 			<model name='FLC-4Nb-PP'>
 				<availability>BAN:2</availability>
@@ -2118,10 +2118,10 @@
 			</model>
 		</chassis>
 		<chassis name='Firefly' unitType='Mek'>
-			<availability>CC:2+,OA:1+,CIH:7,CLAN:8,FS:2+,BAN:7,CB:7</availability>
+			<availability>FS:2+,CC:2+,CLAN:4+,CBS:3+,CB:5+,CCC:3+,CGB:7+,CGS:3+,CHH:5+,CIH:3-,CMG:3-,CDS:3,CSV:5-,OA:1+,BAN:2</availability>
 			<model name='FFL-3A'>
 				<roles>spotter</roles>
-				<availability>CC:8,FS:8</availability>
+				<availability>FS:8,CC:8,CFM:6,CHH:4,CSR:5,BAN:6-</availability>
 			</model>
 			<model name='FFL-3PP'>
 				<availability>BAN:2</availability>
@@ -2133,11 +2133,11 @@
 				<availability>BAN:2</availability>
 			</model>
 			<model name='FFL-3SLE'>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,CFM:5+,CHH:5+,CSR:4+,BAN:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Firestarter' unitType='Mek'>
-			<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
+			<availability>IS:7,LA:8,CS:3,CFM:4-,CHH:3,Periphery:7,NIOPS:3,Periphery.Deep:7</availability>
 			<model name='FS9-A'>
                 <roles>anti_infantry,recon</roles>
 				<deployedWith>Vulcan</deployedWith>
@@ -2146,7 +2146,7 @@
 			<model name='FS9-H'>
                 <roles>anti_infantry,recon</roles>
 				<deployedWith>Vulcan</deployedWith>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CFM:8,CHH:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='FS9-K'>
                 <roles>anti_infantry,recon</roles>
@@ -2753,7 +2753,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hermes' unitType='Mek'>
-			<availability>MOC:4,CC:3,CS:3,CHH:5,OA:4,CLAN:4,FWL:5,NIOPS:3,CGB:5,DC:3,CB:5</availability>
+			<availability>DC:3,FWL:5,CC:3,CS:3,CLAN:2,CB:1,CCO:1,CGB:1,CIH:6+,CDS:3,CSJ!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CWI:1,MOC:4,OA:4,NIOPS:3,BAN:4+</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
 				<availability>FWL:6</availability>
@@ -2764,11 +2764,11 @@
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
-				<availability>CS:8,General:5,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>IS:5,MERC:5,CS:8,CLAN:4,Periphery:5,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='HER-1Sb'>
 				<roles>recon</roles>
-				<availability>CLAN:8,FWL:3+,BAN:4</availability>
+				<availability>FWL:3+,CLAN:3+,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
@@ -2828,13 +2828,13 @@
 			</model>
 		</chassis>
 		<chassis name='Hussar' unitType='Mek'>
-			<availability>CS:4,CIH:9,LA:1+,CSV:9,CLAN:8,NIOPS:4,FS:1+</availability>
+			<availability>FS:1+,LA:1+,CS:4,CLAN:3+,CGB:2+,CIH:6+,CMG:4+,CDS:4+,CSV:4+,CWI:4+,NIOPS:4,BAN:5+</availability>
 			<model name='HSR-200-D'>
 				<roles>recon</roles>
-				<availability>CS:8,General:8,CLAN:6,NIOPS:8,BAN:8,DC:8</availability>
+				<availability>IS:8,CS:8,CLAN:5,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='HSR-200-Db'>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:4+,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Icarus II' unitType='Mek'>
@@ -2844,10 +2844,10 @@
 			</model>
 		</chassis>
 		<chassis name='Icestorm' unitType='Mek'>
-			<availability>CIH:4</availability>
+            <availability>CIH!Keshik:2</availability>
 			<model name=''>
 				<roles>spotter</roles>
-				<availability>CLAN:8</availability>
+				<availability>CIH:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
@@ -3313,16 +3313,16 @@
 			</model>
 		</chassis>
 		<chassis name='Locust IIC' unitType='Mek'>
-			<availability>CHH:4,CW:4,CLAN:4,CJF:4,CGB:4</availability>
+			<availability>CLAN:1+:2833,CMG!Keshik:3,CBS:1+:2834,CFM:1+:2834,BAN:0</availability>
 			<model name=''>
-				<availability>CW:8,General:8</availability>
+				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Locust' unitType='Mek'>
-			<availability>CS:6-,CLAN:3-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:9,CS:6-,CLAN:5,CB:4,CCO:4,CJF:6,CWI:4,CW:6,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:4</availability>
 			<model name='LCT-1E'>
 				<roles>recon</roles>
-				<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
+				<availability>IS:4,Periphery:4,Periphery.Deep:4</availability>
 			</model>
 			<model name='LCT-1M'>
 				<roles>recon</roles>
@@ -3334,11 +3334,11 @@
 			</model>
 			<model name='LCT-1V'>
 				<roles>recon</roles>
-				<availability>LA:4,General:8,CLAN:4-,FS:7,BAN:6</availability>
+				<availability>IS:8,FS:7,LA:4,Periphery:8,BAN:4-</availability>
 			</model>
 			<model name='LCT-1Vb'>
 				<roles>recon</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Lola I Destroyer' unitType='Warship'>
@@ -3469,9 +3469,9 @@
 			</model>
 		</chassis>
 		<chassis name='Mandrill' unitType='Mek'>
-			<availability>CFM:4</availability>
+			<availability>CFM:2+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CFM:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
@@ -3776,14 +3776,14 @@
 			</model>
 		</chassis>
 		<chassis name='Mercury' unitType='Mek'>
-			<availability>CS:8,CC:4+,LA:4+,CLAN:3,NIOPS:8,IS:4+,MERC:4+</availability>
+			<availability>IS:4+,MERC:4+,CS:8,CLAN!Front Line:3!Second Line:2!Solahma:1,CB!Front Line:2!Second Line:1,CCO!Front Line:2!Second Line:1,CIH!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CSJ!Second Line:1!Solahma:1!Provisional Garrison:1,CWI!Front Line:1!Second Line:1,NIOPS:8,BAN:3</availability>
 			<model name='MCY-98'>
 				<roles>recon</roles>
 				<availability>CC:8</availability>
 			</model>
 			<model name='MCY-99'>
 				<roles>recon</roles>
-				<availability>CS:4,General:3+,CLAN:8,NIOPS:4,BAN:6</availability>
+				<availability>IS:3+,CS:4,CLAN:8,NIOPS:4,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Minsk' unitType='Mek'>
@@ -3844,18 +3844,18 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>MOC:3+,CHH:5,CLAN:6,MERC:4+,FS:6+,TC:3+,CS:6,OA:3+,CDS:5,CBS:7,FWL:5+,NIOPS:6,CMG:7,CJF:7,CGB:5,DC:5+</availability>
+			<availability>FS:6+,DC:5+,FWL:5+,MERC:4+,CS:6,CLAN:4+,CBS:3+,CGS:3+,CJF:5+,CMG:6+,CWI:3+,TC:3+,MOC:3+,OA:3+,NIOPS:6,BAN:3+</availability>
             <model name='C'>
                 <roles>recon</roles>
-                <availability>CIH:3:2833,CMG:6:2833,CJF:3:2833,CGB:3:2833</availability>
+                <availability>CMG!Keshik:3</availability>
             </model>
 			<model name='MON-66'>
 				<roles>command,recon</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,IS:5+,BAN:8,Periphery:5+</availability>
+				<availability>IS:5+,CS:8,CLAN:6,Periphery:5+,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='MON-66b'>
 				<roles>command,recon</roles>
-				<availability>CLAN:9,CGS:9,BAN:4</availability>
+				<availability>CLAN:5+,BAN:1</availability>
 			</model>
 			<model name='MON-67'>
 				<roles>command,recon</roles>
@@ -4018,13 +4018,13 @@
 			</model>
 		</chassis>
 		<chassis name='Night Hawk' unitType='Mek'>
-			<availability>CW:7,LA:4+,CLAN:7,FWL:4+,FS:4+,CGS:7,CGB:7</availability>
+			<availability>FS:4+,LA:4+,FWL:4+,CLAN:4+,CBS:5+,CB:5+,CCO:5+,CGB:5+,CJF:5+,CNC:5+,CSJ:5+,CSR:3+,CSV:5+,CW:5+,BAN:3+</availability>
 			<model name='NTK-2Q'>
 				<roles>raider</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CLAN:8,BAN:8</availability>
 			</model>
 			<model name='NTK-2Q-EC'>
-				<availability>CSJ:6</availability>
+				<availability>CSJ!Keshik:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
@@ -4093,14 +4093,14 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CS:4,CLAN:4-,IS:5,Periphery.Deep:5,NIOPS:4,FS:5,MERC:5,Periphery:5</availability>
+			<availability>IS:5,MERC:5,CS:4,CLAN!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CB!Front Line:1!Second Line:1!Solahma:1!Provisional Garrison:1,CCO!Front Line:1!Second Line:1!Solahma:1!Provisional Garrison:1,CSJ!Second Line:1!Solahma:1,Provisional Garrison:1,CWI!Second Line:1!Solahma:1,Provisional Garrison:1,CW!Front Line:1!Second Line:1!Solahma:2!Provisional Garrison:2,Periphery:5,NIOPS:4,Periphery.Deep:5,BAN:1</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
-				<availability>General:8,CLAN:6-,BAN:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8</availability>
 			</model>
 			<model name='OTT-7Jb'>
 				<roles>recon</roles>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CLAN:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
@@ -4167,13 +4167,13 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>CC:3,Periphery.DD:5,FS.RR:3,CLAN:3-,MERC:5,Periphery.OS:5,FS:3,BAN:4,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>FS:3,FS.RR:3,FS.DMM:3,LA:3,DC:10,FWL:3,CC:3,MERC:5,CS:2,CSJ:4-,Periphery:3,Periphery.DD:5,Periphery.OS:5,NIOPS:2</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,TC:8</availability>
 			</model>
 			<model name='PNT-9R'>
 				<roles>fire_support</roles>
-				<availability>CLAN:8,MERC:8,DC:8</availability>
+				<availability>DC:8,MERC:8,CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -4219,6 +4219,12 @@
 				<availability>IS:2</availability>
 			</model>
 		</chassis>
+        <chassis name='Peregrine (Horned Owl)' unitType='Mek'>
+            <availability>CGS!Keshik:3</availability>
+            <model name=''>
+                <availability>CGS:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
 			<availability>IS:2+</availability>
 			<model name='PHX-HK1'>
@@ -4815,14 +4821,14 @@
 			</model>
 		</chassis>
 		<chassis name='Sling' unitType='Mek'>
-			<availability>CC:3+,LA:3+,CLAN:1,CSJ:2</availability>
+			<availability>LA:3+,CC:3+,CSJ:5+</availability>
 			<model name='SL-1G'>
 				<roles>spotter</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,CC:8,CSJ:8</availability>
 			</model>
 			<model name='SL-1H'>
 				<roles>spotter</roles>
-				<availability>LA:4</availability>
+				<availability>LA:4,CSJ:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Snowden Mining Station' unitType='Space Station'>
@@ -4873,14 +4879,14 @@
 			</model>
 		</chassis>
 		<chassis name='Spector' unitType='Mek'>
-			<availability>CLAN:3</availability>
+			<availability>CIH:1+,CMG:2+</availability>
 			<model name='SPR-4F'>
 			    <roles>specops,raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CIH:8,CMG:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>CC:5,CS:4,OA:2,CLAN:2-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
+			<availability>IS:4,FS:5,DC:6,FWL:7,CC:5,MERC:4,CS:4,CIH:3+,CMG:3+,TC:2,OA:2,NIOPS:4</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -4890,7 +4896,7 @@
 				<availability>DC:8</availability>
 			</model>
 			<model name='SDR-5V'>
-				<availability>CLAN:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
+				<availability>IS:8,CIH:8,CMG:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
@@ -4943,18 +4949,21 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>CS:4-,CLAN:3-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6</availability>
+			<availability>IS:9,DC:6,MERC:6,CS:4-,CLAN:4,CB:5,CCO:5,Periphery:6,NIOPS:4-,Periphery.Deep:6,BAN:5</availability>
+            <model name='C'>
+                <availability>CHH!Keshik:5</availability>
+            </model>
 			<model name='STG-3G'>
 				<roles>recon</roles>
-				<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:4,Periphery:4</availability>
+				<availability>IS:4,CLAN!Solahma:2!Provisional Garrison:3,Periphery:4,Periphery.Deep:4,BAN:2-</availability>
 			</model>
 			<model name='STG-3Gb'>
 				<roles>recon</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,BAN:5</availability>
 			</model>
 			<model name='STG-3R'>
 				<roles>recon</roles>
-				<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,CLAN:2-,Periphery:8,Periphery.Deep:8,BAN:3-</availability>
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
@@ -5028,15 +5037,15 @@
 			</model>
 		</chassis>
 		<chassis name='Talon' unitType='Mek'>
-			<availability>CLAN:8</availability>
+			<availability>CLAN:5+,CB:4+,CFM:4+,CGS:3+,CIH:4+,CJF:7+,CNC:7+,CDS:6+,CSJ:6+,CSR:3+,CSV:6+,CW:8+,BAN:3+</availability>
 			<model name='TLN-5V'>
-				<availability>FWL:8,FS:8</availability>
+				<availability>CIH:4-,CMG:4-,CNC:4-,CDS:4-,CW:4-,BAN:8</availability>
 			</model>
 			<model name='TLN-5W'>
-				<availability>LA:8,CLAN:8</availability>
+				<availability>CLAN:8,CIH:6+,CMG:4+,CNC:5,CDS:6,CW:8+</availability>
 			</model>
 			<model name='TLN-5W-EC'>
-				<availability>CIH:8</availability>
+				<availability>CIH!Keshik:3!Front Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Texas Battleship' unitType='Warship'>
@@ -5061,15 +5070,15 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>CC:2,MOC:2+,CLAN:4,MERC:2,FS:2,CCO:2,TC:2+,CSA:2,CS:6,OA:2+,CDS:5,FWL:4,NIOPS:6,CJF:5,CGB:5</availability>
+			<availability>FS:2,CC:2,FWL:4,MERC:2,CS:6,CLAN:4,CGB:5,CHH:6,CIH:4-,CMG:3,CNC:5,CW:5,TC:2+,MOC:2+,OA:2+,NIOPS:6,BAN:3-</availability>
 			<model name='THE-F'>
-				<availability>CC:2+,FWL:2+,FS:2+</availability>
+				<availability>CC:2+,FWL:2+,FS:2+,Periphery:8</availability>
 			</model>
 			<model name='THE-N'>
-				<availability>CS:8,General:5+,CLAN:6,NIOPS:8,BAN:6</availability>
+				<availability>IS:5+,CS:8,CLAN:8,CB:7, CGB:7,CIH:7,CJF:7,CMG:7,CNC:7,CDS:7,CSR:7,CW:7,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='THE-Nb'>
-				<availability>CLAN:8,CGS:8,BAN:4</availability>
+				<availability>CB:6+,CGB:6+,CIH:6+,CJF:6+,CMG:6+,CNC:6+,CDS:6+,CSR:6+,CW:6+,BAN!Second Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
@@ -5346,10 +5355,10 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>CC:5-,CLAN:2-,IS:3-,Periphery:2-,CS:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
+			<availability>IS:3-,CC:5-,CLAN:1-,Periphery:2-,CS:4-,FS.CMM:4-,FWL:4-,NIOPS:4-,DC:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
-				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CLAN:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Valkyrie' unitType='Mek'>
@@ -5526,10 +5535,10 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>CS:4-,CLAN:2-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:5,Periphery:6</availability>
+			<availability>IS:10,CS:4-,CLAN:1-,Periphery:6,NIOPS:4-,CIR:5,Periphery.Deep:6,BAN:1-</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,MERC:8,CLAN:8,Periphery:8,BAN:8</availability>
 			</model>
 			<model name='WSP-1D'>
 				<roles>recon</roles>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -2701,6 +2701,14 @@
                 <availability>CLAN:3,BAN:3,IS:3,FWL:3</availability>
             </model>
         </chassis>
+        <chassis name='Helepolis' unitType='Mek'>
+            <availability>CLAN:1-,CHH:2-</availability>
+            <model name='HEP-3H'>
+                <roles>mixed_artillery</roles>
+                <deployedWith>Helepolis</deployedWith>
+                <availability>CLAN:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 			<availability>CC:4,MOC:3+,CLAN:6,IS:3,FS:4,TC:3+,CS:6,OA:3+,LA:4,FWL:4,NIOPS:6,DC:4</availability>
 			<model name='HCT-213B'>

--- a/megamek/data/forcegenerator/2830.xml
+++ b/megamek/data/forcegenerator/2830.xml
@@ -705,9 +705,9 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>CC:1,MOC:1,CS:3-,LA:4,FS.CMM:4,IS:4,MERC:3,FS:4,TC:1</availability>
+			<availability>IS:4,FS:4,LA:4,CC:1,MERC:3,CS:3-,CCC:1,CIH!Front Line:2!Second Line:1,TC:1,MOC:1</availability>
 			<model name='ASN-21'>
-				<availability>General:8</availability>
+				<availability>IS:8,CCC:8,CIH:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Athena Cruiser' unitType='Warship'>
@@ -1164,10 +1164,10 @@
 			</model>
 		</chassis>
 		<chassis name='Cicada' unitType='Mek'>
-			<availability>CC:5,CS:4-,OA:3,LA:5,IS:5,FWL:5,FS:5,MERC:5,Periphery:3,DC:5</availability>
+			<availability>IS:5,FS:5,LA:5,DC:5,FWL:5,CC:5,MERC:5,CS:4-,CIH:2,Periphery:3,OA:3</availability>
 			<model name='CDA-2A'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CIH:8,Periphery:8</availability>
 			</model>
 			<model name='CDA-2B'>
 				<roles>anti_infantry</roles>
@@ -1467,12 +1467,12 @@
             </model>
         </chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:6,MOC:4,CS:3-,OA:4,CLAN:3-,IS:5,NIOPS:3-,FS:6,MERC:5</availability>
+			<availability>IS:5,FS:6,CC:6,MERC:5,CS:3-,CLAN:1-,CCO:0,CFM:2-,CGS:2-,CIH:2-,CMG:3-,CDS:2-,CSR:2-,CWOV:0,MOC:4,OA:4,NIOPS:3-,BAN:0</availability>
 			<model name='CLNT-1-2R'>
-				<availability>CC:1,FS:1</availability>
+				<availability>FS:1,CC:1</availability>
 			</model>
 			<model name='CLNT-2-3T'>
-				<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+				<availability>IS:8,CLAN:8,Periphery:8,NIOPS:8</availability>
 			</model>
 			<model name='CLNT-2-4T'>
 				<availability>CC:4,FS:4</availability>
@@ -1623,22 +1623,22 @@
             </model>
         </chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:4,CSR:4,CLAN:5,IS:4,CFM:4,MERC:4,CGS:6,Periphery:4,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,CJF:4,CGB:4</availability>
+			<availability>IS:4,MERC:4,CS:5,CLAN:5,CBS:4,CIH:4-,Periphery:4,NIOPS:5,BAN:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
-				<availability>IS:7,Periphery.Deep:7,NIOPS:0,Periphery:7</availability>
+				<availability>IS:7,Periphery:7,NIOPS:0,Periphery.Deep:7,BAN:4-</availability>
 			</model>
 			<model name='CRB-27'>
 				<roles>raider</roles>
-				<availability>CS:8,CC:3+,LA:3+,CLAN:6,NIOPS:8,FWL:3+,BAN:8,DC:3+</availability>
+				<availability>LA:3+,DC:3+,FWL:3+,CC:3+,CS:8,CLAN:5-,NIOPS:8,BAN:3</availability>
 			</model>
 			<model name='CRB-27b'>
 				<roles>raider</roles>
-				<availability>CC:3+,CLAN:8,FWL:3+,CGS:8,BAN:4</availability>
+				<availability>FWL:3+,CC:3+,CLAN:5+,CBS:4+,BAN:3+</availability>
 			</model>
 			<model name='CRB-27sl'>
                 <roles>raider</roles>
-				<availability>LA:3+,CLAN:4,DC:3+</availability>
+				<availability>LA:3+,DC:3+,CLAN:2+,CB:3+,CGB:3+,CHH:1+,CSR:1+,BAN:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
@@ -1840,12 +1840,12 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>CC:4,Periphery.HR:6,CLAN:3,IS:6,Periphery.Deep:6,FS:8,MERC:6,TC:6</availability>
+			<availability>IS:6,FS:8,CC:4,MERC:6,CBS:3+,CDS:3+,Periphery.HR:6,TC:6,Periphery.Deep:6</availability>
 			<model name='DV-6M'>
-				<availability>CLAN:4,IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CBS:8,CDS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='DV-6Md'>
-				<availability>FS:5+</availability>
+				<availability>FS:5+,CBS:6,CDS:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Dictator' unitType='Dropship'>
@@ -1950,7 +1950,7 @@
 			</model>
 		</chassis>
 		<chassis name='Enfield' unitType='Mek'>
-			<availability>CMG:5</availability>
+			<availability>CMG:2+</availability>
 			<model name='END-6J-EC'>
 				<roles>urban</roles>
 				<availability>CMG:8</availability>
@@ -2313,10 +2313,13 @@
 			</model>
 		</chassis>
 		<chassis name='Fox' unitType='Mek'>
-			<availability>CDS:4,CW:2,CSJ:2</availability>
+			<availability>CDS:1+,CSJ:1+,CW:1+</availability>
 			<model name='CS-1'>
-				<availability>General:8</availability>
+				<availability>CDS:6,CSJ:8,CW:8</availability>
 			</model>
+            <model name=''>
+                <availability>CDS!Keshik:5</availability>
+            </model>
 		</chassis>
 		<chassis name='Fury Command Tank' unitType='Tank'>
 			<availability>CC:3,CHH:8,CW:8,LA:3,CLAN:8,FWL:3,FS:4,MERC:3,CJF:8,DC:3,CGB:8</availability>
@@ -2440,16 +2443,19 @@
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>CC:7,MOC:7,CLAN:4,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,NIOPS:4,DC:8</availability>
+			<availability>IS:9,DC:8,CC:7,MERC:7,CS:4,CLAN:5,CBS:6,CCC:6,CCO:6,CGB:6,CGS:6,CIH:5+,CW:6,Periphery:6,TC:7,MOC:7,NIOPS:4,Periphery.Deep:6,BAN:4+</availability>
 			<model name='GRF-1N'>
-				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,CCC:3-,CIH:2-,CJF:2-,Periphery:8,Periphery.Deep:8,BAN:4-</availability>
 			</model>
 			<model name='GRF-1S'>
 				<availability>LA:4</availability>
 			</model>
 			<model name='GRF-2N'>
-				<availability>CC:3+,LA:3+,CLAN:6,FWL:3+,FS:3+,BAN:4</availability>
+				<availability>FS:3+,LA:3+,FWL:3+,CC:3+,CLAN:8,CCC:6,CIH:6,CJF:6,BAN:5</availability>
 			</model>
+            <model name='GRF-2N2'>
+                <availability>CIH:4,CMG:4-,BAN:5-</availability>
+            </model>
 		</chassis>
 		<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 			<availability>IS:2,MERC:2,Periphery:1</availability>
@@ -2732,9 +2738,9 @@
 			</model>
 		</chassis>
 		<chassis name='Hellhound (Conjurer)' unitType='Mek'>
-			<availability>CHH:6,CIH:6,CDS:4,CLAN:7,CNC:6,CJF:6</availability>
+			<availability>CCO:1+,CJF!Keshik:3!Front Line:1,CW:1+</availability>
 			<model name=''>
-				<availability>CHH:8,General:8,CJF:8</availability>
+				<availability>CCO:8,CJF:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hermes II' unitType='Mek'>
@@ -2781,21 +2787,21 @@
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
-			<availability>CC:4,MOC:3,CHH:4,OA:3,LA:4,CLAN:3,FWL:4,FS:4,CGS:5,DC:3,TC:4</availability>
+			<availability>FS:4,LA:4,DC:3,FWL:4,CC:4,CBS:4+,CGB:5+,CGS:5+,CHH:6+,CJF:4,CNC:3+,TC:4,MOC:3,OA:3</availability>
 			<model name='HOP-4B'>
                 <roles>inf_support,fire_support</roles>
 				<availability>CC:1</availability>
 			</model>
 			<model name='HOP-4Bb'>
                 <roles>fire_support</roles>
-				<availability>CLAN:6,BAN:2</availability>
+				<availability>CBS:3,CGB:6,CGS:5,CHH:5,CJF:4,CNC:6</availability>
 			</model>
 			<model name='HOP-4C'>
                 <roles>inf_support</roles>
-				<availability>MOC:8,OA:8,FS:8</availability>
+				<availability>FS:8,CBS:3-,CGB:3-,CGS:4-,CHH:3-,CJF:2-,CNC:3-,MOC:8,OA:8</availability>
 			</model>
 			<model name='HOP-4Cb'>
-				<availability>CHH:8,CLAN:2,BAN:2</availability>
+				<availability>CHH!Keshik:3!Front Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
@@ -2813,9 +2819,9 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>CLAN:2-,IS:5,Periphery.Deep:5,TC:5,Periphery:5,CS:5-,FWL:6,NIOPS:5-</availability>
+			<availability>IS:5,FWL:6,CS:5-,CB:4+,CCO:4+,CSJ:4,CSV:4+,Periphery:5,NIOPS:5-,Periphery.Deep:5</availability>
 			<model name='HBK-4G'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CB:8,CCO:8,CSJ:8,CSV:8,Periphery:8,NIOPS:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='HBK-4H'>
 				<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
@@ -3119,15 +3125,15 @@
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
-			<availability>CS:7,CHH:8,CDS:8,CSV:8,CLAN:7,FWL:3,NIOPS:7,FS:6,MERC:3,DC:3</availability>
+			<availability>FS:6,DC:3,FWL:3,MERC:3,CS:7,CLAN:4,CCC:5,CIH:4-,CMG:3,CSR:3,CSV:3,NIOPS:7,BAN:3+</availability>
 			<model name='KTO-18'>
 				<availability>FS:2</availability>
 			</model>
 			<model name='KTO-19'>
-				<availability>CS:8,General:2+,CLAN:6,NIOPS:8,FS:2+,MERC:2+,BAN:7</availability>
+				<availability>IS:2+,MERC:2+,CS:8,CLAN:4-,CJF:3-,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='KTO-19b'>
-				<availability>CLAN:8,CGS:8,BAN:4</availability>
+				<availability>CLAN:5,BAN:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Kiso' unitType='Mek'>
@@ -3183,10 +3189,10 @@
 			</model>
 		</chassis>
 		<chassis name='Kyudo' unitType='Mek'>
-			<availability>CLAN:2,FWL:3+,FS:3+</availability>
+			<availability>FS:3+,FWL:3+,CBS:3+,CCC:2+,CMG:3+,CDS!Front Line:2!Second Line:1</availability>
 			<model name='KY2-D-02'>
 				<roles>fire_support</roles>
-				<availability>CLAN:8,IS:8</availability>
+				<availability>FS:8,FWL:8,CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='LRM Carrier' unitType='Tank'>
@@ -3420,10 +3426,10 @@
 			</model>
 		</chassis>
 		<chassis name='Lynx' unitType='Mek'>
-			<availability>CIH:4,LA:4+,CLAN:4,FWL:4+,CSJ:4,CJF:4,DC:4+</availability>
+			<availability>LA:4+,DC:4+,FWL:4+,CLAN:5+,CBS:4+,CCC:4+,CFM:4+,CGS:4+,CHH:4+,CMG:4+,CNC:3+,CDS:3+,CSR:4+,CSA:3+,CWI:4+,BAN:2+</availability>
 			<model name='LNX-9Q'>
                 <roles>raider</roles>
-				<availability>CLAN:8,IS:5+</availability>
+				<availability>IS:8,CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -3991,12 +3997,12 @@
 			</model>
 		</chassis>
 		<chassis name='Naja' unitType='Mek'>
-			<availability>CCC:6,CBS:4,CSV:4,CLAN:4,CMG:4</availability>
+			<availability>CLAN!Front Line:1,CBS!Keshik:1!Front Line:1,CB:0,CCC:2+,CCO:0,CFM:1+,CGB:1+,CIH:0,CMG:1+,CSA:0,CSV:0,BAN:0</availability>
             <model name=''>
-                <availability>CCC:8,CLAN:6</availability>
+                <availability>CLAN:8,CBS:5,CCC:3+,CMG:6+</availability>
             </model>
 			<model name='KTO-19b-EC'>
-				<availability>CCC:6,CBS:6,CSV:6,CMG:6</availability>
+				<availability>CBS!Keshik:5!Front Line:8,CCC:8-,CMG:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Narukami Destroyer' unitType='Warship'>
@@ -4240,14 +4246,18 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:7,CLAN:3,IS:8,NIOPS:7,Periphery.Deep:4,Periphery:4</availability>
-			<model name='PXH-1'>
+			<availability>IS:8,CS:7,CLAN:4+,CB:3+,CCO:3+,CGB:3+,CGS:6+,CIH:5+,CWI:3+,Periphery:4,NIOPS:7,Periphery.Deep:4,BAN:4</availability>
+			<model name='C'>
+                <roles>recon</roles>
+                <availability>CGS!Keshik:5,CIH:1+,CJF:1+</availability>
+            </model>
+            <model name='PXH-1'>
 				<roles>command,recon</roles>
-				<availability>General:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,CGB:3-,CIH:2-,CJF:3-,Periphery:8,BAN:5-</availability>
 			</model>
 			<model name='PXH-1-EC'>
                 <roles>command,recon</roles>
-				<availability>CGS:6</availability>
+				<availability>CGS!Keshik:2</availability>
 			</model>
 			<model name='PXH-1D'>
 				<roles>command,recon</roles>
@@ -4263,15 +4273,15 @@
 			</model>
 			<model name='PXH-1b &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:7,BAN:3</availability>
+				<availability>CLAN:8,CGB:5,CGS:4,CIH:6,NIOPS:4+,BAN:3</availability>
 			</model>
 			<model name='PXH-1c &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:4,CGS:6</availability>
+				<availability>CGS:3+</availability>
 			</model>
 			<model name='PXH-2'>
 				<roles>command,recon</roles>
-				<availability>CC:3+,MOC:3+,OA:3+,CLAN:4,FWL:3+,BAN:4</availability>
+				<availability>FWL:3+,CC:3+,CLAN:2+,CCO!Front Line:1,CFM:1+,CGB:1+,CGS:1+,CHH:1+,CJF:3+,CSJ:1+,CSR:1+,CWI:1+,CW:3+,MOC:3+,OA:3+,BAN:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
@@ -4656,9 +4666,9 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>CC:5-,CS:3-,LA:5-,FWL:5-,NIOPS:3-,Periphery.Deep:5-,MERC:5-,Periphery:5-,DC:5-,BAN:2-</availability>
+			<availability>LA:5-,DC:5-,FWL:5-,CC:5-,MERC:5-,CS:3-,CGS:2-,Periphery:5-,NIOPS:3-,Periphery.Deep:5-,BAN:2-</availability>
 			<model name='SCP-1N'>
-				<availability>LA:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CGS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Scout JumpShip' unitType='Jumpship'>
@@ -4682,7 +4692,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>CC:1,CSV:5,CLAN:6,CFM:7,FS:3,CGS:5,CS:4,CDS:5,CW:5,LA:5,CBS:5,FWL:3,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
+			<availability>FS:3,LA:5,DC:3,FWL:3,CC:1,CS:4,CLAN:5-,CBS:6-,CB:4-,CCO:4-,CFM:6-,CGB:5-,CHH:4-,CJF:4-,CNC:4-,CDS:3,CSJ:4-,CSR:6-,CSA:4-,CSV:4-,CWI:4-,CLAN:6,NIOPS:4,BAN:2</availability>
 			<model name='STN-1S'>
 				<availability>LA:1,FWL:1,FS:1</availability>
 			</model>
@@ -4696,10 +4706,10 @@
 				<availability>LA:2</availability>
 			</model>
 			<model name='STN-3L'>
-				<availability>CS:8,LA:4+,CLAN:6,NIOPS:8,FWL:4+,FS:4+,MERC:4+,BAN:8</availability>
+				<availability>FS:4+,LA:4+,FWL:4+,MERC:4+,CS:8,CLAN:8,CBS:4-,CCC:4,CFM:3,CGB:5-,CHH:4-,CJF:4-,CDS:4-,CSR:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='STN-3Lb'>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CBS:4+,CCC:4+,CFM:4+,CGB:4+,CHH:4+,CJF:4+,CDS:4+,CSR:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
@@ -4714,24 +4724,27 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>CLAN:5,BAN:2+</availability>
+			<availability>CLAN!Keshik:2,BAN:0</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
+            <model name='2'>
+                <availability>CGB!Keshik:3</availability>
+            </model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:6-,LA:6,CLAN:4,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5</availability>
+			<availability>IS:7,LA:6,CS:6-,CLAN:5,CIH:4,Periphery:5,NIOPS:6-,Periphery.Deep:5,BAN:5</availability>
             <model name='C'>
-                <availability>CSA:6,CCC:6,CSV:6,CFM:6,CGS:6</availability>
+                <availability>CLAN:1+,CCC!Keshik:5,CCO!Keshik:8,CFM!Keshik:5,CGB!Keshik:5,CHH!Keshik:5,CJF!Keshik:5!Second Line:3,BAN:0</availability>
             </model>
 			<model name='SHD-2D'>
 				<availability>FS:10</availability>
 			</model>
 			<model name='SHD-2H'>
-				<availability>General:8,CLAN:6-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CLAN:2-,CCC:1-,CHH:1-,CIH:1-,CJF:1-,CMG:1-,Periphery:8,Periphery.Deep:8,BAN:2</availability>
 			</model>
 			<model name='SHD-2Hb'>
-				<availability>CLAN:8,FS:3+,BAN:4</availability>
+				<availability>FS:3+,CLAN:8,CCC:7,CGB:7,BAN:3+</availability>
 			</model>
 			<model name='SHD-2K'>
 				<availability>DC:9</availability>
@@ -4924,14 +4937,14 @@
 			</model>
 		</chassis>
 		<chassis name='Starslayer' unitType='Mek'>
-			<availability>CSA:3,LA:5+,CNC:4</availability>
+			<availability>LA:5+,CNC:3+,CSA!Keshik:3!Front Line:1</availability>
 			<model name='STY-2C'>
 				<roles>raider</roles>
-				<availability>IS:8</availability>
+				<availability>LA:8</availability>
 			</model>
 			<model name='STY-2C-EC'>
                 <roles>raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CNC:8,CSA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stinger LAM Mk I' unitType='Mek'>
@@ -5232,10 +5245,10 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
+			<availability>FWL:8,CC:5,MERC:5,CS:5-,CDS:3+,MOC:5,NIOPS:5-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
-				<availability>CC:3+,CS:6,FWL:3+,NIOPS:6</availability>
+				<availability>FWL:3+,CC:3+,CS:6,CDS:8,NIOPS:6</availability>
 			</model>
 			<model name='TBT-5J'>
 				<availability>FWL:4</availability>
@@ -5449,14 +5462,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:4,CS:3,MOC:5,LA:7,CLAN:3-,FWL:7,IS:5,NIOPS:3,CIR:5,TC:5</availability>
+			<availability>IS:5,LA:7,FWL:7,CC:4,CS:3,TC:5,MOC:5,CIR:5,NIOPS:3,BAN:2-</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
-				<availability>General:8,FS:4</availability>
+				<availability>IS:8,FS:4,Periphery:8,BAN:8</availability>
 			</model>
 			<model name='VL-5T'>
 				<roles>anti_infantry</roles>
-				<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,TC:2</availability>
+				<availability>IS:2,FS:6,TC:2,MOC:2,CIR:2,BAN:2,PIR:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Vulture' unitType='Dropship'>
@@ -5582,13 +5595,13 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:3-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+			<availability>FS.CMM:5,DC:6,MERC:3,CS:3-,CB:2-,CWI:2-,Periphery.DD:2,Periphery.OS:2,TC:2,MOC:1,OA:1,NIOPS:3-</availability>
 			<model name='WTH-0'>
 				<availability>TC:6</availability>
 			</model>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
-				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CB:8,CWI:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='WTH-1S'>
 				<roles>fire_support</roles>
@@ -5596,7 +5609,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CS:5-,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,TC:5</availability>
+			<availability>IS:7,FS:8,FWL:9,CS:5-,TC:5,NIOPS:5-,Periphery.Deep:6,BAN:4</availability>
 			<model name='WVR-1R'>
 				<availability>FS:2-</availability>
 			</model>
@@ -5613,21 +5626,21 @@
 			</model>
 			<model name='WVR-6R'>
 				<roles>command,recon</roles>
-				<availability>General:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CS:6,CC:6,CIH:5,CLAN:6,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:5</availability>
+			<availability>FS:6,DC:6,CC:6,MERC:5,CS:6,CLAN:4,CCC:3,CGB:3,CGS:3,CHH:3,CIH:2-,CJF:3,CMG:4-,CDS:3,CSJ:2,CSR:3,CSV:3,CW:3,TC:5,NIOPS:6,BAN:3</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
-				<availability>CS:8,CC:5+,CLAN:6,NIOPS:8,CFM:6,FS:5+,BAN:8,DC:5+,TC:8</availability>
+				<availability>FS:5+,DC:5+,CC:5+,CS:8,CBS:4-,CB:4-,CCO:3-,CFM:3-,TC:8,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='WVE-5Nb'>
 				<roles>urban</roles>
-				<availability>CLAN:8,CFM:8,CGS:8</availability>
+				<availability>CLAN:6,BAN:3+</availability>
 			</model>
 			<model name='WVE-5Nsl'>
-				<availability>LA:3+,FWL:3+</availability>
+				<availability>LA:3+,FWL:3+,CLAN:2-,CCC:3-,CCO:1-,CSA:3-,CW:3-,BAN:0</availability>
 			</model>
 			<model name='WVE-6N'>
 				<roles>urban</roles>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -6,9 +6,9 @@
 >
 	<factions>
 		<faction key='BAN'>
-			<pctOmni>0,0</pctOmni>
-			<pctClan>0,0</pctClan>
-			<pctSL>80,80</pctSL>
+            <!-- Omni percentages: 0,0 -->
+            <!-- Clan percentages: 0,0 -->
+            <!-- Star League percentages: 80,80 -->
 			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS'>
@@ -5901,14 +5901,14 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech IIC' unitType='Mek'>
-			<availability>CHH:4,CIH:4-,CSR:4,CCO:5,CGS:4</availability>
+			<availability>CCO!Second Line:3</availability>
 			<model name=''>
 				<roles>urban</roles>
-				<availability>CLAN:8</availability>
+				<availability>CCO:8</availability>
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>IS:4-,CC:5-,CLAN:1-,Periphery:3-,CS:4-,TC:3-,NIOPS:4-</availability>
+			<availability>IS:4-,CC:5-,CLAN:1-,Periphery:3-,CS:4-,NIOPS:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
 				<availability>IS:8,MERC:8,CLAN:8,Periphery:8,Periphery.Deep:8</availability>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -3007,6 +3007,14 @@
                 <availability>CLAN:3,BAN:3,IS:3,FWL:3</availability>
             </model>
         </chassis>
+        <chassis name='Helepolis' unitType='Mek'>
+            <availability>CHH:1-</availability>
+            <model name='HEP-3H'>
+                <roles>mixed_artillery</roles>
+                <deployedWith>Helepolis</deployedWith>
+                <availability>CHH:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 			<availability>CC:2,MOC:3+,CLAN:5,IS:3,TC:3+,CS:6,OA:3+,FWL:2,NIOPS:6</availability>
 			<model name='HCT-212'>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -1089,7 +1089,7 @@
 			<availability>IS:3,DC:5,CC:5,MERC:2,CS:2,CFM:4+,CDS:3,CWI:3+,CW:3-,Periphery:1,NIOPS:2</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
-				<availability>CC:4,FWL:3,DC:3</availability>
+				<availability>DC:3,FWL:3,CC:4</availability>
 			</model>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
@@ -1128,7 +1128,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cestus' unitType='Mek'>
-			<availability>IS:3+,FS:5,LA:3+,CS:4,CB:3+,CFM:2+,CJF!Front Line:2!Second Line:1,CSJ!Front Line:2!Second Line:1,NIOPS:4</availability>
+			<availability>IS:3+,FS:5,LA:3+,CS:4,CB:3+,CFM:2+,CJF!Front Line:2!Second Line:1,CSJ!Front Line:2!Second Line:1,NIOPS:4+</availability>
 			<model name='CTS-6Y'>
 				<availability>IS:8,CB:8,CFM:5,CJF:8,CSJ:8,NIOPS:8</availability>
 			</model>
@@ -1159,7 +1159,7 @@
 				<availability>CS:4,CFM:8,CGB:5,CHH:5,CIH:8,CDS:4-,NIOPS:5</availability>
 			</model>
 			<model name='CHP-1Nb'>
-				<availability>CDS:3+,CSV!Front Line:3!Second Line:2!Solahma:1</availability>
+				<availability>CDS:3+,CSV:8</availability>
 			</model>
 			<model name='CHP-2N'>
 				<availability>IS:7</availability>
@@ -2434,7 +2434,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>LA:6,FWL:3,CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CJF!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CS:5,Periphery.R:3,NIOPS:5,BAN:3+</availability>
+			<availability>LA:6,FWL:3,CS:5,CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CJF!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,Periphery.R:3,NIOPS:5,BAN:3+</availability>
 			<model name='FLS-7K'>
 				<availability>LA:6,FWL:8,Periphery.R:8</availability>
 			</model>
@@ -4496,7 +4496,7 @@
 				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
             <model name='ON1-Kb'>
-                <availability>CLAN:8,CW:3+,BAN:0</availability>
+                <availability>CLAN:8,CW:4+,BAN:0</availability>
             </model>
 			<model name='ON1-V'>
 				<availability>IS:3,CW:1-,TC:3,OA:3</availability>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -612,23 +612,27 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:7,CS:5-,LA:9,CLAN:1,IS:6,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8</availability>
+			<availability>IS:6,FS:8,LA:9,DC:8,FWL:9,CC:7,CS:5-,CLAN:4,CFM:3,CGS:3,CIH:4-,CMG:3,CSV:3,Periphery:6,NIOPS:5-,Periphery.Deep:6,BAN:4</availability>
 			<model name='ARC-2K'>
 				<roles>command,fire_support</roles>
 				<availability>DC:8</availability>
 			</model>
 			<model name='ARC-2R'>
 				<roles>command,fire_support</roles>
-				<availability>LA:7,CLAN:4,IS:8,Periphery.Deep:8,BAN:7,DC:6,Periphery:8</availability>
+				<availability>IS:8,LA:7,DC:6,CLAN:1-,CGB:2-,CW:2-,Periphery:8,NIOPS:4-,Periphery.Deep:8,BAN:8</availability>
 			</model>
 			<model name='ARC-2Rb'>
 				<roles>command,fire_support</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:4-,BAN:2+</availability>
 			</model>
 			<model name='ARC-2S'>
 				<roles>command,fire_support</roles>
 				<availability>LA:6</availability>
 			</model>
+            <model name='C'>
+                <roles>command,fire_support</roles>
+                <availability>CLAN:3+,CBS:1+,CB:2+,CFM:2+,CGS:2+,CMG:2+,CNC:2+,CSJ:2+,BAN:0</availability>
+            </model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
 			<availability>MOC:8,OA:8,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8,BAN:3</availability>
@@ -900,18 +904,18 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:3,MERC:3,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:3,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:3</availability>
+			<availability>FS:3,LA:3,DC:3,FWL:4,MERC:3,CS:7,CLAN:3+,CGS:4+,CIH:2+,NIOPS:7,BAN:2+</availability>
 			<model name='BL-6-KNT'>
                 <roles>command</roles>
-				<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
+				<availability>FS:2+,FWL:2+,CS:8,CLAN:8,CBS:6-,CCO:5-,CGB:5-,CGS:5-,CNC:5-,CW:5-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='BL-6b-KNT'>
                 <roles>command</roles>
-				<availability>CS:4,CLAN:7,NIOPS:4,FWL:2+,CGS:8,BAN:4</availability>
+				<availability>FWL:2+,CS:4,CBS:7,CCO:7,CGB:7,CGS:7,CNC:7,CW:7,NIOPS:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
                 <roles>command</roles>
-				<availability>LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+				<availability>FS:8,LA:8,DC:8,FWL:4,MERC:8</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
                 <roles>command</roles>
@@ -950,14 +954,14 @@
 			</model>
 		</chassis>
 		<chassis name='Bombardier' unitType='Mek'>
-			<availability>CLAN:5,CS:5,FWL:2,DC:2,NIOPS:5,BAN:3</availability>
+			<availability>DC:2,FWL:2,CS:5,CLAN:3-,CB:2-,CCO:2-,CIH:4,CMG:4-,CDS:4-,CSR:4-,CWI:2-,NIOPS:5,BAN:0</availability>
 			<model name='BMB-10D'>
 				<roles>fire_support</roles>
-				<availability>CLAN:8,CS:8,FWL:8,DC:8,NIOPS:8,BAN:8</availability>
+				<availability>DC:8,FWL:8,CS:8,NIOPS:8</availability>
 			</model>
 			<model name='BMB-12D'>
 				<roles>fire_support</roles>
-				<availability>CS:8,CLAN:8,NIOPS:8,FWL:6+,BAN:8,DC:6+</availability>
+				<availability>DC:6+,FWL:6+,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
         <chassis name='Brunel Dump Truck' unitType='Tank'>
@@ -1082,18 +1086,18 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>CC:5,CLAN:3,IS:3,MERC:2,Periphery:1,CS:2,NIOPS:2,DC:5</availability>
+			<availability>IS:3,DC:5,CC:5,MERC:2,CS:2,CFM:4+,CDS:3,CWI:3+,CW:3-,Periphery:1,NIOPS:2</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4,FWL:3,DC:3</availability>
 			</model>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
-				<availability>CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CDS:8,CW:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='CPLT-C1b'>
 				<roles>fire_support</roles>
-				<availability>CC:2+,CLAN:6,DC:2+</availability>
+				<availability>DC:2+,CC:2+,CFM:8,CWI:8</availability>
 			</model>
 			<model name='CPLT-C4'>
 				<roles>fire_support</roles>
@@ -1124,12 +1128,12 @@
 			</model>
 		</chassis>
 		<chassis name='Cestus' unitType='Mek'>
-			<availability>CS:4,LA:3+,CLAN:4,NIOPS:4,IS:3+,FS:5</availability>
+			<availability>IS:3+,FS:5,LA:3+,CS:4,CB:3+,CFM:2+,CJF!Front Line:2!Second Line:1,CSJ!Front Line:2!Second Line:1,NIOPS:4</availability>
 			<model name='CTS-6Y'>
-				<availability>General:8</availability>
+				<availability>IS:8,CB:8,CFM:5,CJF:8,CSJ:8,NIOPS:8</availability>
 			</model>
 			<model name='CTS-6Y-EC'>
-				<availability>CFM:3</availability>
+				<availability>CFM!Keshik:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
@@ -1146,22 +1150,19 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:7,CS:5,CHH:6,LA:6,CLAN:5,IS:4,NIOPS:5,MERC:4,CGB:6</availability>
-			<model name='C'>
-				<availability>CHH:6,CLAN:8,CGB:6</availability>
-			</model>
+			<availability>IS:4,LA:6,CC:7,MERC:4,CS:5,CBS:4-,CCO:2-,CFM:4+,CGB!Front Line:3!Second Line:2!Solahma:1,CHH:4+,CIH:6+,CDS:4+,CSV!Front Line:3!Second Line:2!Solahma:1,NIOPS:5</availability>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
-				<availability>CC:3+,CS:8,CHH:6,CLAN:6,NIOPS:8,BAN:8,CGB:6</availability>
+				<availability>CC:3+,CS:8,CBS:8,CCO:8,CGB:4-,CHH:4-,NIOPS:8</availability>
 			</model>
 			<model name='CHP-1N2'>
-				<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
+				<availability>CS:4,CFM:8,CGB:5,CHH:5,CIH:8,CDS:4-,NIOPS:5</availability>
 			</model>
 			<model name='CHP-1Nb'>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CDS:3+,CSV!Front Line:3!Second Line:2!Solahma:1</availability>
 			</model>
 			<model name='CHP-2N'>
-				<availability>IS:7,NIOPS:0</availability>
+				<availability>IS:7</availability>
 			</model>
 		</chassis>
 		<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1968,9 +1969,9 @@
 			</model>
 		</chassis>
 		<chassis name='Crusader' unitType='Mek'>
-			<availability>CS:6-,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:8,CS:6-,CLAN:3,CDS:2,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:4</availability>
 			<model name='CRD-2R'>
-				<availability>CLAN:7,IS:3+,CGS:8,BAN:4,Periphery:3+</availability>
+				<availability>IS:3+,CLAN:8,Periphery:3+,NIOPS:5,Periphery.Deep:0,BAN:2+</availability>
 			</model>
 			<model name='CRD-3D'>
 				<availability>FS:5</availability>
@@ -1983,7 +1984,7 @@
 				<availability>CC:9</availability>
 			</model>
 			<model name='CRD-3R'>
-				<availability>General:8,CLAN:3,Periphery.Deep:8,BAN:7,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CCO:1-,CIH:1-,CSA:1-,CWI:1-,Periphery:8,NIOPS:6-,Periphery.Deep:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
@@ -2271,29 +2272,29 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,IS:5,Periphery:2,TC:3,CS:5,NIOPS:5,DC:6</availability>
+			<availability>IS:5,DC:6,CS:5,Periphery:2,TC:3,MOC:3,NIOPS:5</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Mek'>
-			<availability>CS:5,LA:1+,CLAN:4,NIOPS:5,FS:1+,DC:1+</availability>
+			<availability>FS:1+,LA:1+,DC:1+,CS:5,CLAN:3+,CSJ!Front Line:2!Second Line:1,NIOPS:5,BAN:0</availability>
 			<model name='EXC-B1'>
 				<roles>cavalry,fire_support</roles>
-				<availability>LA:8</availability>
+				<availability>LA:8,CGS:4-,CDS:4-,CW:4-</availability>
 			</model>
 			<model name='EXC-B2'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CS:8,LA:0,General:8,CLAN:6,NIOPS:8</availability>
+				<availability>FS:8,LA:0,DC:8,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 			<model name='EXC-B2b'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CLAN:2+,CGB:3+,CJF:3+,CSJ:3+</availability>
 			</model>
 			<model name='EXC-B2b-EC'>
                 <roles>cavalry,fire_support</roles>
-				<availability>CW:6</availability>
+				<availability>CW:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -2308,22 +2309,22 @@
 			</model>
 		</chassis>
 		<chassis name='Exterminator' unitType='Mek'>
-			<availability>CS:4,CLAN:6,NIOPS:4</availability>
+			<availability>CS:4,CLAN!Front Line:2!Second Line:1,CCO!Front Line:1,CIH:4+,CJF:2+,CMG:3+,CDS:3+,CSR:3+,CWI!Front Line:1,NIOPS:4,BAN:1+</availability>
 			<model name='EXT-4C'>
 			    <roles>specops</roles>
-				<availability>BAN:1</availability>
+				<availability>BAN:8</availability>
 			</model>
 			<model name='EXT-4D'>
 			    <roles>cavalry</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:4</availability>
+				<availability>CS:8,CLAN:8,CFM:4-,CIH:4-,CJF:3-,CDS:4-,CSR:4-,NIOPS:8,BAN:0</availability>
 			</model>
 			<model name='EXT-4Db'>
 			    <roles>cavalry</roles>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CFM:8,CIH:5,CJF:4-,CDS:8,CSR:8,NIOPS:3+</availability>
 			</model>
 			<model name='EXT-4Db-EC'>
 			    <roles>cavalry</roles>
-				<availability>CJF:6</availability>
+				<availability>CJF:2+</availability>
 			</model>
 		</chassis>
         <chassis name='Factory' unitType='Space Station'>
@@ -2387,10 +2388,10 @@
 			</model>
 		</chassis>
 		<chassis name='Fire Scorpion' unitType='Mek'>
-			<availability>CGS:7:2852</availability>
+			<availability>CGS!Keshik:3</availability>
 			<model name=''>
 			    <roles>urban</roles>
-				<availability>CLAN:8</availability>
+				<availability>CGS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Firebee' unitType='Mek'>
@@ -2433,13 +2434,13 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:3,CDS:5,LA:6,CBS:5,FWL:3,NIOPS:5,CJF:7,CGB:5</availability>
+			<availability>LA:6,FWL:3,CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CJF!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CS:5,Periphery.R:3,NIOPS:5,BAN:3+</availability>
 			<model name='FLS-7K'>
 				<availability>LA:6,FWL:8,Periphery.R:8</availability>
 			</model>
 			<model name='FLS-8K'>
                 <roles>cavalry</roles>
-				<availability>CS:8,LA:3+,CLAN:8,NIOPS:8,BAN:8</availability>
+				<availability>LA:3+,CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Flatbed Truck' unitType='Tank'>
@@ -2628,19 +2629,19 @@
 			</model>
 		</chassis>
 		<chassis name='Galahad (Glass Spider)' unitType='Mek'>
-			<availability>CSR:8,CW:9,CLAN:8</availability>
+			<availability>CWI:1+,CW:1+</availability>
 			<model name=''>
                 <roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:8</availability>
+				<availability>CWI:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Galahad' unitType='Mek'>
-			<availability>CC:3+,LA:3+,CLAN:3,FS:3+</availability>
+			<availability>FS:3+,LA:3+,CC:3+,CGB!Front Line:1!Second Line:1,CHH!Front Line:1!Second Line:1,CWI!Front Line:1!Second Line:1</availability>
 			<model name='GLH-1D'>
-				<availability>IS:8</availability>
+				<availability>FS:8,LA:8,CC:8</availability>
 			</model>
 			<model name='GLH-2D'>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CHH:8,CWI:8</availability>
 			</model>
 		</chassis>
         <chassis name='Galaport Ground Trailer' unitType='Tank'>
@@ -2761,14 +2762,14 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>CS:7,CHH:9,CSR:9,CLAN:8,IS:6,NIOPS:7,FS:5,MERC:6</availability>
+			<availability>IS:6,FS:5,MERC:6,CS:7,CHH:3+,CSR:3+,NIOPS:7</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
-				<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:8</availability>
+				<availability>IS:4+,CS:8,CHH:8,CSR:8,NIOPS:8</availability>
 			</model>
 			<model name='GLT-4L'>
 				<roles>raider</roles>
-				<availability>FWL:6-,NIOPS:0,MERC:6-</availability>
+				<availability>FWL:6-,MERC:6-</availability>
 			</model>
 			<model name='GLT-4P'>
 				<roles>raider</roles>
@@ -3006,14 +3007,6 @@
                 <availability>CLAN:3,BAN:3,IS:3,FWL:3</availability>
             </model>
         </chassis>
-		<chassis name='Helepolis' unitType='Mek'>
-			<availability>CLAN:3</availability>
-			<model name='HEP-3H'>
-				<roles>mixed_artillery</roles>
-				<deployedWith>Helepolis</deployedWith>
-				<availability>General:8</availability>
-			</model>
-		</chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 			<availability>CC:2,MOC:3+,CLAN:5,IS:3,TC:3+,CS:6,OA:3+,FWL:2,NIOPS:6</availability>
 			<model name='HCT-212'>
@@ -3569,18 +3562,18 @@
 			</model>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>MOC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,NIOPS:6,DC:5</availability>
+			<availability>IS:3,DC:5,MERC:3,CS:6,CLAN:3+,CCC:4+,CCO:2+,CFM:4+,CHH:2+,CIH:4+,CMG:4+,CSV:4+,CWI:2+,TC:3,MOC:3,OA:3,CIR:3,NIOPS:6,BAN:0</availability>
             <model name='C'>
                 <roles>cavalry,anti_aircraft</roles>
-                <availability>CIH:2,CFM:2,CFM.SmJ:6,CB:4,CGB:2</availability>
+                <availability>CB:2+,CFM:1+,CGB!Keshik:2,CIH!Keshik:8!Front Line:5</availability>
             </model>
 			<model name='LNC25-01'>
 				<roles>cavalry,anti_aircraft</roles>
-				<availability>CS:8,CLAN:8,IS:5+,NIOPS:8,BAN:6</availability>
+				<availability>IS:5+,CS:8,CLAN:8,CB:5,CGB:5-,CIH:4-,NIOPS:8</availability>
 			</model>
 			<model name='LNC25-05'>
 				<roles>cavalry,anti_infantry</roles>
-				<availability>CS:4,IS:2,NIOPS:4</availability>
+				<availability>IS:2,CS:4,NIOPS:4</availability>
 			</model>
 		</chassis>
 		<chassis name='League Destroyer' unitType='Warship'>
@@ -3890,18 +3883,18 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>MOC:2+,CLAN:7,IS:4,FS:5,TC:3+,Periphery:2,CS:8,LA:5,NIOPS:8,DC:5</availability>
+			<availability>IS:4,FS:5,LA:5,DC:5,CS:8,CLAN:4+,CIH:3+,CMG:3+,CSV:3+,Periphery:2,TC:3+,MOC:2+,NIOPS:8,BAN:2+</availability>
             <model name='C'>
                 <roles>command</roles>
-                <availability>CLAN:2+</availability>
+                <availability>CLAN:2+,CBS!Keshik:2,CB!Keshik:3!Front Line:1,CCO!Keshik:3!Front Line:1,CGB:3+,CGS:1+,CJF:3+,CMG:1+,CNC:3+,CDS:3+,CSJ:3+,CSR:3+,CSA:3+,CWI:1+,CW:3+,BAN:0</availability>
             </model>
 			<model name='MAD-1R'>
                 <roles>command</roles>
-				<availability>CS:8,MOC:4,CLAN:4,IS:4+,NIOPS:8,MERC:0,BAN:4,TC:4+</availability>
+				<availability>IS:4+,MERC:0,CS:8,CLAN:2-,CBS:3-,CSA:3-,TC:4+,MOC:4,NIOPS:8,BAN:2+</availability>
 			</model>
 			<model name='MAD-2R'>
                 <roles>command</roles>
-				<availability>CLAN:7,FS:3+,CGS:8,BAN:7</availability>
+				<availability>FS:3+,CLAN:5,BAN:0</availability>
 			</model>
 			<model name='MAD-3D'>
                 <roles>command</roles>
@@ -3909,7 +3902,7 @@
 			</model>
 			<model name='MAD-3R'>
                 <roles>command</roles>
-				<availability>CS:4-,IS:8,Periphery.Deep:8,TC:7</availability>
+				<availability>IS:8,CS:4-,Periphery:8,TC:7,BAN:8</availability>
 			</model>
 		</chassis>
         <chassis name='Marco' unitType='Mek'>
@@ -3950,15 +3943,15 @@
 			</model>
 		</chassis>
 		<chassis name='Masauwu' unitType='Mek'>
-			<availability>CCO:3</availability>
+			<availability>CCO:2+,CSA:1+</availability>
             <model name=''>
-                <availability>General:8</availability>
+                <availability>CCO:8,CSA:8</availability>
             </model>
 		</chassis>
 		<chassis name='Matador' unitType='Mek'>
-			<availability>CSV:6</availability>
+			<availability>CSV!Keshik:3</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CSV:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Maultier Hover APC' unitType='Tank'>
@@ -4192,10 +4185,10 @@
 			</model>
 		</chassis>
 		<chassis name='Minsk' unitType='Mek'>
-			<availability>CGB:5</availability>
+			<availability>CGB!Front Line:1</availability>
 			<model name='MNK-101'>
 				<roles>command</roles>
-				<availability>CLAN:6</availability>
+				<availability>CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Mithras Light Tank' unitType='Tank'>
@@ -4492,18 +4485,21 @@
 			</model>
 		</chassis>
 		<chassis name='Orion IIC' unitType='Mek'>
-			<availability>CW:4</availability>
+			<availability>CW!Keshik:3</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CLAN:3,IS:5,Periphery.Deep:4,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,FWL:9,NIOPS:5-</availability>
+			<availability>IS:5,LA:6,FWL:9,CS:5-,CLAN:2+,CBS:3+,CB:3+,CGB:3+,CSA:3+,CSV:3+,CWI:3+,CW:5+,Periphery:4,TC:5,MOC:5,OA:5,CIR:5,NIOPS:5-,Periphery.Deep:4,BAN:2</availability>
 			<model name='ON1-K'>
-				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
+            <model name='ON1-Kb'>
+                <availability>CLAN:8,CW:3+,BAN:0</availability>
+            </model>
 			<model name='ON1-V'>
-				<availability>OA:3,IS:3,TC:3</availability>
+				<availability>IS:3,CW:1-,TC:3,OA:3</availability>
 			</model>
 			<model name='ON1-VA'>
 				<availability>IS:2</availability>
@@ -4523,14 +4519,14 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CS:4,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,DC:6</availability>
+			<availability>IS:5,DC:6,CS:4,CLAN:4,CB:3,CCC!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:3,CCO:3,CIH:5,CMG!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,CWI:3,Periphery:4,NIOPS:4,Periphery.Deep:4,BAN:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
-				<availability>CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:7,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CLAN:1-,CCC:2-,Periphery:8,Periphery.Deep:8,BAN:4-</availability>
 			</model>
 			<model name='OSR-2Cb'>
 				<roles>urban</roles>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CLAN:8,BAN:3</availability>
 			</model>
 			<model name='OSR-2L'>
 				<availability>IS:4</availability>
@@ -4554,10 +4550,10 @@
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
-			<availability>CLAN:4-,CS:6,FWL:7,NIOPS:6,Periphery.Deep:4,FS:7,MERC:7,Periphery:4,BAN:5</availability>
+			<availability>FS:7,FWL:7,MERC:7,CS:6,Periphery:4,NIOPS:6,Periphery.Deep:4,BAN:2-</availability>
 			<model name='OTL-4D'>
                 <roles>raider</roles>
-				<availability>CLAN:8,IS:8,Periphery:8,BAN:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Overlord C' unitType='Dropship'>
@@ -4898,6 +4894,13 @@
 				<availability>CCC:4,CSR:4,CBS:4,CLAN:4,CNC:4</availability>
 			</model>
 		</chassis>
+        <chassis name='Redback' unitType='Mek'>
+            <availability>CWI!Keshik:3!Front Line:1</availability>
+            <model name=''>
+                <roles>cavalry</roles>
+                <availability>CWI:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Rhino Fire Support Tank' unitType='Tank'>
 			<availability>MOC:8,CLAN:9,Periphery.Deep:10,IS:7,CIR:8,MERC:8,Periphery:10,TC:8,CS:9,OA:8,LA:9,NIOPS:9</availability>
 			<model name=''>
@@ -4934,10 +4937,10 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman IIC' unitType='Mek'>
-			<availability>CLAN:3:2845</availability>
+			<availability>CGB!Front Line:3,CNC!Front Line:3,CW!Front Line:3</availability>
 			<model name=''>
                 <roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CNC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Rifleman II' unitType='Mek'>
@@ -4948,14 +4951,14 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CLAN:3,IS:8-,Periphery.Deep:5,CIR:3,Periphery:5,CS:6-,NIOPS:6-</availability>
+			<availability>IS:8-,CS:6-,CLAN!Front Line:1,CSR!Front Line:1!Provisional Garrison:1,Periphery:5,CIR:3,NIOPS:6-,Periphery.Deep:5,BAN:3-</availability>
             <model name='C'>
                 <roles>fire_support,anti_aircraft</roles>
-                <availability>CLAN:8,BAN:4</availability>
+                <availability>CLAN:8,CSR!Front Line:8,BAN:0</availability>
             </model>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:6-,General:8,BAN:7</availability>
+				<availability>IS:8,MERC:8,CSR:1-,Periphery:8,NIOPS:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Riga II Destroyer-Carrier' unitType='Warship'>
@@ -5268,10 +5271,10 @@
 			</model>
 		</chassis>
 		<chassis name='Shootist' unitType='Mek'>
-			<availability>CS:5,LA:2+,CLAN:5,NIOPS:5</availability>
+			<availability>LA:2+,CS:5,CLAN!Front Line:2!Second Line:1,CBS:2+,CB!Front Line:3!Second Line:2!Solahma:1,CFM:2+,CMG!Front Line:1,CDS:2+,NIOPS:5,BAN:0</availability>
 			<model name='ST-8A'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
         <chassis name='Shugosha' unitType='Mek'>
@@ -5620,9 +5623,9 @@
 			</model>
 		</chassis>
 		<chassis name='Thresher' unitType='Mek'>
-			<availability>CHH:5,CDS:4,CSR:4,CLAN:4</availability>
+			<availability>CDS!Keshik:3</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CDS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
@@ -5677,9 +5680,9 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,MERC:7,Periphery:6,DC:8</availability>
+			<availability>IS:7,LA:8,DC:8,CC:9,MERC:7,CS:5-,CLAN:5,CB!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CCC:4,CIH:4,CMG:4,CSR:4,CSV:4,Periphery:6,NIOPS:5-,Periphery.Deep:6,BAN:5</availability>
 			<model name='C'>
-				<availability>CLAN:3</availability>
+				<availability>CLAN:2+,CGS:1+,CIH:1+,BAN:0</availability>
 			</model>
 			<model name='TDR-5D'>
 				<availability>FS:4,MERC:2</availability>
@@ -5691,13 +5694,13 @@
 				<availability>CC:1</availability>
 			</model>
 			<model name='TDR-5S'>
-				<availability>IS:8,CLAN:2-,BAN:6,Periphery:8</availability>
+				<availability>IS:8,CLAN:3-,Periphery:8,BAN:6-</availability>
 			</model>
 			<model name='TDR-5SE'>
 				<availability>MERC.ELH:8,MERC:2</availability>
 			</model>
 			<model name='TDR-5Sb'>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CLAN:4,BAN:5</availability>
 			</model>
 			<model name='TDR-5Sd'>
 				<availability>FS:2+</availability>
@@ -5984,9 +5987,12 @@
 			</model>
 		</chassis>
 		<chassis name='Vision Quest' unitType='Mek'>
-			<availability>CSR:4,CNC:6,CB:4</availability>
+			<availability>CB:1+,CNC!Keshik:3!Front Line:1</availability>
+            <model name=''>
+                <availability>CB:8,CNC!Keshik:3</availability>
+            </model>
 			<model name='VQ-1NC'>
-				<availability>CNC:4</availability>
+				<availability>CNC:4-</availability>
 			</model>
 		</chassis>
 		<chassis name='Volga Transport' unitType='Warship'>
@@ -6059,9 +6065,9 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:8,LA:9,FWL:9,CS:6-,CLAN:6+,CB:5+,CCC:5+,CFM:5+,CHH:5+,CIH:4-,CMG:5+,CNC:5+,CSR:5+,CSV:5+,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:5+</availability>
             <model name='C'>
-                <availability>CLAN:2</availability>
+                <availability>CLAN:3+,CBS!Keshik:3!Front Line:1,CB!Keshik:3!Front Line:1,CCO!Keshik:3!Front Line:1,CGS:2+,CHH:2+,CSJ:2+,CWI:2+,BAN:0</availability>
             </model>
 			<model name='WHM-6D'>
 				<availability>FS:4</availability>
@@ -6073,17 +6079,17 @@
 				<availability>CC:4</availability>
 			</model>
 			<model name='WHM-6R'>
-				<availability>General:8,CLAN:2,BAN:8</availability>
+				<availability>IS:8,CLAN:1-,Periphery:8,Periphery.Deep:8,BAN:6-</availability>
 			</model>
 			<model name='WHM-6Rb'>
-				<availability>CC:3+,LA:3+,CLAN:4,FWL:3+,FS:3+,BAN:4</availability>
+				<availability>FS:3+,LA:3+,FWL:3+,CC:3+,CLAN:4-,BAN:5</availability>
 			</model>
 			<model name='WHM-6Rk'>
                 <roles>cavalry</roles>
 				<availability>DC:2+</availability>
 			</model>
 			<model name='WHM-7A'>
-				<availability>CLAN:6</availability>
+				<availability>CLAN:2+,CBS:3+,CCC:3+,CCO:3+,CGB:3+,CGS:3+,CIH:3+,BAN:0</availability>
 			</model>
 		</chassis>
 		<chassis name='Wasp LAM Mk I' unitType='Mek'>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -6087,10 +6087,10 @@
 				<availability>CC:4</availability>
 			</model>
 			<model name='WHM-6R'>
-				<availability>IS:8,CLAN:1-,Periphery:8,Periphery.Deep:8,BAN:6-</availability>
+				<availability>IS:8,CLAN:1-,Periphery:8,NIOPS:3-,Periphery.Deep:8,BAN:6-</availability>
 			</model>
 			<model name='WHM-6Rb'>
-				<availability>FS:3+,LA:3+,FWL:3+,CC:3+,CLAN:4-,BAN:5</availability>
+				<availability>FS:3+,LA:3+,FWL:3+,CC:3+,CLAN:4-,NIOPS:6,BAN:5</availability>
 			</model>
 			<model name='WHM-6Rk'>
                 <roles>cavalry</roles>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -2235,6 +2235,7 @@
 				<availability>FS:2+,LA:2+,FWL:2+,CC:2+,CS:8,CLAN:8,CSA:4-,NIOPS:8</availability>
 			</model>
 			<model name='EMP-6A-EC'>
+                <roles>command</roles>
 				<availability>CSA:1+</availability>
 			</model>
 		</chassis>
@@ -3765,7 +3766,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>IS:7,FS:8,DC:5,FWL:9,CC:6,CS:4,CDS:3,CSR:3,Periphery:7,NIOPS:4,Periphery.Deep:7,BAN:0</availability>
+			<availability>IS:7,FS:8,DC:5,FWL:9,CC:6,CS:4,CDS:3,CSR:3,Periphery:7,NIOPS:4,Periphery.Deep:7</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>IS:8,Periphery:8</availability>
@@ -3776,7 +3777,7 @@
 			</model>
 			<model name='LGB-7Q'>
 				<roles>fire_support</roles>
-				<availability>IS:6,CDS:3,CSR:8,TC:6,MOC:6,OA:6</availability>
+				<availability>IS:6,CDS:8,CSR:8,TC:6,MOC:6,OA:6</availability>
 			</model>
 			<model name='LGB-8C'>
                 <roles>fire_support</roles>
@@ -5685,6 +5686,12 @@
 				<availability>LA:8,DC:8,CS:8,CB:8,NIOPS:8</availability>
 			</model>
 		</chassis>
+        <chassis name='Thunder Stallion' unitType='Mek'>
+            <availability>CHH!Keshik:3</availability>
+            <model name=''>
+                <availability>CHH:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
 			<availability>CLAN:4,IS:5,Periphery.Deep:5,FS:6,TC:6,Periphery:5,CS:5-,LA:8,NIOPS:5-</availability>
 			<model name='TRB-D36'>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -623,7 +623,7 @@
 			</model>
 			<model name='ARC-2Rb'>
 				<roles>command,fire_support</roles>
-				<availability>CLAN:4-,BAN:2+</availability>
+				<availability>CLAN:4-,NIOPS:5,BAN:2+</availability>
 			</model>
 			<model name='ARC-2S'>
 				<roles>command,fire_support</roles>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -1758,7 +1758,7 @@
             </model>
         </chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>LA:9,CSJ:2,CIR:4,MERC:4,CGS:2</availability>
+			<availability>LA:9,MERC:4,CGS:2-,CSJ:3-,CIR:4</availability>
 			<model name='COM-1D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
@@ -1767,7 +1767,7 @@
 			<model name='COM-2D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
-				<availability>LA:8,General:8,Periphery.Deep:8</availability>
+				<availability>LA:8,MERC:8,CGS:8,CSJ:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Commonwealth Light Cruiser' unitType='Warship'>
@@ -2165,9 +2165,9 @@
 			</model>
 		</chassis>
 		<chassis name='Drift Shag' unitType='Mek'>
-			<availability>CIH:3,CMG:2,CGS:2</availability>
+			<availability>CGS!Keshik:3!Front Line:1,CIH!Keshik:3!Front Line:1,CMG:2+</availability>
             <model name=''>
-                <availability>CLAN:8</availability>
+                <availability>CGS:8,CIH:8,CMG:8</availability>
             </model>
 		</chassis>
 		<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -2342,18 +2342,18 @@
             </model>
 		</chassis>
 		<chassis name='Falcon' unitType='Mek'>
-			<availability>CC:1,MOC:1,OA:1,CIH:6,LA:2,CLAN:4,FWL:1,FS:2,MERC:1,CGS:5,TC:1</availability>
+			<availability>FS:2,LA:2,FWL:1,CC:1,MERC:1,CGS!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,TC:1,MOC:1,OA:1,BAN:1</availability>
 			<model name='FLC-4N'>
-				<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,CGS:4-,Periphery:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
 			<model name='FLC-4Nb'>
-				<availability>CLAN:8,BAN:2</availability>
+				<availability>CGS:2,BAN:1</availability>
 			</model>
 			<model name='FLC-4Nb-PP'>
-				<availability>BAN:2</availability>
+				<availability>BAN:1</availability>
 			</model>
 			<model name='FLC-4Nb-PP2'>
-				<availability>BAN:2</availability>
+				<availability>BAN:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Field Artillery' unitType='Infantry'>
@@ -2400,33 +2400,27 @@
 			</model>
 		</chassis>
 		<chassis name='Firefly' unitType='Mek'>
-			<availability>CC:2+,OA:1+,CIH:7,CLAN:8,FS:2+,BAN:7,CB:7</availability>
+			<availability>FS:2+,CC:2+,CLAN:4+,CBS:3+,CB:5+,CCC:3+,CGB:7+,CGS:3+,CHH:5+,CIH:3-,CMG:3-,CDS:3,CSV:5-,OA:1+,BAN:2</availability>
 			<model name='C'>
-				<availability>CLAN:5,BAN:2</availability>
+				<availability>CSJ!Keshik:5!Front Line:1</availability>
 			</model>
 			<model name='FFL-3A'>
 				<roles>spotter</roles>
-				<availability>CC:8,FS:8</availability>
-			</model>
-			<model name='FFL-3PP'>
-				<availability>BAN:2</availability>
+				<availability>FS:8,CC:8,CFM:3-,CHH:4-,CSR:5,BAN:6-</availability>
 			</model>
 			<model name='FFL-3PP2'>
 				<availability>BAN:2</availability>
 			</model>
-			<model name='FFL-3PP3'>
-				<availability>BAN:2</availability>
-			</model>
 			<model name='FFL-3SLE'>
-				<availability>CLAN:6,BAN:4</availability>
+				<availability>CLAN:8,CFM:4,CHH:4,CSR:4+,BAN:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Firestarter' unitType='Mek'>
-			<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
+			<availability>IS:7,LA:8,CS:3,CFM:4-,CHH:4-,Periphery:7,NIOPS:3,Periphery.Deep:7</availability>
 			<model name='FS9-H'>
                 <roles>anti_infantry,recon</roles>
 				<deployedWith>Vulcan</deployedWith>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CFM:8,CHH:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='FS9-K'>
                 <roles>anti_infantry,recon</roles>
@@ -3071,7 +3065,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hermes' unitType='Mek'>
-			<availability>MOC:4,CC:3,CS:3,CHH:5,OA:4,CLAN:4,FWL:4,NIOPS:3,CGB:5,DC:3,CB:5</availability>
+			<availability>DC:3,FWL:4,CC:3,CS:3,CLAN:2,CB:1,CCO:1,CGB:1,CIH:6+,CDS:3,CSJ!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CWI:1,MOC:4,OA:4,NIOPS:3,BAN:4+</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
 				<availability>FWL:8</availability>
@@ -3082,11 +3076,11 @@
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
-				<availability>CS:8,General:4+,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>IS:4+,MERC:4+,CS:8,CLAN:4,Periphery:4+,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='HER-1Sb'>
 				<roles>recon</roles>
-				<availability>CLAN:7,FWL:3+,BAN:4</availability>
+				<availability>FWL:3+,CLAN:3+,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
@@ -3151,13 +3145,13 @@
 			</model>
 		</chassis>
 		<chassis name='Hussar' unitType='Mek'>
-			<availability>CS:4,CIH:9,LA:1+,CSV:9,CLAN:8,NIOPS:4,FS:1+</availability>
+			<availability>FS:1+,LA:1+,CS:4,CLAN:3+,CGB:2+,CIH:6+,CMG:4+,CDS:4+,CSV:4+,CWI:4+,NIOPS:4,BAN:5+</availability>
 			<model name='HSR-200-D'>
 				<roles>recon</roles>
-				<availability>CS:8,General:8,CLAN:6,NIOPS:8,BAN:8,DC:8</availability>
+				<availability>IS:8,CS:8,CLAN:5,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='HSR-200-Db'>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CLAN:4+,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
@@ -3173,10 +3167,10 @@
 			</model>
 		</chassis>
 		<chassis name='Icestorm' unitType='Mek'>
-			<availability>CIH:6+,CW:4</availability>
+            <availability>CIH!Keshik:4!Front Line:2!Second Line:1</availability>
 			<model name=''>
 				<roles>spotter</roles>
-				<availability>CLAN:8</availability>
+				<availability>CIH:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
@@ -3689,25 +3683,25 @@
 			</model>
 		</chassis>
 		<chassis name='Locust IIC' unitType='Mek'>
-			<availability>CHH:5,CW:5,CLAN:5,CJF:5,CGB:5</availability>
+			<availability>CLAN:2+,CBS!Keshik:3!Front Line:1,CB!Keshik:3!Front Line:1,CCO!Keshik:3!Front Line:1,CIH!Keshik:4!Front Line:1,CMG!Keshik:5!Front Line:1,CDS!Keshik:3!Front Line:1,CSJ!Keshik:3!Front Line:1,BAN:1+</availability>
 			<model name=''>
-				<availability>CW:8,General:8</availability>
+				<availability>CLAN:8,CIH:4,CJF:5,CSJ:5,BAN:8</availability>
 			</model>
 			<model name='2'>
-				<availability>CCC:4,CIH:4,CJF:4</availability>
+				<availability>CIH:8,CJF:8</availability>
 			</model>
 			<model name='3'>
-				<availability>General:3</availability>
+				<availability>CSJ!Keshik:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Locust' unitType='Mek'>
-			<availability>CS:6-,CLAN:3-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:9,CS:6-,CLAN:5,CB:4,CCO:4,CGS:4,CWI:4,CW:6,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:4</availability>
 			<model name='C'>
-				<availability>CCC:2,CFM:2</availability>
+				<availability>CCC!Keshik:5!Front Line:1,CFM!Keshik:8!Front Line:1,CJF!Keshik:8!Front Line:5,CSJ!Keshik:8!Front Line:1,CSV!Keshik:5</availability>
 			</model>
 			<model name='LCT-1E'>
 				<roles>recon</roles>
-				<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
+				<availability>IS:4,Periphery:4,Periphery.Deep:4</availability>
 			</model>
 			<model name='LCT-1M'>
 				<roles>recon</roles>
@@ -3719,11 +3713,11 @@
 			</model>
 			<model name='LCT-1V'>
 				<roles>recon</roles>
-				<availability>LA:4,General:8,CLAN:4-,FS:7,BAN:6</availability>
+				<availability>IS:8,FS:7,LA:4,Periphery:8,BAN:1-</availability>
 			</model>
 			<model name='LCT-1Vb'>
 				<roles>recon</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Lola II Destroyer' unitType='Warship'>
@@ -3862,9 +3856,9 @@
 			</model>
 		</chassis>
 		<chassis name='Mandrill' unitType='Mek'>
-			<availability>CFM:5</availability>
+			<availability>CFM!Keshik:3!Front Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CFM:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
@@ -4181,14 +4175,14 @@
 			</model>
 		</chassis>
 		<chassis name='Mercury' unitType='Mek'>
-			<availability>CS:8,CC:3+,LA:3+,CLAN:3,NIOPS:8,IS:3+,MERC:3+</availability>
+			<availability>IS:3+,MERC:3+,CS:8,CLAN!Front Line:3!Second Line:2!Solahma:1,CB!Second Line:2!Solahma:1,CCO!Second Line:2!Solahma:1,CIH!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CSJ!Second Line:1!Solahma:1!Provisional Garrison:1,CWI!Front Line:1!Second Line:1,CW:3-,NIOPS:8,BAN:3</availability>
 			<model name='MCY-98'>
 				<roles>recon</roles>
 				<availability>CC:8</availability>
 			</model>
 			<model name='MCY-99'>
 				<roles>recon</roles>
-				<availability>CS:4,CLAN:8,NIOPS:4,BAN:6</availability>
+				<availability>CS:4,CLAN:8,NIOPS:4,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Minsk' unitType='Mek'>
@@ -4267,18 +4261,18 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>MOC:3+,CHH:5,CLAN:6,MERC:4+,FS:5+,TC:3+,CS:6,OA:3+,CDS:5,CBS:7,FWL:4+,NIOPS:6,CMG:8,CJF:7,CGB:5,DC:4+</availability>
+			<availability>FS:5+,DC:4+,FWL:4+,MERC:4+,CS:6,CLAN:4+,CBS:3+,CGS:3+,CJF:5+,CMG:6+,CWI:3+,TC:3+,MOC:3+,OA:3+,NIOPS:6,BAN:2+</availability>
 			<model name='C'>
                 <roles>recon</roles>
-				<availability>CIH:3,CMG:6,CJF:3,CGB:3</availability>
+				<availability>CMG!Keshik:7!Front Line:3</availability>
 			</model>
 			<model name='MON-66'>
 				<roles>command,recon</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,IS:4+,BAN:8,Periphery:4+</availability>
+				<availability>IS:4+,CS:8,CLAN:6,CMG:5,Periphery:4+,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='MON-66b'>
 				<roles>command,recon</roles>
-				<availability>CLAN:8,CGS:8,BAN:4</availability>
+				<availability>CLAN:5+,BAN:1</availability>
 			</model>
 			<model name='MON-67'>
 				<roles>command,recon</roles>
@@ -4440,13 +4434,13 @@
 			</model>
 		</chassis>
 		<chassis name='Night Hawk' unitType='Mek'>
-			<availability>CW:6,LA:3+,CLAN:6,FWL:3+,FS:3+,CGS:7,CGB:6</availability>
+			<availability>FS:3+,LA:3+,FWL:3+,CLAN:4+,CBS:5+,CB:5+,CCO:5+,CGB:5+,CJF:5+,CNC:5+,CSJ:5+,CSR:3+,CSV:5+,CW:5+,BAN:3+</availability>
 			<model name='NTK-2Q'>
 				<roles>raider</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CLAN:8,BAN:8</availability>
 			</model>
 			<model name='NTK-2Q-EC'>
-				<availability>CSJ:5</availability>
+				<availability>CSJ!Keshik:3!Front Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
@@ -4543,14 +4537,14 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CS:4,CLAN:4-,IS:4,Periphery.Deep:5,NIOPS:4,MERC:4,Periphery:5</availability>
+			<availability>IS:4,MERC:4,CS:4,CLAN!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CB!Second Line:1!Solahma:1!Provisional Garrison:1,CCO!Second Line:1!Solahma:1!Provisional Garrison:1,CHH!Second Line:2!Solahma:2!Provisional Garrison:2,CJF!Second Line:2!Solahma:2!Provisional Garrison:2,CSJ!Second Line:1!Solahma:1!Provisional Garrison:1,CWI!Second Line:1!Solahma:1!Provisional Garrison:1,CW!Front Line:1!Second Line:1!Solahma:2!Provisional Garrison:2,Periphery:5,NIOPS:4,Periphery.Deep:5,BAN:1</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
-				<availability>General:8,CLAN:6-,BAN:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8</availability>
 			</model>
 			<model name='OTT-7Jb'>
 				<roles>recon</roles>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CLAN:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
@@ -4621,13 +4615,13 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>CC:3,Periphery.DD:5,FS.RR:3,CLAN:3-,MERC:5,Periphery.OS:5,FS:3,BAN:4,Periphery:3,CS:2,LA:3,FS.DMM:3,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>FS:3,FS.RR:3,FS.DMM:3,LA:3,DC:10,FWL:3,CC:3,MERC:5,CS:2,CSJ:3-,Periphery:3,Periphery.DD:5,Periphery.OS:5,NIOPS:2</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,TC:8</availability>
 			</model>
 			<model name='PNT-9R'>
 				<roles>fire_support</roles>
-				<availability>CLAN:8,MERC:8,DC:8</availability>
+				<availability>DC:8,MERC:8,CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -4678,9 +4672,9 @@
 			</model>
 		</chassis>
 		<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
-			<availability>CLAN:6,CSJ:8,CGB:6</availability>
+			<availability>CGS:2+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CGS:8</availability>
 			</model>
 		</chassis>
         <chassis name='Phoenix Hawk IIC' unitType='Mek'>
@@ -5327,14 +5321,14 @@
 			</model>
 		</chassis>
 		<chassis name='Sling' unitType='Mek'>
-			<availability>CC:3+,LA:3+,CLAN:1,CSJ:2</availability>
+			<availability>LA:3+,CC:3+,CSJ:5+</availability>
 			<model name='SL-1G'>
 				<roles>spotter</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,CC:8,CSJ:8</availability>
 			</model>
 			<model name='SL-1H'>
 				<roles>spotter</roles>
-				<availability>LA:4</availability>
+				<availability>LA:4,CSJ:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Snowden Mining Station' unitType='Space Station'>
@@ -5389,14 +5383,14 @@
 			</model>
 		</chassis>
 		<chassis name='Spector' unitType='Mek'>
-			<availability>CLAN:3</availability>
+			<availability>CMG:1+</availability>
 			<model name='SPR-4F'>
                 <roles>specops,raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CMG:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>CC:5,CS:4,OA:2,CLAN:1-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
+			<availability>IS:4,FS:5,DC:6,FWL:7,CC:5,MERC:4,CS:4,CIH!Front Line:3!Second Line:2!Solahma:1,CMG!Front Line:3!Second Line:2!Solahma:1,TC:2,OA:2,NIOPS:4</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -5406,7 +5400,7 @@
 				<availability>DC:8</availability>
 			</model>
 			<model name='SDR-5V'>
-				<availability>CLAN:8,IS:8,Periphery.Deep:8,FS:8,Periphery:8</availability>
+				<availability>IS:8,CIH:8,CMG:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
@@ -5459,18 +5453,24 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>CS:4-,CLAN:3-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6</availability>
-			<model name='STG-3G'>
+			<availability>IS:9,DC:6,MERC:6,CS:4-,CLAN!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CBS:4,CB:5,CGS:4,CHH:4,CJF:4,CDS:4,CSJ:4,CSR:4,CSA:4,CSV:4,CWI:4,CW:4,Periphery:6,NIOPS:4-,Periphery.Deep:6,BAN:5</availability>
+            <model name='C'>
+                <availability>CHH!Keshik:8,CW!Keshik:8</availability>
+            </model>
+            <model name='C 2'>
+                <availability>CBS!Keshik:5</availability>
+            </model>
+            <model name='STG-3G'>
 				<roles>recon</roles>
-				<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:4,Periphery:4</availability>
+				<availability>IS:4,CLAN!Solahma:2!Provisional Garrison:3,Periphery:4,Periphery.Deep:4,BAN:2-</availability>
 			</model>
 			<model name='STG-3Gb'>
 				<roles>recon</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,BAN:5</availability>
 			</model>
 			<model name='STG-3R'>
 				<roles>recon</roles>
-				<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,CLAN:2-,Periphery:8,Periphery.Deep:8,BAN:3-</availability>
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
@@ -5564,15 +5564,15 @@
 			</model>
 		</chassis>
 		<chassis name='Talon' unitType='Mek'>
-			<availability>CLAN:8</availability>
+			<availability>CLAN:5+,CB:4+,CFM:4+,CGS:3+,CIH:4+,CJF:6+,CNC:7+,CDS:6+,CSJ:6+,CSR:3+,CW:7+,BAN:3+</availability>
 			<model name='TLN-5V'>
-				<availability>FWL:8,FS:8</availability>
+				<availability>CIH!Second Line:6!Solahma:6!Provisional Garrison:6,CMG!Second Line:5!Solahma:5!Provisional Garrison:5,CNC:4-,CDS:4-,CW:3-,BAN:5-</availability>
 			</model>
 			<model name='TLN-5W'>
-				<availability>LA:8,CLAN:8</availability>
+				<availability>CLAN:8,CIH:6+,CMG:4+,CNC:5,CDS:6,CW:8+,BAN:8</availability>
 			</model>
 			<model name='TLN-5W-EC'>
-				<availability>CIH:8</availability>
+				<availability>CIH!Keshik:3!Front Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Texas Battleship' unitType='Warship'>
@@ -5601,12 +5601,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>CSA:2,CS:6,CDS:5,CLAN:4,FWL:2,NIOPS:6,CCO:2,CJF:5,CGB:5</availability>
+			<availability>FWL:2,CS:6,CLAN:4,CBS!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CCC!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CFM:4-,CGB:5,CGS!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CHH!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CIH:4-,CMG:3,CNC:5,CSR!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CSA:4-,CWI!Front Line:1!Second Line:4!Solahma:4!Provisional Garrison:4,CW:5,NIOPS:6,BAN:2-</availability>
 			<model name='THE-N'>
-				<availability>CS:8,CLAN:6,General:5+,NIOPS:8,BAN:6</availability>
+				<availability>FWL:5+,CS:8,CLAN:8,CB:4-,CGB:4-,CIH:5-,CJF:4-,CMG:4-,CNC:4-,CDS:5-,CSR:5-,CW:4-,NIOPS:8,BAN:6</availability>
 			</model>
 			<model name='THE-Nb'>
-				<availability>CLAN:6,CGS:7,BAN:4</availability>
+				<availability>CB:5,CGB:6,CIH:5,CJF:6,CMG:5,CNC:5,CDS:6,CSR:5,CW:6,BAN:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Thresher' unitType='Mek'>
@@ -5908,10 +5908,10 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>CC:5-,CLAN:2-,IS:4-,TC:3-,Periphery:3-,CS:4-,NIOPS:4-</availability>
+			<availability>IS:4-,CC:5-,CLAN:1-,Periphery:3-,CS:4-,TC:3-,NIOPS:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
-				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CLAN:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Valkyrie' unitType='Mek'>
@@ -6095,10 +6095,10 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>CS:4-,CLAN:2-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:5,Periphery:6</availability>
+			<availability>IS:10,CS:4-,CLAN:1-,Periphery:6,CIR:5,NIOPS:4-,Periphery.Deep:6,BAN:1-</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,MERC:8,CLAN:8,Periphery:8,BAN:8</availability>
 			</model>
 			<model name='WSP-1D'>
 				<roles>recon</roles>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -1878,9 +1878,9 @@
 			</model>
 		</chassis>
 		<chassis name='Corvis' unitType='Mek'>
-			<availability>CHH!Keshik:3,CGB:1+</availability>
+			<availability>CGB:1+,CHH!Keshik:3</availability>
 			<model name=''>
-				<availability>CHH:8,CGB:8</availability>
+				<availability>CGB:8,CHH:8</availability>
 			</model>
 		</chassis>
         <chassis name='Corx Mobile Tunnel Miner' unitType='Tank'>
@@ -2727,15 +2727,15 @@
 			</model>
 		</chassis>
 		<chassis name='Great Wyrm' unitType='Mek'>
-			<availability>CMG!Keshik:3,CBS:1+:2846,CB:1+:2846,CJF:1+:2846,CNC:1+:2846,CSJ:1+:2846,CSA:1+:2845,CW:1+:2846</availability>
+			<availability>CBS:1+:2846,CB:1+:2846,CJF:1+:2846,CMG!Keshik:3,CNC:1+:2846,CSJ:1+:2846,CSA:1+:2845,CW:1+:2846</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Griffin IIC' unitType='Mek'>
-			<availability>CSJ!Keshik:3,CNC:1+:2853</availability>
+			<availability>CNC:1+:2853,CSJ!Keshik:3</availability>
 			<model name=''>
-				<availability>CSJ:8,CNC:8</availability>
+				<availability>CNC:8,CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
@@ -4420,7 +4420,7 @@
 			</model>
 		</chassis>
 		<chassis name='Naja' unitType='Mek'>
-			<availability>CLAN!Front Line:1,CBS!Keshik:1!Front Line:1,CB:0,CCC!Keshik:3!Front Line:1,CFM:1+,BAN:0</availability>
+			<availability>CLAN!Front Line:1,CBS!Keshik:1!Front Line:1,CCC!Keshik:3!Front Line:1,CFM:1+,BAN:0</availability>
             <model name=''>
                 <availability>CLAN:8,CCC:3+</availability>
             </model>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -30,17 +30,17 @@
 			<weightDistribution era='2835' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 		</faction>
 		<faction key='CBS'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,5,20</pctClan>
-			<pctSL>100,100,100,95,80</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,5,20 -->
+            <!-- Star League percentages: 100,100,100,95,80 -->
 			<pctClan unitType='Vehicle'>0,0,0,5,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,95,90</pctSL>
 			<salvage pct='5'>CHH:5,CCC:5,CDS:1,CW:5,CSV:10,CNC:5,CCO:5,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CB'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,25,50</pctClan>
-			<pctSL>100,100,100,75,50</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,25,50 -->
+            <!-- Star League percentages: 100,100,100,75,50 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CCC:1,CHH:5,CSR:6,CIH:4,CSV:3,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CMG:1,CJF:4</salvage>
@@ -48,17 +48,17 @@
 			<weightDistribution era='2835' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CCC'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,10,25,40</pctClan>
-			<pctSL>100,100,90,75,60</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,10,25,40 -->
+            <!-- Star League percentages: 100,100,90,75,60 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CHH:2,CSR:1,CIH:5,CSV:3,CFM:3,CCO:10,CGS:2,CSA:7,CDS:1,CW:5,CBS:2,CNC:7,CJF:5,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CCO'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,5,25,40</pctClan>
-			<pctSL>100,100,95,75,60</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,5,25,40 -->
+            <!-- Star League percentages: 100,100,95,75,60 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CHH:1,CCC:7,CIH:10,CSR:5,CSV:3,CFM:7,CGS:1,CSA:8,CDS:1,CW:1,CBS:1,CNC:3,CSJ:7,CJF:3,CB:3</salvage>
@@ -66,17 +66,17 @@
 			<weightDistribution era='2835' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CFM'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,5,30,40</pctClan>
-			<pctSL>100,100,95,70,60</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,5,30,40 -->
+            <!-- Star League percentages: 100,100,95,70,60 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CCC:1,CHH:3,CSR:3,CIH:10,CSV:4,CCO:6,CGS:5,CSA:10,CDS:2,CW:1,CNC:2,CSJ:4,CMG:1,CJF:4,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CGB'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>10,10,25,30,40</pctClan>
-			<pctSL>90,90,75,70,60</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 10,10,25,30,40 -->
+            <!-- Star League percentages: 90,90,75,70,60 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CSA:10,CHH:10,CCC:3,CIH:5,CSR:1,CDS:1,CW:10,CSV:10,CFM:3,CGS:1,CCO:1,CJF:5</salvage>
@@ -84,25 +84,25 @@
 			<weightDistribution era='2835' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CGS'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,10,15,20</pctClan>
-			<pctSL>100,100,90,85,80</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,10,15,20 -->
+            <!-- Star League percentages: 100,100,90,85,80 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CCC:1,CHH:4,CSR:1,CIH:6,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:2,CNC:3,CSJ:1,CMG:3,CJF:10,CB:3</salvage>
 		</faction>
 		<faction key='CHH'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,10,30,40</pctClan>
-			<pctSL>100,100,90,70,60</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,10,30,40 -->
+            <!-- Star League percentages: 100,100,90,70,60 -->
 			<pctClan unitType='Vehicle'>0,0,10,15,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,80</pctSL>
 			<salvage pct='10'>CCC:2,CSR:7,CIH:10,CSV:3,CFM:7,CCO:1,CGS:5,CSA:5,CDS:7,CW:3,CBS:2,CNC:10,CSJ:3,CMG:3,CJF:3,CGB:7,CB:7</salvage>
 		</faction>
 		<faction key='CIH'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,10,30,40</pctClan>
-			<pctSL>100,100,90,70,60</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,10,30,40 -->
+            <!-- Star League percentages: 100,100,90,70,60 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CCC:3,CHH:4,CSR:4,CSV:1,CFM:10,CCO:9,CGS:5,CSA:1,CDS:4,CW:6,CNC:3,CSJ:3,CMG:3,CJF:3,CGB:2,CB:3</salvage>
@@ -110,57 +110,57 @@
 			<weightDistribution era='2835' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
 		<faction key='CJF'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,10,30,40</pctClan>
-			<pctSL>100,100,90,70,60</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,10,30,40 -->
+            <!-- Star League percentages: 100,100,90,70,60 -->
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 			<salvage pct='10'>CCC:2,CHH:3,CSR:7,CIH:7,CSV:7,CFM:10,CCO:7,CGS:4,CSA:3,CDS:3,CW:7,CNC:2,CSJ:3,CMG:2,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CMG'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,10,25,40</pctClan>
-			<pctSL>100,100,90,75,60</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,10,25,40 -->
+            <!-- Star League percentages: 100,100,90,75,60 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CHH:3,CIH:10,CSR:3,CSV:8,CFM:8,CGS:5,CSA:8,CDS:3,CW:3,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
 		</faction>
 		<faction key='CNC'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,5,30,40</pctClan>
-			<pctSL>100,100,95,70,60</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,5,30,40 -->
+            <!-- Star League percentages: 100,100,95,70,60 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CCC:5,CHH:10,CSR:3,CIH:7,CSV:1,CFM:4,CCO:7,CGS:3,CSA:5,CDS:3,CW:7,CBS:3,CSJ:3,CJF:5,CB:7</salvage>
 		</faction>
 		<faction key='CDS'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,15,25,40</pctClan>
-			<pctSL>100,100,85,75,60</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,15,25,40 -->
+            <!-- Star League percentages: 100,100,85,75,60 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='12'>CCC:2,CHH:7,CSR:7,CIH:10,CSV:3,CFM:3,CCO:3,CGS:3,CSA:7,CW:3,CNC:3,CSJ:7,CMG:1,CJF:5,CB:3</salvage>
 		</faction>
 		<faction key='CSJ'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,10,30,40</pctClan>
-			<pctSL>100,100,90,60,60</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,10,30,40 -->
+            <!-- Star League percentages: 100,100,90,60,60 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
 		</faction>
 		<faction key='CSR'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,15,40,50</pctClan>
-			<pctSL>100,100,85,60,50</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,15,40,50 -->
+            <!-- Star League percentages: 100,100,85,60,50 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CCC:1,CHH:7,CIH:10,CSV:4,CFM:7,CCO:10,CGS:1,CSA:2,CDS:7,CW:10,CNC:3,CSJ:3,CMG:1,CJF:7,CB:10</salvage>
 		</faction>
 		<faction key='CSA'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,10,30,40</pctClan>
-			<pctSL>100,100,90,70,60</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,10,30,40 -->
+            <!-- Star League percentages: 100,100,90,70,60 -->
 			<pctClan unitType='Vehicle'>0,0,10,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,80,80</pctSL>
 			<salvage pct='10'>CCC:3,CHH:2,CSR:1,CIH:10,CSV:10,CFM:10,CCO:4,CGS:4,CDS:4,CW:10,CNC:3,CSJ:1,CMG:2,CJF:10,CGB:3,CB:2</salvage>
@@ -168,17 +168,17 @@
 			<weightDistribution era='2835' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CSV'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,20,30,40</pctClan>
-			<pctSL>100,100,80,70,60</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,20,30,40 -->
+            <!-- Star League percentages: 100,100,80,70,60 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:5,CBS:1,CNC:1,CSJ:1,CMG:1,CJF:10,CGB:3,CB:1</salvage>
 		</faction>
 		<faction key='CW'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,10,30,40</pctClan>
-			<pctSL>100,100,90,70,60</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,10,30,40 -->
+            <!-- Star League percentages: 100,100,90,70,60 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CHH:2,CCC:5,CIH:10,CSR:8,CSV:10,CFM:3,CGS:1,CCO:1,CSA:3,CDS:3,CNC:5,CSJ:10,CMG:3,CJF:5,CGB:2,CB:5</salvage>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2835-->
-<ratgen
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
             <!-- Omni percentages: 0,0 -->

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -590,18 +590,21 @@
 			</model>
 		</chassis>
 		<chassis name='Annihilator' unitType='Mek'>
-			<availability>CSA:3,CHH:2,CSR:3,CLAN:2,CCO:3,BAN:1,CGB:2</availability>
+			<availability>CB!Front Line:3!Second Line:2!Solahma:1,CCO:3+,CGB:3+,CSA:3+</availability>
 			<model name='ANH-1G'>
-				<availability>CSA:4,CCO:4,BAN:1</availability>
+				<availability>CCO:3+,CGB:3+,CSA:3+</availability>
 			</model>
 			<model name='ANH-1X'>
-				<availability>CLAN:3,BAN:5</availability>
+				<availability>CCO:3,CGB:3,CSA:3</availability>
 			</model>
 			<model name='C'>
-				<availability>CLAN:8,BAN:2</availability>
+				<availability>CCO!Keshik:3,CGB!Keshik:3,CSA!Keshik:3</availability>
 			</model>
+            <model name='C &apos;Gausszilla&apos;'>
+                <availability>CGB!Keshik:3</availability>
+            </model>
 			<model name='C 2'>
-				<availability>CLAN:6,BAN:1</availability>
+				<availability>CCO!Keshik:3,CGB!Keshik:3,CSA!Keshik:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Aquarius Escort' unitType='Small Craft'>
@@ -742,37 +745,37 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas II' unitType='Mek'>
-			<availability>CLAN:4</availability>
+			<availability>CLAN!Front Line:2!Second Line:1,CBS:2+,CCC!Front Line:1,CCO:3+,CGS:3+,CIH!Front Line:1,CMG!Front Line:1,CSA!Front Line:1,CWI:2+,BAN:0</availability>
 			<model name='AS7-D-H'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CLAN:5</availability>
 			</model>
 			<model name='AS7-D-H2'>
                 <roles>command</roles>
-				<availability>CLAN:4</availability>
+				<availability>CLAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
+			<availability>IS:3,FS:5,LA:4,DC:5,CS:4-,CLAN:4,CCC:3,CGS:3,CIH:2,CMG:3,CDS:3,CSV:3,TC:1,MOC:1,OA:1,NIOPS:4-,BAN:4-</availability>
 			<model name='AS7-D'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CLAN:4-,CGS:5-,Periphery:8,BAN:8</availability>
 			</model>
 			<model name='AS7-D-DC'>
 				<roles>command</roles>
-				<availability>IS:1,MERC:0,DC:2</availability>
+				<availability>IS:1+,DC:2+,MERC:0,CLAN!Front Line:1,CCO:0,CFM:0,CIH:0,CSJ:0,CSV:0,BAN:1+</availability>
 			</model>
 			<model name='C'>
                 <roles>command</roles>
-				<availability>CW:2+,CSV:2+,CSJ:2+,CB:2+</availability>
+				<availability>CB!Keshik:3!Front Line:1,CSJ!Keshik:3!Front Line:1,CSV!Keshik:3!Front Line:1,CWI!Keshik:3!Front Line:1,CW!Keshik:3!Front Line:1</availability>
 			</model>
             <model name='C 2'>
                 <roles>command</roles>
-                <availability>CLAN:1+:2840</availability>
+                <availability>CLAN!Keshik:3,CBS:1+,CFM:1+,CGS:1+,CIH:1+,CMG:1+,CSR:1+,BAN:0</availability>
             </model>
             <model name='C 3'>
                 <roles>command,mixed_artillery</roles>
-                <availability>CLAN:1+:2843</availability>
+                <availability>CLAN!Keshik:3,CBS:1+,CFM:1+,CGS:1+,CIH:1+,CMG:1+,CSR:1+,BAN:0</availability>
             </model>
 		</chassis>
 		<chassis name='Atreus Battleship' unitType='Warship'>
@@ -797,9 +800,9 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,CLAN:4-,IS:7,Periphery.Deep:6,CIR:8,TC:8,Periphery:6,CS:8,OA:8,FWL:10,NIOPS:8</availability>
+			<availability>IS:7,FWL:10,CS:8,CSA:4-,Periphery:6,TC:8,MOC:8,OA:8,CIR:8,NIOPS:8,Periphery.Deep:6+,BAN:3</availability>
 			<model name='AWS-8Q'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CSA:8,Periphery:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
 			<model name='AWS-8R'>
 				<availability>CS:2,FWL:4</availability>
@@ -845,9 +848,9 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:6,MOC:6,CLAN:3,IS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,DC:6</availability>
+			<availability>IS:5,LA:7,DC:6,FWL:8,CC:6,CS:8-,CLAN:5,CSJ:4,CW:6,TC:6,MOC:6,NIOPS:8-,BAN:5,PIR:6</availability>
 			<model name='BLR-1G'>
-				<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
+				<availability>IS:8,FS:6,Periphery:8,Periphery.Deep:8,BAN:5,PIR:8</availability>
 			</model>
             <model name='BLR-1G-DC'>
                 <roles>command</roles>
@@ -855,15 +858,15 @@
             </model>
 			<model name='BLR-1Gb'>
                 <roles>command</roles>
-				<availability>CC:2+,CLAN:8,BAN:4</availability>
+				<availability>CC:2+,CLAN:8,BAN:6+</availability>
 			</model>
 			<model name='BLR-1Gbc'>
                 <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>CLAN!Front Line:1,CCO:0,CFM:0,CIH:0,CJF!Second Line:1,CSJ:0,CSA:1+,CSV:0,BAN:0</availability>
 			</model>
 			<model name='BLR-1Gc'>
                 <roles>command</roles>
-				<availability>CC:2+,LA:2+,CLAN:4,FWL:2+,FS:2+,DC:2+</availability>
+				<availability>FS:2+,LA:2+,DC:2+,FWL:2+,CC:2+,BAN:1+</availability>
 			</model>
 			<model name='BLR-1Gd'>
                 <roles>command</roles>
@@ -885,15 +888,15 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
-			<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
+			<availability>CSJ!Keshik:3</availability>
 			<model name=''>
-				<availability>CSR:8,General:8</availability>
+				<availability>CSJ:3+</availability>
 			</model>
 			<model name='4'>
-				<availability>General:4</availability>
+				<availability>CSJ:6</availability>
 			</model>
 			<model name='5'>
-				<availability>General:4</availability>
+				<availability>CSJ:5-</availability>
 			</model>
 		</chassis>
 		<chassis name='Behemoth' unitType='Dropship'>
@@ -1924,15 +1927,15 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>CC:5,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:5,CGS:8,CS:8,CDS:8,CW:10,LA:5,CBS:10,FWL:5,NIOPS:8,CJF:8,CGB:10,DC:5</availability>
+			<availability>FS:5,LA:5,DC:5,FWL:5,CC:5,CS:8,CLAN:4-,CBS:5-,NIOPS:8,BAN:4-</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:8,NIOPS:0</availability>
 			</model>
 			<model name='CRK-5003-1'>
-				<availability>CS:8,General:4+,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>IS:4+,CS:8,CLAN:8,CBS:4-,CB:4-,CCO:4-,CGB:4-,CHH:4-,CW:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='CRK-5003-1b'>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CBS:5,CB:5,CCO:5,CGB:5,CHH:5,CW:5,BAN:3+</availability>
 			</model>
 		</chassis>
         <chassis name='Crosscut' unitType='Mek'>
@@ -1988,7 +1991,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,CS:3,OA:2,LA:5,CLAN:5,IS:3,FWL:4,NIOPS:3,FS:5,TC:2,DC:5</availability>
+			<availability>IS:3,FS:5,LA:5,DC:5,FWL:4,CC:5,CS:3,CBS!Solahma:1,CCC!Solahma:1,CGS!Solahma:1,CIH!Solahma:1,CMG!Solahma:1,CDS!Solahma:1,TC:2,OA:2,NIOPS:3,BAN:1</availability>
 			<model name='CP-10-HQ'>
                 <roles>command</roles>
 				<availability>IS:2</availability>
@@ -1999,7 +2002,7 @@
 			</model>
 			<model name='CP-10-Z'>
                 <roles>command</roles>
-				<availability>OA:8,IS:8,MERC:8,TC:8</availability>
+				<availability>IS:8,MERC:8,CBS:8,CCC:8,CGS:8,CIH:8,CMG:8,CDS:8,TC:8,OA:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
@@ -2128,6 +2131,12 @@
 				<availability>FS:5+,CBS:6,CDS:6</availability>
 			</model>
 		</chassis>
+        <chassis name='Devastator' unitType='Mek'>
+            <availability>CSJ:2+</availability>
+            <model name='DVS-2-EC'>
+                <availability>CSJ:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Dictator' unitType='Dropship'>
 			<availability>IS:4</availability>
 			<model name=''>
@@ -2216,17 +2225,17 @@
             </model>
         </chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>MOC:4,CC:5,CS:7,OA:5,CLAN:3,FWL:6,NIOPS:7,FS:5,MERC:5,TC:5</availability>
+			<availability>FS:5,FWL:6,CC:5,MERC:5,CS:7,CLAN:3+,CSA:2+,TC:5,MOC:4,OA:5,NIOPS:7,BAN:0</availability>
 			<model name='EMP-5A'>
                 <roles>command</roles>
-				<availability>General:8,BAN:2</availability>
+				<availability>IS:8,Periphery:8,NIOPS:1-</availability>
 			</model>
 			<model name='EMP-6A'>
                 <roles>command</roles>
-				<availability>CC:2+,CS:8,LA:2+,CLAN:8,NIOPS:8,FWL:2+,FS:2+,BAN:6</availability>
+				<availability>FS:2+,LA:2+,FWL:2+,CC:2+,CS:8,CLAN:8,CSA:4-,NIOPS:8</availability>
 			</model>
 			<model name='EMP-6A-EC'>
-				<availability>CSA:5</availability>
+				<availability>CSA:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Enfield' unitType='Mek'>
@@ -3091,14 +3100,14 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>CS:9,CLAN:9,NIOPS:9,IS:2,CFM:10,MERC:2,CJF:10</availability>
+			<availability>IS:2,MERC:2,CS:9,CLAN:4+,CCC:3+,CIH:3+,CSV:3+,NIOPS:9+,BAN:2+</availability>
 			<model name='HGN-732'>
 			    <roles>command</roles>
-				<availability>CS:8,CLAN:6,FWL:5+,IS:8,NIOPS:8,BAN:8</availability>
+				<availability>IS:8,FWL:5+,CS:8,CLAN:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='HGN-732b'>
                 <roles>command</roles>
-				<availability>CLAN:7,FWL:3+,BAN:4</availability>
+				<availability>FWL:3+,CLAN:6,BAN:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
@@ -3192,18 +3201,18 @@
 			</model>
 		</chassis>
 		<chassis name='Imp' unitType='Mek'>
-			<availability>CSA:2,CW:2,CLAN:2</availability>
+			<availability>CB:2+,CCO!Keshik:3!Front Line:1,CGB:2+,CSJ:2+,CW!Keshik:3!Front Line:1</availability>
 			<model name='IMP-1A'>
                 <roles>command</roles>
-				<availability>CLAN:5</availability>
+				<availability>CB:6,CCO:6,CGB:6,CSJ:6,CW:6</availability>
 			</model>
 			<model name='IMP-1B'>
                 <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>CB!Keshik:6!Front Line:1,CCO!Keshik:6!Front Line:1,CGB!Keshik:6!Front Line:1,CSJ!Keshik:6!Front Line:1,CW!Keshik:6!Front Line:1</availability>
 			</model>
 			<model name='IMP-1C'>
                 <roles>command</roles>
-				<availability>CHH:5,CLAN:2</availability>
+				<availability>CB:1+,CCO:1+,CGB:1+,CSJ:1+,CWI!Keshik:4!Front Line:1,CW:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Indra Infantry Transport' unitType='Tank'>
@@ -3458,10 +3467,10 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CS:6,CLAN:6,IS:2+,FWL:1+,NIOPS:6,MERC:2+,CGS:7,CGB:7</availability>
+			<availability>IS:2+,FWL:1+,MERC:2+,CS:6,CLAN:4-,CCC!Second Line:1,CCO:5-,CFM:5-,CGB:5-,CGS:3-,CIH!Second Line:1,CMG:3-,CDS:3-,CSR:3-,CSV:3-,NIOPS:6,BAN:1</availability>
 			<model name='KGC-000'>
                 <roles>command</roles>
-				<availability>CS:8,CIH:5,General:4,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
+				<availability>IS:4,CS:8,CCO:1-,CGB:1-,NIOPS:8,BAN:5</availability>
 			</model>
 			<model name='KGC-0000'>
                 <roles>command</roles>
@@ -3469,11 +3478,11 @@
 			</model>
 			<model name='KGC-000b'>
                 <roles>command</roles>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CB:4-,CFM:4-,CGB:4-,CGS:3-,CWI:5,CW:4-,BAN:2+</availability>
 			</model>
 			<model name='KGC-010'>
                 <roles>command</roles>
-				<availability>CLAN:4</availability>
+				<availability>CLAN:4+,CCC:8,CCO:8,CFM:3+,CGS:3+,CHH:8,CIH:8,CWI:3+,BAN:0</availability>
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
@@ -3537,9 +3546,9 @@
 			</model>
 		</chassis>
 		<chassis name='Kraken (Bane)' unitType='Mek'>
-			<availability>CSR:7,CLAN:7,CJF:7</availability>
+			<availability>CJF:2+,CDS!Front Line:1,CSR!Front Line:1,CW:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CJF:8,CDS:8,CSR:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Kruger Combat Car' unitType='Tank'>
@@ -3756,7 +3765,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>CC:6,CDS:3,CSR:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>IS:7,FS:8,DC:5,FWL:9,CC:6,CS:4,CDS:3,CSR:3,Periphery:7,NIOPS:4,Periphery.Deep:7,BAN:0</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>IS:8,Periphery:8</availability>
@@ -3767,11 +3776,11 @@
 			</model>
 			<model name='LGB-7Q'>
 				<roles>fire_support</roles>
-				<availability>MOC:6,OA:6,IS:6,TC:6,CLAN:6</availability>
+				<availability>IS:6,CDS:3,CSR:8,TC:6,MOC:6,OA:6</availability>
 			</model>
 			<model name='LGB-8C'>
                 <roles>fire_support</roles>
-				<availability>MOC:3,CS:6,OA:3,IS:6,MERC:3,TC:3,CLAN:6</availability>
+				<availability>IS:6,MERC:3,CS:6,CSR:1-,TC:3,MOC:3,OA:3</availability>
 			</model>
 		</chassis>
         <chassis name='Luciano White Wolverine' unitType='Tank'>
@@ -3882,12 +3891,12 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder IIC' unitType='Mek'>
-			<availability>CSA:5,CSR:5,CW:5,CLAN:5,CNC:5,CJF:5,CGB:5</availability>
+			<availability>CLAN:3+,CBS:2+,CB!Keshik:3!Front Line:1,CCC!Keshik:4!Front Line:2,CHH!Keshik:3!Front Line:1,CSJ!Keshik:3!Front Line:1,CSA:2+,CSV!Keshik:3!Front Line:1,CW!Keshik:3!Front Line:1,BAN:0</availability>
 			<model name=''>
-				<availability>CLAN:8,CJF:8,CGB:8</availability>
+				<availability>CLAN:8,CJF:4,CW:4</availability>
 			</model>
 			<model name='9'>
-				<availability>CSA:4,CSV:4,CLAN:4,CJF:4</availability>
+				<availability>CJF:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
@@ -4466,10 +4475,10 @@
 			</model>
 		</chassis>
 		<chassis name='Nightstar' unitType='Mek'>
-			<availability>CSA:2+,CS:4,CLAN:5,NIOPS:4</availability>
+			<availability>CS:4,CCO!Front Line:1,NIOPS:4+</availability>
 			<model name='NSR-9J'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CS:8,CCO:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Odin Scout Tank' unitType='Tank'>
@@ -4688,18 +4697,18 @@
 			</model>
 		</chassis>
         <chassis name='Phoenix Hawk IIC' unitType='Mek'>
-            <availability>CSV:4:2851,CLAN:3:2851,CB:2:2851</availability>
+            <availability>CSV!Keshik:3</availability>
             <model name=''>
                 <roles>cavalry</roles>
-                <availability>CLAN:8</availability>
+                <availability>CSV:8</availability>
             </model>
             <model name='2'>
                 <roles>cavalry,fire_support</roles>
-                <availability>CCC:6:2852,CSR:6:2852,CDS:6:2852,CSV:6:2852,CNC:6:2852,CFM:6:2852,CCO:6:2852</availability>
+                <availability>CSV:5</availability>
             </model>
             <model name='9'>
                 <roles>cavalry,fire_support</roles>
-                <availability>CLAN:2:2853</availability>
+                <availability>CSV:3</availability>
             </model>
         </chassis>
 		<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
@@ -4756,7 +4765,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
-			<availability>CLAN:4,CC:6+,CS:5,LA:5+,FWL:5+,NIOPS:5,FS:5+,BAN:0</availability>
+			<availability>FS:5+,LA:5+,FWL:5+,CC:6+,CS:5,CLAN:2+,CCC:1+,CIH!Front Line:1,CMG!Front Line:1,NIOPS:5+,BAN:0</availability>
 			<model name='PLG-3Z'>
 				<availability>IS:8,CLAN:8,NIOPS:8</availability>
 			</model>
@@ -4848,15 +4857,15 @@
 			</model>
 		</chassis>
 		<chassis name='Pulverizer' unitType='Mek'>
-			<availability>CSR:4</availability>
+			<availability>CSR:1</availability>
 			<model name=''>
-				<availability>CSR:4</availability>
+				<availability>CSR!Keshik:3</availability>
 			</model>
 			<model name='PUL-2V'>
-				<availability>General:8</availability>
+				<availability>CSR!Front Line:3!Second Line:1</availability>
 			</model>
 			<model name='PUL-3R'>
-				<availability>General:6</availability>
+				<availability>CSR!Front Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -4952,10 +4961,10 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman II' unitType='Mek'>
-			<availability>CLAN:5</availability>
+			<availability>CGB:3+</availability>
 			<model name='RFL-3N-2'>
 				<roles>anti_aircraft</roles>
-				<availability>General:8</availability>
+				<availability>CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
@@ -5260,12 +5269,12 @@
 			</model>
 		</chassis>
 		<chassis name='Shogun' unitType='Mek'>
-			<availability>CSA:3,CIH:3,CBS:3,CLAN:3,FWL:3+,CCO:3,CB:3</availability>
+			<availability>FWL:3+,CBS:3+,CB!Front Line:3!Second Line:2!Solahma:1,CCC!Front Line:3!Second Line:2!Solahma:1,CCO!Front Line:3!Second Line:2!Solahma:1,CSA:2</availability>
 			<model name='C'>
-				<availability>CLAN:5</availability>
+				<availability>CBS:1+,CB!Front Line:1,CCC:2+,CCO:2+,CSA!Keshik:3</availability>
 			</model>
 			<model name='SHG-2H'>
-				<availability>General:8,CLAN:8,BAN:8</availability>
+				<availability>FWL:8,CBS:8,CB:8,CCC:3-,CCO:4-,CSA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Sholagar' unitType='AeroSpaceFighter'>
@@ -5397,11 +5406,15 @@
 			</model>
 		</chassis>
 		<chassis name='Spartan' unitType='Mek'>
-			<availability>CS:5</availability>
+			<availability>CS:5,CFM:3-,CIH:6+,CMG:4-,CDS:2-,CSV:2-,BAN:4+</availability>
 			<model name='SPT-N2'>
 				<roles>cavalry,spotter</roles>
-				<availability>IS:8</availability>
+				<availability>CS:8,CFM:8,BAN:3-</availability>
 			</model>
+            <model name='SPT-NF'>
+                <roles>cavalry</roles>
+                <availability>CIH:8,CMG:8,CDS:8,CSV:8,BAN:5</availability>
+            </model>
 		</chassis>
 		<chassis name='Spector' unitType='Mek'>
 			<availability>CMG:1+</availability>
@@ -5425,18 +5438,18 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,Periphery:10,CS:6,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>IS:9,FS:7,DC:7,FWL:10,CC:7,CS:6,CLAN:5-,CBS:6-,CGB:6-,CHH:6-,CIH:4,CJF:6-,CMG:4-,CNC:6-,CSR:4-,CWI:6-,CW:6-,Periphery:10,NIOPS:6,Periphery.Deep:10,BAN:3</availability>
 			<model name='STK-3F'>
-				<availability>CLAN:1,IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CLAN:1-,Periphery:8,Periphery.Deep:8,BAN:5</availability>
 			</model>
 			<model name='STK-3Fb'>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,BAN:3+</availability>
 			</model>
 			<model name='STK-3Fk'>
 				<availability>DC:1+</availability>
 			</model>
 			<model name='STK-3H'>
-				<availability>MOC:2,OA:2,CLAN:1,IS:2,TC:2</availability>
+				<availability>IS:2,TC:2,MOC:2,OA:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -5516,7 +5529,7 @@
 			</model>
 		</chassis>
 		<chassis name='Striker' unitType='Mek'>
-			<availability>MOC:6,CC:8,CS:4,OA:6,LA:8,PIR:4,Periphery.Deep:4,NIOPS:4,MERC:6,FS:6,TC:6,DC:6</availability>
+			<availability>FS:6,LA:8,DC:6,CC:8,MERC:6,CS:4,CIH:1-,TC:6,MOC:6,OA:6,NIOPS:4,Periphery.Deep:4,PIR:4</availability>
 			<model name='STC-2C'>
 				<availability>CC:8,General:8</availability>
 			</model>
@@ -5537,9 +5550,9 @@
 			</model>
 		</chassis>
 		<chassis name='Supernova' unitType='Mek'>
-			<availability>CNC:6</availability>
+			<availability>CNC!Keshik:3,CDS:1+:2847</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CNC:8,CDS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Svantovit Infantry Fighting Vehicle' unitType='Tank'>
@@ -5647,15 +5660,15 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>CHH:7,CSV:9,CLAN:8,IS:4,CFM:10,TC:3+,CS:7,CDS:7,CW:9,CBS:7,LA:5,CNC:7,FWL:6,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>IS:4,LA:5,FWL:6,CS:7,CLAN:5,CIH!Keshik:2!Front Line:3!Second Line:4!Solahma:4!Provisional Garrison:4,TC:3+,NIOPS:7,BAN:4+</availability>
 			<model name='THG-10E'>
-				<availability>FWL:4,DC:4</availability>
+				<availability>DC:4,FWL:4</availability>
 			</model>
 			<model name='THG-11E'>
-				<availability>CS:8,CLAN:6,FWL:2+,IS:2+,NIOPS:8,FS:2+,BAN:8,DC:2+,TC:8</availability>
+				<availability>IS:2+,CS:8,CLAN:4-,TC:8,NIOPS:8,BAN:5</availability>
 			</model>
 			<model name='THG-11Eb'>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CLAN:6,BAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -5666,10 +5679,10 @@
 			</model>
 		</chassis>
 		<chassis name='Thunder Hawk' unitType='Mek'>
-			<availability>CS:2,LA:3+,CLAN:4,NIOPS:2,DC:3+</availability>
+			<availability>LA:3+,DC:3+,CS:2,CB:1+,NIOPS:2+</availability>
 			<model name='TDK-7X'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,DC:8,CS:8,CB:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
@@ -5957,7 +5970,10 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:5,CC:6,CLAN:3-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,DC:5</availability>
+			<availability>IS:4,FS:9,LA:5,DC:5,FWL:5,CC:6,CS:5-,CBS!Front Line:1,CB!Front Line:1,CCO:2-,CNC!Front Line:1,CSJ!Front Line:1,CW!Front Line:1,Periphery:4,Periphery.OS:5,Periphery.HR:5,TC:5,MOC:5,OA:5,CIR:5,NIOPS:5-,Periphery.Deep:4+</availability>
+            <model name='C'>
+                <availability>CBS:8,CB:8,CCO!Front Line:3,CNC:8,CSJ:8,CW!Front Line:3</availability>
+            </model>
 			<model name='VTR-9A'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
@@ -5965,7 +5981,7 @@
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
 			<model name='VTR-9B'>
-				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CCO:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Vigilant Corvette' unitType='Warship'>
@@ -6061,15 +6077,15 @@
 			</model>
 		</chassis>
 		<chassis name='Wakazashi' unitType='Mek'>
-			<availability>CJF:5</availability>
+			<availability>CJF:3+</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CJF:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Warhammer IIC' unitType='Mek'>
-			<availability>CLAN:5</availability>
+			<availability>CGB!Keshik:3!Front Line:1,CSA:3+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CSA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -718,9 +718,9 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>CC:1,MOC:1,CS:3-,LA:4,FS.CMM:4,IS:4,MERC:3,FS:4,TC:1</availability>
+			<availability>IS:4,FS:4,LA:4,CC:1,MERC:3,CS:3-,CCC!Front Line:1!Second Line:1!Solahma:1,CIH!Front Line:2!Second Line:1,TC:1,MOC:1</availability>
 			<model name='ASN-21'>
-				<availability>General:8</availability>
+				<availability>IS:8,CCC:8,CIH:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Asshur Fast Reconnaissance Vehicle' unitType='Tank'>
@@ -1212,10 +1212,10 @@
 			</model>
 		</chassis>
 		<chassis name='Cicada' unitType='Mek'>
-			<availability>CC:4,CS:4-,OA:3,LA:4,IS:4,FWL:4,FS:4,MERC:4,Periphery:3,DC:4</availability>
+			<availability>IS:4,FS:4,LA:4,DC:4,FWL:4,CC:4,MERC:4,CS:4-,CIH:1,Periphery:3,OA:3</availability>
 			<model name='CDA-2A'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CIH:8,Periphery:8</availability>
 			</model>
 			<model name='CDA-2B'>
 				<roles>anti_infantry</roles>
@@ -1714,18 +1714,18 @@
             </model>
         </chassis>
 		<chassis name='Clint IIC' unitType='Mek'>
-			<availability>CSR:6</availability>
+			<availability>CSR!Keshik:3</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CSR:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:6,MOC:4,CS:3-,OA:4,CLAN:3-,IS:4,NIOPS:3-,FS:6,MERC:4</availability>
+			<availability>IS:4,FS:6,CC:6,MERC:4,CS:3-,MOC:4,OA:4,NIOPS:3-</availability>
 			<model name='CLNT-1-2R'>
-				<availability>CC:1,FS:1</availability>
+				<availability>FS:1,CC:1</availability>
 			</model>
 			<model name='CLNT-2-3T'>
-				<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,NIOPS:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='CLNT-2-4T'>
 				<availability>CC:4,FS:4</availability>
@@ -1878,9 +1878,9 @@
 			</model>
 		</chassis>
 		<chassis name='Corvis' unitType='Mek'>
-			<availability>CHH:4,CLAN:3</availability>
+			<availability>CHH!Keshik:3,CGB:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CHH:8,CGB:8</availability>
 			</model>
 		</chassis>
         <chassis name='Corx Mobile Tunnel Miner' unitType='Tank'>
@@ -1891,35 +1891,35 @@
             </model>
         </chassis>
         <chassis name='Coyotl' unitType='Mek' omni='Clan'>
-            <availability>CCO:6:2854</availability>
+            <availability>CCO!Keshik:3</availability>
             <model name='A'>
                 <roles>raider</roles>
-                <availability>General:6</availability>
+                <availability>CCO:4+</availability>
             </model>
             <model name='B'>
-                <availability>General:6</availability>
+                <availability>CCO:5</availability>
             </model>
             <model name='Prime'>
-                <availability>General:8</availability>
+                <availability>CCO:8</availability>
             </model>
         </chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,CJF:4,CGB:4</availability>
+			<availability>IS:3,MERC:3,CS:5,CLAN:5,CBS:4,CIH:4-,CDS:4,CSA:4,Periphery:3,NIOPS:5,BAN!Keshik:5!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
-				<availability>IS:7,Periphery.Deep:7,NIOPS:0,Periphery:7</availability>
+				<availability>IS:7,Periphery:7,NIOPS:0,Periphery.Deep:7,BAN:4-</availability>
 			</model>
 			<model name='CRB-27'>
 				<roles>raider</roles>
-				<availability>CS:8,CC:2+,LA:2+,CLAN:6,NIOPS:8,FWL:2+,BAN:8,DC:2+</availability>
+				<availability>LA:2+,DC:2+,FWL:2+,CC:2+,CS:8,CLAN:5-,NIOPS:8,BAN:3</availability>
 			</model>
 			<model name='CRB-27b'>
 				<roles>raider</roles>
-				<availability>CC:2+,CLAN:7,FWL:2+,CGS:8,BAN:4</availability>
+				<availability>FWL:2+,CC:2+,CLAN:5+,CBS:4+,BAN:3+</availability>
 			</model>
 			<model name='CRB-27sl'>
                 <roles>raider</roles>
-				<availability>LA:3+,CLAN:4,DC:3+</availability>
+				<availability>LA:3+,DC:3+,CLAN:2+,CGB:3+,CGS:1+,CHH:1+,CDS:1+,CSR:1+,CSA:1+,BAN:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
@@ -2119,12 +2119,12 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>CC:4,Periphery.HR:5,CLAN:3,IS:5,Periphery.Deep:5,FS:8,MERC:5,TC:5</availability>
+			<availability>IS:5,FS:8,CC:4,MERC:5,CBS:3+,CDS:3+,Periphery.HR:5,TC:5,Periphery.Deep:5</availability>
 			<model name='DV-6M'>
-				<availability>CLAN:4,IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CBS:8,CDS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='DV-6Md'>
-				<availability>FS:5+</availability>
+				<availability>FS:5+,CBS:6,CDS:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Dictator' unitType='Dropship'>
@@ -2229,7 +2229,7 @@
 			</model>
 		</chassis>
 		<chassis name='Enfield' unitType='Mek'>
-			<availability>CMG:6</availability>
+			<availability>CMG:2+</availability>
 			<model name='END-6J-EC'>
 				<roles>urban</roles>
 				<availability>CMG:8</availability>
@@ -2591,10 +2591,13 @@
 			</model>
 		</chassis>
 		<chassis name='Fox' unitType='Mek'>
-			<availability>CDS:6,CW:3,CSJ:3</availability>
+			<availability>CGB:1+,CDS:2+,CSJ:1+,CW:1+</availability>
 			<model name='CS-1'>
-				<availability>General:8</availability>
+				<availability>CDS:6,CSJ:8,CW:5</availability>
 			</model>
+            <model name=''>
+                <availability>CGB:8,CDS!Keshik:8!Front Line:6,CSJ:5+,CW:8</availability>
+            </model>
 		</chassis>
 		<chassis name='Fury Command Tank' unitType='Tank'>
 			<availability>CC:2,CHH:8,CW:8,LA:2,CLAN:7,FWL:2,FS:3,MERC:2,CJF:8,DC:2,CGB:8</availability>
@@ -2696,9 +2699,9 @@
 			</model>
 		</chassis>
         <chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
-            <availability>CSV:7:2850</availability>
+            <availability>CLAN:1+:2852,CSV!Keshik:3,CCC:1+:2851,CFM!Keshik:2,CIH:1+:2851,BAN:0</availability>
             <model name='6'>
-                <availability>CSV:8</availability>
+                <availability>CLAN:8</availability>
             </model>
         </chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
@@ -2724,28 +2727,31 @@
 			</model>
 		</chassis>
 		<chassis name='Great Wyrm' unitType='Mek'>
-			<availability>CSA:3,CCC:3,CHH:3,CSV:3,CLAN:3,CFM:3,CSJ:3,CMG:5,CCO:3,CGB:3</availability>
+			<availability>CMG!Keshik:3,CBS:1+:2846,CB:1+:2846,CJF:1+:2846,CNC:1+:2846,CSJ:1+:2846,CSA:1+:2845,CW:1+:2846</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Griffin IIC' unitType='Mek'>
-			<availability>CCC:4:2852,CCO:4:2852,CGB:4:2852,CNC:4:2852,CDS:4:2852,CSJ:4:2852</availability>
+			<availability>CSJ!Keshik:3,CNC:1+:2853</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CSJ:8,CNC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>CC:7,MOC:7,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,NIOPS:4,DC:8</availability>
+			<availability>IS:9,DC:8,CC:7,MERC:7,CS:4,CLAN:5,CGB:6,CGS:6,CIH:5+,Periphery:6,TC:7,MOC:7,NIOPS:4,Periphery.Deep:6,BAN:4+</availability>
 			<model name='GRF-1N'>
-				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,CCC:2-,CIH:1-,CJF:1-,Periphery:8,Periphery.Deep:8,BAN:3-</availability>
 			</model>
 			<model name='GRF-1S'>
 				<availability>LA:6</availability>
 			</model>
 			<model name='GRF-2N'>
-				<availability>CC:2+,LA:2+,CLAN:6,FWL:2+,FS:2+,BAN:4</availability>
+				<availability>FS:2+,LA:2+,FWL:2+,CC:2+,CLAN:8,CCC:6,CIH:6,CJF:6,BAN:5</availability>
 			</model>
+            <model name='GRF-2N2'>
+                <availability>CIH:4-,CMG:3-,BAN:4-</availability>
+            </model>
 		</chassis>
 		<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 			<availability>IS:4,MERC:4,Periphery:2</availability>
@@ -3041,12 +3047,12 @@
 			</model>
 		</chassis>
 		<chassis name='Hellhound (Conjurer)' unitType='Mek'>
-			<availability>CHH:6,CIH:6,CDS:4,CLAN:7,CNC:6,CJF:6</availability>
+			<availability>CCO!Keshik:2,CJF!Keshik:4!Front Line:2!Second Line:1,CSJ:1+,CW!Keshik:3!Front Line:1</availability>
 			<model name=''>
-				<availability>CHH:8,General:8,CJF:8</availability>
+				<availability>CCO:8,CJF:5,CW:8</availability>
 			</model>
 			<model name='7'>
-				<availability>CW:3,CLAN:3</availability>
+				<availability>CJF:8,CSJ:8,CW:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Hermes II' unitType='Mek'>
@@ -3095,17 +3101,17 @@
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
-			<availability>CC:3,MOC:1,CHH:4,OA:1,LA:3,CLAN:3,FWL:3,FS:3,CGS:5,DC:2,TC:3</availability>
+			<availability>FS:3,LA:3,DC:2,FWL:3,CC:3,CBS:4+,CGB:5+,CGS:5+,CHH:5+,CJF:4,CNC:3+,TC:3,MOC:1,OA:1</availability>
 			<model name='HOP-4Bb'>
                 <roles>fire_support</roles>
-				<availability>CLAN:6,BAN:2</availability>
+				<availability>CBS:3,CGB:8,CGS:5,CHH:5,CJF:8,CNC:6</availability>
 			</model>
 			<model name='HOP-4C'>
                 <roles>inf_support</roles>
-				<availability>MOC:8,OA:8,FS:8</availability>
+				<availability>FS:8,CBS:3-,CGS:4-,CHH:3-,CNC:3-,MOC:8,OA:8</availability>
 			</model>
 			<model name='HOP-4Cb'>
-				<availability>CHH:8,CLAN:2,BAN:2</availability>
+				<availability>CHH:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
@@ -3130,9 +3136,9 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>CC:6,CLAN:2-,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
+			<availability>IS:5,DC:6,FWL:8,CC:6,CS:5-,CB:4+,CCO:4+,CSJ:4,CSV:4+,Periphery:5,Periphery.MW:6,Periphery.ME:6,NIOPS:5-,Periphery.Deep:5</availability>
 			<model name='HBK-4G'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CB:8,CCO:8,CSJ:8,CSV:8,Periphery:8,NIOPS:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='HBK-4H'>
 				<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
@@ -3470,15 +3476,15 @@
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
-			<availability>CS:7,CHH:8,CDS:8,CSV:8,CLAN:7,FWL:3,NIOPS:7,FS:6,MERC:3,DC:3</availability>
+			<availability>FS:6,DC:3,FWL:3,MERC:3,CS:7,CLAN:4,CCC:4-,CGS:3,CIH:4-,CMG:3,CSR:3,CSV:3,NIOPS:7,BAN:3+</availability>
 			<model name='KTO-18'>
 				<availability>FS:2</availability>
 			</model>
 			<model name='KTO-19'>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
+				<availability>CS:8,CLAN:4-,CJF:3-,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='KTO-19b'>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CLAN:5,BAN:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Kiso' unitType='Mek'>
@@ -3549,10 +3555,10 @@
 			</model>
 		</chassis>
 		<chassis name='Kyudo' unitType='Mek'>
-			<availability>FWL:3+,FS:3+</availability>
+			<availability>FS:3+,FWL:3+,CBS:2+,CCC!Front Line:2!Second Line:1,CMG!Front Line:2!Second Line:1,CDS!Front Line:2!Second Line:1</availability>
 			<model name='KY2-D-02'>
 				<roles>fire_support</roles>
-				<availability>IS:8</availability>
+				<availability>FS:8,FWL:8,CBS:8,CCC:8,CMG:8,CDS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='LRM Carrier' unitType='Tank'>
@@ -3799,18 +3805,18 @@
 			</model>
 		</chassis>
 		<chassis name='Lynx' unitType='Mek'>
-			<availability>CIH:5,LA:3,CLAN:4,FWL:3,CSJ:5,CJF:4,DC:3</availability>
+			<availability>LA:3,DC:3,FWL:3,CLAN:5+,CBS:4+,CCC:4+,CFM:4+,CGS:4+,CHH:4+,CIH:4+,CMG:4+,CNC:3+,CDS:3+,CSR:4+,CSA:3+,CWI:4+,BAN:2+</availability>
 			<model name='C'>
                 <roles>raider</roles>
-				<availability>CCC:3:2848,CW:3:2848,CNC:3:2848,CSJ:5:2848,CJF:3:2848,CGS:3:2848</availability>
+				<availability>CCC:1+:2850,CGS:1+:2850,CJF:1+:2849,CNC:1+:2850,CSJ!Keshik:3,CW:1+:2849</availability>
 			</model>
 			<model name='LNX-8Q'>
                 <roles>raider</roles>
-				<availability>LA:5:2853</availability>
+				<availability>LA:5</availability>
 			</model>
 			<model name='LNX-9Q'>
                 <roles>raider</roles>
-				<availability>CLAN:8,IS:5+</availability>
+				<availability>IS:5+,CLAN:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -4414,12 +4420,12 @@
 			</model>
 		</chassis>
 		<chassis name='Naja' unitType='Mek'>
-			<availability>CCC:6,CLAN:4</availability>
+			<availability>CLAN!Front Line:1,CBS!Keshik:1!Front Line:1,CB:0,CCC!Keshik:3!Front Line:1,CFM:1+,BAN:0</availability>
             <model name=''>
-                <availability>CCC:8,CLAN:6</availability>
+                <availability>CLAN:8,CCC:3+</availability>
             </model>
 			<model name='KTO-19b-EC'>
-				<availability>CCC:5,CBS:5,CSV:5,CMG:5</availability>
+				<availability>CCC:8-</availability>
 			</model>
 		</chassis>
 		<chassis name='Narukami Destroyer' unitType='Warship'>
@@ -4707,14 +4713,18 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:7,CLAN:3,IS:9,NIOPS:7,Periphery.Deep:5,Periphery:5</availability>
-			<model name='PXH-1'>
+			<availability>IS:9,CS:7,CLAN:4+,CB:3+,CCO:3+,CGB:3+,CGS:6+,CIH:5+,CWI:3+,Periphery:5,NIOPS:7,Periphery.Deep:5,BAN:4</availability>
+            <model name='C'>
+                <roles>recon</roles>
+                <availability>CGS!Keshik:5!Front Line:1,CIH!Keshik:5!Front Line:3,CJF!Keshik:5!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='PXH-1'>
 				<roles>command,recon</roles>
-				<availability>General:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,CGB:3-,CIH:2-,CJF:2-,Periphery:8,BAN:5-</availability>
 			</model>
 			<model name='PXH-1-EC'>
                 <roles>command,recon</roles>
-				<availability>CGS:5</availability>
+				<availability>CGS!Front Line:3!Second Line:1</availability>
 			</model>
 			<model name='PXH-1D'>
 				<roles>command,recon</roles>
@@ -4730,15 +4740,15 @@
 			</model>
 			<model name='PXH-1b &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:7,BAN:3</availability>
+				<availability>CLAN:8,CGB:5,CGS:4,CIH:6,NIOPS:4+,BAN:3</availability>
 			</model>
 			<model name='PXH-1c &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:4,CGS:6</availability>
+				<availability>CGS:3+</availability>
 			</model>
 			<model name='PXH-2'>
 				<roles>command,recon</roles>
-				<availability>CC:2+,MOC:2+,OA:2+,CLAN:4,FWL:2+,BAN:4</availability>
+				<availability>FWL:2+,CC:2+,CNC:1+,CDS:1+,MOC:2+,OA:2+,BAN:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
@@ -5133,9 +5143,9 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>CC:4-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:4-,BAN:2-</availability>
+			<availability>LA:4-,DC:4-,FWL:4-,CC:4-,MERC:4-,CS:3-,CGS:1-,Periphery:4-,NIOPS:3-,Periphery.Deep:4-</availability>
 			<model name='SCP-1N'>
-				<availability>LA:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CGS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Scout JumpShip' unitType='Jumpship'>
@@ -5159,7 +5169,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>CC:1-,CSV:5,CLAN:6,CFM:7,FS:2-,CGS:5,CS:4,CDS:5,CW:5,LA:5-,CBS:5,FWL:2-,NIOPS:4,CJF:7,CGB:7,DC:3</availability>
+			<availability>FS:2-,LA:5-,DC:3,FWL:2-,CC:1-,CS:4,CLAN:5-,CB:4-,CCO:4-,CFM:6-,CGS:4-,CHH:4-,CJF:4-,CDS:3,CSJ:4-,CSR:6-,CSA:4-,CSV:4-,CWI:4-,NIOPS:4,BAN:2</availability>
 			<model name='STN-3K'>
 				<availability>LA:8,DC:8</availability>
 			</model>
@@ -5170,10 +5180,10 @@
 				<availability>LA:4</availability>
 			</model>
 			<model name='STN-3L'>
-				<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
+				<availability>FS:1+,LA:1+,FWL:1+,MERC:1+,CS:8,CLAN:8,CBS:4-,CCC:4,CFM:3,CGB:4-,CHH:4-,CJF:3-,CDS:4-,CSR:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='STN-3Lb'>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CBS:4+,CCC:4+,CFM:4+,CGB:4+,CHH:4+,CJF:4+,CDS:4+,CSR:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
@@ -5192,27 +5202,27 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>CLAN:6,BAN:2+</availability>
+			<availability>CLAN:2+,CB!Keshik:2,CGB!Keshik:3!Front Line:1,CHH!Keshik:3!Front Line:1,CIH!Keshik:2,CJF!Keshik:3!Front Line:1,CSJ!Keshik:2,CSR!Keshik:2,CWI!Keshik:3!Front Line:1,BAN:0</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CLAN:8,CGB:5</availability>
 			</model>
 			<model name='2'>
-				<availability>CGB:6</availability>
+				<availability>CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5,CGB:3</availability>
+			<availability>IS:7,LA:6,CS:6-,CLAN:5,CIH:4,Periphery:5,NIOPS:6-,Periphery.Deep:5,BAN:5</availability>
             <model name='C'>
-                <availability>CSA:6,CCC:6,CSV:6,CFM:6,CGS:6</availability>
+                <availability>CLAN!Keshik:6!Front Line:1,CCC!Keshik:5,CCO!Keshik:8,CGB!Keshik:5!Front Line:1,CGS!Keshik:5!Front Line:1,CHH!Keshik:5!Front Line:1,CJF!Keshik:5!Front Line:3,CNC:1+,BAN:1+</availability>
             </model>
 			<model name='SHD-2D'>
 				<availability>FS:10</availability>
 			</model>
 			<model name='SHD-2H'>
-				<availability>General:8,CLAN:6-,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CLAN:1-,CBS:2-,CCO:2-,CFM:2-,CSR:2-,CW:2-,Periphery:8,Periphery.Deep:8,BAN:2</availability>
 			</model>
 			<model name='SHD-2Hb'>
-				<availability>CLAN:8,FS:3+,BAN:4</availability>
+				<availability>FS:3+,CLAN:8,CB:7,CCC:7,CCO!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CGB:7,CIH:6,BAN:3+</availability>
 			</model>
 			<model name='SHD-2K'>
 				<availability>DC:9</availability>
@@ -5428,14 +5438,14 @@
 			</model>
 		</chassis>
 		<chassis name='Starslayer' unitType='Mek'>
-			<availability>CSA:2,LA:4+,CNC:3</availability>
+			<availability>LA:4+,CNC!Front Line:2!Second Line:1,CSA:3+</availability>
 			<model name='STY-2C'>
 				<roles>raider</roles>
-				<availability>IS:8</availability>
+				<availability>LA:8</availability>
 			</model>
 			<model name='STY-2C-EC'>
                 <roles>raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CNC:8,CSA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stinger LAM Mk I' unitType='Mek'>
@@ -5778,10 +5788,10 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
+			<availability>FWL:8,CC:5,MERC:5,CS:5-,CDS!Front Line:2!Second Line:1,MOC:5,NIOPS:5-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
-				<availability>CC:2+,CS:6,FWL:2+,NIOPS:6</availability>
+				<availability>FWL:2+,CC:2+,CS:6,CDS:8,NIOPS:6</availability>
 			</model>
 			<model name='TBT-5J'>
 				<availability>FWL:4</availability>
@@ -6009,14 +6019,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:4,CS:3,MOC:5,LA:7,CLAN:3-,FWL:7,IS:5,NIOPS:3,CIR:5,TC:5</availability>
+			<availability>IS:5,LA:7,FWL:7,CC:4,CS:3,TC:5,MOC:5,CIR:5,NIOPS:3</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
-				<availability>General:8,FS:4</availability>
+				<availability>IS:8,FS:4,Periphery:8</availability>
 			</model>
 			<model name='VL-5T'>
 				<roles>anti_infantry</roles>
-				<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,TC:2</availability>
+				<availability>IS:2,FS:6,TC:2,MOC:2,CIR:2,PIR:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Vulture' unitType='Dropship'>
@@ -6142,13 +6152,13 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:3-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+			<availability>FS.CMM:5,DC:6,MERC:3,CS:3-,CB:1-,CWI:1-,Periphery.DD:2,Periphery.OS:2,TC:2,MOC:1,OA:1,NIOPS:3-</availability>
 			<model name='WTH-0'>
 				<availability>TC:6</availability>
 			</model>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
-				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CB:8,CWI:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='WTH-1S'>
 				<roles>fire_support</roles>
@@ -6156,7 +6166,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CS:5-,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,TC:5</availability>
+			<availability>IS:7,FS:8,FWL:10,CS:5-,NIOPS:5-,TC:5,Periphery.Deep:6,BAN:4-</availability>
 			<model name='WVR-1R'>
 				<availability>FS:2-</availability>
 			</model>
@@ -6173,28 +6183,28 @@
 			</model>
 			<model name='WVR-6R'>
 				<roles>command,recon</roles>
-				<availability>General:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Wyvern IIC' unitType='Mek'>
-			<availability>CHH:3,CW:3,CLAN:3</availability>
+			<availability>CB!Keshik:3,CCC!Front Line:1</availability>
 			<model name=''>
 				<roles>urban</roles>
-				<availability>CW:8,CLAN:8</availability>
+				<availability>CB:8,CCC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CS:6,CC:6,CIH:4,CLAN:5,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:4</availability>
+			<availability>FS:6,DC:6,CC:6,MERC:5,CS:6,CLAN:3,CBS:4,CB:4,CCO:4,CFM:4,CIH:2-,CMG:4-,CNC:4,CSJ:2,CWI:4,TC:4,NIOPS:6,BAN:3</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,CFM:6,BAN:8,TC:8</availability>
+				<availability>CS:8,CBS:3-,CB:4-,CCO:3-,CFM:2-,NIOPS:8,TC:8,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='WVE-5Nb'>
 				<roles>urban</roles>
-				<availability>CLAN:7,CFM:7,CGS:7</availability>
+				<availability>CLAN:6,BAN:3+</availability>
 			</model>
 			<model name='WVE-5Nsl'>
-				<availability>LA:3+,FWL:3+</availability>
+				<availability>LA:3+,FWL:3+,CLAN:1-,CB:2-,CCO:2-,CSA:2-,CWI:2-</availability>
 			</model>
 			<model name='WVE-6N'>
 				<roles>urban</roles>

--- a/megamek/data/forcegenerator/2835.xml
+++ b/megamek/data/forcegenerator/2835.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2835-->
-<ratgen>
+<ratgen
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -590,18 +590,21 @@
 			</model>
 		</chassis>
 		<chassis name='Annihilator' unitType='Mek'>
-			<availability>CSA:3,CHH:2,CSR:3,CLAN:2,CCO:3,BAN:1,CGB:2</availability>
+			<availability>CB!Front Line:3!Second Line:2!Solahma:1,CCO:3+,CGB:3+,CSA:3+</availability>
 			<model name='ANH-1G'>
-				<availability>CSA:4,CCO:4,BAN:1</availability>
+				<availability>CCO!Front Line:2!Second Line:1,CGB!Front Line:2!Second Line:1,CSA!Front Line:2!Second Line:1</availability>
 			</model>
 			<model name='ANH-1X'>
-				<availability>CLAN:3,BAN:4</availability>
+				<availability>CB:8,CCO:4-,CGB:4-,CSA:4-</availability>
 			</model>
 			<model name='C'>
-				<availability>CLAN:8,BAN:2</availability>
+				<availability>CCO:2+,CGB:2+,CSA:2+</availability>
 			</model>
+            <model name='C &apos;Gausszilla&apos;'>
+                <availability>CGB:1+,CSA:1+</availability>
+            </model>
 			<model name='C 2'>
-				<availability>CLAN:6,BAN:1</availability>
+				<availability>CCO:1+,CGB:1+,CSA:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Aquarius Escort' unitType='Small Craft'>
@@ -742,37 +745,37 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas II' unitType='Mek'>
-			<availability>CLAN:4</availability>
+			<availability>CLAN!Front Line:2!Second Line:1,CBS:2+,CCC!Front Line:1,CIH!Front Line:1,CMG!Front Line:1,CSA!Front Line:1,BAN:0</availability>
 			<model name='AS7-D-H'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CLAN:5</availability>
 			</model>
 			<model name='AS7-D-H2'>
                 <roles>command</roles>
-				<availability>CLAN:4</availability>
+				<availability>CLAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
+			<availability>IS:3,FS:5,LA:4,DC:5,CS:4-,CLAN:4,CCC:3,CGS:3,CIH:2,CMG:3,CDS:3,CSV:3,TC:1,MOC:1,OA:1,NIOPS:4-,BAN:4-</availability>
 			<model name='AS7-D'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CLAN:4-,CB:3-,CSJ:3-,CSV:3-,CW:3-,Periphery:8,BAN:5-</availability>
 			</model>
 			<model name='AS7-D-DC'>
 				<roles>command</roles>
-				<availability>IS:1,MERC:0,DC:2</availability>
+				<availability>IS:1+,DC:2+,MERC:0,BAN:1+</availability>
 			</model>
 			<model name='C'>
                 <roles>command</roles>
-				<availability>CW:2+,CSV:2+,CSJ:2+,CB:2+</availability>
+				<availability>CB!Front Line:8!Second Line:1,CSJ!Front Line:8!Second Line:1,CSV!Front Line:8!Second Line:1,CW!Front Line:8!Second Line:1,BAN:2+</availability>
 			</model>
 			<model name='C 2'>
                 <roles>command</roles>
-				<availability>CLAN:1+</availability>
+				<availability>CLAN!Keshik:5!Front Line:1,BAN:0</availability>
 			</model>
 			<model name='C 3'>
 				<roles>command,mixed_artillery</roles>
-				<availability>CLAN:1+</availability>
+				<availability>CLAN:1+,CSJ!Front Line:1,BAN:0</availability>
 			</model>
 		</chassis>
 		<chassis name='Atreus Battleship' unitType='Warship'>
@@ -797,9 +800,9 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,CLAN:3-,IS:7,Periphery.Deep:6,CIR:8,TC:8,Periphery:6,CS:8,OA:8,FWL:10,NIOPS:8</availability>
+			<availability>IS:7,FWL:10,CS:8,Periphery:6,TC:8,MOC:8,OA:8,CIR:8,NIOPS:8,Periphery.Deep:6+,BAN:3</availability>
 			<model name='AWS-8Q'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
 			<model name='AWS-8R'>
 				<availability>CS:2,FWL:4</availability>
@@ -845,10 +848,10 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:6,MOC:6,CLAN:3,IS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,CJF:3,DC:6</availability>
+			<availability>IS:5,LA:7,DC:6,FWL:8,CC:6,CS:8-,CLAN:5-,CFM:5,CGS:5,CIH!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,CMG!Keshik:2!Front Line:3!Second Line:4!Solahma:5!Provisional Garrison:5,CSJ:4-,CW:6-,TC:6,MOC:6,NIOPS:8-,BAN:4,PIR:6</availability>
 			<model name='BLR-1G'>
                 <roles>command</roles>
-				<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
+				<availability>IS:8,FS:6,Periphery:8,Periphery.Deep:8,BAN:5,PIR:8</availability>
 			</model>
 			<model name='BLR-1G-DC'>
 				<roles>command</roles>
@@ -856,15 +859,15 @@
 			</model>
 			<model name='BLR-1Gb'>
                 <roles>command</roles>
-				<availability>CC:1+,CLAN:8,BAN:4</availability>
+				<availability>CC:1+,CLAN:8,BAN:6+</availability>
 			</model>
 			<model name='BLR-1Gbc'>
                 <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>CLAN!Second Line:1,CCO:0,CFM:0,CGS!Front Line:1,CIH:0,CSJ:0,CSA!Front Line:1,CSV:0,BAN:0</availability>
 			</model>
 			<model name='BLR-1Gc'>
                 <roles>command</roles>
-				<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,DC:1+</availability>
+				<availability>FS:1+,LA:1+,DC:1+,FWL:1+,CC:1+,BAN:1+</availability>
 			</model>
 			<model name='BLR-1Gd'>
                 <roles>command</roles>
@@ -886,15 +889,15 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
-			<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
+			<availability>CSJ:2+</availability>
 			<model name=''>
-				<availability>CSR:8,General:8</availability>
+				<availability>CSJ:3+</availability>
 			</model>
 			<model name='4'>
-				<availability>General:4</availability>
+				<availability>CSJ:6</availability>
 			</model>
 			<model name='5'>
-				<availability>General:4</availability>
+				<availability>CSJ:4-</availability>
 			</model>
 		</chassis>
 		<chassis name='Behemoth' unitType='Dropship'>
@@ -1955,15 +1958,15 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>CC:4,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:4,CGS:8,CS:8,CDS:8,CW:10,LA:4,CBS:10,FWL:4,NIOPS:8,CJF:8,CGB:10,DC:4</availability>
+			<availability>FS:4,LA:4,DC:4,FWL:4,CC:4,CS:8,CLAN:3-,CBS:5-,CGS:4-,CIH:4-,NIOPS:8,BAN:4-</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:8,NIOPS:0</availability>
 			</model>
 			<model name='CRK-5003-1'>
-				<availability>CS:8,General:3+,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>IS:3+,CS:8,CLAN:8,CBS:4-,CB:4-,CCO:4-,CGB:4-,CHH:4-,CW:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='CRK-5003-1b'>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CBS:5,CB:5,CCO:5,CGB:5,CHH:5,CW:5,BAN:3+</availability>
 			</model>
 		</chassis>
         <chassis name='Crosscut' unitType='Mek'>
@@ -2019,7 +2022,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,CS:3,OA:2,LA:5,CLAN:4,IS:3,FWL:4,NIOPS:3,FS:5,TC:2,DC:5</availability>
+			<availability>IS:3,FS:5,LA:5,DC:5,FWL:4,CC:5,CS:3,TC:2,OA:2,NIOPS:3,BAN:1</availability>
 			<model name='CP-10-HQ'>
                 <roles>command</roles>
 				<availability>IS:2</availability>
@@ -2028,7 +2031,7 @@
 				<availability>IS:3</availability>
 			</model>
 			<model name='CP-10-Z'>
-				<availability>OA:8,IS:8,MERC:8,TC:8</availability>
+				<availability>IS:8,MERC:8,TC:8,OA:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
@@ -2157,6 +2160,12 @@
 				<availability>FS:4+</availability>
 			</model>
 		</chassis>
+        <chassis name='Devastator' unitType='Mek'>
+            <availability>CSJ!Keshik:3!Front Line:1</availability>
+            <model name='DVS-2-EC'>
+                <availability>CSJ:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Dictator' unitType='Dropship'>
 			<availability>IS:3</availability>
 			<model name=''>
@@ -2245,18 +2254,18 @@
             </model>
         </chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>MOC:3,CC:4,CS:7,OA:4,CLAN:2,FWL:5,NIOPS:7,FS:4,MERC:4,TC:4</availability>
+			<availability>FS:4,FWL:5,CC:4,MERC:4,CS:7,CLAN!Front Line:2!Second Line:1,CBS:3+,CCC:3+,CGS:3+,CIH:3+,CJF:3+,CMG:3+,CNC:3+,CDS:3+,CSR:3+,CSA:2+,TC:4,MOC:3,OA:4,NIOPS:7,BAN:0</availability>
 			<model name='EMP-5A'>
                 <roles>command</roles>
-				<availability>General:8,BAN:2</availability>
+				<availability>IS:8,Periphery:8,NIOPS:1-</availability>
 			</model>
 			<model name='EMP-6A'>
                 <roles>command</roles>
-				<availability>CC:2+,CS:8,LA:2+,CLAN:8,NIOPS:8,FWL:2+,FS:2+,BAN:6</availability>
+				<availability>FS:2+,LA:2+,FWL:2+,CC:2+,CS:8,CLAN:8,CSA:4-,NIOPS:8</availability>
 			</model>
 			<model name='EMP-6A-EC'>
                 <roles>command</roles>
-				<availability>CSA:4</availability>
+				<availability>CSA:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Enfield' unitType='Mek'>
@@ -3109,21 +3118,21 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander IIC' unitType='Mek'>
-			<availability>CLAN:5:2858</availability>
+			<availability>CBS:1+:2859,CCC!Keshik:2,CCO!Keshik:3,CDS!Keshik:2</availability>
 			<model name=''>
 			    <roles>command</roles>
 				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>CS:9,CLAN:9,NIOPS:9,IS:2,CFM:10,MERC:2,CJF:10</availability>
+			<availability>IS:2,MERC:2,CS:9,CLAN:4+,CCC:3+,CIH:3+,CSV:3+,NIOPS:9+,BAN:2+</availability>
 			<model name='HGN-732'>
                 <roles>command</roles>
-				<availability>CS:8,CLAN:6,FWL:4+,IS:8,NIOPS:8,BAN:8</availability>
+				<availability>IS:8,FWL:4+,CS:8,CLAN:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='HGN-732b'>
                 <roles>command</roles>
-				<availability>CLAN:7,FWL:2+,BAN:4</availability>
+				<availability>FWL:2+,CLAN:6,BAN:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
@@ -3226,18 +3235,18 @@
 			</model>
 		</chassis>
 		<chassis name='Imp' unitType='Mek'>
-			<availability>CSA:2,CW:2,CLAN:2</availability>
+			<availability>CB!Front Line:2!Second Line:1,CCO!Front Line:3!Second Line:1,CGB!Front Line:3!Second Line:1,CSJ!Front Line:3!Second Line:1,CW!Front Line:3!Second Line:1</availability>
 			<model name='IMP-1A'>
                 <roles>command</roles>
-				<availability>CLAN:5</availability>
+				<availability>CB:4-,CCO:6,CGB:4-,CSJ:4-,CW:4-</availability>
 			</model>
 			<model name='IMP-1B'>
                 <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>CB:6,CCO!Keshik:6!Front Line:1,CGB:6,CSJ:6,CW:6</availability>
 			</model>
 			<model name='IMP-1C'>
                 <roles>command</roles>
-				<availability>CHH:5,CLAN:2</availability>
+				<availability>CB:4,CCO:1+,CGB:4,CSJ:4,CW:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Indra Infantry Transport' unitType='Tank'>
@@ -3489,10 +3498,10 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CS:6,CLAN:6,IS:2+,FWL:1+,NIOPS:6,MERC:2+,CGS:7,CGB:7</availability>
+			<availability>IS:2+,FWL:1+,MERC:2+,CS:6,CB:3-,CFM:4-,CGB:3-,CGS:2-,CW:3-,NIOPS:6,BAN:1</availability>
 			<model name='KGC-000'>
                 <roles>command</roles>
-				<availability>CS:8,CIH:5,General:2,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
+				<availability>IS:2,CS:8,NIOPS:8,BAN:5</availability>
 			</model>
 			<model name='KGC-0000'>
                 <roles>command</roles>
@@ -3500,11 +3509,7 @@
 			</model>
 			<model name='KGC-000b'>
                 <roles>command</roles>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
-			</model>
-			<model name='KGC-010'>
-                <roles>command</roles>
-				<availability>CLAN:3</availability>
+				<availability>CB:8,CFM:8,CGB:8,CGS:8,CW:8,BAN:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
@@ -3568,9 +3573,9 @@
 			</model>
 		</chassis>
 		<chassis name='Kraken (Bane)' unitType='Mek'>
-			<availability>CSR:7,CLAN:7,CJF:7</availability>
+			<availability>CJF:2+,CDS!Front Line:2,CSR!Front Line:2!Second Line:1,CW!Front Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CJF:8,CDS:8,CSR:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
@@ -3784,7 +3789,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>CC:6,CDS:3,CSR:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>IS:7,FS:8,DC:5,FWL:9,CC:6,CS:4,CDS:3,CSR:3-,Periphery:7,NIOPS:4,Periphery.Deep:7</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>IS:8,Periphery:8</availability>
@@ -3795,11 +3800,11 @@
 			</model>
 			<model name='LGB-7Q'>
 				<roles>fire_support</roles>
-				<availability>MOC:6,OA:6,IS:6,TC:6,CLAN:6</availability>
+				<availability>IS:6,CDS:8,CSR:8,TC:6,MOC:6,OA:6</availability>
 			</model>
 			<model name='LGB-8C'>
                 <roles>fire_support</roles>
-				<availability>MOC:3,CS:6,OA:3,IS:5,MERC:4,TC:3,CLAN:5</availability>
+				<availability>IS:5,MERC:4,CS:6,TC:3,MOC:3,OA:3</availability>
 			</model>
 		</chassis>
         <chassis name='Luciano White Wolverine' unitType='Tank'>
@@ -3923,12 +3928,12 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder IIC' unitType='Mek'>
-			<availability>CSA:6,CSR:6,CW:6,CLAN:6,CNC:6,CJF:6,CGB:6</availability>
+			<availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS:2+,CB!Keshik:4!Front Line:1,CCO:3+,CGB:3+,CIH!Keshik:5!Front Line:2!Second Line:1,CJF:3+,CNC:3+,CSJ:3+,CSR:3+,CSA:2+,CSV:3+,CW!Keshik:5!Front Line:2,BAN:1+</availability>
 			<model name=''>
-				<availability>CLAN:8,CJF:8,CGB:8</availability>
+				<availability>CLAN:8,CJF:4,CW:4</availability>
 			</model>
 			<model name='9'>
-				<availability>CSA:4,CSV:4,CLAN:4,CJF:4</availability>
+				<availability>CJF:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
@@ -4490,10 +4495,10 @@
 			</model>
 		</chassis>
 		<chassis name='Nightstar' unitType='Mek'>
-			<availability>CSA:6,CS:4,CLAN:4,NIOPS:4</availability>
+			<availability>CS:4,CCO!Front Line:1,NIOPS:4+</availability>
 			<model name='NSR-9J'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CS:8,CCO:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Odin Scout Tank' unitType='Tank'>
@@ -4716,18 +4721,18 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk IIC' unitType='Mek'>
-			<availability>CSV:4,CLAN:3,CB:2</availability>
+			<availability>CJF:1+,CSR:1+,CSV!Keshik:3!Front Line:1</availability>
 			<model name=''>
 			    <roles>cavalry</roles>
-				<availability>CLAN:8</availability>
+				<availability>CJF:8,CSR:8,CSV:8</availability>
 			</model>
 			<model name='2'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CCC:6,CSR:6,CDS:6,CSV:6,CNC:6,CFM:6,CCO:6</availability>
+				<availability>CSR:5,CSV:5</availability>
 			</model>
 			<model name='9'>
 			    <roles>cavalry,fire_support</roles>
-				<availability>CLAN:2</availability>
+				<availability>CSV:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
@@ -4780,7 +4785,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
-			<availability>CLAN:4,CC:5+,CS:5,LA:4+,FWL:4+,NIOPS:5,FS:4+,BAN:0</availability>
+			<availability>FS:4+,LA:4+,FWL:4+,CC:5+,CS:5,CLAN:2+,CCC:1+,CIH!Front Line:1,CMG!Front Line:1,CSV!Front Line:1,NIOPS:5+,BAN:0</availability>
 			<model name='PLG-3Z'>
 				<availability>IS:8,CLAN:8,NIOPS:8</availability>
 			</model>
@@ -4872,15 +4877,15 @@
 			</model>
 		</chassis>
 		<chassis name='Pulverizer' unitType='Mek'>
-			<availability>CSR:4</availability>
+			<availability>CSR!Front Line:1!Second Line:1</availability>
 			<model name=''>
-				<availability>CSR:6</availability>
+				<availability>CSR!Front Line:1</availability>
 			</model>
 			<model name='PUL-2V'>
-				<availability>General:6</availability>
+				<availability>CSR!Second Line:1</availability>
 			</model>
 			<model name='PUL-3R'>
-				<availability>General:4</availability>
+				<availability>CSR!Second Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -4969,10 +4974,10 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman II' unitType='Mek'>
-			<availability>CLAN:4</availability>
+			<availability>CGB:3+</availability>
 			<model name='RFL-3N-2'>
 				<roles>anti_aircraft</roles>
-				<availability>General:8</availability>
+				<availability>CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
@@ -5271,12 +5276,12 @@
 			</model>
 		</chassis>
 		<chassis name='Shogun' unitType='Mek'>
-			<availability>CSA:4,CIH:4,CBS:4,CLAN:4,FWL:2+,CCO:4,CB:4</availability>
+			<availability>FWL:2+,CBS:2,CB!Front Line:3!Second Line:2!Solahma:1,CCC!Front Line:3!Second Line:1,CCO!Front Line:3!Second Line:2!Solahma:1,CSA!Front Line:2!Second Line:1</availability>
 			<model name='C'>
-				<availability>CLAN:6</availability>
+				<availability>CBS:1+,CB!Front Line:8,CCC:8,CSA:8</availability>
 			</model>
 			<model name='SHG-2H'>
-				<availability>General:8,CLAN:6-,BAN:7</availability>
+				<availability>FWL:8,CBS:4-,CB:3-</availability>
 			</model>
 		</chassis>
 		<chassis name='Sholagar' unitType='AeroSpaceFighter'>
@@ -5408,11 +5413,15 @@
 			</model>
 		</chassis>
 		<chassis name='Spartan' unitType='Mek'>
-			<availability>CS:5</availability>
+			<availability>CS:5,CFM:2-,CIH:6+,BAN:4+</availability>
 			<model name='SPT-N2'>
 				<roles>cavalry,spotter</roles>
-				<availability>IS:8</availability>
+				<availability>CS:8,CFM:8,BAN:3-</availability>
 			</model>
+            <model name='SPT-NF'>
+                <roles>cavalry</roles>
+                <availability>CIH:8,BAN:5</availability>
+            </model>
 		</chassis>
 		<chassis name='Spector' unitType='Mek'>
 			<availability>CMG:1+</availability>
@@ -5436,15 +5445,15 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,Periphery:10,CS:6,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>IS:9,FS:7,DC:7,FWL:10,CC:7,CS:6,CLAN:5-,CBS:6-,CCC:4-,CGB:6-,CIH:4-,CMG:4-,CSR:4-,CW:6-,Periphery:10,NIOPS:6,Periphery.Deep:10,BAN:3</availability>
 			<model name='STK-3F'>
-				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CBS:1-,CFM:1-,CGS:1-,Periphery:8,Periphery.Deep:8,BAN:5</availability>
 			</model>
 			<model name='STK-3Fb'>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,BAN:3+</availability>
 			</model>
 			<model name='STK-3H'>
-				<availability>MOC:2,OA:2,IS:2,TC:2</availability>
+				<availability>IS:2,TC:2,MOC:2,OA:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -5544,9 +5553,9 @@
 			</model>
 		</chassis>
 		<chassis name='Supernova' unitType='Mek'>
-			<availability>CCC:3,CW:3,CNC:7,CGB:2</availability>
+			<availability>CNC:2+,CDS:2+,CSJ:1+</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CNC:8,CDS:8,CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Svantovit Infantry Fighting Vehicle' unitType='Tank'>
@@ -5655,15 +5664,15 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,TC:2+,CS:7,CDS:7,CW:9,CBS:7,LA:4,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>IS:3,LA:4,FWL:5,CS:7,CLAN!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,CBS:5,CIH!Keshik:2!Front Line:3!Second Line:4!Solahma:4!Provisional Garrison:4,CSJ:5,CSV!Keshik:2!Front Line:3!Second Line:4!Solahma:4!Provisional Garrison:4,TC:2+,NIOPS:7,BAN:4+</availability>
 			<model name='THG-10E'>
 				<availability>FWL:5,DC:5</availability>
 			</model>
 			<model name='THG-11E'>
-				<availability>CS:8,CLAN:6,FWL:2+,IS:2+,NIOPS:8,FS:2+,BAN:8,DC:2+,TC:8</availability>
+				<availability>IS:2+,CS:8,CLAN:4-,TC:8,NIOPS:8,BAN:5</availability>
 			</model>
 			<model name='THG-11Eb'>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CLAN:6,BAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -5674,19 +5683,16 @@
 			</model>
 		</chassis>
 		<chassis name='Thunder Hawk' unitType='Mek'>
-			<availability>CS:2,LA:2+,CLAN:4,NIOPS:2,DC:2+</availability>
+			<availability>LA:2+,DC:2+,CS:2,CB!Front Line:1,NIOPS:2</availability>
 			<model name='TDK-7X'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,DC:8,CS:8,CB:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thunder Stallion' unitType='Mek'>
-			<availability>CHH:5</availability>
+			<availability>CHH:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='2 &apos;Fire Stallion&apos;'>
-				<availability>CHH:6,CGS:6</availability>
+				<availability>CHH:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
@@ -5955,15 +5961,18 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:5,CC:6,CLAN:2-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,DC:5</availability>
-			<model name='VTR-9A'>
+			<availability>IS:4,FS:9,LA:5,DC:5,FWL:5,CC:6,CS:5-,CBS!Second Line:1,CB!Second Line:1,CCO!Second Line:1!Provisional Garrison:1,CGB!Second Line:1,CJF!Second Line:1,CNC!Front Line:1,CSJ!Front Line:1,CW!Second Line:1,Periphery:4,Periphery.OS:5,Periphery.HR:5,TC:5,MOC:5,OA:5,CIR:5,NIOPS:5-,Periphery.Deep:4+</availability>
+            <model name='C'>
+                <availability>CBS:8,CB:8,CCO!Second Line:8,CGB:8,CJF:8,CNC:8,CSJ:8,CW:8</availability>
+            </model>
+            <model name='VTR-9A'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
 			<model name='VTR-9A1'>
 				<availability>CC:2,CS:2,IS:1,FS:2</availability>
 			</model>
 			<model name='VTR-9B'>
-				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CCO:1-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Vigilant Corvette' unitType='Warship'>
@@ -6056,15 +6065,15 @@
 			</model>
 		</chassis>
 		<chassis name='Wakazashi' unitType='Mek'>
-			<availability>CJF:6</availability>
+			<availability>CJF:3+</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CJF:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Warhammer IIC' unitType='Mek'>
-			<availability>CLAN:6</availability>
+			<availability>CGB!Keshik:5!Front Line:3,CSA!Keshik:4!Front Line:3!Second Line:1,BAN:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CSA:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -623,7 +623,7 @@
 			</model>
 			<model name='ARC-2Rb'>
 				<roles>command,fire_support</roles>
-				<availability>CLAN:4-,BAN:2+</availability>
+				<availability>CLAN:4-,NIOPS:5,BAN:2+</availability>
 			</model>
 			<model name='ARC-2S'>
 				<roles>command,fire_support</roles>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -3121,7 +3121,7 @@
 			<availability>CBS:1+:2859,CCC!Keshik:2,CCO!Keshik:3,CDS!Keshik:2</availability>
 			<model name=''>
 			    <roles>command</roles>
-				<availability>CLAN:8</availability>
+				<availability>CBS:8,CCC:8,CCO:8,CDS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
@@ -5278,7 +5278,7 @@
 		<chassis name='Shogun' unitType='Mek'>
 			<availability>FWL:2+,CBS:2,CB!Front Line:3!Second Line:2!Solahma:1,CCC!Front Line:3!Second Line:1,CCO!Front Line:3!Second Line:2!Solahma:1,CSA!Front Line:2!Second Line:1</availability>
 			<model name='C'>
-				<availability>CBS:1+,CB!Front Line:8,CCC:8,CSA:8</availability>
+				<availability>CBS:1+,CB!Front Line:8,CCC:8,CCO:8,CSA:8</availability>
 			</model>
 			<model name='SHG-2H'>
 				<availability>FWL:8,CBS:4-,CB:3-</availability>
@@ -5532,9 +5532,9 @@
 			</model>
 		</chassis>
 		<chassis name='Striker' unitType='Mek'>
-			<availability>MOC:6,CC:8,CS:4,OA:6,LA:8,PIR:3,NIOPS:4,MERC:6,FS:6,TC:6,DC:6</availability>
+			<availability>FS:6,LA:8,DC:6,CC:8,MERC:6,CS:4,TC:6,MOC:6,OA:6,NIOPS:4,PIR:3</availability>
 			<model name='STC-2C'>
-				<availability>CC:8,General:8</availability>
+				<availability>IS:8,Periphery:8,PIR:8</availability>
 			</model>
 			<model name='STC-2S'>
 				<availability>LA:5</availability>
@@ -5683,7 +5683,7 @@
 			</model>
 		</chassis>
 		<chassis name='Thunder Hawk' unitType='Mek'>
-			<availability>LA:2+,DC:2+,CS:2,CB!Front Line:1,NIOPS:2</availability>
+			<availability>LA:2+,DC:2+,CS:2,CB!Front Line:1,NIOPS:2+</availability>
 			<model name='TDK-7X'>
                 <roles>command</roles>
 				<availability>LA:8,DC:8,CS:8,CB:8,NIOPS:8</availability>
@@ -5966,10 +5966,10 @@
                 <availability>CBS:8,CB:8,CCO!Second Line:8,CGB:8,CJF:8,CNC:8,CSJ:8,CW:8</availability>
             </model>
             <model name='VTR-9A'>
-				<availability>CC:2,CS:2,IS:1,FS:2</availability>
+				<availability>IS:1,FS:2,CC:2,CS:2</availability>
 			</model>
 			<model name='VTR-9A1'>
-				<availability>CC:2,CS:2,IS:1,FS:2</availability>
+				<availability>IS:1,FS:2,CC:2,CS:2</availability>
 			</model>
 			<model name='VTR-9B'>
 				<availability>IS:8,CCO:1-,Periphery:8,Periphery.Deep:8</availability>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -3097,7 +3097,7 @@
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
-				<availability>IS:2+,MERC:2+,CS:8,CLAN:4-,CGS:4,CMG:4,CSJ:3-,CSV:3-,Periphery:2+,NIOPS:8,BAN:5-</availability>
+				<availability>IS:2+,CS:8,CLAN:4-,CGS:4,CMG:4,CSJ:3-,CSV:3-,Periphery:2+,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='HER-1Sb'>
 				<roles>recon</roles>
@@ -5479,7 +5479,7 @@
 		<chassis name='Stinger' unitType='Mek'>
 			<availability>IS:9,DC:6,MERC:6,CS:4-,CLAN!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CBS:4,CB:5,CCC:4,CGS:4,CHH:4,CJF:4,CDS:4,CSR:4,CSA:4,CSV:4,CW:4,Periphery:6,NIOPS:4-,Periphery.Deep:6,BAN:5</availability>
             <model name='C'>
-                <availability>CCC!Keshik:8!Front Line:1,CHH!Keshik:8!Front Line:3,CIH!Front Line:8!Second Line:1,CSV!Keshik:8,CW!Keshik:8!Second Line:8,BAN:2+</availability>
+                <availability>CCC!Keshik:8!Front Line:1,CHH!Keshik:8!Front Line:3,CIH!Front Line:8!Second Line:1,CSV!Keshik:8,CW!Keshik:8!Front Line:8,BAN:2+</availability>
             </model>
             <model name='C 2'>
                 <availability>CBS!Keshik:8!Front Line:3,CB!Keshik:5!Front Line:1,BAN:2+</availability>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -4767,7 +4767,7 @@
 			</model>
 			<model name='PXH-1b &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:8,CGS:4,CIH:5-,BAN:3</availability>
+				<availability>CLAN:8,CGS:4,CIH:5-,NIOPS:4+,BAN:3</availability>
 			</model>
 			<model name='PXH-1c &apos;Special&apos;'>
 				<roles>command,recon</roles>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -6082,10 +6082,10 @@
 				<availability>CC:4</availability>
 			</model>
 			<model name='WHM-6R'>
-				<availability>IS:8,CCC:1-,CFM:1-,CHH:1-,CMG:1,CNC:1-,CSJ:1-,Periphery:8,Periphery.Deep:8,BAN:6-</availability>
+				<availability>IS:8,CCC:1-,CFM:1-,CHH:1-,CMG:1,CNC:1-,CSJ:1-,Periphery:8,NIOPS:3-,Periphery.Deep:8,BAN:6-</availability>
 			</model>
 			<model name='WHM-6Rb'>
-				<availability>FS:2+,LA:2+,FWL:2+,CC:2+,CLAN:3-,CBS:4-,CCC:4-,CCO:4-,CFM:4-,CGB:4-,CIH:4-,CMG:4-,CSR:4-,BAN:5</availability>
+				<availability>FS:2+,LA:2+,FWL:2+,CC:2+,CLAN:3-,CBS:4-,CCC:4-,CCO:4-,CFM:4-,CGB:4-,CIH:4-,CMG:4-,CSR:4-,NIOPS:6,BAN:5</availability>
 			</model>
 			<model name='WHM-6Rk'>
                 <roles>cavalry</roles>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2855-->
-<ratgen
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
             <!-- Omni percentages: 0,0 -->

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -6,9 +6,9 @@
 >
 	<factions>
 		<faction key='BAN'>
-			<pctOmni>0,0</pctOmni>
-			<pctClan>5,5</pctClan>
-			<pctSL>85,85</pctSL>
+            <!-- Omni percentages: 0,0 -->
+            <!-- Clan percentages: 5,5 -->
+            <!-- Star League percentages: 85,85 -->
 			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS'>
@@ -30,17 +30,17 @@
 			<weightDistribution era='2855' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 		</faction>
 		<faction key='CBS'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,10,25</pctClan>
-			<pctSL>100,100,100,90,75</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,10,25 -->
+            <!-- Star League percentages: 100,100,100,90,75 -->
 			<pctClan unitType='Vehicle'>0,0,0,5,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,95,90</pctSL>
 			<salvage pct='5'>CHH:5,CCC:5,CDS:1,CW:5,CSV:10,CNC:10,CCO:5,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CB'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,30,60</pctClan>
-			<pctSL>100,100,100,70,40</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,30,60 -->
+            <!-- Star League percentages: 100,100,100,70,40 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CCC:1,CHH:5,CSR:6,CIH:4,CSV:3,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CMG:1,CJF:4</salvage>
@@ -48,17 +48,17 @@
 			<weightDistribution era='2855' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CCC'>
-			<pctOmni>0,0,0,5,10</pctOmni>
-			<pctClan>0,0,15,30,50</pctClan>
-			<pctSL>100,100,85,70,50</pctSL>
+            <!-- Omni percentages: 0,0,0,5,10 -->
+            <!-- Clan percentages: 0,0,15,30,50 -->
+            <!-- Star League percentages: 100,100,85,70,50 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:2,CFM:2,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CCO'>
-			<pctOmni>0,0,0,20,25</pctOmni>
-			<pctClan>10,10,15,40,50</pctClan>
-			<pctSL>90,90,85,60,50</pctSL>
+            <!-- Omni percentages: 0,0,0,20,25 -->
+            <!-- Clan percentages: 10,10,15,40,50 -->
+            <!-- Star League percentages: 90,90,85,60,50 -->
 			<pctClan unitType='Vehicle'>0,0,25,25,25</pctClan>
 			<pctSL unitType='Vehicle'>100,100,75,75,75</pctSL>
 			<salvage pct='10'>CHH:1,CCC:10,CIH:10,CSR:8,CSV:2,CFM:8,CGS:1,CSA:3,CDS:3,CW:1,CBS:1,CNC:10,CSJ:7,CJF:3,CB:7</salvage>
@@ -66,17 +66,17 @@
 			<weightDistribution era='2855' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CFM'>
-			<pctOmni>0,0,0,5,10</pctOmni>
-			<pctClan>0,0,10,35,45</pctClan>
-			<pctSL>100,100,90,65,55</pctSL>
+            <!-- Omni percentages: 0,0,0,5,10 -->
+            <!-- Clan percentages: 0,0,10,35,45 -->
+            <!-- Star League percentages: 100,100,90,65,55 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CCC:1,CHH:3,CSR:4,CIH:10,CSV:4,CCO:7,CGS:5,CSA:6,CDS:1,CW:1,CNC:3,CSJ:4,CMG:1,CJF:4,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CGB'>
-			<pctOmni>0,0,0,5,10</pctOmni>
-			<pctClan>10,10,30,40,50</pctClan>
-			<pctSL>90,90,70,60,50</pctSL>
+            <!-- Omni percentages: 0,0,0,5,10 -->
+            <!-- Clan percentages: 10,10,30,40,50 -->
+            <!-- Star League percentages: 90,90,70,60,50 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CSA:10,CHH:10,CCC:3,CIH:5,CSR:1,CDS:1,CW:10,CSV:10,CFM:3,CGS:1,CCO:1,CJF:5</salvage>
@@ -84,25 +84,25 @@
 			<weightDistribution era='2855' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CGS'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,15,20,30</pctClan>
-			<pctSL>100,100,85,80,70</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,15,20,30 -->
+            <!-- Star League percentages: 100,100,85,80,70 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CCC:1,CHH:10,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:5,CW:4,CNC:10,CSJ:1,CMG:3,CJF:5,CB:5</salvage>
 		</faction>
 		<faction key='CHH'>
-			<pctOmni>0,0,0,5,10</pctOmni>
-			<pctClan>0,0,15,30,45</pctClan>
-			<pctSL>100,100,85,70,55</pctSL>
+            <!-- Omni percentages: 0,0,0,5,10 -->
+            <!-- Clan percentages: 0,0,15,30,45 -->
+            <!-- Star League percentages: 100,100,85,70,55 -->
 			<pctClan unitType='Vehicle'>0,0,15,20,25</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,75</pctSL>
 			<salvage pct='10'>CCC:2,CSR:7,CIH:10,CSV:3,CFM:7,CCO:1,CGS:7,CSA:3,CDS:7,CW:4,CBS:2,CNC:10,CSJ:3,CJF:3,CGB:7,CB:7</salvage>
 		</faction>
 		<faction key='CIH'>
-			<pctOmni>0,0,0,5,10</pctOmni>
-			<pctClan>0,0,10,35,45</pctClan>
-			<pctSL>100,100,90,65,55</pctSL>
+            <!-- Omni percentages: 0,0,0,5,10 -->
+            <!-- Clan percentages: 0,0,10,35,45 -->
+            <!-- Star League percentages: 100,100,90,65,55 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CCC:3,CHH:4,CSR:4,CSV:1,CFM:10,CCO:9,CGS:1,CSA:4,CDS:4,CW:7,CNC:3,CSJ:3,CMG:3,CJF:3,CGB:2,CB:3</salvage>
@@ -110,57 +110,57 @@
 			<weightDistribution era='2855' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
 		<faction key='CJF'>
-			<pctOmni>0,0,0,15,20</pctOmni>
-			<pctClan>0,0,20,35,45</pctClan>
-			<pctSL>100,100,80,65,55</pctSL>
+            <!-- Omni percentages: 0,0,0,15,20 -->
+            <!-- Clan percentages: 0,0,20,35,45 -->
+            <!-- Star League percentages: 100,100,80,65,55 -->
 			<pctClan unitType='Vehicle'>0,0,5,5,5</pctClan>
 			<pctSL unitType='Vehicle'>100,100,95,95,95</pctSL>
 			<salvage pct='10'>CCC:2,CHH:3,CSR:5,CIH:5,CSV:5,CFM:8,CCO:5,CGS:3,CSA:3,CDS:3,CW:10,CNC:2,CSJ:3,CMG:2,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CMG'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,10,30,50</pctClan>
-			<pctSL>100,100,90,70,50</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,10,30,50 -->
+            <!-- Star League percentages: 100,100,90,70,50 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CHH:3,CIH:10,CSR:3,CSV:8,CFM:8,CGS:5,CSA:8,CDS:3,CW:3,CSJ:3,CJF:10,CGB:3,CB:3</salvage>
 		</faction>
 		<faction key='CNC'>
-			<pctOmni>0,0,0,5,10</pctOmni>
-			<pctClan>0,0,5,35,45</pctClan>
-			<pctSL>100,100,95,65,55</pctSL>
+            <!-- Omni percentages: 0,0,0,5,10 -->
+            <!-- Clan percentages: 0,0,5,35,45 -->
+            <!-- Star League percentages: 100,100,95,65,55 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CCC:5,CHH:5,CSR:10,CIH:3,CSV:2,CFM:3,CCO:10,CGS:3,CSA:5,CDS:3,CW:7,CBS:3,CSJ:2,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CDS'>
-			<pctOmni>0,0,0,15,20</pctOmni>
-			<pctClan>0,0,20,30,50</pctClan>
-			<pctSL>100,100,80,70,50</pctSL>
+            <!-- Omni percentages: 0,0,0,15,20 -->
+            <!-- Clan percentages: 0,0,20,30,50 -->
+            <!-- Star League percentages: 100,100,80,70,50 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='12'>CCC:2,CHH:5,CSR:10,CIH:8,CSV:5,CFM:3,CCO:4,CGS:3,CSA:3,CW:4,CNC:4,CSJ:5,CMG:1,CJF:5,CB:8</salvage>
 		</faction>
 		<faction key='CSJ'>
-			<pctOmni>0,0,0,10,20</pctOmni>
-			<pctClan>0,0,10,35,45</pctClan>
-			<pctSL>100,100,90,55,55</pctSL>
+            <!-- Omni percentages: 0,0,0,10,20 -->
+            <!-- Clan percentages: 0,0,10,35,45 -->
+            <!-- Star League percentages: 100,100,90,55,55 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
 		</faction>
 		<faction key='CSR'>
-			<pctOmni>0,0,0,5,10</pctOmni>
-			<pctClan>0,0,20,15,55</pctClan>
-			<pctSL>100,100,80,55,45</pctSL>
+            <!-- Omni percentages: 0,0,0,5,10 -->
+            <!-- Clan percentages: 0,0,20,15,55 -->
+            <!-- Star League percentages: 100,100,80,55,45 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CCC:2,CHH:3,CIH:5,CSV:4,CFM:5,CCO:8,CGS:1,CSA:1,CDS:7,CW:7,CNC:10,CSJ:2,CMG:1,CJF:3,CB:8</salvage>
 		</faction>
 		<faction key='CSA'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,20,40,50</pctClan>
-			<pctSL>100,100,80,60,50</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,20,40,50 -->
+            <!-- Star League percentages: 100,100,80,60,50 -->
 			<pctClan unitType='Vehicle'>0,0,10,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,80,80</pctSL>
 			<salvage pct='10'>CCC:5,CHH:3,CSR:2,CIH:8,CSV:5,CFM:10,CCO:5,CGS:4,CDS:3,CW:5,CNC:8,CSJ:1,CMG:2,CJF:3,CGB:3,CB:5</salvage>
@@ -168,17 +168,17 @@
 			<weightDistribution era='2855' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CSV'>
-			<pctOmni>0,0,0,5,10</pctOmni>
-			<pctClan>0,0,25,40,50</pctClan>
-			<pctSL>100,100,75,60,50</pctSL>
+            <!-- Omni percentages: 0,0,0,5,10 -->
+            <!-- Clan percentages: 0,0,25,40,50 -->
+            <!-- Star League percentages: 100,100,75,60,50 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:5,CBS:1,CNC:1,CSJ:1,CMG:1,CJF:10,CGB:3,CB:1</salvage>
 		</faction>
 		<faction key='CW'>
-			<pctOmni>0,0,0,15,20</pctOmni>
-			<pctClan>0,0,10,35,45</pctClan>
-			<pctSL>100,100,90,65,55</pctSL>
+            <!-- Omni percentages: 0,0,0,15,20 -->
+            <!-- Clan percentages: 0,0,10,35,45 -->
+            <!-- Star League percentages: 100,100,90,65,55 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CHH:3,CCC:4,CIH:10,CSR:8,CSV:8,CFM:2,CGS:2,CCO:1,CSA:4,CDS:3,CNC:8,CSJ:8,CJF:8,CGB:2,CB:6</salvage>
@@ -1782,14 +1782,14 @@
             </model>
         </chassis>
 		<chassis name='Commando IIC' unitType='Mek'>
-			<availability>CHH:3,CIH:3,CLAN:3,CGS:5</availability>
+			<availability>CGS!Keshik:3</availability>
 			<model name=''>
 				<roles>recon</roles>
-				<availability>CLAN:8</availability>
+				<availability>CGS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>LA:9,CSJ:2,CIR:4,MERC:4,CGS:2</availability>
+			<availability>LA:9,MERC:4,CGS:2-,CSJ:3-,CIR:4</availability>
 			<model name='COM-1D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
@@ -1798,7 +1798,7 @@
 			<model name='COM-2D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
-				<availability>LA:8,General:8,Periphery.Deep:8</availability>
+				<availability>LA:8,MERC:8,CGS:8,CSJ:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Commonwealth Light Cruiser' unitType='Warship'>
@@ -2194,9 +2194,9 @@
 			</model>
 		</chassis>
 		<chassis name='Drift Shag' unitType='Mek'>
-			<availability>CIH:4,CMG:2,CGS:2</availability>
+			<availability>CGS!Keshik:3!Front Line:1,CIH!Keshik:3!Front Line:1,CMG:2+</availability>
             <model name=''>
-                <availability>CLAN:8</availability>
+                <availability>CGS:8,CIH:8,CMG:8</availability>
             </model>
 		</chassis>
 		<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -2372,18 +2372,12 @@
             </model>
 		</chassis>
 		<chassis name='Falcon' unitType='Mek'>
-			<availability>CC:1,MOC:1,OA:1,CIH:5,LA:2,CLAN:3,FWL:1,FS:1,MERC:1,CGS:5,TC:1</availability>
+			<availability>FS:1,LA:2,FWL:1,CC:1,MERC:1,CGS!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,TC:1,MOC:1,OA:1</availability>
 			<model name='FLC-4N'>
-				<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,CGS:4-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='FLC-4Nb'>
-				<availability>CLAN:8,BAN:2</availability>
-			</model>
-			<model name='FLC-4Nb-PP'>
-				<availability>BAN:2</availability>
-			</model>
-			<model name='FLC-4Nb-PP2'>
-				<availability>BAN:2</availability>
+				<availability>CGS:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Field Artillery' unitType='Infantry'>
@@ -2430,33 +2424,27 @@
 			</model>
 		</chassis>
 		<chassis name='Firefly' unitType='Mek'>
-			<availability>CC:1+,CIH:7,CLAN:7,FS:1+,BAN:6,CB:7</availability>
+			<availability>FS:1+,CC:1+,CLAN!Front Line:3!Second Line:2!Solahma:1,CBS:3+,CGB!Front Line:6!Second Line:5!Solahma:4!Provisional Garrison:3,CGS:3+,CHH!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:3-,CJF:4+,CMG:3-,CSJ:4+,CSR:4+,CSV:4-,CW:3-,BAN:2</availability>
 			<model name='C'>
-				<availability>CLAN:6,BAN:2</availability>
+				<availability>CSJ!Keshik:8!Front Line:8!Second Line:1</availability>
 			</model>
 			<model name='FFL-3A'>
 				<roles>spotter</roles>
-				<availability>CC:8,FS:8</availability>
-			</model>
-			<model name='FFL-3PP'>
-				<availability>BAN:2</availability>
+				<availability>FS:8,CC:8,CFM:3-,CHH:3-,CSR:3-,BAN:5-</availability>
 			</model>
 			<model name='FFL-3PP2'>
-				<availability>BAN:2</availability>
-			</model>
-			<model name='FFL-3PP3'>
-				<availability>BAN:2</availability>
+				<availability>BAN:1</availability>
 			</model>
 			<model name='FFL-3SLE'>
-				<availability>CLAN:5,BAN:3</availability>
+				<availability>CLAN:8,CFM:4,CHH:4,CSR:5,BAN:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Firestarter' unitType='Mek'>
-			<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
+			<availability>IS:7,LA:8,CS:3,CFM:3-,CHH:2-,Periphery:7,NIOPS:3,Periphery.Deep:7</availability>
 			<model name='FS9-H'>
                 <roles>anti_infantry,recon</roles>
 				<deployedWith>Vulcan</deployedWith>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CFM:8,CHH:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='FS9-K'>
                 <roles>anti_infantry,recon</roles>
@@ -3098,7 +3086,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hermes' unitType='Mek'>
-			<availability>MOC:3,CC:2,CS:3,CHH:5,OA:3,CLAN:4,FWL:4,NIOPS:3,CGB:5,DC:2,CB:5</availability>
+			<availability>DC:2,FWL:4,CC:2,CS:3,CLAN:2,CB:1,CCO:1,CGB:1,CIH:6+,CDS:3,CSJ!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,MOC:3,OA:3,NIOPS:3,BAN:4+</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
 				<availability>FWL:8</availability>
@@ -3109,11 +3097,11 @@
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
-				<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>IS:2+,MERC:2+,CS:8,CLAN:4-,CGS:4,CMG:4,CSJ:3-,CSV:3-,Periphery:2+,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='HER-1Sb'>
 				<roles>recon</roles>
-				<availability>CLAN:6,FWL:2+,BAN:3</availability>
+				<availability>FWL:2+,CLAN:3+,CCO:3,CFM:3,CGB:3,CHH:3,CDS:3,CSR:3,CSV:3,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Highlander IIC' unitType='Mek'>
@@ -3194,13 +3182,13 @@
 			</model>
 		</chassis>
 		<chassis name='Hussar' unitType='Mek'>
-			<availability>CS:4,CIH:9,CSV:9,CLAN:8,NIOPS:4</availability>
+			<availability>CS:4,CLAN:3+,CGB:2+,CIH:6+,CMG:4+,CDS:4+,CSV:4+,NIOPS:4,BAN:5+</availability>
 			<model name='HSR-200-D'>
 				<roles>recon</roles>
-				<availability>CS:8,General:8,CLAN:6,NIOPS:8,BAN:8,DC:8</availability>
+				<availability>CS:8,CLAN:4-,CBS:5,CGS:5,CIH!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CDS:5,NIOPS:8,BAN:4-</availability>
 			</model>
 			<model name='HSR-200-Db'>
-				<availability>CLAN:6,BAN:4</availability>
+				<availability>CLAN:4,CBS:4+,CB:4+,CCC:4+,CCO:3,CFM:3,CGS:4+,CHH:3,CNC:4,CSJ:5,CW:4+,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
@@ -3216,10 +3204,10 @@
 			</model>
 		</chassis>
 		<chassis name='Icestorm' unitType='Mek'>
-			<availability>CIH:6+,CW:4</availability>
+            <availability>CIH!Keshik:5!Front Line:3!Second Line:1</availability>
 			<model name=''>
 				<roles>spotter</roles>
-				<availability>CLAN:8</availability>
+				<availability>CIH:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
@@ -3726,25 +3714,25 @@
 			</model>
 		</chassis>
 		<chassis name='Locust IIC' unitType='Mek'>
-			<availability>CHH:6,CW:6,CLAN:6,CJF:6,CGB:6</availability>
+			<availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:3!Front Line:1,CFM:3+,CGB!Keshik:3!Front Line:1,CGS:3+,CHH!Keshik:3!Front Line:1,CIH!Keshik:6!Front Line:3!Second Line:1,CJF!Keshik:5!Front Line:1,CNC:3+,CDS:3+,CSA!Keshik:3!Front Line:1,CSV:3+,CW:3+,BAN!Keshik:2</availability>
 			<model name=''>
-				<availability>CW:8,General:8</availability>
+				<availability>CLAN:8,CIH:4,CJF:5,CSJ:3,BAN:8</availability>
 			</model>
 			<model name='2'>
-				<availability>CCC:4,CIH:4,CJF:4</availability>
+				<availability>CIH:8,CJF:8</availability>
 			</model>
 			<model name='3'>
-				<availability>General:3</availability>
+				<availability>CSJ!Keshik:8!Front Line:5!Second Line:1,CSA!Keshik:5</availability>
 			</model>
 		</chassis>
 		<chassis name='Locust' unitType='Mek'>
-			<availability>CS:6-,CLAN:3-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:9,CS:6-,CLAN:5,CBS!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CB!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CCO!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CGB!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CGS!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CIH!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CW:4-,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:4</availability>
 			<model name='C'>
-				<availability>CCC:2,CFM:2</availability>
+				<availability>CCC!Keshik:8!Front Line:3!Second Line:1,CFM!Keshik:8!Front Line:1,CJF!Keshik:6!Front Line:8,CSJ!Keshik:8!Front Line:5!Second Line:1,CSV!Keshik:8!Front Line:1,BAN:1+</availability>
 			</model>
 			<model name='LCT-1E'>
 				<roles>recon</roles>
-				<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
+				<availability>IS:4,Periphery:4,Periphery.Deep:4</availability>
 			</model>
 			<model name='LCT-1M'>
 				<roles>recon</roles>
@@ -3756,11 +3744,11 @@
 			</model>
 			<model name='LCT-1V'>
 				<roles>recon</roles>
-				<availability>LA:4,General:8,CLAN:2-,FS:7,BAN:5</availability>
+				<availability>IS:8,FS:7,LA:4,Periphery:8</availability>
 			</model>
 			<model name='LCT-1Vb'>
 				<roles>recon</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Lola II Destroyer' unitType='Warship'>
@@ -3912,9 +3900,9 @@
 			</model>
 		</chassis>
 		<chassis name='Mandrill' unitType='Mek'>
-			<availability>CFM:6</availability>
+			<availability>CFM!Keshik:4!Front Line:3!Second Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CFM:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
@@ -4219,14 +4207,14 @@
 			</model>
 		</chassis>
 		<chassis name='Mercury' unitType='Mek'>
-			<availability>CS:8,CC:2+,LA:2+,CLAN:2,NIOPS:8,IS:2+,MERC:2+</availability>
+			<availability>IS:2+,CS:8,CLAN!Front Line:3!Second Line:2!Solahma:1,CB!Second Line:2!Solahma:1,CCO!Second Line:2!Solahma:1,CGB!Second Line:3!Solahma:2!Provisional Garrison:1,CHH!Second Line:3!Solahma:2!Provisional Garrison:1,CIH!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CJF!Second Line:3!Solahma:2!Provisional Garrison:1,CMG!Second Line:3!Solahma:2!Provisional Garrison:1,CSJ!Second Line:1!Solahma:1!Provisional Garrison:1,CW:3-,NIOPS:8,BAN:4</availability>
 			<model name='MCY-98'>
 				<roles>recon</roles>
 				<availability>CC:8</availability>
 			</model>
 			<model name='MCY-99'>
 				<roles>recon</roles>
-				<availability>CS:4,CLAN:8,NIOPS:4,BAN:6</availability>
+				<availability>CS:4,CLAN:8,NIOPS:4,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Minsk' unitType='Mek'>
@@ -4305,22 +4293,26 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>MOC:2+,CHH:5,CLAN:6,MERC:4+,FS:4+,TC:2+,CS:6,OA:2+,CDS:5,CBS:7,FWL:3+,NIOPS:6,CMG:9,CJF:7,CGB:5,DC:3+</availability>
+			<availability>FS:4+,DC:3+,FWL:3+,MERC:4+,CS:6,CLAN:4+,CBS:3+,CGS:3+,CJF:5+,CMG:6+,TC:2+,MOC:2+,OA:2+,NIOPS:6,BAN:2+</availability>
 			<model name='C'>
                 <roles>recon</roles>
-				<availability>CIH:4,CMG:8,CJF:4,CGB:4</availability>
+				<availability>CGB!Keshik:5,CIH!Keshik:5,CJF!Keshik:3!Front Line:1,CMG!Keshik:7!Front Line:3</availability>
 			</model>
+            <model name='C 2'>
+                <roles>recon</roles>
+                <availability>CMG!Keshik:3</availability>
+            </model>
 			<model name='MON-66'>
 				<roles>command,recon</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,IS:3+,BAN:8,Periphery:3+</availability>
+				<availability>IS:3+,CS:8,CLAN:6,CFM:5-,CJF:4,CMG:4,CNC:5-,Periphery:3+,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='MON-66b'>
 				<roles>command,recon</roles>
-				<availability>CLAN:8,CGS:8,BAN:4</availability>
+				<availability>CLAN:5+,CFM:4,CNC:5,BAN:1</availability>
 			</model>
 			<model name='MON-67'>
 				<roles>command,recon</roles>
-				<availability>MOC:6,OA:6,FWL:6,NIOPS:0,MERC:8,FS:6,DC:6,TC:6</availability>
+				<availability>FS:6,DC:6,FWL:6,MERC:8,NIOPS:0,TC:6,MOC:6,OA:6</availability>
 			</model>
 			<model name='MON-69'>
 				<roles>command,recon</roles>
@@ -4472,13 +4464,13 @@
 			</model>
 		</chassis>
 		<chassis name='Night Hawk' unitType='Mek'>
-			<availability>CW:6,LA:2+,CLAN:6,FWL:2+,FS:2+,CGS:7,CGB:6</availability>
+			<availability>FS:2+,LA:2+,FWL:2+,CLAN:4+,CBS:5+,CB:5+,CCO:5+,CGB:5+,CJF:5+,CNC:5+,CSJ:5+,CSR:3+,CW:5+,BAN:3+</availability>
 			<model name='NTK-2Q'>
 				<roles>raider</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CLAN:8,BAN:8</availability>
 			</model>
 			<model name='NTK-2Q-EC'>
-				<availability>CSJ:4</availability>
+				<availability>CSJ!Keshik:3!Front Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
@@ -4575,14 +4567,14 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CS:4,CLAN:4-,IS:4,Periphery.Deep:4,NIOPS:4,MERC:4,Periphery:4</availability>
+			<availability>IS:4,MERC:4,CS:4,CLAN!Second Line:2!Solahma:2!Provisional Garrison:2,CBS!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CB!Second Line:1!Solahma:1!Provisional Garrison:1,CCO!Second Line:1!Solahma:1!Provisional Garrison:1,CGS!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CIH!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CJF!Solahma:2!Provisional Garrison:2,CMG!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CNC!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CSJ!Second Line:1!Solahma:1!Provisional Garrison:1,CW!Front Line:1!Second Line:1!Solahma:2!Provisional Garrison:1,Periphery:4,NIOPS:4,Periphery.Deep:4,BAN:1</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
-				<availability>General:8,CLAN:5-,BAN:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8</availability>
 			</model>
 			<model name='OTT-7Jb'>
 				<roles>recon</roles>
-				<availability>CLAN:6,BAN:4</availability>
+				<availability>CLAN:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
@@ -4653,13 +4645,13 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>CC:3,Periphery.DD:5,FS.RR:4,CLAN:2-,MERC:5,Periphery.OS:5,FS:3,BAN:3,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>FS:3,FS.RR:4,FS.DMM:4,LA:3,DC:10,FWL:3,CC:3,MERC:5,CS:2,CSJ:3-,Periphery:3,Periphery.DD:5,Periphery.OS:5,NIOPS:2</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,TC:8</availability>
 			</model>
 			<model name='PNT-9R'>
 				<roles>fire_support</roles>
-				<availability>CLAN:8,MERC:8,DC:8</availability>
+				<availability>DC:8,MERC:8,CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -4710,13 +4702,13 @@
 			</model>
 		</chassis>
 		<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
-			<availability>CLAN:6,CSJ:8,CGB:6</availability>
+			<availability>CGS:2+,CSJ:1+,CW:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CGS:8,CW:8</availability>
 			</model>
 			<model name='2'>
 				<roles>fire_support</roles>
-				<availability>CLAN:5</availability>
+				<availability>CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk IIC' unitType='Mek'>
@@ -5353,14 +5345,14 @@
 			</model>
 		</chassis>
 		<chassis name='Sling' unitType='Mek'>
-			<availability>CC:2+,LA:2+,CLAN:1,CSJ:2</availability>
+			<availability>LA:2+,CC:2+,CSJ:5+</availability>
 			<model name='SL-1G'>
 				<roles>spotter</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,CC:8,CSJ:8</availability>
 			</model>
 			<model name='SL-1H'>
 				<roles>spotter</roles>
-				<availability>LA:4</availability>
+				<availability>LA:4,CSJ:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Snowden Mining Station' unitType='Space Station'>
@@ -5415,14 +5407,14 @@
 			</model>
 		</chassis>
 		<chassis name='Spector' unitType='Mek'>
-			<availability>CLAN:2</availability>
+			<availability>CMG:1+</availability>
 			<model name='SPR-4F'>
 			    <roles>specops,raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CMG:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>CC:5,CS:4,OA:2,CLAN:1-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
+			<availability>IS:4,FS:5,DC:6,FWL:7,CC:5,MERC:4,CS:4,CIH!Front Line:3!Second Line:2!Solahma:1,CMG!Front Line:3!Second Line:2!Solahma:1,TC:2,OA:2,NIOPS:4</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -5432,7 +5424,7 @@
 				<availability>DC:8</availability>
 			</model>
 			<model name='SDR-5V'>
-				<availability>CLAN:8,IS:8,Periphery.Deep:8,FS:6,Periphery:8</availability>
+				<availability>IS:8,FS:6,CIH:8,CMG:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
@@ -5485,18 +5477,24 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6</availability>
-			<model name='STG-3G'>
+			<availability>IS:9,DC:6,MERC:6,CS:4-,CLAN!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CBS:4,CB:5,CCC:4,CGS:4,CHH:4,CJF:4,CDS:4,CSR:4,CSA:4,CSV:4,CW:4,Periphery:6,NIOPS:4-,Periphery.Deep:6,BAN:5</availability>
+            <model name='C'>
+                <availability>CCC!Keshik:8!Front Line:1,CHH!Keshik:8!Front Line:3,CIH!Front Line:8!Second Line:1,CSV!Keshik:8,CW!Keshik:8!Second Line:8,BAN:2+</availability>
+            </model>
+            <model name='C 2'>
+                <availability>CBS!Keshik:8!Front Line:3,CB!Keshik:5!Front Line:1,BAN:2+</availability>
+            </model>
+            <model name='STG-3G'>
 				<roles>recon</roles>
-				<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
+				<availability>IS:4,CLAN!Solahma:2!Provisional Garrison:3,Periphery:4,Periphery.Deep:4,BAN:2-</availability>
 			</model>
 			<model name='STG-3Gb'>
 				<roles>recon</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,CBS!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CB!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CCC!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CHH!Front Line:5!Second Line:8!Solahma:8!Provisional Garrison:8,CIH:4-,CSV!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CW:4-,BAN:5</availability>
 			</model>
 			<model name='STG-3R'>
 				<roles>recon</roles>
-				<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,CLAN:1-,Periphery:8,Periphery.Deep:8,BAN:3-</availability>
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
@@ -5586,15 +5584,15 @@
 			</model>
 		</chassis>
 		<chassis name='Talon' unitType='Mek'>
-			<availability>CLAN:8</availability>
+			<availability>CLAN:5+,CB:4+,CFM:4+,CGS:3+,CIH:4+,CJF:6+,CNC:6+,CDS:6+,CSJ:6+,CSR:3+,CW:6+,BAN:3+</availability>
 			<model name='TLN-5V'>
-				<availability>FWL:8,FS:8</availability>
+				<availability>CIH!Solahma:6!Provisional Garrison:6,CMG!Second Line:5!Solahma:5!Provisional Garrison:5,CNC:4-,CDS:4-,CW:3-,BAN:1-</availability>
 			</model>
 			<model name='TLN-5W'>
-				<availability>LA:8,CLAN:8</availability>
+				<availability>CLAN:8,CGB:7,CIH:6+,CMG:4+,CNC:5,CDS:6,CW:8+,BAN:8</availability>
 			</model>
 			<model name='TLN-5W-EC'>
-				<availability>CIH:8</availability>
+				<availability>CIH!Keshik:3!Front Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Texas Battleship' unitType='Warship'>
@@ -5623,12 +5621,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>CSA:2,CS:6,CDS:5,CLAN:4,FWL:2,NIOPS:6,CCO:2,CJF:5,CGB:5</availability>
+			<availability>FWL:2,CS:6,CLAN:4-,CB!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CCC:3-,CGS!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CHH!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CIH:3-,CJF!Second Line:4!Solahma:4!Provisional Garrison:4,CMG!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CW!Front Line:1!Second Line:2!Solahma:4!Provisional Garrison:5,NIOPS:6,BAN:0</availability>
 			<model name='THE-N'>
-				<availability>CS:8,CLAN:6,General:4+,NIOPS:8,BAN:6</availability>
+				<availability>FWL:4+,CS:8,CLAN:8,CB!Second Line:6!Solahma:6!Provisional Garrison:6,CGB:5-,CIH:7,CJF:6,CMG!Second Line:6!Solahma:6!Provisional Garrison:6,CNC:4-,CDS:4-,CSR:4-,CW:4-,NIOPS:8</availability>
 			</model>
 			<model name='THE-Nb'>
-				<availability>CLAN:6,CGS:7,BAN:4</availability>
+				<availability>CB:6+,CGB:5,CIH:6+,CJF!Second Line:6!Solahma:5!Provisional Garrison:4,CMG:6+,CNC:5,CDS:4,CSR:5,CW:6+</availability>
 			</model>
 		</chassis>
 		<chassis name='Thresher' unitType='Mek'>
@@ -5914,17 +5912,17 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech IIC' unitType='Mek'>
-			<availability>CHH:4,CIH:4-,CSR:4,CCO:5,CGS:4</availability>
+			<availability>CLAN!Second Line:3!Solahma:2!Provisional Garrison:1,CIH!Solahma:2!Provisional Garrison:1,CJF!Solahma:2!Provisional Garrison:1,CSJ!Solahma:2!Provisional Garrison:1,CSV!Solahma:2!Provisional Garrison:1,BAN:0</availability>
 			<model name=''>
 				<roles>urban</roles>
 				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>CC:5-,CLAN:1-,IS:4-,CIR:3-,Periphery:3-,CS:4-,NIOPS:4-</availability>
+			<availability>CC:5-,IS:4-,CIR:3-,Periphery:3-,CS:4-,NIOPS:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
-				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Valkyrie' unitType='Mek'>
@@ -6108,10 +6106,10 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>CS:4-,CLAN:1-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:4,Periphery:6</availability>
+			<availability>IS:10,CS:4-,Periphery:6,CIR:4,NIOPS:4-,Periphery.Deep:6,BAN:1-</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,BAN:8</availability>
 			</model>
 			<model name='WSP-1D'>
 				<roles>recon</roles>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -612,23 +612,27 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CS:5-,LA:9,CLAN:1,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8</availability>
+			<availability>IS:7,FS:8,LA:9,DC:8,FWL:9,CS:5-,CLAN:4,CFM:3,CGS:3,CIH:4-,CMG:3,CSV:3,Periphery:6,NIOPS:5-,Periphery.Deep:6,BAN:4</availability>
 			<model name='ARC-2K'>
 				<roles>command,fire_support</roles>
 				<availability>DC:8</availability>
 			</model>
 			<model name='ARC-2R'>
 				<roles>command,fire_support</roles>
-				<availability>LA:7,CLAN:3,IS:8,Periphery.Deep:8,BAN:6,DC:6,Periphery:8</availability>
+				<availability>IS:8,LA:7,DC:6,Periphery:8,NIOPS:4-,Periphery.Deep:8,BAN:8</availability>
 			</model>
 			<model name='ARC-2Rb'>
 				<roles>command,fire_support</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:4-,BAN:2+</availability>
 			</model>
 			<model name='ARC-2S'>
 				<roles>command,fire_support</roles>
 				<availability>LA:6</availability>
 			</model>
+            <model name='C'>
+                <roles>command,fire_support</roles>
+                <availability>CLAN:3+,CBS:1+,CB:2+,CGS:2+,CMG:2+,CSJ:2+,BAN:0</availability>
+            </model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
 			<availability>MOC:8,OA:8,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8,BAN:3</availability>
@@ -901,18 +905,18 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:2,MERC:2,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:2</availability>
+			<availability>FS:2,LA:2,DC:2,FWL:4,MERC:2,CS:7,CLAN:3+,CCC!Front Line:2!Second Line:1,CGS:4+,CIH:2+,NIOPS:7,BAN:2+</availability>
 			<model name='BL-6-KNT'>
                 <roles>command</roles>
-				<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
+				<availability>FS:2+,FWL:2+,CS:8,CLAN:8,CBS:6-,CCO:5-,CGB:4-,CGS:5-,CNC:4-,CW:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='BL-6b-KNT'>
                 <roles>command</roles>
-				<availability>CS:4,CLAN:7,NIOPS:4,FWL:1+,CGS:8,BAN:4</availability>
+				<availability>FWL:1+,CS:4,CBS:7,CCO:7,CGB:7,CGS:7,CNC:7,CW:7,NIOPS:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
                 <roles>command</roles>
-				<availability>LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+				<availability>FS:8,LA:8,DC:8,FWL:4,MERC:8</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
                 <roles>command</roles>
@@ -951,14 +955,14 @@
 			</model>
 		</chassis>
 		<chassis name='Bombardier' unitType='Mek'>
-			<availability>CLAN:4-,CS:5,FWL:2,DC:2,NIOPS:5,BAN:2</availability>
+			<availability>DC:2,FWL:2,CS:5,CLAN:3-,CB:2-,CCO:2-,CIH:4,CMG:4-,CDS:4-,CSR:4-,NIOPS:5,BAN:0</availability>
 			<model name='BMB-10D'>
 				<roles>fire_support</roles>
-				<availability>CLAN:8,CS:8,FWL:8,DC:8,NIOPS:8,BAN:8</availability>
+				<availability>DC:8,FWL:8,CS:8,NIOPS:8</availability>
 			</model>
 			<model name='BMB-12D'>
 				<roles>fire_support</roles>
-				<availability>CS:8,CLAN:8,NIOPS:8,FWL:5+,BAN:8,DC:5+</availability>
+				<availability>DC:5+,FWL:5+,CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
 			</model>
 		</chassis>
         <chassis name='Brunel Dump Truck' unitType='Tank'>
@@ -1083,18 +1087,18 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>CC:5,CLAN:2,IS:3,MERC:2,Periphery:1,CS:2,NIOPS:2,DC:5</availability>
+			<availability>IS:3,DC:5,CC:5,MERC:2,CS:2,CFM:4+,CDS:3,Periphery:1,NIOPS:2</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
-				<availability>CC:4,FWL:2,DC:2</availability>
+				<availability>DC:2,FWL:2,CC:4</availability>
 			</model>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
-				<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,CC:8,MERC:8,CDS:8,Periphery:8,Periphery.Deep:8,BAN:6</availability>
 			</model>
 			<model name='CPLT-C1b'>
 				<roles>fire_support</roles>
-				<availability>CC:1+,CLAN:6,DC:1+</availability>
+				<availability>DC:1+,CC:1+,CFM:8</availability>
 			</model>
 			<model name='CPLT-C4'>
 				<roles>fire_support</roles>
@@ -1125,12 +1129,12 @@
 			</model>
 		</chassis>
 		<chassis name='Cestus' unitType='Mek'>
-			<availability>CS:4,LA:2+,CLAN:4,NIOPS:4,IS:2+,FS:4</availability>
+			<availability>IS:2+,FS:4,LA:2+,CS:4,CB:3+,CFM:2+,CJF!Front Line:2!Second Line:1,CSJ!Front Line:2!Second Line:1,NIOPS:4+</availability>
 			<model name='CTS-6Y'>
-				<availability>General:8</availability>
+				<availability>IS:8,CB:8,CFM:5,CJF:8,CSJ:8,NIOPS:8</availability>
 			</model>
 			<model name='CTS-6Y-EC'>
-				<availability>CFM:2</availability>
+				<availability>CFM!Keshik:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
@@ -1147,22 +1151,19 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:6,CS:5,CHH:6,LA:5,CLAN:4,IS:4,NIOPS:5,MERC:4,CGB:6</availability>
-			<model name='C'>
-				<availability>CHH:6,CLAN:8,CGB:6</availability>
-			</model>
+			<availability>IS:4,LA:5,CC:6,MERC:4,CS:5,CBS:4-,CFM:4+,CGB!Second Line:2!Solahma:1,CHH!Front Line:3!Second Line:2!Solahma:1,CIH:6+,CDS:4+,CSV!Front Line:3!Second Line:2!Solahma:1,NIOPS:5</availability>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
-				<availability>CC:2+,CS:8,CHH:6,CLAN:5,NIOPS:8,BAN:7,CGB:6</availability>
+				<availability>CC:2+,CS:8,CBS:8,CGB:8,CHH:3-,NIOPS:8</availability>
 			</model>
 			<model name='CHP-1N2'>
-				<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
+				<availability>CS:4,CFM:8,CHH:5,CIH:8,CDS:3-,NIOPS:5</availability>
 			</model>
 			<model name='CHP-1Nb'>
-				<availability>CLAN:6,BAN:3</availability>
+				<availability>CDS:3+,CSV:8</availability>
 			</model>
 			<model name='CHP-2N'>
-				<availability>IS:8,NIOPS:0</availability>
+				<availability>IS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1999,9 +2000,9 @@
 			</model>
 		</chassis>
 		<chassis name='Crusader' unitType='Mek'>
-			<availability>CS:6-,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:8,CS:6-,CLAN:2,CBS:3,CB:3,CCC:3,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:4</availability>
 			<model name='CRD-2R'>
-				<availability>CLAN:7,IS:2+,CGS:8,BAN:4,Periphery:2+</availability>
+				<availability>IS:2+,CLAN:8,Periphery:2+,BAN:2+</availability>
 			</model>
 			<model name='CRD-3D'>
 				<availability>FS:5</availability>
@@ -2014,7 +2015,7 @@
 				<availability>CC:9</availability>
 			</model>
 			<model name='CRD-3R'>
-				<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,NIOPS:6-,Periphery.Deep:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
@@ -2301,29 +2302,29 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,IS:5,Periphery:2,TC:3,CS:5,NIOPS:5,DC:6</availability>
+			<availability>IS:5,DC:6,CS:5,Periphery:2,TC:3,MOC:3,NIOPS:5</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Mek'>
-			<availability>CS:5,LA:1+,CLAN:4,NIOPS:5,FS:1+,DC:1+</availability>
+			<availability>FS:1+,LA:1+,DC:1+,CS:5,CLAN:3+,CSJ!Front Line:2!Second Line:1,NIOPS:5,BAN:0</availability>
 			<model name='EXC-B1'>
 				<roles>cavalry,fire_support</roles>
-				<availability>LA:8</availability>
+				<availability>LA:8,CDS:4-</availability>
 			</model>
 			<model name='EXC-B2'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CS:8,LA:0,General:8,CLAN:5,NIOPS:8</availability>
+				<availability>FS:8,LA:0,DC:8,CS:8,CLAN:5-,CW:0,NIOPS:8</availability>
 			</model>
 			<model name='EXC-B2b'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CLAN:2+,CGB:3+,CJF:3+,CSJ:3+,CW:4-</availability>
 			</model>
 			<model name='EXC-B2b-EC'>
                 <roles>cavalry,fire_support</roles>
-				<availability>CW:5</availability>
+				<availability>CW:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -2338,22 +2339,22 @@
 			</model>
 		</chassis>
 		<chassis name='Exterminator' unitType='Mek'>
-			<availability>CS:4,CLAN:5,NIOPS:4</availability>
+			<availability>CS:4,CLAN!Front Line:2!Second Line:1,CCO!Front Line:1,CGS!Second Line:1,CHH!Second Line:1,CIH:4+,CMG:3+,CNC!Second Line:1,CDS:3+,CSJ!Second Line:1,CSR:3+,CSV!Second Line:1,CW!Second Line:1,NIOPS:4,BAN:1+</availability>
 			<model name='EXT-4C'>
 			    <roles>specops</roles>
-				<availability>BAN:1</availability>
+				<availability>BAN:8</availability>
 			</model>
 			<model name='EXT-4D'>
 			    <roles>cavalry</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:4</availability>
+				<availability>CS:8,CLAN:8,CFM:4-,CIH:4-,CJF:3-,CDS:3-,CSR:4-,NIOPS:8,BAN:0</availability>
 			</model>
 			<model name='EXT-4Db'>
 			    <roles>cavalry</roles>
-				<availability>CLAN:6,BAN:3</availability>
+				<availability>CFM:8,CIH:5,CJF:4-,CDS:8,CSR:8,NIOPS:3+</availability>
 			</model>
 			<model name='EXT-4Db-EC'>
 			    <roles>cavalry</roles>
-				<availability>CJF:5</availability>
+				<availability>CJF:3+</availability>
 			</model>
 		</chassis>
 	    <chassis name='Factory' unitType='Space Station'>
@@ -2411,10 +2412,10 @@
 			</model>
 		</chassis>
 		<chassis name='Fire Scorpion' unitType='Mek'>
-			<availability>CGS:7</availability>
+			<availability>CGS:1+</availability>
 			<model name=''>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
+				<availability>CGS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Firebee' unitType='Mek'>
@@ -2457,13 +2458,13 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:3,CDS:5,LA:6,CBS:5,FWL:3,NIOPS:5,CJF:7,CGB:5</availability>
+			<availability>LA:6,FWL:3,CS:5,CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CJF!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,Periphery.R:3,NIOPS:5,BAN:3+</availability>
 			<model name='FLS-7K'>
 				<availability>LA:7,FWL:8,Periphery.R:8</availability>
 			</model>
 			<model name='FLS-8K'>
                 <roles>cavalry</roles>
-				<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
+				<availability>LA:2+,CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Flatbed Truck' unitType='Tank'>
@@ -2649,19 +2650,16 @@
 			</model>
 		</chassis>
 		<chassis name='Galahad (Glass Spider)' unitType='Mek'>
-			<availability>CSR:8,CW:9,CLAN:8</availability>
+			<availability>CW:2+</availability>
 			<model name=''>
                 <roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:8</availability>
+				<availability>CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Galahad' unitType='Mek'>
-			<availability>CC:2+,LA:2+,CLAN:2,FS:2+</availability>
+			<availability>FS:2+,LA:2+,CC:2+</availability>
 			<model name='GLH-1D'>
-				<availability>IS:8</availability>
-			</model>
-			<model name='GLH-2D'>
-				<availability>CLAN:8</availability>
+				<availability>FS:8,LA:8,CC:8</availability>
 			</model>
 		</chassis>
         <chassis name='Galaport Ground Trailer' unitType='Tank'>
@@ -2782,14 +2780,14 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>CS:7,CHH:8,CSR:8,CLAN:7,IS:6,NIOPS:7,FS:5,MERC:6</availability>
+			<availability>IS:6,FS:5,MERC:6,CS:7,CHH:3+,CSR:3+,NIOPS:7</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
-				<availability>CS:8,CLAN:8,IS:3+,NIOPS:8,BAN:8</availability>
+				<availability>IS:3+,CS:8,CHH:8,CSR:8,NIOPS:8</availability>
 			</model>
 			<model name='GLT-4L'>
 				<roles>raider</roles>
-				<availability>FWL:6,NIOPS:0,MERC:6</availability>
+				<availability>FWL:6,MERC:6</availability>
 			</model>
 			<model name='GLT-4P'>
 				<roles>raider</roles>
@@ -3027,14 +3025,6 @@
                 <availability>CLAN:3,BAN:3,IS:3,FWL:3</availability>
             </model>
         </chassis>
-		<chassis name='Helepolis' unitType='Mek'>
-			<availability>CLAN:2</availability>
-			<model name='HEP-3H'>
-				<roles>mixed_artillery</roles>
-				<deployedWith>Helepolis</deployedWith>
-				<availability>General:8</availability>
-			</model>
-		</chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
 			<availability>CC:1,MOC:2+,CLAN:4,IS:2,FS:3,TC:2+,CS:6,OA:2+,CNC:4,NIOPS:6</availability>
 			<model name='HCT-212'>
@@ -3596,22 +3586,22 @@
 			</model>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>MOC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,NIOPS:6,DC:4</availability>
+			<availability>IS:3,DC:4,MERC:3,CS:6,CLAN!Front Line:2!Second Line:1,CBS:3+,CB:3+,CCC:4+,CFM:3+,CGB:3+,CGS:3+,CIH:4+,CMG:4+,CSV!Front Line:3!Second Line:2!Solahma:1,TC:3,MOC:3,OA:3,CIR:3,NIOPS:6,BAN:0</availability>
             <model name='C'>
                 <roles>cavalry,anti_aircraft</roles>
-                <availability>CIH:2,CFM:2,CFM.SmJ:6,CB:4,CGB:2</availability>
+                <availability>CB!Keshik:3!Front Line:1,CFM!Keshik:3!Front Line:1,CGB:2+,CIH!Keshik:8!Front Line:5</availability>
             </model>
             <model name='C 2'>
                 <roles>cavalry,anti_aircraft</roles>
-                <availability>CIH:2,CFM:1,CFM.SmJ:3,CB:2</availability>
+                <availability>CB:1+,CFM!Keshik:3!Front Line:1,CIH!Keshik:5!Front Line:1</availability>
             </model>
 			<model name='LNC25-01'>
 				<roles>cavalry,anti_aircraft</roles>
-				<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6</availability>
+				<availability>IS:4+,CS:8,CLAN:8,CB:4-,CFM:4-,CGB:4-,CIH:3-,NIOPS:8</availability>
 			</model>
 			<model name='LNC25-05'>
 				<roles>cavalry,anti_infantry</roles>
-				<availability>CS:4,IS:1,NIOPS:4</availability>
+				<availability>IS:1,CS:4,NIOPS:4</availability>
 			</model>
 		</chassis>
 		<chassis name='League Destroyer' unitType='Warship'>
@@ -3836,16 +3826,16 @@
 			</model>
 		</chassis>
 		<chassis name='Lupus' unitType='Mek' omni='Clan'>
-			<availability>CCO:6</availability>
+			<availability>CCO!Keshik:3</availability>
 			<model name='A'>
-				<availability>CLAN:6</availability>
+				<availability>CCO:6</availability>
 			</model>
 			<model name='B'>
-				<availability>CLAN:6</availability>
+				<availability>CCO:4+</availability>
 			</model>
 			<model name='Prime'>
 				<roles>fire_support</roles>
-				<availability>CLAN:8</availability>
+				<availability>CCO:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Lynx' unitType='Mek'>
@@ -3934,18 +3924,18 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>MOC:2+,CS:8,LA:5,CLAN:6,IS:4,NIOPS:8,FS:5,TC:3+,DC:5</availability>
+			<availability>IS:4,FS:5,LA:5,DC:5,CS:8,CLAN:4+,CIH:3+,CMG:3+,CSV:3+,TC:3+,MOC:2+,NIOPS:8,BAN:2+</availability>
             <model name='C'>
                 <roles>command</roles>
-                <availability>CLAN:2+</availability>
+                <availability>CLAN:3+,CBS!Keshik:2,CB!Keshik:3!Front Line:1,CCC:2+,CFM:2+,CGS:2+,CHH:2+,CIH:2+,CMG:1+,CSV:2+,CW:2+,BAN:0</availability>
             </model>
 			<model name='MAD-1R'>
                 <roles>command</roles>
-				<availability>CS:8,MOC:3,CLAN:4,IS:3+,NIOPS:8,MERC:0,BAN:4,TC:3+</availability>
+				<availability>IS:3+,MERC:0,CS:8,CLAN:2-,CBS:3-,TC:3+,MOC:3,NIOPS:8,BAN:2+</availability>
 			</model>
 			<model name='MAD-2R'>
                 <roles>command</roles>
-				<availability>CLAN:6,FS:2+,CGS:7,BAN:6</availability>
+				<availability>FS:2+,CLAN:5,BAN:0</availability>
 			</model>
 			<model name='MAD-3D'>
                 <roles>command</roles>
@@ -3953,7 +3943,7 @@
 			</model>
 			<model name='MAD-3R'>
                 <roles>command</roles>
-				<availability>CS:4-,IS:8,TC:8</availability>
+				<availability>IS:8,CS:4-,Periphery:8,BAN:8</availability>
 			</model>
 		</chassis>
         <chassis name='Marco' unitType='Mek'>
@@ -3982,15 +3972,15 @@
 			</model>
 		</chassis>
 		<chassis name='Masauwu' unitType='Mek'>
-			<availability>CSA:2,CCO:4</availability>
+			<availability>CCO:2+,CSA:2+</availability>
             <model name=''>
-                <availability>General:8</availability>
+                <availability>CCO:8,CSA:8</availability>
             </model>
 		</chassis>
 		<chassis name='Matador' unitType='Mek'>
-			<availability>CSV:6</availability>
+			<availability>CSV:2+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CSV:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Maultier Hover APC' unitType='Tank'>
@@ -4224,10 +4214,10 @@
 			</model>
 		</chassis>
 		<chassis name='Minsk' unitType='Mek'>
-			<availability>CGB:5</availability>
+			<availability>CGB!Second Line:1</availability>
 			<model name='MNK-101'>
 				<roles>command</roles>
-				<availability>CLAN:6</availability>
+				<availability>CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Mithras Light Tank' unitType='Tank'>
@@ -4519,18 +4509,21 @@
 			</model>
 		</chassis>
 		<chassis name='Orion IIC' unitType='Mek'>
-			<availability>CW:4</availability>
+			<availability>CW:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CLAN:3,IS:5,Periphery.Deep:4,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-</availability>
+			<availability>IS:5,LA:6,FWL:9,CS:5-,CLAN!Front Line:2!Second Line:1,CBS:3+,CCO:2+,CFM:2+,CIH:2+,CMG:1+,CNC:2+,CDS:2+,CW:5+,Periphery.MW:5,Periphery.ME:5,Periphery:4,TC:5,MOC:5,OA:5,CIR:5,NIOPS:5-,Periphery.Deep:4,BAN:2</availability>
 			<model name='ON1-K'>
-				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
+            <model name='ON1-Kb'>
+                <availability>CLAN:8,BAN:0</availability>
+            </model>
 			<model name='ON1-V'>
-				<availability>OA:2,IS:3,TC:3</availability>
+				<availability>IS:3,TC:3,OA:2</availability>
 			</model>
 			<model name='ON1-VA'>
 				<availability>IS:2</availability>
@@ -4550,14 +4543,14 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CC:5,MOC:4,CS:4,LA:5,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,TC:4,DC:6</availability>
+			<availability>IS:5,DC:6,CS:4,CLAN:4,CB:3,CCC!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:3,CCO:3,CFM:4-,CIH:5,CMG!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,CNC:4-,CDS:4-,CSJ:4-,CSA:4-,CSV:4-,CW:4-,Periphery:4,TC:4,MOC:4,NIOPS:4,Periphery.Deep:4,BAN:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
-				<availability>CLAN:3,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CHH:1-,CIH:1-,CMG:1-,CNC:1-,CSJ:1-,CSR:1-,Periphery:8,Periphery.Deep:8,BAN:4-</availability>
 			</model>
 			<model name='OSR-2Cb'>
 				<roles>urban</roles>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CLAN:8,BAN:3</availability>
 			</model>
 			<model name='OSR-2L'>
 				<availability>IS:4</availability>
@@ -4581,10 +4574,10 @@
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
-			<availability>CLAN:3-,CS:6,FWL:7,NIOPS:6,Periphery.Deep:4,FS:7,MERC:7,Periphery:4,BAN:4</availability>
+			<availability>FS:7,FWL:7,MERC:7,CS:6,NIOPS:6,Periphery:4,Periphery.Deep:4,BAN:2-</availability>
 			<model name='OTL-4D'>
                 <roles>raider</roles>
-				<availability>CLAN:8,IS:8,Periphery:8,BAN:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Overlord C' unitType='Dropship'>
@@ -4961,10 +4954,10 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman IIC' unitType='Mek'>
-			<availability>CLAN:4</availability>
+			<availability>CGB!Front Line:1,CNC!Front Line:1,CDS!Front Line:1,CSR!Front Line:1,CW!Front Line:1</availability>
 			<model name=''>
                 <roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CNC:8,CDS:8,CSR:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Rifleman II' unitType='Mek'>
@@ -4975,14 +4968,14 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CLAN:3,IS:8-,Periphery.Deep:5,CIR:3,Periphery:5,CS:6-,NIOPS:6-</availability>
+			<availability>IS:8-,CS:6-,CLAN!Second Line:1,CBS!Front Line:1,CB!Front Line:1,CCC!Front Line:1,CFM!Front Line:1,CGS!Front Line:1,CMG!Front Line:1,CSJ!Front Line:1,Periphery:5,CIR:3,NIOPS:6-,Periphery.Deep:5,BAN:3-</availability>
             <model name='C'>
                 <roles>fire_support,anti_aircraft</roles>
-                <availability>CLAN:8,BAN:4</availability>
+                <availability>CLAN:8,BAN:3+</availability>
             </model>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:5-,General:8,BAN:6</availability>
+				<availability>IS:8,MERC:8,Periphery:8,NIOPS:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Riga II Destroyer-Carrier' unitType='Warship'>
@@ -5289,10 +5282,10 @@
 			</model>
 		</chassis>
 		<chassis name='Shootist' unitType='Mek'>
-			<availability>CS:5,LA:1+,CLAN:5,NIOPS:5</availability>
+			<availability>LA:1+,CS:5,CLAN!Front Line:2!Second Line:1,CBS:2+,CB!Front Line:3!Second Line:2!Solahma:1,CIH!Second Line:2!Solahma:1,CMG!Second Line:1,NIOPS:5,BAN:0</availability>
 			<model name='ST-8A'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
         <chassis name='Shugosha' unitType='Mek'>
@@ -5637,13 +5630,13 @@
 			</model>
 		</chassis>
 		<chassis name='Thresher' unitType='Mek'>
-			<availability>CHH:6,CDS:4,CSR:4,CLAN:4</availability>
+			<availability>CHH:2+,CDS:2+</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CHH:8,CDS:8</availability>
 			</model>
 			<model name='2'>
 				<roles>fire_support</roles>
-				<availability>CHH:4</availability>
+				<availability>CHH:5</availability>
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
@@ -5704,9 +5697,9 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:9,CS:5-,LA:8,CLAN:4,IS:7,Periphery.Deep:6,NIOPS:5-,MERC:7,Periphery:6,DC:8</availability>
+			<availability>IS:7,LA:8,DC:8,CC:9,MERC:7,CS:5-,CLAN:5,CB!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CCC:4,CGS!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,CHH!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,CIH:4,CMG:4,CNC!Keshik:5!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CSR:4,CSV:4,Periphery:6,NIOPS:5-,Periphery.Deep:6,BAN:5</availability>
 			<model name='C'>
-				<availability>CLAN:2</availability>
+				<availability>CLAN:2+,CGS:1+,CJF:3+,BAN:0</availability>
 			</model>
 			<model name='TDR-5D'>
 				<availability>FS:4,MERC:2</availability>
@@ -5718,13 +5711,13 @@
 				<availability>CC:2</availability>
 			</model>
 			<model name='TDR-5S'>
-				<availability>IS:8,CLAN:1-,BAN:5,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,BAN:6-</availability>
 			</model>
 			<model name='TDR-5SE'>
 				<availability>MERC.ELH:8,MERC:2</availability>
 			</model>
 			<model name='TDR-5Sb'>
-				<availability>CLAN:6-,BAN:4</availability>
+				<availability>CLAN:4,CB:4-,CIH:4-,CJF:4-,BAN:5</availability>
 			</model>
 			<model name='TDR-5Sd'>
 				<availability>FS:1+</availability>
@@ -5992,10 +5985,10 @@
 			</model>
 		</chassis>
 		<chassis name='Vision Quest' unitType='Mek'>
-			<availability>CSR:5,CNC:7,CB:5</availability>
-			<model name='VQ-1NC'>
-				<availability>CNC:3</availability>
-			</model>
+			<availability>CB:2+,CNC:3+</availability>
+            <model name=''>
+                <availability>CB:8,CNC:8</availability>
+            </model>
 		</chassis>
 		<chassis name='Volga Transport' unitType='Warship'>
 			<availability>CS:1,CLAN:2,NIOPS:1</availability>
@@ -6067,9 +6060,9 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:8,LA:9,FWL:9,CS:6-,CLAN:6+,CB:5+,CCC:5+,CFM:5+,CGB!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CGS:5+,CHH:5+,CIH:4-,CJF:5+,CMG:5+,CNC:5+,CDS:5+,CSR:5+,CSV:5+,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:5+</availability>
             <model name='C'>
-                <availability>CLAN:3</availability>
+                <availability>CLAN:3+,CBS!Keshik:3!Front Line:1,CB:2+,CHH:2+,CSJ:2+,CW:2+,BAN:0</availability>
             </model>
 			<model name='WHM-6D'>
 				<availability>FS:4</availability>
@@ -6081,17 +6074,17 @@
 				<availability>CC:4</availability>
 			</model>
 			<model name='WHM-6R'>
-				<availability>General:8,CLAN:2,BAN:8</availability>
+				<availability>IS:8,CCC:1-,CFM:1-,CHH:1-,CMG:1,CNC:1-,CSJ:1-,Periphery:8,Periphery.Deep:8,BAN:6-</availability>
 			</model>
 			<model name='WHM-6Rb'>
-				<availability>CC:2+,LA:2+,CLAN:4,FWL:2+,FS:2+,BAN:4</availability>
+				<availability>FS:2+,LA:2+,CC:2+,FWL:2+,CLAN:3-,CBS:4-,CCC:4-,CCO:4-,CFM:4-,CGB:4-,CIH:4-,CMG:4-,CSR:4-,BAN:5</availability>
 			</model>
 			<model name='WHM-6Rk'>
                 <roles>cavalry</roles>
 				<availability>DC:1+</availability>
 			</model>
 			<model name='WHM-7A'>
-				<availability>CLAN:5</availability>
+				<availability>CLAN!Front Line:2,CBS:3+,CB!Front Line:2!Second Line:1,CCC!Front Line:2!Second Line:1,CCO:3+,CFM:2+,CGB!Front Line:2!Second Line:1,CGS!Front Line:2!Second Line:1,CIH:4+,BAN:0</availability>
 			</model>
 		</chassis>
 		<chassis name='Wasp LAM Mk I' unitType='Mek'>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -1922,7 +1922,7 @@
             </model>
         </chassis>
 		<chassis name='Coyotl' unitType='Mek' omni='Clan'>
-			<availability>CLAN:1+:2856,CB!Keshik:2,CCO!Keshik:2,CGB!Keshik:2,CJF!Keshik:2,CSJ!Keshik:2,CW!Keshik:2</availability>
+			<availability>CLAN:1+:2856,CB!Keshik:2,CCO!Keshik:2,CGB!Keshik:2,CJF!Keshik:2,CSJ!Keshik:2,CW!Keshik:2,BAN:0</availability>
 			<model name='A'>
                 <roles>raider</roles>
 				<availability>CLAN:4+</availability>
@@ -2720,7 +2720,7 @@
 			</model>
 		</chassis>
         <chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
-            <availability>CLAN:1+,CB:2+,CFM:2+,CMG:2+,CSA:2+</availability>
+            <availability>CLAN:1+,CB:2+,CFM:2+,CMG:2+,CSA:2+,BAN:0</availability>
             <model name='6'>
                 <availability>CLAN:8</availability>
             </model>
@@ -3585,7 +3585,7 @@
 			<availability>FS:2+,FWL:2+,CBS:2+,CMG!Front Line:2!Second Line:1,CDS!Front Line:2!Second Line:1</availability>
 			<model name='KY2-D-02'>
 				<roles>fire_support</roles>
-				<availability>IS:8</availability>
+				<availability>FS:8,FWL:8,CBS:8,CMG:8,CDS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='LRM Carrier' unitType='Tank'>
@@ -6174,7 +6174,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>IS:7,FS:8,LA:7,FWL:10,CS:5-,NIOPS:5-,TC:5,Periphery.Deep:6</availability>
+			<availability>IS:7,FS:8,FWL:10,CS:5-,NIOPS:5-,TC:5,Periphery.Deep:6</availability>
 			<model name='WVR-1R'>
 				<availability>FS:2-</availability>
 			</model>
@@ -6205,7 +6205,7 @@
 			<availability>FS:6,DC:6,CC:6,MERC:5,CS:6,CLAN:3,CBS:4,CB:4,CFM:4,CIH:2-,CMG:4-,CNC:4,CSJ:2,TC:4,NIOPS:6,BAN:3</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
-				<availability>CS:8,CBS:3-,CB:3-,CCO:3-,CFM:2-,NIOPS:8,TC:8,BAN:5-</availability>
+				<availability>CS:8,CBS:3-,CB:3-,CCO:3-,CFM:2-,TC:8,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='WVE-5Nb'>
 				<roles>urban</roles>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -718,9 +718,9 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>CC:1,MOC:1,CS:3-,LA:4,FS.CMM:4,IS:4,MERC:3,FS:4,TC:1</availability>
+			<availability>IS:4,FS:4,LA:4,CC:1,MERC:3,CS:3-,CIH!Front Line:2!Second Line:1,TC:1,MOC:1</availability>
 			<model name='ASN-21'>
-				<availability>General:8</availability>
+				<availability>IS:8,CIH:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Asshur Fast Reconnaissance Vehicle' unitType='Tank'>
@@ -1213,10 +1213,10 @@
 			</model>
 		</chassis>
 		<chassis name='Cicada' unitType='Mek'>
-			<availability>CC:4,CS:4-,OA:3,LA:4,IS:4,FWL:4,FS:4,MERC:4,Periphery:3,DC:4</availability>
+			<availability>IS:4,FS:4,LA:4,DC:4,FWL:4,CC:4,MERC:4,CS:4-,Periphery:3,OA:3</availability>
 			<model name='CDA-2A'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,Periphery:8</availability>
 			</model>
 			<model name='CDA-2B'>
 				<roles>anti_infantry</roles>
@@ -1738,18 +1738,18 @@
             </model>
         </chassis>
 		<chassis name='Clint IIC' unitType='Mek'>
-			<availability>CSR:6</availability>
+			<availability>CSR:2+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CSR:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:6,MOC:3,CS:3-,OA:3,LA:4,CLAN:2-,IS:4,FWL:4,NIOPS:3-,FS:6,MERC:4,DC:4</availability>
+			<availability>IS:4,FS:6,CC:6,MERC:4,CS:3-,MOC:3,OA:3,NIOPS:3-</availability>
 			<model name='CLNT-1-2R'>
 				<availability>CC:1,FS:1</availability>
 			</model>
 			<model name='CLNT-2-3T'>
-				<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,NIOPS:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='CLNT-2-4T'>
 				<availability>CC:4,FS:4</availability>
@@ -1909,9 +1909,9 @@
 			</model>
 		</chassis>
 		<chassis name='Corvis' unitType='Mek'>
-			<availability>CHH:4,CLAN:3</availability>
+			<availability>CGB:2+,CHH:3+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CHH:8</availability>
 			</model>
 		</chassis>
         <chassis name='Corx Mobile Tunnel Miner' unitType='Tank'>
@@ -1922,35 +1922,35 @@
             </model>
         </chassis>
 		<chassis name='Coyotl' unitType='Mek' omni='Clan'>
-			<availability>CCO:6</availability>
+			<availability>CLAN:1+:2856,CB!Keshik:2,CCO!Keshik:2,CGB!Keshik:2,CJF!Keshik:2,CSJ!Keshik:2,CW!Keshik:2</availability>
 			<model name='A'>
                 <roles>raider</roles>
-				<availability>General:6</availability>
+				<availability>CLAN:4+</availability>
 			</model>
 			<model name='B'>
-				<availability>General:6</availability>
+				<availability>CLAN:5</availability>
 			</model>
 			<model name='Prime'>
-				<availability>General:8</availability>
+				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,CJF:4,CGB:4</availability>
+			<availability>IS:3,MERC:3,CS:5,CLAN:4,CCC:5,CFM:5,CGS:5,CIH:3-,CNC:5,Periphery:3,NIOPS:5,BAN!Keshik:6!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
-				<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
+				<availability>IS:8,NIOPS:0,Periphery:8,Periphery.Deep:8,BAN:4-</availability>
 			</model>
 			<model name='CRB-27'>
 				<roles>raider</roles>
-				<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
+				<availability>LA:1+,DC:1+,FWL:1+,CC:1+,CS:8,CLAN:5-,NIOPS:8,BAN:3</availability>
 			</model>
 			<model name='CRB-27b'>
 				<roles>raider</roles>
-				<availability>CC:2+,CLAN:7,FWL:2+,CGS:8,BAN:4</availability>
+				<availability>FWL:2+,CC:2+,CLAN:5+,CBS:5+,BAN:3+</availability>
 			</model>
 			<model name='CRB-27sl'>
                 <roles>raider</roles>
-				<availability>LA:2+,CLAN:3,DC:2+</availability>
+				<availability>LA:2+,DC:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
@@ -2148,9 +2148,9 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>CC:4,Periphery.HR:6,CLAN:2,IS:5,Periphery.Deep:5,FS:8,MERC:5,TC:5</availability>
+			<availability>IS:5,FS:8,CC:4,MERC:5,CBS:3+,CDS!Front Line:3!Second Line:2!Solahma:1,Periphery.HR:6,TC:5,Periphery.Deep:5</availability>
 			<model name='DV-6M'>
-				<availability>CLAN:4,IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CBS:8,CDS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='DV-6Md'>
 				<availability>FS:4+</availability>
@@ -2259,7 +2259,7 @@
 			</model>
 		</chassis>
 		<chassis name='Enfield' unitType='Mek'>
-			<availability>CMG:6</availability>
+			<availability>CMG:3+</availability>
 			<model name='END-6J-EC'>
 				<roles>urban</roles>
 				<availability>CMG:8</availability>
@@ -2612,10 +2612,13 @@
 			</model>
 		</chassis>
 		<chassis name='Fox' unitType='Mek'>
-			<availability>CDS:6,CW:4,CSJ:4</availability>
+			<availability>CGB:2+,CDS!Keshik:3!Front Line:1,CSJ:1+,CW:1+</availability>
 			<model name='CS-1'>
-				<availability>General:8</availability>
+				<availability>CDS:4-,CSJ:8,CW:4-</availability>
 			</model>
+            <model name=''>
+                <availability>CGB:8,CDS:3,CSJ:5+,CW:8</availability>
+            </model>
 		</chassis>
 		<chassis name='Fury Command Tank' unitType='Tank'>
 			<availability>CC:1,CHH:8,CW:8,LA:1,CLAN:7,FWL:1,FS:2,MERC:1,CJF:8,DC:1,CGB:8</availability>
@@ -2717,9 +2720,9 @@
 			</model>
 		</chassis>
         <chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
-            <availability>CSV:7</availability>
+            <availability>CLAN:1+,CB:2+,CFM:2+,CMG:2+,CSA:2+</availability>
             <model name='6'>
-                <availability>CSV:8</availability>
+                <availability>CLAN:8</availability>
             </model>
         </chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
@@ -2745,28 +2748,31 @@
 			</model>
 		</chassis>
 		<chassis name='Great Wyrm' unitType='Mek'>
-			<availability>CSA:3,CCC:5,CHH:3,CSV:5,CLAN:3,CFM:5,CSJ:5,CMG:5,CCO:5,CB:5,CGB:3</availability>
+			<availability>CBS:1+,CB:2+,CJF!Front Line:1,CMG:2+,CNC:1+,CSJ:1+,CSA:2+,CW:1+</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Griffin IIC' unitType='Mek'>
-			<availability>CCC:5,CCO:5,CGB:5,CNC:5,CDS:5,CSJ:5,BAN:2+</availability>
+			<availability>CCC:1+,CCO:1+,CGB:1+,CNC!Keshik:3!Front Line:1,CDS:1+,CSJ!Keshik:3!Front Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CCC:8,CCO:8,CGB:8,CNC:8,CDS:8,CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>CC:7,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,LA:9,NIOPS:4,DC:8</availability>
+			<availability>IS:9,DC:8,CC:7,MERC:7,CS:4,CLAN:5,CGS:6,CIH:5+,Periphery:6,TC:7,OA:5,NIOPS:4,Periphery.Deep:6,BAN:4+</availability>
 			<model name='GRF-1N'>
-				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:7,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:8,BAN:2-</availability>
 			</model>
 			<model name='GRF-1S'>
 				<availability>LA:6</availability>
 			</model>
 			<model name='GRF-2N'>
-				<availability>CC:2+,LA:2+,CLAN:6,FWL:2+,FS:2+,BAN:4</availability>
+				<availability>FS:2+,LA:2+,FWL:2+,CC:2+,CLAN:8,BAN:5</availability>
 			</model>
+            <model name='GRF-2N2'>
+                <availability>BAN:3-</availability>
+            </model>
 		</chassis>
 		<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 			<availability>IS:5,MERC:5,Periphery:3</availability>
@@ -3062,12 +3068,12 @@
 			</model>
 		</chassis>
 		<chassis name='Hellhound (Conjurer)' unitType='Mek'>
-			<availability>CHH:6,CIH:6,CDS:4,CLAN:7,CNC:6,CJF:6</availability>
+			<availability>CCO!Keshik:3!Front Line:1,CJF!Keshik:4!Front Line:2!Second Line:1,CSJ!Keshik:3!Front Line:1,CW!Keshik:5!Front Line:1</availability>
 			<model name=''>
-				<availability>CHH:8,General:8,CJF:8</availability>
+				<availability>CCO:8,CJF:5,CW:5</availability>
 			</model>
 			<model name='7'>
-				<availability>CW:4,CLAN:4</availability>
+				<availability>CJF:8,CSJ:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hermes II' unitType='Mek'>
@@ -3123,17 +3129,17 @@
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
-			<availability>CC:2,MOC:1,CHH:4,OA:1,LA:2,CLAN:3,FWL:2,FS:2,CGS:5,DC:2,TC:2</availability>
+			<availability>FS:2,LA:2,DC:2,FWL:2,CC:2,CBS:4+,CGB:4+,CGS:5+,CHH:5+,CJF:3,CNC!Front Line:3!Second Line:2!Solahma:1,TC:2,MOC:1,OA:1</availability>
 			<model name='HOP-4Bb'>
                 <roles>fire_support</roles>
-				<availability>CLAN:5,BAN:2</availability>
+				<availability>CBS:3,CGB:8,CGS:5,CHH:5,CJF:8,CNC:8</availability>
 			</model>
 			<model name='HOP-4C'>
                 <roles>inf_support</roles>
-				<availability>MOC:8,OA:8,FS:8</availability>
+				<availability>FS:8,CBS:2-,CGS:3-,MOC:8,OA:8</availability>
 			</model>
 			<model name='HOP-4Cb'>
-				<availability>CHH:8,CLAN:2,BAN:2</availability>
+				<availability>CHH:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
@@ -3158,15 +3164,15 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback IIC' unitType='Mek'>
-			<availability>CDS:4,CSR:4,CW:4,CSV:5,CLAN:4,CSJ:5,CJF:4,CGB:4</availability>
+			<availability>CSJ!Keshik:3</availability>
 			<model name=''>
-				<availability>CSR:8,General:8</availability>
+				<availability>CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>CC:6,CLAN:2-,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
+			<availability>IS:5,DC:6,FWL:8,CC:6,CS:5-,CB!Front Line:3!Second Line:2!Solahma:1,CCO!Second Line:3!Solahma:2!Provisional Garrison:1,CSJ:4-,Periphery:5,Periphery.MW:6,Periphery.ME:6,NIOPS:5-,Periphery.Deep:5</availability>
 			<model name='HBK-4G'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CB:8,CCO:8,CSJ:8,Periphery:8,NIOPS:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='HBK-4H'>
 				<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
@@ -3504,15 +3510,15 @@
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
-			<availability>CS:7,CHH:7,CDS:7,CSV:7,CLAN:6,FWL:2,NIOPS:7,FS:6,MERC:2,DC:2</availability>
+			<availability>FS:6,DC:2,FWL:2,MERC:2,CS:7,CLAN:4-,CBS:4,CCO:4,CBG:4,CGS:3,CJF:4,CSR:3-,CSV:3-,NIOPS:7,BAN:3+</availability>
 			<model name='KTO-18'>
 				<availability>FS:4</availability>
 			</model>
 			<model name='KTO-19'>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
+				<availability>CS:8,CLAN:3-,CBS:4-,CB:4-,CCC:4-,CIH:4-,CSA:4-,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='KTO-19b'>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CLAN:5,BAN:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Kiso' unitType='Mek'>
@@ -3576,7 +3582,7 @@
 			</model>
 		</chassis>
 		<chassis name='Kyudo' unitType='Mek'>
-			<availability>FWL:2+,FS:2+</availability>
+			<availability>FS:2+,FWL:2+,CBS:2+,CMG!Front Line:2!Second Line:1,CDS!Front Line:2!Second Line:1</availability>
 			<model name='KY2-D-02'>
 				<roles>fire_support</roles>
 				<availability>IS:8</availability>
@@ -3843,10 +3849,10 @@
 			</model>
 		</chassis>
 		<chassis name='Lynx' unitType='Mek'>
-			<availability>CIH:6,LA:2,CLAN:4,FWL:2,CSJ:6,CJF:4,DC:2</availability>
+			<availability>LA:2,DC:2,FWL:2,CLAN!Front Line:3!Second Line:2!Solahma:1,CBS:4+,CB:5+,CCC:4+,CCO:5+,CGS:4+,CIH:4+,CJF:5+,CMG:4+,CNC:3+,CSJ:5+,CSR:4+,CSV:5+,CW:5+,BAN:2+</availability>
 			<model name='C'>
                 <roles>raider</roles>
-				<availability>CCC:5,CW:5,CNC:5,CSJ:6,CJF:5,CGS:5</availability>
+				<availability>CCC!Keshik:8,CGS!Keshik:3!Front Line:1,CJF:3+,CNC:1+,CSJ!Keshik:3!Front Line:1,CW:3+</availability>
 			</model>
 			<model name='LNX-8Q'>
                 <roles>raider</roles>
@@ -3854,7 +3860,7 @@
 			</model>
 			<model name='LNX-9Q'>
                 <roles>raider</roles>
-				<availability>CLAN:8,IS:4+</availability>
+				<availability>IS:4+,CLAN:8,CCC!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CGS:4-,CJF:4-,CW:4-,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -4444,13 +4450,10 @@
 			</model>
 		</chassis>
 		<chassis name='Naja' unitType='Mek'>
-			<availability>CCC:6,CBS:5,CSV:5,CLAN:4,CMG:5</availability>
+			<availability>CLAN!Front Line:1,CBS!Keshik:1!Front Line:1,CCC:2+,CFM:1+,BAN:0</availability>
             <model name=''>
-                <availability>CCC:8,CLAN:6</availability>
+                <availability>CLAN:8</availability>
             </model>
-			<model name='KTO-19b-EC'>
-				<availability>CCC:4,CBS:4,CSV:4,CMG:4</availability>
-			</model>
 		</chassis>
 		<chassis name='Narukami Destroyer' unitType='Warship'>
 			<availability>DC:1</availability>
@@ -4741,14 +4744,18 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:7,CLAN:3,IS:9,FWL:9,NIOPS:7,Periphery.Deep:5,Periphery:5,CGB:3</availability>
-			<model name='PXH-1'>
+			<availability>IS:9,CS:7,CLAN:4+,CB:3+,CCO!Front Line:3!Second Line:2!Solahma:1,CGB:3+,CGS:6+,CIH:5+,Periphery:5,NIOPS:7,Periphery.Deep:5,BAN:4</availability>
+            <model name='C'>
+                <roles>recon</roles>
+                <availability>CGS!Keshik:5!Front Line:1,CIH!Keshik:8!Front Line:3,CJF!Keshik:5!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='PXH-1'>
 				<roles>command,recon</roles>
-				<availability>General:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,BAN:5-</availability>
 			</model>
 			<model name='PXH-1-EC'>
                 <roles>command,recon</roles>
-				<availability>CGS:4</availability>
+				<availability>CGS!Front Line:3!Second Line:1</availability>
 			</model>
 			<model name='PXH-1D'>
 				<roles>command,recon</roles>
@@ -4760,15 +4767,15 @@
 			</model>
 			<model name='PXH-1b &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:7,BAN:3</availability>
+				<availability>CLAN:8,CGS:4,CIH:5-,BAN:3</availability>
 			</model>
 			<model name='PXH-1c &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:4,CGS:6</availability>
+				<availability>CGS:3+</availability>
 			</model>
 			<model name='PXH-2'>
 				<roles>command,recon</roles>
-				<availability>CC:1+,MOC:1+,OA:1+,CLAN:3,FWL:1+,BAN:4</availability>
+				<availability>FWL:1+,CC:1+,MOC:1+,OA:1+,BAN:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
@@ -5141,7 +5148,7 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion Light Tank' unitType='Tank'>
-			<availability>CC:8,LA:8,FWL:8,IS:8,Periphery.Deep:8,FS:8,DC:8,Periphery:8</availability>
+			<availability>IS:8,FS:8,LA:8,DC:8,FWL:8,CC:8,Periphery:8,Periphery.Deep:8</availability>
 			<model name=''>
 				<availability>General:8</availability>
 			</model>
@@ -5157,9 +5164,9 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>CC:4-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:4-,BAN:2-</availability>
+			<availability>LA:4-,DC:4-,FWL:4-,CC:4-,MERC:4-,CS:3-,Periphery:4-,NIOPS:3-,Periphery.Deep:4-</availability>
 			<model name='SCP-1N'>
-				<availability>LA:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Scout JumpShip' unitType='Jumpship'>
@@ -5183,7 +5190,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>CC:1-,CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
+			<availability>FS:1-,LA:4-,DC:2,FWL:1-,CC:1-,CS:4,CLAN:4-,CBS:5-,CFM:5-,CIH!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,CNC:5-,CDS:2,CSR:5-,CW:5-,NIOPS:4,BAN:2</availability>
 			<model name='STN-3K'>
 				<availability>LA:8,DC:8</availability>
 			</model>
@@ -5194,10 +5201,10 @@
 				<availability>LA:4</availability>
 			</model>
 			<model name='STN-3L'>
-				<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
+				<availability>FS:1+,LA:1+,FWL:1+,MERC:1+,CS:8,CLAN:8,CBS:4-,CCC:4,CFM:3,CGB:4-,CHH:4-,CJF:3-,CDS:4-,CSR:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='STN-3Lb'>
-				<availability>CLAN:6,BAN:3</availability>
+				<availability>CBS:4+,CCC:4+,CFM:4+,CGB:4+,CHH:4+,CJF:4+,CDS:4+,CSR:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
@@ -5216,27 +5223,27 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>CLAN:6,BAN:3+</availability>
+			<availability>CLAN!Keshik:3!Front Line:1,CCC:3+,CCO:2+,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:4!Front Line:3!Second Line:1,CIH:2+,CMG:2+,CNC:2+,CDS:2+,CSJ:2+,CSV:3+,CW!Keshik:4!Front Line:3!Second Line:1,BAN:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CLAN:8,CGB:5,BAN:8</availability>
 			</model>
 			<model name='2'>
-				<availability>CGB:6</availability>
+				<availability>CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5</availability>
+			<availability>IS:7,LA:6,CS:6-,CLAN:5,CIH:4,Periphery:5,NIOPS:6-,Periphery.Deep:5,BAN:5</availability>
             <model name='C'>
-                <availability>CSA:6,CCC:6,CSV:6,CFM:6,CGS:6</availability>
+                <availability>CLAN!Keshik:6!Front Line:3!Second Line:1,CBS!Keshik:5!Second Line:1,CB!Keshik:6!Front Line:3,CCC!Keshik:5!Front Line:1,CCO!Keshik:8!Front Line:1,CFM!Keshik:8!Front Line:3!Second Line:1,CGB!Keshik:8!Front Line:3!Second Line:1,CGS!Keshik:5!Front Line:3!Second Line:1,CIH!Keshik:8!Front Line:1,BAN!Keshik:3!Front Line:1</availability>
             </model>
 			<model name='SHD-2D'>
 				<availability>FS:10</availability>
 			</model>
 			<model name='SHD-2H'>
-				<availability>General:8,CLAN:5-,Periphery.Deep:8,BAN:7,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8,BAN:2</availability>
 			</model>
 			<model name='SHD-2Hb'>
-				<availability>CLAN:6,FS:2+,BAN:4</availability>
+				<availability>FS:2+,CLAN:4-,CBS:8,CB:7,CCC:7,CGS:8,BAN:3+</availability>
 			</model>
 			<model name='SHD-2K'>
 				<availability>DC:9</availability>
@@ -5452,14 +5459,14 @@
 			</model>
 		</chassis>
 		<chassis name='Starslayer' unitType='Mek'>
-			<availability>CSA:2,LA:3+,CNC:2</availability>
+			<availability>LA:3+,CNC!Second Line:1,CSA!Front Line:3!Second Line:2!Solahma:1</availability>
 			<model name='STY-2C'>
 				<roles>raider</roles>
-				<availability>IS:8</availability>
+				<availability>LA:8</availability>
 			</model>
 			<model name='STY-2C-EC'>
                 <roles>raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CNC:8,CSA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stinger LAM Mk I' unitType='Mek'>
@@ -5804,10 +5811,10 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
+			<availability>FWL:8,CC:5,MERC:5,CS:5-,CDS!Front Line:2!Second Line:1,MOC:5,NIOPS:5-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
-				<availability>CC:1+,CS:6,FWL:1+,NIOPS:6</availability>
+				<availability>FWL:1+,CC:1+,CS:6,CDS:8,NIOPS:6</availability>
 			</model>
 			<model name='TBT-5J'>
 				<availability>FWL:4</availability>
@@ -6014,20 +6021,20 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='AeroSpaceFighter'>
-			<availability>MOC:3,OA:3,MERC:5,Periphery:3,TC:4</availability>
+			<availability>MERC:5,Periphery:3,TC:4,MOC:3,OA:3</availability>
 			<model name='VLC-5N'>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:4,CS:3,MOC:5,LA:7,CLAN:2-,FWL:7,IS:5,NIOPS:3,CIR:5,TC:5</availability>
+			<availability>IS:5,LA:7,FWL:7,CC:4,CS:3,TC:5,MOC:5,CIR:5,NIOPS:3</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
-				<availability>General:8,FS:4</availability>
+				<availability>IS:8,FS:4,Periphery:8</availability>
 			</model>
 			<model name='VL-5T'>
 				<roles>anti_infantry</roles>
-				<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,TC:2</availability>
+				<availability>IS:2,FS:6,TC:2,MOC:2,CIR:2,PIR:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Vulture' unitType='Dropship'>
@@ -6153,13 +6160,13 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:2-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+			<availability>FS.CMM:5,DC:6,MERC:3,CS:3-,Periphery.DD:2,Periphery.OS:2,TC:2,MOC:1,OA:1,NIOPS:3-</availability>
 			<model name='WTH-0'>
 				<availability>TC:6</availability>
 			</model>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
-				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='WTH-1S'>
 				<roles>fire_support</roles>
@@ -6167,7 +6174,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CS:5-,LA:7,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,TC:5</availability>
+			<availability>IS:7,FS:8,LA:7,FWL:10,CS:5-,NIOPS:5-,TC:5,Periphery.Deep:6</availability>
 			<model name='WVR-1R'>
 				<availability>FS:2-</availability>
 			</model>
@@ -6184,25 +6191,25 @@
 			</model>
 			<model name='WVR-6R'>
 				<roles>command,recon</roles>
-				<availability>General:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Wyvern IIC' unitType='Mek'>
-			<availability>CHH:4,CW:4,CLAN:4</availability>
+			<availability>CB:2+,CCC!Front Line:1!Second Line:1</availability>
 			<model name=''>
 				<roles>urban</roles>
-				<availability>CW:8,CLAN:8</availability>
+				<availability>CB:8,CCC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CS:6,CC:6,CIH:4,CLAN:5,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:4</availability>
+			<availability>FS:6,DC:6,CC:6,MERC:5,CS:6,CLAN:3,CBS:4,CB:4,CFM:4,CIH:2-,CMG:4-,CNC:4,CSJ:2,TC:4,NIOPS:6,BAN:3</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
-				<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
+				<availability>CS:8,CBS:3-,CB:3-,CCO:3-,CFM:2-,NIOPS:8,TC:8,BAN:5-</availability>
 			</model>
 			<model name='WVE-5Nb'>
 				<roles>urban</roles>
-				<availability>CLAN:6,CFM:6,CGS:6</availability>
+				<availability>CLAN:8,CBS:6,CB:6,CCO:6,CFM:6,BAN:3+</availability>
 			</model>
 			<model name='WVE-5Nsl'>
 				<availability>LA:2+,FWL:2+</availability>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -1094,7 +1094,7 @@
 			</model>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
-				<availability>IS:8,CC:8,MERC:8,CDS:8,Periphery:8,Periphery.Deep:8,BAN:6</availability>
+				<availability>IS:8,CC:8,MERC:8,CDS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='CPLT-C1b'>
 				<roles>fire_support</roles>
@@ -2002,7 +2002,7 @@
 		<chassis name='Crusader' unitType='Mek'>
 			<availability>IS:8,CS:6-,CLAN:2,CBS:3,CB:3,CCC:3,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:4</availability>
 			<model name='CRD-2R'>
-				<availability>IS:2+,CLAN:8,Periphery:2+,BAN:2+</availability>
+				<availability>IS:2+,CLAN:8,Periphery:2+,NIOPS:5,BAN:2+</availability>
 			</model>
 			<model name='CRD-3D'>
 				<availability>FS:5</availability>
@@ -3023,6 +3023,14 @@
                 <roles>cargo,civilian</roles>
                 <deployedWith>req:Hector Road Train Tractor</deployedWith>
                 <availability>CLAN:3,BAN:3,IS:3,FWL:3</availability>
+            </model>
+        </chassis>
+        <chassis name='Helepolis' unitType='Mek'>
+            <availability>CHH:1-</availability>
+            <model name='HEP-3H'>
+                <roles>mixed_artillery</roles>
+                <deployedWith>Helepolis</deployedWith>
+                <availability>CHH:8</availability>
             </model>
         </chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
@@ -6077,7 +6085,7 @@
 				<availability>IS:8,CCC:1-,CFM:1-,CHH:1-,CMG:1,CNC:1-,CSJ:1-,Periphery:8,Periphery.Deep:8,BAN:6-</availability>
 			</model>
 			<model name='WHM-6Rb'>
-				<availability>FS:2+,LA:2+,CC:2+,FWL:2+,CLAN:3-,CBS:4-,CCC:4-,CCO:4-,CFM:4-,CGB:4-,CIH:4-,CMG:4-,CSR:4-,BAN:5</availability>
+				<availability>FS:2+,LA:2+,FWL:2+,CC:2+,CLAN:3-,CBS:4-,CCC:4-,CCO:4-,CFM:4-,CGB:4-,CIH:4-,CMG:4-,CSR:4-,BAN:5</availability>
 			</model>
 			<model name='WHM-6Rk'>
                 <roles>cavalry</roles>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -3930,7 +3930,7 @@
 		<chassis name='Marauder IIC' unitType='Mek'>
 			<availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS:2+,CB!Keshik:4!Front Line:1,CCO:3+,CGB:3+,CIH!Keshik:5!Front Line:2!Second Line:1,CJF:3+,CNC:3+,CSJ:3+,CSR:3+,CSA:2+,CSV:3+,CW!Keshik:5!Front Line:2,BAN:1+</availability>
 			<model name=''>
-				<availability>CLAN:8,CJF:4,CW:4</availability>
+				<availability>CLAN:8,CJF:4,CW:4,BAN:8</availability>
 			</model>
 			<model name='9'>
 				<availability>CJF:8,CW:8</availability>

--- a/megamek/data/forcegenerator/2855.xml
+++ b/megamek/data/forcegenerator/2855.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2855-->
-<ratgen>
+<ratgen
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -584,18 +584,21 @@
 			</model>
 		</chassis>
 		<chassis name='Annihilator' unitType='Mek'>
-			<availability>CSA:3,CHH:2,CSR:3,CLAN:2,CCO:3,BAN:1,CGB:2</availability>
+			<availability>CB!Front Line:3!Second Line:2!Solahma:1,CCO:3+,CGB:3+,CSA:3+</availability>
 			<model name='ANH-1G'>
-				<availability>CSA:4,CCO:4,BAN:1</availability>
+				<availability>CCO!Front Line:2!Second Line:1,CGB!Front Line:2!Second Line:1,CSA!Front Line:2!Second Line:1</availability>
 			</model>
 			<model name='ANH-1X'>
-				<availability>CLAN:3,BAN:4</availability>
+				<availability>CB:8,CCO:3-,CGB:3-,CSA:3-</availability>
 			</model>
 			<model name='C'>
-				<availability>CLAN:8,BAN:2</availability>
+				<availability>CCO!Keshik:5!Front Line:1,CGB!Keshik:5!Front Line:1,CSA!Keshik:5!Front Line:1</availability>
 			</model>
+            <model name='C &apos;Gausszilla&apos;'>
+                <availability>CCO:1+,CGB:1+,CSA:1+</availability>
+            </model>
 			<model name='C 2'>
-				<availability>CLAN:6,BAN:1</availability>
+				<availability>CCO!Keshik:3!Front Line:1,CGB!Keshik:3!Front Line:1,CSA!Keshik:3!Front Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Aquarius Escort' unitType='Small Craft'>
@@ -736,37 +739,37 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas II' unitType='Mek'>
-			<availability>CLAN:4</availability>
+			<availability>CLAN!Front Line:2!Second Line:1,CBS:2+,CCC!Front Line:1,CIH!Front Line:1,CMG!Front Line:1,CSA!Front Line:1,BAN:0</availability>
 			<model name='AS7-D-H'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CLAN:5</availability>
 			</model>
 			<model name='AS7-D-H2'>
                 <roles>command</roles>
-				<availability>CLAN:4</availability>
+				<availability>CLAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
+			<availability>IS:3,FS:5,LA:4,DC:5,CS:4-,CLAN:4,CCC:3,CGS:3,CIH:2,CMG:3,CDS:3,CSV:3,TC:1,MOC:1,OA:1,NIOPS:4-,BAN:4-</availability>
 			<model name='AS7-D'>
                 <roles>command</roles>
-				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CLAN:3-,CBS:4-,Periphery:8,Periphery.Deep:8,BAN:5-</availability>
 			</model>
 			<model name='AS7-D-DC'>
 				<roles>command</roles>
-				<availability>IS:1,MERC:0,DC:2</availability>
+				<availability>IS:1+,DC:2+,MERC:0,BAN!Front Line:1</availability>
 			</model>
 			<model name='C'>
                 <roles>command</roles>
-				<availability>CW:2+,CSV:2+,CSJ:2+,CB:2+</availability>
+				<availability>CB!Front Line:5!Second Line:1,CSJ!Front Line:5!Second Line:1,CSV!Front Line:5!Second Line:1,CW!Front Line:5!Second Line:1,BAN:3+</availability>
 			</model>
 			<model name='C 2'>
                 <roles>command</roles>
-				<availability>CLAN:2+</availability>
+				<availability>CLAN!Keshik:5!Front Line:3,CBS!Keshik:5!Front Line:1,BAN:2+</availability>
 			</model>
 			<model name='C 3'>
 				<roles>mixed_artillery</roles>
-				<availability>CLAN:2+</availability>
+				<availability>CLAN!Front Line:1,CBS:1+,BAN:0</availability>
 			</model>
 		</chassis>
 		<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
@@ -784,9 +787,9 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,CLAN:3-,IS:7,Periphery.Deep:6,CIR:8,TC:8,Periphery:6,CS:8,OA:8,FWL:10,NIOPS:8</availability>
+			<availability>IS:7,FWL:10,CS:8,Periphery:6,TC:8,MOC:8,OA:8,CIR:8,NIOPS:8,Periphery.Deep:6+,BAN:2</availability>
 			<model name='AWS-8Q'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
 			<model name='AWS-8R'>
 				<availability>CS:2,FWL:4</availability>
@@ -825,10 +828,10 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:6,MOC:6,CLAN:3,IS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,DC:6</availability>
+			<availability>IS:5,LA:7,DC:6,FWL:8,CC:6,CS:8-,CLAN:5-,CFM:5,CGS:5,CIH!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,CMG!Keshik:2!Front Line:3!Second Line:4!Solahma:5!Provisional Garrison:5,CSJ:4-,CW:6-,TC:6,MOC:6,NIOPS:8-,BAN:4,PIR:6</availability>
 			<model name='BLR-1G'>
                 <roles>command</roles>
-				<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
+				<availability>IS:8,FS:6,Periphery:8,Periphery.Deep:8,BAN:5,PIR:8</availability>
 			</model>
 			<model name='BLR-1G-DC'>
 				<roles>command</roles>
@@ -836,15 +839,15 @@
 			</model>
 			<model name='BLR-1Gb'>
                 <roles>command</roles>
-				<availability>CC:1+,CLAN:8,BAN:4</availability>
+				<availability>CC:1+,CLAN:8,BAN:6+</availability>
 			</model>
 			<model name='BLR-1Gbc'>
                 <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>CLAN!Second Line:1,CCO:0,CFM:0,CIH:0,CSJ:0,CSA!Front Line:1,CSV:0,BAN:0</availability>
 			</model>
 			<model name='BLR-1Gc'>
                 <roles>command</roles>
-				<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,DC:1+</availability>
+				<availability>FS:1+,LA:1+,DC:1+,FWL:1+,CC:1+,BAN:1+</availability>
 			</model>
 			<model name='BLR-1Gd'>
                 <roles>command</roles>
@@ -866,15 +869,15 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
-			<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
+			<availability>CSJ:2+</availability>
 			<model name=''>
-				<availability>CSR:8,General:8</availability>
+				<availability>CSJ:3+</availability>
 			</model>
 			<model name='4'>
-				<availability>General:4</availability>
+				<availability>CSJ:5-</availability>
 			</model>
 			<model name='5'>
-				<availability>General:4</availability>
+				<availability>CSJ:4-</availability>
 			</model>
 		</chassis>
 		<chassis name='Behemoth' unitType='Dropship'>
@@ -1900,15 +1903,15 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>CC:3,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:3,CGS:8,CS:8,CDS:8,CW:10,LA:3,CBS:10,FWL:3,NIOPS:8,CJF:8,CGB:10,DC:3</availability>
+			<availability>FS:3,LA:3,DC:3,FWL:3,CC:3,CS:8,CLAN:3-,CBS:5-,CGS:4-,NIOPS:8,BAN:4-</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:8,NIOPS:0</availability>
 			</model>
 			<model name='CRK-5003-1'>
-				<availability>CS:8,General:3+,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>IS:3+,CS:8,CLAN:8,CBS:4-,CB:4-,CCO:4-,CGB:4-,CHH:4-,CW:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='CRK-5003-1b'>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CBS:5,CB:5,CCO:5,CGB:5,CHH:5,CW:5,BAN:3+</availability>
 			</model>
 		</chassis>
         <chassis name='Crosscut' unitType='Mek'>
@@ -1957,7 +1960,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,CS:3,OA:2,LA:5,CLAN:4,IS:3,FWL:4,NIOPS:3,FS:5,TC:2,DC:5</availability>
+			<availability>IS:3,FS:5,LA:5,DC:5,FWL:4,CC:5,CS:3,TC:2,OA:2,NIOPS:3</availability>
 			<model name='CP-10-HQ'>
                 <roles>command</roles>
 				<availability>IS:2</availability>
@@ -1966,7 +1969,7 @@
 				<availability>IS:3</availability>
 			</model>
 			<model name='CP-10-Z'>
-				<availability>OA:8,IS:8,MERC:8,TC:8</availability>
+				<availability>IS:8,MERC:8,TC:8,OA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
@@ -2070,6 +2073,12 @@
 				<availability>FS:3+</availability>
 			</model>
 		</chassis>
+        <chassis name='Devastator' unitType='Mek'>
+            <availability>CSJ!Front Line:2!Second Line:1</availability>
+            <model name='DVS-2-EC'>
+                <availability>CSJ:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Dictator' unitType='Dropship'>
 			<availability>IS:3</availability>
 			<model name=''>
@@ -2151,17 +2160,18 @@
             </model>
         </chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>MOC:2,CC:3,CS:7,OA:3,CLAN:2,FWL:4,NIOPS:7,FS:3,MERC:3,TC:3</availability>
+			<availability>FS:3,FWL:4,CC:3,MERC:3,CS:7,CLAN!Front Line:2!Second Line:1,CBS:3+,CGS:3+,CIH:3+,CMG:3+,CSA:2+,TC:3,MOC:2,OA:3,NIOPS:7,BAN:0</availability>
 			<model name='EMP-5A'>
                 <roles>command</roles>
-				<availability>General:8,BAN:2</availability>
+				<availability>IS:8,Periphery:8,NIOPS:1-</availability>
 			</model>
 			<model name='EMP-6A'>
                 <roles>command</roles>
-				<availability>CC:2+,CS:8,LA:2+,CLAN:8,NIOPS:8,FWL:2+,FS:2+,BAN:6</availability>
+				<availability>FS:2+,LA:2+,FWL:2+,CC:2+,CS:8,CLAN:8,CSA:4-,NIOPS:8</availability>
 			</model>
 			<model name='EMP-6A-EC'>
-				<availability>CSA:4</availability>
+                <roles>command</roles>
+				<availability>CSA:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Enfield' unitType='Mek'>
@@ -3019,21 +3029,21 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander IIC' unitType='Mek'>
-			<availability>CLAN:5</availability>
+			<availability>CBS:1+,CCC:2+,CCO:2+,CFM:1+,CDS:2+,CSR:1+</availability>
 			<model name=''>
                 <roles>command</roles>
-				<availability>CLAN:8</availability>
+				<availability>CBS:8,CCC:8,CCO:8,CFM:8,CDS:8,CSR:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>CS:9,CLAN:9,NIOPS:9,IS:2,CFM:10,MERC:2,CJF:10</availability>
+			<availability>IS:2,MERC:2,CS:9,CLAN:4+,CCC:3+,CIH:3+,CSV:3+,NIOPS:9+,BAN:2+</availability>
 			<model name='HGN-732'>
                 <roles>command</roles>
-				<availability>CS:8,CLAN:6,FWL:3+,IS:8,NIOPS:8,BAN:8</availability>
+				<availability>IS:8,FWL:3+,CS:8,CLAN:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='HGN-732b'>
                 <roles>command</roles>
-				<availability>CLAN:7,FWL:2+,BAN:4</availability>
+				<availability>FWL:2+,CLAN:6,BAN:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
@@ -3136,22 +3146,22 @@
 			</model>
 		</chassis>
 		<chassis name='Imp' unitType='Mek'>
-			<availability>CSA:2,CW:2,CLAN:2</availability>
+			<availability>CB!Keshik:1!Front Line:2!Second Line:1,CCO!Keshik:1!Front Line:3!Second Line:1,CGB!Front Line:3!Second Line:1,CSJ!Keshik:1!Front Line:3!Second Line:1,CW!Keshik:1!Front Line:3!Second Line:1</availability>
 			<model name='C'>
                 <roles>command</roles>
-				<availability>CLAN:5:2863</availability>
+				<availability>CB:1+,CCO!Keshik:3,CGB!Front Line:8,CSJ:1+,CW!Keshik:3</availability>
 			</model>
 			<model name='IMP-1A'>
                 <roles>command</roles>
-				<availability>CLAN:5</availability>
+				<availability>CB:4-,CCO:4-,CGB:3-,CSJ:4-,CW:4-</availability>
 			</model>
 			<model name='IMP-1B'>
                 <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>CB!Front Line:6!Second Line:6,CCO!Front Line:6!Second Line:1,CGB:6,CSJ!Front Line:6!Second Line:6,CW:6</availability>
 			</model>
 			<model name='IMP-1C'>
                 <roles>command</roles>
-				<availability>CHH:5,CLAN:2</availability>
+				<availability>CB!Front Line:4!Second Line:4,CCO!Keshik:1!Front Line:1,CGB:4,CSJ!Front Line:4!Second Line:4,CW:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Indra Infantry Transport' unitType='Tank'>
@@ -3403,10 +3413,10 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CS:6,CLAN:6,IS:2+,FWL:1+,NIOPS:6,MERC:2+,CGS:7,CGB:7</availability>
+			<availability>IS:2+,FWL:1+,MERC:2+,CS:6,CB:3-,CFM:3-,CGB:3-,CGS:2-,CW:3-,NIOPS:6,BAN:1</availability>
 			<model name='KGC-000'>
                 <roles>command</roles>
-				<availability>CS:8,CIH:5,General:2,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
+				<availability>IS:2,CS:8,NIOPS:8,BAN:5</availability>
 			</model>
 			<model name='KGC-0000'>
                 <roles>command</roles>
@@ -3414,11 +3424,7 @@
 			</model>
 			<model name='KGC-000b'>
                 <roles>command</roles>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
-			</model>
-			<model name='KGC-010'>
-                <roles>command</roles>
-				<availability>CLAN:3</availability>
+				<availability>CB:8,CFM:8,CGB:8,CGS:8,CW:8,BAN:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
@@ -3482,9 +3488,9 @@
 			</model>
 		</chassis>
 		<chassis name='Kraken (Bane)' unitType='Mek'>
-			<availability>CSR:7,CLAN:7,CJF:7</availability>
+			<availability>CJF!Front Line:2!Second Line:1,CDS!Front Line:2!Second Line:1,CSR!Front Line:2!Second Line:1,CW!Front Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CJF:8,CDS:8,CSR:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
@@ -3691,7 +3697,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>CC:6,CDS:3,CSR:3,IS:7,Periphery.Deep:7,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>IS:7,FS:8,DC:5,FWL:9,CC:6,CS:4,Periphery:7,NIOPS:4,Periphery.Deep:7</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>IS:8,Periphery:8</availability>
@@ -3702,11 +3708,11 @@
 			</model>
 			<model name='LGB-7Q'>
 				<roles>fire_support</roles>
-				<availability>MOC:6,OA:6,IS:6,TC:6,CLAN:6</availability>
+				<availability>IS:6,TC:6,MOC:6,OA:6</availability>
 			</model>
 			<model name='LGB-8C'>
                 <roles>fire_support</roles>
-				<availability>MOC:3,CS:6,OA:3,IS:5,MERC:4,TC:2,CLAN:5</availability>
+				<availability>IS:5,MERC:4,CS:6,TC:2,MOC:3,OA:3</availability>
 			</model>
 		</chassis>
         <chassis name='Luciano White Wolverine' unitType='Tank'>
@@ -3823,12 +3829,12 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder IIC' unitType='Mek'>
-			<availability>CSA:7,CSR:6,CW:6,CLAN:6,CNC:6,CJF:6,CGB:7</availability>
+			<availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS:2+,CB!Keshik:4!Front Line:1,CCO:3+,CGB:3+,CHH!Keshik:5!Front Line:3!Second Line:1,CIH!Keshik:5!Front Line:2!Second Line:1,CJF:3+,CNC:3+,CSJ:3+,CSA:2+,CSV:3+,CW!Keshik:5!Front Line:3,BAN!Keshik:1!Front Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8,CJF:8,CGB:8</availability>
+				<availability>CLAN:8,CJF:4,CW:4</availability>
 			</model>
 			<model name='9'>
-				<availability>CSA:4,CSV:4,CLAN:4,CJF:4</availability>
+				<availability>CJF:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
@@ -4392,10 +4398,10 @@
 			</model>
 		</chassis>
 		<chassis name='Nightstar' unitType='Mek'>
-			<availability>CSA:6,CS:4,CLAN:4,NIOPS:4</availability>
+			<availability>CS:4,CCO!Front Line:1,NIOPS:4+</availability>
 			<model name='NSR-9J'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CS:8,CCO:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Odin Scout Tank' unitType='Tank'>
@@ -4621,18 +4627,18 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk IIC' unitType='Mek'>
-			<availability>CSV:4,CLAN:3,CB:2</availability>
+			<availability>CFM:1+,CJF!Keshik:2,CSR:2+,CSV!Keshik:4!Front Line:3!Second Line:1</availability>
 			<model name=''>
                 <roles>cavalry</roles>
-				<availability>CLAN:8</availability>
+				<availability>CFM:8,CJF:8,CSR:8,CSV:8</availability>
 			</model>
 			<model name='2'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CCC:6,CSR:6,CDS:6,CSV:6,CNC:6,CFM:6,CCO:6</availability>
+				<availability>CSR:5,CSV:5</availability>
 			</model>
 			<model name='9'>
-                <roles>cavalry</roles>
-				<availability>CLAN:2</availability>
+			    <roles>cavalry,fire_support</roles>
+				<availability>CSV:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
@@ -4685,7 +4691,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
-			<availability>CLAN:4,CC:5+,CS:5,LA:4+,FWL:4+,NIOPS:5,FS:4+,BAN:0</availability>
+			<availability>FS:4+,LA:4+,FWL:4+,CC:5+,CS:5,CLAN:1+,CBS:2+,CGS:2+,CIH!Front Line:1,CJF:2+,CMG!Front Line:1,CSA!Front Line:1,CSV!Front Line:1,NIOPS:5+,BAN:0</availability>
 			<model name='PLG-3Z'>
 				<availability>IS:8,CLAN:8,NIOPS:8</availability>
 			</model>
@@ -4774,15 +4780,12 @@
 			</model>
 		</chassis>
 		<chassis name='Pulverizer' unitType='Mek'>
-			<availability>CSR:4</availability>
+			<availability>CSR!Second Line:1!Solahma:1</availability>
 			<model name=''>
-				<availability>CSR:8</availability>
-			</model>
-			<model name='PUL-2V'>
-				<availability>General:5</availability>
+				<availability>CSR!Second Line:1</availability>
 			</model>
 			<model name='PUL-3R'>
-				<availability>General:2</availability>
+				<availability>CSR!Solahma:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -4871,10 +4874,10 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman II' unitType='Mek'>
-			<availability>CLAN:4</availability>
+			<availability>CGB!Front Line:2!Second Line:1</availability>
 			<model name='RFL-3N-2'>
 				<roles>anti_aircraft</roles>
-				<availability>General:8</availability>
+				<availability>CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
@@ -5151,12 +5154,12 @@
 			</model>
 		</chassis>
 		<chassis name='Shogun' unitType='Mek'>
-			<availability>CSA:4,CIH:4,CBS:4,CLAN:4,FWL:2+,CCO:4,CB:4</availability>
+			<availability>FWL:2+,CBS:2,CB!Front Line:3!Second Line:2!Solahma:1,CCC!Front Line:2!Second Line:1,CCO!Front Line:3!Second Line:2!Solahma:1,CSA!Front Line:2!Second Line:1</availability>
 			<model name='C'>
-				<availability>CLAN:6</availability>
+				<availability>CBS:2+,CB!Front Line:8,CCC:8,CCO:8,CSA:8</availability>
 			</model>
 			<model name='SHG-2H'>
-				<availability>General:8,CLAN:4-,BAN:7</availability>
+				<availability>FWL:8,CBS:4-,CB:3-</availability>
 			</model>
 		</chassis>
 		<chassis name='Sholagar' unitType='AeroSpaceFighter'>
@@ -5281,15 +5284,19 @@
 			</model>
 		</chassis>
 		<chassis name='Spartan' unitType='Mek'>
-			<availability>CS:5,CHH:3,CFM:4,CCO:3</availability>
+			<availability>CS:5,CFM!Front Line:3,CIH:5+,BAN:4+</availability>
 			<model name='C'>
                 <roles>cavalry</roles>
-				<availability>CLAN:8</availability>
+				<availability>CFM:8</availability>
 			</model>
 			<model name='SPT-N2'>
 				<roles>cavalry,spotter</roles>
-				<availability>IS:8</availability>
+				<availability>CS:8,BAN:3-</availability>
 			</model>
+            <model name='SPT-NF'>
+                <roles>cavalry</roles>
+                <availability>CIH:8,BAN:5</availability>
+            </model>
 		</chassis>
 		<chassis name='Spector' unitType='Mek'>
 			<availability>CMG:1+</availability>
@@ -5313,15 +5320,15 @@
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,Periphery:10,CS:6,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>IS:9,FS:7,DC:7,FWL:10,CC:7,CS:6,CLAN:5-,CBS:6-,CCC:4-,CIH:4-,CMG:4-,CSR:4-,Periphery:10,NIOPS:6,Periphery.Deep:10,BAN:3</availability>
 			<model name='STK-3F'>
-				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CBS:1-,Periphery:8,Periphery.Deep:8,BAN:5</availability>
 			</model>
 			<model name='STK-3Fb'>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,BAN:3+</availability>
 			</model>
 			<model name='STK-3H'>
-				<availability>MOC:2,OA:2,IS:2,TC:2</availability>
+				<availability>IS:2,TC:2,MOC:2,OA:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -5400,15 +5407,18 @@
 			</model>
 		</chassis>
 		<chassis name='Storm Giant' unitType='Mek'>
-			<availability>CSV:4</availability>
+			<availability>CSV!Keshik:3</availability>
+            <model name=''>
+                <availability>CSV:8</availability>
+            </model>
 			<model name='2'>
-				<availability>General:4</availability>
+				<availability>CSV:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Striker' unitType='Mek'>
-			<availability>MOC:5,CC:8,CS:4,OA:5,LA:8,PIR:3,NIOPS:4,MERC:5,FS:5,TC:5,DC:5</availability>
+			<availability>FS:5,LA:8,DC:5,CC:8,MERC:5,CS:4,TC:5,MOC:5,OA:5,NIOPS:4,PIR:3</availability>
 			<model name='STC-2C'>
-				<availability>CC:8,General:8</availability>
+				<availability>IS:8,Periphery:8,PIR:8</availability>
 			</model>
 			<model name='STC-2S'>
 				<availability>LA:5</availability>
@@ -5427,9 +5437,9 @@
 			</model>
 		</chassis>
 		<chassis name='Supernova' unitType='Mek'>
-			<availability>CSA:2,CCC:4,CDS:2,CW:4,CNC:7,CGB:3</availability>
+			<availability>CNC:3+,CDS!Keshik:3!Front Line:1,CSJ:2+</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CNC:8,CDS:8,CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Svantovit Infantry Fighting Vehicle' unitType='Tank'>
@@ -5528,15 +5538,15 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,TC:2+,CS:7,CDS:7,CW:9,CBS:7,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>IS:3,FWL:5,CS:7,CLAN!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,CBS:5,CIH!Keshik:2!Front Line:3!Second Line:4!Solahma:4!Provisional Garrison:4,CSV!Keshik:2!Front Line:3!Second Line:4!Solahma:4!Provisional Garrison:4,TC:2+,NIOPS:7,BAN:4+</availability>
 			<model name='THG-10E'>
 				<availability>FWL:6,DC:6</availability>
 			</model>
 			<model name='THG-11E'>
-				<availability>CS:8,CLAN:6,FWL:2+,IS:2+,NIOPS:8,FS:2+,BAN:8,DC:2+,TC:8</availability>
+				<availability>IS:2+,CS:8,CLAN:4-,TC:8,NIOPS:8,BAN:5</availability>
 			</model>
 			<model name='THG-11Eb'>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CLAN:6,BAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -5547,19 +5557,16 @@
 			</model>
 		</chassis>
 		<chassis name='Thunder Hawk' unitType='Mek'>
-			<availability>CS:2,LA:2+,CLAN:4,NIOPS:2,DC:2+</availability>
+			<availability>LA:2+,DC:2+,CS:2,CB!Front Line:1,NIOPS:2+</availability>
 			<model name='TDK-7X'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,DC:8,CS:8,CB:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thunder Stallion' unitType='Mek'>
-			<availability>CHH:5</availability>
+			<availability>CHH:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='2 &apos;Fire Stallion&apos;'>
-				<availability>CHH:6,CGS:6</availability>
+				<availability>CHH:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
@@ -5824,15 +5831,18 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:5,CC:6,CLAN:2-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,DC:5</availability>
-			<model name='VTR-9A'>
-				<availability>CC:2,CS:2,IS:1,FS:2</availability>
+			<availability>IS:4,FS:9,LA:5,DC:5,FWL:5,CC:6,CS:5-,CBS!Second Line:1,CB!Second Line:1,CCO!Second Line:1!Provisional Garrison:1,CGB!Second Line:1,CJF!Second Line:1,CNC!Second Line:1,CSJ!Front Line:1,CW!Second Line:1,Periphery:4,Periphery.OS:5,Periphery.HR:5,TC:5,MOC:5,OA:5,CIR:5,NIOPS:5-,Periphery.Deep:4+</availability>
+            <model name='C'>
+                <availability>CBS:8,CB:8,CCO!Second Line:8,CGB:8,CJF:8,CNC:8,CSJ:8,CW:8</availability>
+            </model>
+            <model name='VTR-9A'>
+				<availability>IS:1,FS:2,CC:2,CS:2</availability>
 			</model>
 			<model name='VTR-9A1'>
-				<availability>CC:2,CS:2,IS:1,FS:2</availability>
+				<availability>IS:1,FS:2,CC:2,CS:2</availability>
 			</model>
 			<model name='VTR-9B'>
-				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CCO:1-,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
@@ -5912,15 +5922,15 @@
 			</model>
 		</chassis>
 		<chassis name='Wakazashi' unitType='Mek'>
-			<availability>CJF:6</availability>
+			<availability>CJF!Keshik:2!Front Line:2!Second Line:1</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CJF:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Warhammer IIC' unitType='Mek'>
-			<availability>CLAN:6</availability>
+			<availability>CGB!Keshik:5!Front Line:3!Second Line:1,CSA!Keshik:4!Front Line:3!Second Line:1,BAN:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CSA:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -606,23 +606,27 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CS:5-,LA:9,CLAN:1,IS:7,Periphery.Deep:6,FWL:9,NIOPS:5-,FS:8,Periphery:6,DC:8</availability>
+			<availability>IS:7,FS:8,LA:9,DC:8,FWL:9,CS:5-,CLAN!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CBS:4,CB:4,CCC:4,CFM!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CGS!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CHH:4,CIH:4-,CMG:3,CSJ:4,CSA:4,CSV:3,Periphery:6,NIOPS:5-,Periphery.Deep:6,BAN:4</availability>
 			<model name='ARC-2K'>
 				<roles>command,fire_support</roles>
 				<availability>DC:8</availability>
 			</model>
 			<model name='ARC-2R'>
 				<roles>command,fire_support</roles>
-				<availability>LA:7,CLAN:3,IS:8,Periphery.Deep:8,BAN:6,DC:6,Periphery:8</availability>
+				<availability>IS:8,LA:7,DC:6,Periphery:8,NIOPS:4-,Periphery.Deep:8,BAN:8</availability>
 			</model>
 			<model name='ARC-2Rb'>
 				<roles>command,fire_support</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:4-,CB:3-,BAN:2+</availability>
 			</model>
 			<model name='ARC-2S'>
 				<roles>command,fire_support</roles>
 				<availability>LA:6</availability>
 			</model>
+            <model name='C'>
+                <roles>command,fire_support</roles>
+                <availability>CLAN:3+,CBS:1+,CB:2+,CFM!Front Line:3!Second Line:1,CGS!Front Line:3!Second Line:1,CJF!Front Line:3!Second Line:1,CDS!Front Line:3!Second Line:1,CSJ:2+,CSR!Front Line:3!Second Line:1,CW!Front Line:3!Second Line:1,BAN:0</availability>
+            </model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
 			<availability>MOC:8,OA:8,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8,BAN:3</availability>
@@ -881,18 +885,18 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:2,MERC:2,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:2</availability>
+			<availability>FS:2,LA:2,DC:2,FWL:4,MERC:2,CS:7,CLAN:3+,CCC!Front Line:2!Second Line:1,CGS:4+,CIH:2+,NIOPS:7,BAN:2+</availability>
 			<model name='BL-6-KNT'>
                 <roles>command</roles>
-				<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
+				<availability>FS:2+,FWL:2+,CS:8,CLAN:8,CBS:6-,CCO:4-,CGB:4-,CGS:5-,CNC:4-,CW:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='BL-6b-KNT'>
                 <roles>command</roles>
-				<availability>CS:4,CLAN:7,NIOPS:4,FWL:1+,CGS:8,BAN:4</availability>
+				<availability>FWL:1+,CS:4,CBS:7,CCO:7,CGB:7,CGS:7,CNC:7,CW:7,NIOPS:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
                 <roles>command</roles>
-				<availability>LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+				<availability>FS:8,LA:8,DC:8,FWL:4,MERC:8</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
                 <roles>command</roles>
@@ -924,14 +928,14 @@
 			</model>
 		</chassis>
 		<chassis name='Bombardier' unitType='Mek'>
-			<availability>CLAN:4-,CS:5,IS:2,FWL:3,DC:3,Periphery:2,NIOPS:5,BAN:2</availability>
+			<availability>IS:2,DC:3,FWL:3,CS:5,CLAN:3-,CB:2-,CCO:2-,CIH:4,CMG:4-,CDS:4-,CSR:4-,Periphery:2,NIOPS:5,BAN:0</availability>
 			<model name='BMB-10D'>
 				<roles>fire_support</roles>
 				<availability>IS:8,CS:4-,Periphery:8,NIOPS:0</availability>
 			</model>
 			<model name='BMB-12D'>
 				<roles>fire_support</roles>
-				<availability>CLAN:8,CS:8,FWL:4+,DC:4+,NIOPS:8,BAN:8</availability>
+				<availability>DC:4+,FWL:4+,CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
 			</model>
 		</chassis>
         <chassis name='Brunel Dump Truck' unitType='Tank'>
@@ -1050,18 +1054,18 @@
             </model>
         </chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>CC:5,CLAN:2,IS:3,MERC:2,Periphery:1,CS:2,NIOPS:2,DC:5</availability>
+			<availability>IS:3,DC:5,CC:5,MERC:2,CS:2,CFM:4+,CDS:3,Periphery:1,NIOPS:2</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
-				<availability>CC:4,FWL:2,DC:2</availability>
+				<availability>DC:2,FWL:2,CC:4</availability>
 			</model>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
-				<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,CC:8,MERC:8,CDS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='CPLT-C1b'>
 				<roles>fire_support</roles>
-				<availability>CC:1+,CLAN:6,DC:1+</availability>
+				<availability>DC:1+,CC:1+,CFM:8</availability>
 			</model>
 			<model name='CPLT-C4'>
 				<roles>fire_support</roles>
@@ -1092,12 +1096,12 @@
 			</model>
 		</chassis>
 		<chassis name='Cestus' unitType='Mek'>
-			<availability>CS:4,LA:2+,CLAN:4,NIOPS:4,IS:2+,FS:4</availability>
+			<availability>IS:2+,FS:4,LA:2+,CS:4,CB!Front Line:2!Second Line:1,CFM!Front Line:2!Second Line:1,NIOPS:4+</availability>
 			<model name='CTS-6Y'>
-				<availability>General:8</availability>
+				<availability>IS:8,CB:8,CFM:5</availability>
 			</model>
 			<model name='CTS-6Y-EC'>
-				<availability>CFM:2</availability>
+				<availability>CFM!Front Line:8!Second Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
@@ -1114,22 +1118,19 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:6,CS:5,CHH:6,LA:5,CLAN:4,IS:4,NIOPS:5,MERC:4,CGB:6</availability>
-			<model name='C'>
-				<availability>CHH:6,CLAN:8,CGB:6</availability>
-			</model>
+			<availability>IS:4,LA:5,CC:6,MERC:4,CS:5,CBS:4-,CGB!Second Line:2!Solahma:1,CHH!Front Line:3!Second Line:2!Solahma:1,CIH:6+,CDS!Front Line:3!Second Line:2!Solahma:1,NIOPS:5</availability>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
-				<availability>CC:2+,CS:8,CHH:6,CLAN:5,NIOPS:8,BAN:7,CGB:6</availability>
+				<availability>CC:2+,CS:8,CBS:8,CGB:8,CHH:3-,NIOPS:8</availability>
 			</model>
 			<model name='CHP-1N2'>
-				<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
+				<availability>CS:4,CHH:5,CIH:8</availability>
 			</model>
 			<model name='CHP-1Nb'>
-				<availability>CLAN:6,BAN:3</availability>
+				<availability>CDS:8</availability>
 			</model>
 			<model name='CHP-2N'>
-				<availability>IS:8,NIOPS:0</availability>
+				<availability>IS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chaparral Missile Artillery Tank' unitType='Tank'>
@@ -1937,9 +1938,9 @@
             </model>
         </chassis>
 		<chassis name='Crusader' unitType='Mek'>
-			<availability>CS:6-,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:8,CS:6-,CLAN!Front Line:1!Second Line:2!Solahma:1!Provisional Garrison:1,CBS:3,CB:3,CIH:2,CMG:2,CSJ:2,CSA:2,CSV:2,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:4</availability>
 			<model name='CRD-2R'>
-				<availability>CLAN:7,IS:2+,CGS:8,BAN:4,Periphery:2+</availability>
+				<availability>IS:2+,CLAN:8,Periphery:2+,NIOPS:5,BAN:2+</availability>
 			</model>
 			<model name='CRD-3D'>
 				<availability>FS:5</availability>
@@ -1952,7 +1953,7 @@
 				<availability>CC:9</availability>
 			</model>
 			<model name='CRD-3R'>
-				<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,NIOPS:6-,Periphery.Deep:8,BAN:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
@@ -2210,29 +2211,29 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,IS:5,Periphery:2,TC:3,CS:5,NIOPS:5,DC:6</availability>
+			<availability>IS:5,DC:6,CS:5,Periphery:2,TC:3,MOC:3,NIOPS:5</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Mek'>
-			<availability>CS:5,LA:1+,CLAN:4,NIOPS:5,FS:1+,DC:1+</availability>
+			<availability>FS:1+,LA:1+,DC:1+,CS:5,CLAN!Front Line:2!Second Line:1,CBS:3+,CB:3+,CGS:3+,CIH:3+,CJF:3+,CMG:3+,CNC:3+,CSR:3+,CSA:3+,CSV:3+,NIOPS:5</availability>
 			<model name='EXC-B1'>
 				<roles>cavalry,fire_support</roles>
-				<availability>LA:8</availability>
+				<availability>LA:8,CDS:4-</availability>
 			</model>
 			<model name='EXC-B2'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CS:8,LA:0,General:8,CLAN:5,NIOPS:8</availability>
+				<availability>FS:8,LA:0,DC:8,CS:8,CLAN:5-,CW:0,NIOPS:8</availability>
 			</model>
 			<model name='EXC-B2b'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CLAN:2+,CGB:3+,CJF:3+,CSJ:3+,CW:4-</availability>
 			</model>
 			<model name='EXC-B2b-EC'>
                 <roles>cavalry,fire_support</roles>
-				<availability>CW:4</availability>
+				<availability>CW!Front Line:2!Second Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -2247,22 +2248,22 @@
 			</model>
 		</chassis>
 		<chassis name='Exterminator' unitType='Mek'>
-			<availability>CS:4,CLAN:5,NIOPS:4</availability>
+			<availability>CS:4,CLAN!Second Line:1,CBS!Front Line:2!Second Line:1,CB!Front Line:2!Second Line:1,CCC!Front Line:2!Second Line:1,CFM!Front Line:2!Second Line:1,CIH:4+,CJF!Front Line:2!Second Line:1,CMG:3+,CDS:3+,CSR:3+,NIOPS:4,BAN:1+</availability>
 			<model name='EXT-4C'>
 			    <roles>specops</roles>
-				<availability>BAN:1</availability>
+				<availability>BAN:8</availability>
 			</model>
 			<model name='EXT-4D'>
 			    <roles>cavalry</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:4</availability>
+				<availability>CS:8,CLAN:8,CFM:4-,CIH:4-,CJF:3-,CDS:3-,CSR:4-,NIOPS:8,BAN:0</availability>
 			</model>
 			<model name='EXT-4Db'>
 			    <roles>cavalry</roles>
-				<availability>CLAN:6,BAN:3</availability>
+				<availability>CFM:8,CIH:5,CJF:4-,CDS:8,CSR:8,NIOPS:3+</availability>
 			</model>
 			<model name='EXT-4Db-EC'>
 			    <roles>cavalry</roles>
-				<availability>CJF:4</availability>
+				<availability>CJF:3+</availability>
 			</model>
 		</chassis>
 	    <chassis name='Factory' unitType='Space Station'>
@@ -2320,10 +2321,10 @@
 			</model>
 		</chassis>
 		<chassis name='Fire Scorpion' unitType='Mek'>
-			<availability>CGS:7</availability>
+			<availability>CGS:2+</availability>
 			<model name=''>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
+				<availability>CGS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Firebee' unitType='Mek'>
@@ -2363,13 +2364,13 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:2,CDS:5,LA:6,CBS:5,FWL:2,NIOPS:5,CJF:7,CGB:5</availability>
+			<availability>LA:6,FWL:2,CS:5,CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CJF!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,Periphery.R:2,NIOPS:5,BAN:3+</availability>
 			<model name='FLS-7K'>
 				<availability>LA:7,FWL:8,Periphery.R:8</availability>
 			</model>
 			<model name='FLS-8K'>
                 <roles>cavalry</roles>
-				<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
+				<availability>LA:2+,CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Flatbed Truck' unitType='Tank'>
@@ -2555,19 +2556,16 @@
 			</model>
 		</chassis>
 		<chassis name='Galahad (Glass Spider)' unitType='Mek'>
-			<availability>CSR:8,CW:9,CLAN:8</availability>
+			<availability>CW!Front Line:2!Second Line:1</availability>
 			<model name=''>
                 <roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:8</availability>
+				<availability>CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Galahad' unitType='Mek'>
-			<availability>CC:2+,LA:2+,CLAN:2,FS:2+</availability>
+			<availability>FS:2+,LA:2+,CC:2+</availability>
 			<model name='GLH-1D'>
-				<availability>IS:8</availability>
-			</model>
-			<model name='GLH-2D'>
-				<availability>CLAN:8</availability>
+				<availability>FS:8,LA:8,CC:8</availability>
 			</model>
 		</chassis>
         <chassis name='Galaport Ground Trailer' unitType='Tank'>
@@ -2692,14 +2690,14 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>CS:7,CHH:8,CSR:8,CLAN:7,IS:6,NIOPS:7,FS:5,MERC:6</availability>
+			<availability>IS:6,FS:5,MERC:6,CS:7,CHH!Front Line:3!Second Line:2!Solahma:1,CSR!Front Line:2!Second Line:1,NIOPS:7</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
-				<availability>CS:8,CLAN:8,IS:3+,NIOPS:8,BAN:8</availability>
+				<availability>IS:3+,CS:8,CHH:8,CSR:8,NIOPS:8</availability>
 			</model>
 			<model name='GLT-4L'>
 				<roles>raider</roles>
-				<availability>FWL:7,NIOPS:0,MERC:7</availability>
+				<availability>FWL:7,MERC:7</availability>
 			</model>
 			<model name='GLT-4P'>
 				<roles>raider</roles>
@@ -2938,11 +2936,11 @@
             </model>
         </chassis>
 		<chassis name='Helepolis' unitType='Mek'>
-			<availability>CLAN:2</availability>
+            <availability>CHH:1-</availability>
 			<model name='HEP-3H'>
 				<roles>mixed_artillery</roles>
 				<deployedWith>Helepolis</deployedWith>
-				<availability>General:8</availability>
+                <availability>CHH:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
@@ -3510,10 +3508,18 @@
 			</model>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>MOC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,NIOPS:6,DC:4</availability>
-			<model name='LNC25-01'>
+			<availability>IS:3,DC:4,MERC:3,CS:6,CLAN!Front Line:2!Second Line:1,CBS:3+,CB:3+,CCC:4+,CFM:4+,CGB:3+,CGS:3+,CIH:4+,CMG:4+,CSV!Front Line:3!Second Line:2!Solahma:1,TC:3,MOC:3,OA:3,CIR:3,NIOPS:6,BAN:0</availability>
+            <model name='C'>
+                <roles>cavalry,anti_aircraft</roles>
+                <availability>CB!Keshik:3!Front Line:1,CFM!Front Line:2!Second Line:1,CGB:2+,CIH!Keshik:8!Front Line:8!Second Line:5</availability>
+            </model>
+            <model name='C 2'>
+                <roles>cavalry,anti_aircraft</roles>
+                <availability>CB:2+,CFM:3+,CIH!Keshik:5!Front Line:3!Second Line:1</availability>
+            </model>
+            <model name='LNC25-01'>
 				<roles>cavalry,anti_aircraft</roles>
-				<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6,DC:4+</availability>
+				<availability>IS:4+,CS:8,CLAN:8,CB:3-,CFM:4-,CGB:4-,CIH:3-,NIOPS:8</availability>
 			</model>
 			<model name='LNC25-02'>
 				<roles>anti_aircraft,fire_support</roles>
@@ -3521,7 +3527,7 @@
 			</model>
 			<model name='LNC25-05'>
 				<roles>cavalry,anti_infantry</roles>
-				<availability>CS:4,IS:1,NIOPS:4</availability>
+				<availability>IS:1,CS:4,NIOPS:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Leopard CV' unitType='Dropship'>
@@ -3735,12 +3741,12 @@
 			</model>
 		</chassis>
 		<chassis name='Lupus' unitType='Mek' omni='Clan'>
-			<availability>CDS:2,CBS:2,CSV:2,CLAN:2,CCO:6,CGS:2</availability>
+			<availability>CLAN:1+,CCO!Keshik:3!Front Line:1,CGS:0,BAN:0</availability>
 			<model name='A'>
 				<availability>CLAN:6</availability>
 			</model>
 			<model name='B'>
-				<availability>CLAN:6</availability>
+				<availability>CLAN:4+</availability>
 			</model>
 			<model name='Prime'>
 				<roles>fire_support</roles>
@@ -3826,18 +3832,18 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>MOC:2+,CS:8,LA:5,CLAN:6,IS:4,NIOPS:8,FS:5,TC:3+,DC:5</availability>
+			<availability>IS:4,FS:5,LA:5,DC:5,CS:8,CLAN!Front Line:3!Second Line:2!Solahma:1,CBS:4+,CCC:4+,CGS:4+,CIH:3+,CJF:4+,CMG:3+,CDS:4+,CSJ:4+,CSR:4+,CSA:4+,CSV:3+,TC:3+,MOC:2+,NIOPS:8,BAN:2+</availability>
             <model name='C'>
                 <roles>command</roles>
-                <availability>CLAN:2+</availability>
+                <availability>CLAN:3+,CBS!Keshik:3,CHH:2+,CIH:2+,CMG:1+,BAN:0</availability>
             </model>
 			<model name='MAD-1R'>
 			    <roles>command</roles>
-				<availability>CS:8,MOC:3,CLAN:4,IS:2+,NIOPS:8,MERC:0,BAN:4,TC:3+</availability>
+				<availability>IS:2+,MERC:0,CS:8,CLAN:2-,TC:3+,MOC:3,NIOPS:8,BAN:2+</availability>
 			</model>
 			<model name='MAD-2R'>
                 <roles>command</roles>
-				<availability>CLAN:6,FS:2+,CGS:7,BAN:6</availability>
+				<availability>FS:2+,CLAN:5,BAN:0</availability>
 			</model>
 			<model name='MAD-3D'>
                 <roles>command</roles>
@@ -3845,7 +3851,7 @@
 			</model>
 			<model name='MAD-3R'>
                 <roles>command</roles>
-				<availability>CS:4-,IS:8,TC:8</availability>
+				<availability>IS:8,CS:4-,Periphery:8,BAN:8</availability>
 			</model>
 		</chassis>
         <chassis name='Marco' unitType='Mek'>
@@ -3874,15 +3880,15 @@
 			</model>
 		</chassis>
 		<chassis name='Masauwu' unitType='Mek'>
-			<availability>CSA:3,CCO:5</availability>
+			<availability>CCO:2+,CSA:3+</availability>
             <model name=''>
-                <availability>General:8</availability>
+                <availability>CCO:8,CSA:8</availability>
             </model>
 		</chassis>
 		<chassis name='Matador' unitType='Mek'>
-			<availability>CSV:6</availability>
+			<availability>CSV:3+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CSV:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Maultier Hover APC' unitType='Tank'>
@@ -4116,14 +4122,14 @@
 			</model>
 		</chassis>
 		<chassis name='Minsk' unitType='Mek'>
-			<availability>CW:4,CJF:4,CGB:5</availability>
+			<availability>CGB!Second Line:1!Solahma:1</availability>
 		    <model name=''>
 			    <roles>command</roles>
-			    <availability>CLAN:8:2862</availability>
+			    <availability>CGB:6</availability>
 		    </model>
 			<model name='MNK-101'>
 				<roles>command</roles>
-				<availability>CGB:5</availability>
+				<availability>CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Mithras Light Tank' unitType='Tank'>
@@ -4416,18 +4422,21 @@
 			</model>
 		</chassis>
 		<chassis name='Orion IIC' unitType='Mek'>
-			<availability>CW:4</availability>
+			<availability>CW:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CLAN:3,IS:5,Periphery.Deep:4,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-</availability>
+			<availability>IS:5,LA:6,FWL:9,CS:5-,CLAN!Front Line:2!Second Line:1,CBS:3+,CIH:2+,CMG:1+,CW!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,Periphery.MW:5,Periphery.ME:5,Periphery:4,TC:5,MOC:5,OA:5,CIR:5,NIOPS:5-,Periphery.Deep:4,BAN:2</availability>
 			<model name='ON1-K'>
-				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
+            <model name='ON1-Kb'>
+                <availability>CLAN:8,BAN:0</availability>
+            </model>
 			<model name='ON1-V'>
-				<availability>OA:2,IS:3,TC:3</availability>
+				<availability>IS:3,TC:3,OA:2</availability>
 			</model>
 			<model name='ON1-VA'>
 				<availability>IS:2</availability>
@@ -4447,14 +4456,14 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CS:4,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,DC:6</availability>
+			<availability>IS:5,DC:6,CS:4,CLAN:4,CB:3,CCC!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:3,CCO:4-,CFM:4-,CGS:3,CIH!Keshik:5!Front Line:5!Second Line:5!Solahma:4!Provisional Garrison:4,CJF:4-,CMG!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,CNC:4-,CDS:4-,CSJ:4-,CSR:4-,CSA:4-,CSV:4-,CW:4-,Periphery:4,NIOPS:4,Periphery.Deep:4,BAN:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
-				<availability>CLAN:3,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CMG:1-,Periphery:8,Periphery.Deep:8,BAN:4-</availability>
 			</model>
 			<model name='OSR-2Cb'>
 				<roles>urban</roles>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CLAN:8,BAN:3</availability>
 			</model>
 			<model name='OSR-2L'>
 				<availability>IS:4</availability>
@@ -4478,10 +4487,10 @@
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
-			<availability>CLAN:2-,CS:6,FWL:7,NIOPS:6,Periphery.Deep:4,FS:7,MERC:7,Periphery:4,BAN:3</availability>
+			<availability>FS:7,FWL:7,MERC:7,CS:6,NIOPS:6,Periphery:4,Periphery.Deep:4,BAN:2-</availability>
 			<model name='OTL-4D'>
                 <roles>raider</roles>
-				<availability>CLAN:8,IS:8,Periphery:8,BAN:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Overlord C' unitType='Dropship'>
@@ -4855,10 +4864,10 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman IIC' unitType='Mek'>
-			<availability>CLAN:4</availability>
+			<availability>CGB!Front Line:1,CNC!Front Line:1,CDS!Front Line:1,CSR!Front Line:1,CW!Front Line:1</availability>
 			<model name=''>
                 <roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CNC:8,CDS:8,CSR:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Rifleman II' unitType='Mek'>
@@ -4869,14 +4878,14 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CLAN:3,IS:8-,Periphery.Deep:5,CIR:3,Periphery:5,CS:6-,NIOPS:6-</availability>
+			<availability>IS:8-,CS:6-,CLAN!Second Line:1,CBS!Front Line:1,CB!Front Line:1,CCC!Front Line:1,CFM!Front Line:1,CGS!Front Line:1,CMG!Front Line:1,Periphery:5,CIR:3,NIOPS:6-,Periphery.Deep:5,BAN:3-</availability>
             <model name='C'>
                 <roles>fire_support,anti_aircraft</roles>
-                <availability>CLAN:8,BAN:4</availability>
+                <availability>CLAN:8,BAN:3+</availability>
             </model>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
-				<availability>General:8,CLAN:5-,BAN:6</availability>
+				<availability>IS:8,MERC:8,Periphery:8,NIOPS:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Riga II Destroyer-Carrier' unitType='Warship'>
@@ -5161,10 +5170,10 @@
 			</model>
 		</chassis>
 		<chassis name='Shootist' unitType='Mek'>
-			<availability>CS:5,LA:1+,CLAN:5,NIOPS:5</availability>
+			<availability>LA:1+,CS:5,CLAN!Front Line:2!Second Line:1,CBS:2+,CB!Front Line:3!Second Line:2!Solahma:1,CCC!Second Line:1,CIH!Second Line:2!Solahma:1,CMG!Second Line:1,NIOPS:5,BAN:0</availability>
 			<model name='ST-8A'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
         <chassis name='Shugosha' unitType='Mek'>
@@ -5502,13 +5511,13 @@
 			</model>
 		</chassis>
 		<chassis name='Thresher' unitType='Mek'>
-			<availability>CHH:6,CDS:4,CSR:4,CLAN:4</availability>
+			<availability>CHH!Keshik:4!Front Line:2!Second Line:1,CDS:3+</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CHH:8,CDS:8</availability>
 			</model>
 			<model name='2'>
 				<roles>fire_support</roles>
-				<availability>CHH:4</availability>
+				<availability>CHH:5</availability>
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
@@ -5569,9 +5578,9 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:9,CS:5-,LA:8,CLAN:4-,IS:7,Periphery.Deep:6,NIOPS:5-,MERC:7,Periphery:6,DC:8</availability>
+			<availability>IS:7,LA:8,DC:8,CC:9,MERC:7,CS:5-,CLAN:5,CB!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CCC:4,CCO!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:3,CFM!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:3,CGS!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,CHH!Keshik:5!Front Line:5!Second Line:5!Solahma:4!Provisional Garrison:4,CIH:4,CMG:4,CNC:4,CDS:4,CSR:4,CSV:4,Periphery:6,NIOPS:5-,Periphery.Deep:6,BAN:5</availability>
 			<model name='C'>
-				<availability>CLAN:2</availability>
+				<availability>CLAN:2+,CBS!Keshik:4!Front Line:1,CCC:3+,CCO:3+,CGS:1+,CHH:3+,CJF:3+,CNC:3+,BAN:0</availability>
 			</model>
 			<model name='TDR-5D'>
 				<availability>FS:4,MERC:2</availability>
@@ -5580,13 +5589,13 @@
 				<availability>CC:2</availability>
 			</model>
 			<model name='TDR-5S'>
-				<availability>IS:8,CLAN:1-,BAN:5,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,BAN:6-</availability>
 			</model>
 			<model name='TDR-5SE'>
 				<availability>MERC.ELH:8,MERC:2</availability>
 			</model>
 			<model name='TDR-5Sb'>
-				<availability>CLAN:6-,BAN:4</availability>
+				<availability>CLAN:4,CB:4-,CIH:4-,CJF:4-,BAN:5</availability>
 			</model>
 			<model name='TDR-5Sd'>
 				<availability>FS:1+</availability>
@@ -5846,9 +5855,9 @@
 			</model>
 		</chassis>
 		<chassis name='Vision Quest' unitType='Mek'>
-			<availability>CSR:5,CNC:7,CB:5</availability>
-			<model name='VQ-1NC'>
-				<availability>CNC:2</availability>
+			<availability>CB!Keshik:3!Front Line:1,CNC!Keshik:4!Front Line:2!Second Line:1</availability>
+			<model name=''>
+				<availability>CB:8,CNC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Volga Transport' unitType='Warship'>
@@ -5915,12 +5924,12 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:8,LA:9,FWL:9,CS:6-,CLAN:5+,CBS:6+,CGB!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CIH:3-,CSA:6+,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:5+</availability>
             <model name='C'>
-                <availability>CLAN:3</availability>
+                <availability>CLAN:3+,CBS!Keshik:3!Front Line:1,CB:2+,CGB!Keshik:1!Front Line:1!Second Line:1,CSJ:2+,BAN:0</availability>
             </model>
             <model name='C 3'>
-                <availability>CLAN:3+:2862</availability>
+                <availability>CGB:3+</availability>
             </model>
 			<model name='WHM-6D'>
 				<availability>FS:4</availability>
@@ -5932,17 +5941,17 @@
 				<availability>CC:4</availability>
 			</model>
 			<model name='WHM-6R'>
-				<availability>General:8,CLAN:2,BAN:8</availability>
+				<availability>IS:8,CCC:1-,CFM:1-,CMG:1-,CSJ:1-,Periphery:8,Periphery.Deep:8,BAN:6-</availability>
 			</model>
 			<model name='WHM-6Rb'>
-				<availability>CC:2+,LA:2+,CLAN:4,FWL:2+,FS:2+,BAN:4</availability>
+				<availability>FS:2+,LA:2+,FWL:2+,CC:2+,CLAN:3-,CBS:4-,CMG:4-,BAN:5</availability>
 			</model>
 			<model name='WHM-6Rk'>
                 <roles>cavalry</roles>
 				<availability>DC:1+</availability>
 			</model>
 			<model name='WHM-7A'>
-				<availability>CLAN:5</availability>
+				<availability>CLAN!Second Line:2,CBS:3+,CB!Front Line:2!Second Line:1,CFM!Front Line:2!Second Line:2,CIH:4+,CMG!Front Line:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Wasp LAM Mk I' unitType='Mek'>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2860-->
-<ratgen
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
             <!-- Omni percentages: 0,0 -->

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -3496,7 +3496,7 @@
 			</model>
 		</chassis>
 		<chassis name='Kyudo' unitType='Mek'>
-			<availability>FS:2+,FWL:2+,CBS!Front Line:2!Second Line:1,CMG!Second Line:1,CDS!Secodn Line:1</availability>
+			<availability>FS:2+,FWL:2+,CBS!Front Line:2!Second Line:1,CMG!Second Line:1,CDS!Second Line:1</availability>
 			<model name='KY2-D-02'>
 				<roles>fire_support</roles>
 				<availability>FS:8,FWL:8,CBS:8,CMG:8,CDS:8</availability>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -4664,7 +4664,7 @@
 			</model>
 			<model name='PXH-1b &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:8,CGS:4,CIH:5-,BAN:3</availability>
+				<availability>CLAN:8,CGS:4,CIH:5-,NIOPS:4+,BAN:3</availability>
 			</model>
 			<model name='PXH-1c &apos;Special&apos;'>
 				<roles>command,recon</roles>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -3831,7 +3831,7 @@
 		<chassis name='Marauder IIC' unitType='Mek'>
 			<availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS:2+,CB!Keshik:4!Front Line:1,CCO:3+,CGB:3+,CHH!Keshik:5!Front Line:3!Second Line:1,CIH!Keshik:5!Front Line:2!Second Line:1,CJF:3+,CNC:3+,CSJ:3+,CSA:2+,CSV:3+,CW!Keshik:5!Front Line:3,BAN!Keshik:1!Front Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8,CJF:4,CW:4</availability>
+				<availability>CLAN:8,CJF:4,CW:4,BAN:8</availability>
 			</model>
 			<model name='9'>
 				<availability>CJF:8,CW:8</availability>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -1758,14 +1758,14 @@
             </model>
         </chassis>
 		<chassis name='Commando IIC' unitType='Mek'>
-			<availability>CHH:3,CIH:3,CLAN:3,CGS:5</availability>
+			<availability>CGS:1+</availability>
 			<model name=''>
 				<roles>recon</roles>
-				<availability>CLAN:8</availability>
+				<availability>CGS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>LA:9,CSJ:2,CIR:4,MERC:4,CGS:2</availability>
+			<availability>LA:9,MERC:4,CGS:1-,CSJ:2-,CIR:4</availability>
 			<model name='COM-1D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
@@ -1774,7 +1774,7 @@
 			<model name='COM-2D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
-				<availability>LA:8,General:8,Periphery.Deep:8</availability>
+				<availability>LA:8,MERC:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
@@ -2107,7 +2107,7 @@
 			</model>
 		</chassis>
 		<chassis name='Drift Shag' unitType='Mek'>
-			<availability>CIH:4,CMG:2,CGS:2</availability>
+			<availability>CGS!Keshik:3!Front Line:1,CIH!Keshik:3!Front Line:1,CMG:2+</availability>
             <model name=''>
                 <availability>CLAN:8</availability>
             </model>
@@ -2281,18 +2281,12 @@
             </model>
 		</chassis>
 		<chassis name='Falcon' unitType='Mek'>
-			<availability>CC:1,MOC:1,OA:1,CIH:5,LA:2,CLAN:3,FWL:1,FS:1,MERC:1,CGS:5,TC:1</availability>
+			<availability>FS:1,LA:2,FWL:1,CC:1,MERC:1,CGS!Second Line:4!Solahma:3!Provisional Garrison:2,TC:1,MOC:1,OA:1</availability>
 			<model name='FLC-4N'>
-				<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='FLC-4Nb'>
-				<availability>CLAN:8,BAN:2</availability>
-			</model>
-			<model name='FLC-4Nb-PP'>
-				<availability>BAN:2</availability>
-			</model>
-			<model name='FLC-4Nb-PP2'>
-				<availability>BAN:2</availability>
+				<availability>CGS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Field Artillery' unitType='Infantry'>
@@ -2339,33 +2333,24 @@
 			</model>
 		</chassis>
 		<chassis name='Firefly' unitType='Mek'>
-			<availability>CC:1+,CIH:7,CLAN:7,FS:1+,BAN:6,CB:7</availability>
+			<availability>FS:1+,CC:1+,CLAN!Front Line:3!Second Line:2!Solahma:1,CBS:3+,CB!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CCO!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CGB!Second Line:5!Solahma:4!Provisional Garrison:3,CGS:3+,CHH!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:3-,CMG:3-,CNC!Second Line:3!Solahma:2!Provisional Garrison:1,CDS!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CSJ:4+,CSV:4-,CW:3-,BAN:2</availability>
 			<model name='C'>
-				<availability>CLAN:6,BAN:2</availability>
+				<availability>CSJ!Keshik:8!Front Line:8!Second Line:1</availability>
 			</model>
 			<model name='FFL-3A'>
 				<roles>spotter</roles>
-				<availability>CC:8,FS:8</availability>
-			</model>
-			<model name='FFL-3PP'>
-				<availability>BAN:2</availability>
-			</model>
-			<model name='FFL-3PP2'>
-				<availability>BAN:2</availability>
-			</model>
-			<model name='FFL-3PP3'>
-				<availability>BAN:2</availability>
+				<availability>FS:8,CC:8,CFM:3-,CHH:3-,CSR:3-,BAN:4-</availability>
 			</model>
 			<model name='FFL-3SLE'>
-				<availability>CLAN:5,BAN:3</availability>
+				<availability>CLAN:8,CFM:4,CHH:4,CSJ!Front Line:5!Second Line:8!Solahma:8!Provisional Garrison:8,CSR:5,BAN:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Firestarter' unitType='Mek'>
-			<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
+			<availability>IS:7,LA:8,CS:3,Periphery:7,NIOPS:3,Periphery.Deep:7</availability>
 			<model name='FS9-H'>
                 <roles>anti_infantry,recon</roles>
 				<deployedWith>Vulcan</deployedWith>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CFM:8,CHH:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='FS9-K'>
                 <roles>anti_infantry,recon</roles>
@@ -3011,7 +2996,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hermes' unitType='Mek'>
-			<availability>MOC:3,CC:2,CS:3,CHH:5,OA:3,CLAN:4,FWL:4,NIOPS:3,CGB:5,DC:2,CB:5</availability>
+			<availability>DC:2,FWL:4,CC:2,CS:3,CLAN!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CBS:2,CB!Second Line:1!Solahma:1!Provisional Garrison:1,CCO:1,CGB!Front Line:1!Second Line:1!Solahma:1!Provisional Garrison:1,CGS:2,CHH:2,CIH!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CNC!Second Line:2!Solahma:2!Provisional Garrison:2,CSR:2,CSV:2,MOC:3,OA:3,NIOPS:3,BAN:4+</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
 				<availability>FWL:8</availability>
@@ -3022,11 +3007,11 @@
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
-				<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>IS:2+,CS:8,CLAN:4-,CBS!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CB:4,CCC:4,CGS:4,CIH!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CMG:4,CSJ:4,CSV:3-,CW:4-,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='HER-1Sb'>
 				<roles>recon</roles>
-				<availability>CLAN:6,FWL:2+,BAN:3</availability>
+				<availability>FWL:2+,CLAN:3,CBS:3+,CB:4+,CCC:4+,CGS:3+,CIH:4+,CJF:4+,CMG:4+,CSJ:3+,CW:4+,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Highlander IIC' unitType='Mek'>
@@ -3107,13 +3092,13 @@
 			</model>
 		</chassis>
 		<chassis name='Hussar' unitType='Mek'>
-			<availability>CS:4,CIH:9,CSV:9,CLAN:8,NIOPS:4</availability>
+			<availability>CS:4,CLAN!Front Line:3!Second Line:2!Solahma:1,CCO:3+,CGB!Front Line:2!Second Line:1,CGS:3+,CHH:3+,CIH!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CMG!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CNC:3+,CDS:4+,CSR:3+,CSA:3+,CSV:4+,CW!Second Line:3!Solahma:2!Provisional Garrison:1,NIOPS:4,BAN:4+</availability>
 			<model name='HSR-200-D'>
 				<roles>recon</roles>
-				<availability>CS:8,General:8,CLAN:6,NIOPS:8,BAN:8,DC:8</availability>
+				<availability>CS:8,CLAN:4-,CBS:5,CB:4,CGS:5,CIH!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CMG:4,CDS:5,CW:5,NIOPS:8,BAN:4-</availability>
 			</model>
 			<model name='HSR-200-Db'>
-				<availability>CLAN:6,BAN:4</availability>
+				<availability>CLAN:4+,CB:5+,CCC:3,CCO:3,CFM:3,CGB:4,CHH:3,CNC:4,CSJ:5,CSR:4,CSA:4,CSV:4,CW!Second Line:4!Solahma:3!Provisional Garrison:2,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
@@ -3129,10 +3114,10 @@
 			</model>
 		</chassis>
 		<chassis name='Icestorm' unitType='Mek'>
-			<availability>CIH:6+,CW:4</availability>
+            <availability>CIH!Keshik:4!Front Line:3!Second Line:1</availability>
 			<model name=''>
 				<roles>spotter</roles>
-				<availability>CLAN:8</availability>
+				<availability>CIH:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
@@ -3628,25 +3613,25 @@
 			</model>
 		</chassis>
 		<chassis name='Locust IIC' unitType='Mek'>
-			<availability>CHH:6,CW:6,CLAN:6,CJF:6,CGB:6</availability>
+			<availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:3!Front Line:2,CFM:3+,CGB!Keshik:3!Front Line:1,CGS:3+,CHH:3+,CIH!Keshik:4!Front Line:2!Second Line:1,CJF!Keshik:6!Front Line:3!Second Line:1,CDS!Keshik:4!Front Line:2!Second Line:1,CSV!Keshik:4!Front Line:2!Second Line:1,CW!Keshik:4!Front Line:3!Second Line:1,BAN!Keshik:2</availability>
 			<model name=''>
-				<availability>CW:8,General:8</availability>
+				<availability>CLAN:8,CIH:4,CJF:5,CSJ:3,CSA!Front Line:5!Second Line:8,BAN:8</availability>
 			</model>
 			<model name='2'>
-				<availability>CCC:4,CIH:4,CJF:4</availability>
+				<availability>CIH:8,CJF:8</availability>
 			</model>
 			<model name='3'>
-				<availability>General:3</availability>
+				<availability>CSJ!Keshik:8!Front Line:5!Second Line:1,CSA!Keshik:8!Front Line:5!Second Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Locust' unitType='Mek'>
-			<availability>CS:6-,CLAN:3-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:9,CS:6-,CLAN!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CB!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CCC:5,CCO!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CFM:5,CGB!Second Line:5!Solahma:5!Provisional Garrison:5,CGS!Second Line:4!Solahma:4!Provisional Garrison:4,CJF:5,CNC:5,CDS:4,CSJ:5,CSR:5,CSA:5,CSV:5,CW:4-,Periphery:6,NIOPS:6-,Periphery.Deep:6</availability>
 			<model name='C'>
-				<availability>CCC:2,CFM:2</availability>
+				<availability>CCC!Keshik:8!Front Line:3!Second Line:1,CFM!Keshik:8!Front Line:1,CJF!Keshik:8!Front Line:8!Second Line:1,CSJ!Keshik:5!Front Line:8!Second Line:5,CSV!Keshik:8!Front Line:5,BAN:1+</availability>
 			</model>
 			<model name='LCT-1E'>
 				<roles>recon</roles>
-				<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
+				<availability>IS:4,Periphery:4,Periphery.Deep:4</availability>
 			</model>
 			<model name='LCT-1M'>
 				<roles>recon</roles>
@@ -3658,11 +3643,11 @@
 			</model>
 			<model name='LCT-1V'>
 				<roles>recon</roles>
-				<availability>LA:4,General:8,CLAN:2-,FS:7,BAN:5</availability>
+				<availability>IS:8,FS:7,LA:4</availability>
 			</model>
 			<model name='LCT-1Vb'>
 				<roles>recon</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,CCC!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CFM!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CJF!Front Line:1!Second Line:5!Solahma:5!Provisional Garrison:5,CSJ!Second Line:8!Solahma:8!Provisional Garrison:8,CSV!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Lola II Destroyer' unitType='Warship'>
@@ -3807,9 +3792,9 @@
 			</model>
 		</chassis>
 		<chassis name='Mandrill' unitType='Mek'>
-			<availability>CFM:6</availability>
+			<availability>CFM!Keshik:4!Front Line:3!Second Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CFM:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
@@ -4114,14 +4099,14 @@
 			</model>
 		</chassis>
 		<chassis name='Mercury' unitType='Mek'>
-			<availability>CS:8,CC:2+,LA:2+,CLAN:2,NIOPS:8,IS:2+,MERC:2+</availability>
+			<availability>IS:2+,CS:8,CLAN!Front Line:3!Second Line:2!Solahma:1,CB!Second Line:2!Solahma:1,CCC!Second Line:3!Solahma:2!Provisional Garrison:1,CCO!Second Line:2!Solahma:1,CGB!Second Line:3!Solahma:2!Provisional Garrison:1,CGS!Second Line:3!Solahma:2!Provisional Garrison:1,CHH!Second Line:3!Solahma:2!Provisional Garrison:1,CIH!Second Line:4!Solahma:3!Provisional Garrison:2,CJF!Second Line:3!Solahma:2!Provisional Garrison:1,CMG!Second Line:3!Solahma:2!Provisional Garrison:1,CSJ!Second Line:1!Solahma:1!Provisional Garrison:1,CW:3-,NIOPS:8,BAN:3</availability>
 			<model name='MCY-98'>
 				<roles>recon</roles>
 				<availability>CC:8</availability>
 			</model>
 			<model name='MCY-99'>
 				<roles>recon</roles>
-				<availability>CS:4,CLAN:8,NIOPS:4,BAN:6</availability>
+				<availability>CS:4,CLAN:8,NIOPS:4,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Minsk' unitType='Mek'>
@@ -4204,22 +4189,22 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>MOC:2+,CHH:5,CLAN:6,MERC:4+,FS:3+,TC:2+,CS:6,OA:2+,CDS:5,CBS:7,FWL:2+,NIOPS:6,CMG:10,CJF:7,CGB:5,DC:2+</availability>
+			<availability>FS:3+,DC:2+,FWL:2+,MERC:4+,CS:6,CLAN:4+,CBS:3+,CGS:3+,CMG:6+,CW:3+,TC:2+,MOC:2+,OA:2+,NIOPS:6,BAN:2+</availability>
 			<model name='C'>
                 <roles>recon</roles>
-				<availability>CIH:4,CMG:8,CJF:4,CGB:4</availability>
+				<availability>CGB!Keshik:5!Front Line:1,CIH!Keshik:5,CJF!Keshik:5!Front Line:1,CMG!Keshik:7!Front Line:3!Second Line:1</availability>
 			</model>
 			<model name='C 2'>
                 <roles>recon</roles>
-				<availability>CMG:3</availability>
+				<availability>CMG!Keshik:5!Front Line:1</availability>
 			</model>
 			<model name='MON-66'>
 				<roles>command,recon</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,IS:2+,BAN:8,Periphery:2+</availability>
+				<availability>IS:2+,CS:8,CLAN:6,CB:5,CCC:4-,CFM:5-,CJF!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CMG:4-,CSJ:4-,CW!Front Line:6!Second Line:6!Solahma:6!Provisional Garrison:6,Periphery:2+,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='MON-66b'>
 				<roles>command,recon</roles>
-				<availability>CLAN:8,CGS:8,BAN:4</availability>
+				<availability>CLAN:5+,CCC:4,CFM:4,CNC:5,CSJ:4,BAN:1</availability>
 			</model>
 			<model name='MON-67'>
 				<roles>command,recon</roles>
@@ -4364,13 +4349,13 @@
 			</model>
 		</chassis>
 		<chassis name='Night Hawk' unitType='Mek'>
-			<availability>CW:6,LA:2+,CLAN:6,FWL:2+,FS:2+,CGS:7,CGB:6</availability>
+			<availability>FS:2+,LA:2+,FWL:2+,CLAN:4+,CBS:5+,CB:5+,CCO:5+,CGB:5+,CJF:5+,CMG:3+,CNC:5+,CSJ:5+,CSR:3+,CW:5+,BAN:3+</availability>
 			<model name='NTK-2Q'>
 				<roles>raider</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CLAN:8,BAN:8</availability>
 			</model>
 			<model name='NTK-2Q-EC'>
-				<availability>CSJ:3</availability>
+				<availability>CSJ!Keshik:3!Front Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
@@ -4470,14 +4455,14 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CS:4,CLAN:4-,IS:4,Periphery.Deep:4,NIOPS:4,MERC:4,Periphery:4</availability>
+			<availability>IS:4,MERC:4,CS:4,CLAN!Second Line:2!Solahma:2!Provisional Garrison:2,CBS!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CB!Second Line:1!Solahma:1!Provisional Garrison:1,CCO!Second Line:1!Solahma:1!Provisional Garrison:1,CGS!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CJF!Solahma:2!Provisional Garrison:2,CMG!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CSJ!Second Line:1!Solahma:1!Provisional Garrison:1,CW!Front Line:1!Second Line:1!Solahma:2!Provisional Garrison:2,Periphery:4,NIOPS:4,Periphery.Deep:4,BAN:1</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
-				<availability>General:8,CLAN:5-,BAN:6</availability>
+				<availability>IS:8,MERC:8,Periphery:8</availability>
 			</model>
 			<model name='OTT-7Jb'>
 				<roles>recon</roles>
-				<availability>CLAN:6,BAN:4</availability>
+				<availability>CLAN:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
@@ -4548,13 +4533,13 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>CC:3,Periphery.DD:5,FS.RR:4,CLAN:2-,MERC:5,Periphery.OS:5,FS:3,BAN:3,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>FS:3,FS.RR:4,FS.DMM:4,LA:3,DC:10,FWL:3,CC:3,MERC:5,CS:2,CSJ:2-,Periphery:3,Periphery.DD:5,Periphery.OS:5,NIOPS:2</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,TC:8</availability>
 			</model>
 			<model name='PNT-9R'>
 				<roles>fire_support</roles>
-				<availability>CLAN:8,MERC:8,DC:8</availability>
+				<availability>DC:8,MERC:8,CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -4605,13 +4590,13 @@
 			</model>
 		</chassis>
 		<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
-			<availability>CLAN:6,CSJ:8,CGB:6</availability>
+			<availability>CFM:1+,CGS!Keshik:3!Front Line:1,CHH:2+,CNC:1+,CDS:1+,CSJ:2+,CW:2+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CFM:8,CGS:8,CIH:8,CW:8</availability>
 			</model>
 			<model name='2'>
 				<roles>fire_support</roles>
-				<availability>CLAN:5</availability>
+				<availability>CNC:8,CDS:8,CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk IIC' unitType='Mek'>
@@ -5223,14 +5208,14 @@
 			</model>
 		</chassis>
 		<chassis name='Sling' unitType='Mek'>
-			<availability>CC:2+,LA:2+,CLAN:1,CSJ:2</availability>
+			<availability>LA:2+,CC:2+,CSJ!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1</availability>
 			<model name='SL-1G'>
 				<roles>spotter</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,CC:8,CSJ:8</availability>
 			</model>
 			<model name='SL-1H'>
 				<roles>spotter</roles>
-				<availability>LA:4</availability>
+				<availability>LA:4,CSJ:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Snowden Mining Station' unitType='Space Station'>
@@ -5282,14 +5267,14 @@
 			</model>
 		</chassis>
 		<chassis name='Spector' unitType='Mek'>
-			<availability>CLAN:2</availability>
+			<availability>CMG:1+</availability>
 			<model name='SPR-4F'>
 			    <roles>specops,raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CMG:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>CC:5,CS:4,OA:2,CLAN:1-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
+			<availability>IS:4,FS:5,DC:6,FWL:7,CC:5,MERC:4,CS:4,CIH!Second Line:2!Solahma:1,CMG!Front Line:3!Second Line:2!Solahma:1,TC:2,OA:2,NIOPS:4</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -5299,7 +5284,7 @@
 				<availability>DC:8</availability>
 			</model>
 			<model name='SDR-5V'>
-				<availability>CLAN:8,IS:8,Periphery.Deep:8,FS:5,Periphery:8</availability>
+				<availability>IS:8,FS:5,CIH:8,CMG:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
@@ -5352,18 +5337,24 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6</availability>
-			<model name='STG-3G'>
+			<availability>IS:9,DC:6,MERC:6,CS:4-,CLAN!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CBS:4,CB:5,CCC:4,CGS:4,CHH:4,CDS:4,CSR:4,CSA:4,CSV:4,CW:4,Periphery:6,NIOPS:4-,Periphery.Deep:6,BAN:5</availability>
+            <model name='C'>
+                <availability>CCC!Keshik:8!Front Line:1,CHH!Keshik:8!Front Line:8,CIH!Front Line:8!Second Line:1,CSV!Keshik:8!Front Line:1,CW!Keshik:8!Front Line:8!Second Line:1,BAN:2+</availability>
+            </model>
+            <model name='C 2'>
+                <availability>CBS!Keshik:8!Front Line:5,CB!Keshik:5!Front Line:3,BAN:2+</availability>
+            </model>
+            <model name='STG-3G'>
 				<roles>recon</roles>
-				<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
+				<availability>IS:4,CLAN!Solahma:2!Provisional Garrison:3,Periphery:4,Periphery.Deep:4,BAN:2-</availability>
 			</model>
 			<model name='STG-3Gb'>
 				<roles>recon</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,CBS!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CB!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CCC!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CHH!Front Line:1!Second Line:8!Solahma:8!Provisional Garrison:8,CIH:4-,CJF!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CSV!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CW:3-,BAN:5</availability>
 			</model>
 			<model name='STG-3R'>
 				<roles>recon</roles>
-				<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,CLAN:1-,Periphery:8,Periphery.Deep:8,BAN:3-</availability>
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
@@ -5459,15 +5450,12 @@
 			</model>
 		</chassis>
 		<chassis name='Talon' unitType='Mek'>
-			<availability>CLAN:8</availability>
-			<model name='TLN-5V'>
-				<availability>FWL:8,FS:8</availability>
-			</model>
+			<availability>CLAN:5+,CB:4+,CFM:4+,CGS:3+,CHH:3+,CIH:4+,CNC:6+,CSR:3+,CW:6+,BAN:3+</availability>
 			<model name='TLN-5W'>
-				<availability>LA:8,CLAN:8</availability>
+				<availability>CLAN:8,CIH:5,BAN:8</availability>
 			</model>
 			<model name='TLN-5W-EC'>
-				<availability>CIH:8</availability>
+				<availability>CIH!Keshik:3!Front Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Texas Battleship' unitType='Warship'>
@@ -5489,12 +5477,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>CSA:2,CS:6,CDS:5,CLAN:4,FWL:2,NIOPS:6,CCO:2,CJF:5,CGB:5</availability>
+			<availability>FWL:2,CS:6,CLAN:4-,CB!Second Line:4!Solahma:4!Provisional Garrison:4,CCC:3-,CGS!Second Line:4!Solahma:4!Provisional Garrison:4,CHH!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CIH:3-,CJF!Second Line:4!Solahma:4!Provisional Garrison:4,CMG!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CW!Front Line:1!Second Line:2!Solahma:4!Provisional Garrison:5,NIOPS:6,BAN:0</availability>
 			<model name='THE-N'>
-				<availability>CS:8,CLAN:6,General:4+,NIOPS:8,BAN:6</availability>
+				<availability>FWL:4+,CS:8,CLAN:8,CB:6,CGB:5-,CIH:7,CJF:6,CMG!Second Line:6!Solahma:6!Provisional Garrison:6,CDS:4-,CSR:4-,CW:4-,NIOPS:8</availability>
 			</model>
 			<model name='THE-Nb'>
-				<availability>CLAN:6,CGS:7,BAN:4</availability>
+				<availability>CB:6+,CGB:5,CIH:6+,CJF:8+,CMG:6+,CNC:5,CDS:4,CSR:5,CW:6+</availability>
 			</model>
 		</chassis>
 		<chassis name='Thresher' unitType='Mek'>
@@ -5776,17 +5764,17 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech IIC' unitType='Mek'>
-			<availability>CHH:4,CIH:4-,CSR:4,CCO:5,CGS:4</availability>
+			<availability>CLAN!Second Line:3!Solahma:2!Provisional Garrison:1,CIH!Solahma:2!Provisional Garrison:1,CJF!Solahma:2!Provisional Garrison:1,CSJ!Solahma:2!Provisional Garrison:1,CSV!Solahma:2!Provisional Garrison:1,BAN:0</availability>
 			<model name=''>
 				<roles>urban</roles>
 				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>CC:5-,CLAN:1-,IS:4-,Periphery:3-,CS:4-,NIOPS:4-</availability>
+			<availability>CC:5-,IS:4-,Periphery:3-,CS:4-,NIOPS:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
-				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Valkyrie' unitType='Mek'>
@@ -5960,10 +5948,10 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>CS:4-,CLAN:1-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:4,Periphery:6</availability>
+			<availability>IS:10,CS:4-,Periphery:6,CIR:4,NIOPS:4-,Periphery.Deep:6,BAN:1-</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,BAN:8</availability>
 			</model>
 			<model name='WSP-1D'>
 				<roles>recon</roles>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2860-->
-<ratgen>
+<ratgen
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -625,7 +625,7 @@
 			</model>
             <model name='C'>
                 <roles>command,fire_support</roles>
-                <availability>CLAN:3+,CBS:1+,CB:2+,CFM!Front Line:3!Second Line:1,CGS!Front Line:3!Second Line:1,CJF!Front Line:3!Second Line:1,CDS!Front Line:3!Second Line:1,CSJ:2+,CSR!Front Line:3!Second Line:1,CW!Front Line:3!Second Line:1,BAN:0</availability>
+                <availability>CLAN:3+,CBS:1+,CB:2+,CFM!Front Line:3!Second Line:1,CGS!Front Line:3!Second Line:1,CJF!Front Line:3!Second Line:1,CMG:2+,CDS!Front Line:3!Second Line:1,CSJ:2+,CSR!Front Line:3!Second Line:1,CW!Front Line:3!Second Line:1,BAN:0</availability>
             </model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
@@ -1096,7 +1096,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cestus' unitType='Mek'>
-			<availability>IS:2+,FS:4,LA:2+,CS:4,CB!Front Line:2!Second Line:1,CFM!Front Line:2!Second Line:1,NIOPS:4+</availability>
+			<availability>IS:2+,FS:4,CS:4,CB!Front Line:2!Second Line:1,CFM!Front Line:2!Second Line:1,NIOPS:4+</availability>
 			<model name='CTS-6Y'>
 				<availability>IS:8,CB:8,CFM:5</availability>
 			</model>
@@ -1118,7 +1118,7 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>IS:4,LA:5,CC:6,MERC:4,CS:5,CBS:4-,CGB!Second Line:2!Solahma:1,CHH!Front Line:3!Second Line:2!Solahma:1,CIH:6+,CDS!Front Line:3!Second Line:2!Solahma:1,NIOPS:5</availability>
+			<availability>IS:4,LA:5,CC:6,MERC:4,CS:5,CBS:4-,CCO!Second Line:1,CGB!Second Line:2!Solahma:1,CHH!Front Line:3!Second Line:2!Solahma:1,CIH:6+,CDS!Front Line:3!Second Line:2!Solahma:1,NIOPS:5</availability>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
 				<availability>CC:2+,CS:8,CBS:8,CGB:8,CHH:3-,NIOPS:8</availability>
@@ -1953,7 +1953,7 @@
 				<availability>CC:9</availability>
 			</model>
 			<model name='CRD-3R'>
-				<availability>IS:8,MERC:8,Periphery:8,NIOPS:6-,Periphery.Deep:8,BAN:6</availability>
+				<availability>IS:8,MERC:8,Periphery:8,NIOPS:6-,Periphery.Deep:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
@@ -3508,7 +3508,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>IS:3,DC:4,MERC:3,CS:6,CLAN!Front Line:2!Second Line:1,CBS:3+,CB:3+,CCC:4+,CFM:4+,CGB:3+,CGS:3+,CIH:4+,CMG:4+,CSV!Front Line:3!Second Line:2!Solahma:1,TC:3,MOC:3,OA:3,CIR:3,NIOPS:6,BAN:0</availability>
+			<availability>IS:3,DC:4,MERC:3,CS:6,CLAN!Front Line:2!Second Line:1,CBS:3+,CB:3+,CCC:4+,CCO!Second Line:1,CFM:4+,CGB:3+,CGS:3+,CIH:4+,CMG:4+,CSV!Front Line:3!Second Line:2!Solahma:1,TC:3,MOC:3,OA:3,CIR:3,NIOPS:6,BAN:0</availability>
             <model name='C'>
                 <roles>cavalry,anti_aircraft</roles>
                 <availability>CB!Keshik:3!Front Line:1,CFM!Front Line:2!Second Line:1,CGB:2+,CIH!Keshik:8!Front Line:8!Second Line:5</availability>
@@ -4487,7 +4487,7 @@
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
-			<availability>FS:7,FWL:7,MERC:7,CS:6,NIOPS:6,Periphery:4,Periphery.Deep:4,BAN:2-</availability>
+			<availability>FS:7,FWL:7,MERC:7,CS:6,Periphery:4,NIOPS:6,Periphery.Deep:4,BAN:2-</availability>
 			<model name='OTL-4D'>
                 <roles>raider</roles>
 				<availability>IS:8,MERC:8,Periphery:8,BAN:8</availability>
@@ -5941,17 +5941,17 @@
 				<availability>CC:4</availability>
 			</model>
 			<model name='WHM-6R'>
-				<availability>IS:8,CCC:1-,CFM:1-,CMG:1-,CSJ:1-,Periphery:8,Periphery.Deep:8,BAN:6-</availability>
+				<availability>IS:8,CCC:1-,CFM:1-,CMG:1-,CSJ:1-,Periphery:8,NIOPS:3-,Periphery.Deep:8,BAN:6-</availability>
 			</model>
 			<model name='WHM-6Rb'>
-				<availability>FS:2+,LA:2+,FWL:2+,CC:2+,CLAN:3-,CBS:4-,CMG:4-,BAN:5</availability>
+				<availability>FS:2+,LA:2+,FWL:2+,CC:2+,CLAN:3-,CBS:4-,CMG:4-,NIOPS:6,BAN:5</availability>
 			</model>
 			<model name='WHM-6Rk'>
                 <roles>cavalry</roles>
 				<availability>DC:1+</availability>
 			</model>
 			<model name='WHM-7A'>
-				<availability>CLAN!Second Line:2,CBS:3+,CB!Front Line:2!Second Line:1,CFM!Front Line:2!Second Line:2,CIH:4+,CMG!Front Line:2</availability>
+				<availability>CLAN!Second Line:2,CBS:3+,CB!Front Line:2!Second Line:1,CFM!Front Line:2!Second Line:1,CIH:4+,CMG!Front Line:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Wasp LAM Mk I' unitType='Mek'>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -1774,7 +1774,7 @@
 			<model name='COM-2D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
-				<availability>LA:8,MERC:8,Periphery:8,Periphery.Deep:8</availability>
+				<availability>LA:8,MERC:8,CGS:8,CSJ:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
@@ -2109,7 +2109,7 @@
 		<chassis name='Drift Shag' unitType='Mek'>
 			<availability>CGS!Keshik:3!Front Line:1,CIH!Keshik:3!Front Line:1,CMG:2+</availability>
             <model name=''>
-                <availability>CLAN:8</availability>
+                <availability>CGS:8,CIH:8,CMG:8</availability>
             </model>
 		</chassis>
 		<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -2346,7 +2346,7 @@
 			</model>
 		</chassis>
 		<chassis name='Firestarter' unitType='Mek'>
-			<availability>IS:7,LA:8,CS:3,Periphery:7,NIOPS:3,Periphery.Deep:7</availability>
+			<availability>IS:7,LA:8,CS:3,CFM:3-,CHH:2-,Periphery:7,NIOPS:3,Periphery.Deep:7</availability>
 			<model name='FS9-H'>
                 <roles>anti_infantry,recon</roles>
 				<deployedWith>Vulcan</deployedWith>
@@ -2996,7 +2996,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hermes' unitType='Mek'>
-			<availability>DC:2,FWL:4,CC:2,CS:3,CLAN!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CBS:2,CB!Second Line:1!Solahma:1!Provisional Garrison:1,CCO:1,CGB!Front Line:1!Second Line:1!Solahma:1!Provisional Garrison:1,CGS:2,CHH:2,CIH!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CNC!Second Line:2!Solahma:2!Provisional Garrison:2,CSR:2,CSV:2,MOC:3,OA:3,NIOPS:3,BAN:4+</availability>
+			<availability>DC:2,FWL:4,CC:2,CS:3,CLAN!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CBS:2,CB!Second Line:1!Solahma:1!Provisional Garrison:1,CCO:1,CGB!Front Line:1!Second Line:1!Solahma:1!Provisional Garrison:1,CGS:2,CHH:2,CIH!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CNC!Second Line:2!Solahma:2!Provisional Garrison:2,CSR:2,CSA:2,CSV:2,MOC:3,OA:3,NIOPS:3,BAN:4+</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
 				<availability>FWL:8</availability>
@@ -3625,7 +3625,7 @@
 			</model>
 		</chassis>
 		<chassis name='Locust' unitType='Mek'>
-			<availability>IS:9,CS:6-,CLAN!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CB!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CCC:5,CCO!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CFM:5,CGB!Second Line:5!Solahma:5!Provisional Garrison:5,CGS!Second Line:4!Solahma:4!Provisional Garrison:4,CJF:5,CNC:5,CDS:4,CSJ:5,CSR:5,CSA:5,CSV:5,CW:4-,Periphery:6,NIOPS:6-,Periphery.Deep:6</availability>
+			<availability>IS:9,CS:6-,CLAN!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CB!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CCC:5,CCO!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CFM:5,CGB!Second Line:5!Solahma:5!Provisional Garrison:5,CGS!Second Line:4!Solahma:4!Provisional Garrison:4,CJF:5,CNC:5,CDS:4,CSJ:5,CSR:5,CSA:5,CSV:5,CW:4-,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:4</availability>
 			<model name='C'>
 				<availability>CCC!Keshik:8!Front Line:3!Second Line:1,CFM!Keshik:8!Front Line:1,CJF!Keshik:8!Front Line:8!Second Line:1,CSJ!Keshik:5!Front Line:8!Second Line:5,CSV!Keshik:8!Front Line:5,BAN:1+</availability>
 			</model>
@@ -4590,7 +4590,7 @@
 			</model>
 		</chassis>
 		<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
-			<availability>CFM:1+,CGS!Keshik:3!Front Line:1,CHH:2+,CNC:1+,CDS:1+,CSJ:2+,CW:2+</availability>
+			<availability>CFM:1+,CGS!Keshik:3!Front Line:1,CIH:2+,CNC:1+,CDS:1+,CSJ:2+,CW:2+</availability>
 			<model name=''>
 				<availability>CFM:8,CGS:8,CIH:8,CW:8</availability>
 			</model>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -6,9 +6,9 @@
 >
 	<factions>
 		<faction key='BAN'>
-			<pctOmni>0,0</pctOmni>
-			<pctClan>5,5</pctClan>
-			<pctSL>85,85</pctSL>
+            <!-- Omni percentages: 0,0 -->
+            <!-- Clan percentages: 5,5 -->
+            <!-- Star League percentages: 85,85 -->
 			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS'>
@@ -30,17 +30,17 @@
 			<weightDistribution era='2860' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 		</faction>
 		<faction key='CBS'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,0,10,30</pctClan>
-			<pctSL>100,100,100,90,70</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,0,10,30 -->
+            <!-- Star League percentages: 100,100,100,90,70 -->
 			<pctClan unitType='Vehicle'>0,0,0,5,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,95,85</pctSL>
 			<salvage pct='5'>CHH:5,CCC:5,CDS:1,CW:5,CSV:10,CNC:10,CCO:5,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CB'>
-			<pctOmni>0,0,0,10,20</pctOmni>
-			<pctClan>0,0,0,35,70</pctClan>
-			<pctSL>100,100,100,65,30</pctSL>
+            <!-- Omni percentages: 0,0,0,10,20 -->
+            <!-- Clan percentages: 0,0,0,35,70 -->
+            <!-- Star League percentages: 100,100,100,65,30 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CCC:1,CHH:5,CSR:6,CIH:4,CSV:3,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CMG:1,CJF:4</salvage>
@@ -48,17 +48,17 @@
 			<weightDistribution era='2860' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CCC'>
-			<pctOmni>0,0,0,10,15</pctOmni>
-			<pctClan>0,0,15,35,50</pctClan>
-			<pctSL>100,100,85,65,50</pctSL>
+            <!-- Omni percentages: 0,0,0,10,15 -->
+            <!-- Clan percentages: 0,0,15,35,50 -->
+            <!-- Star League percentages: 100,100,85,65,50 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:2,CFM:2,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CCO'>
-			<pctOmni>0,0,0,30,40</pctOmni>
-			<pctClan>10,10,15,45,55</pctClan>
-			<pctSL>90,90,85,55,45</pctSL>
+            <!-- Omni percentages: 0,0,0,30,40 -->
+            <!-- Clan percentages: 10,10,15,45,55 -->
+            <!-- Star League percentages: 90,90,85,55,45 -->
 			<pctClan unitType='Vehicle'>0,0,25,25,25</pctClan>
 			<pctSL unitType='Vehicle'>100,100,75,75,75</pctSL>
 			<salvage pct='10'>CHH:1,CCC:10,CIH:10,CSR:8,CSV:2,CFM:8,CGS:1,CSA:3,CDS:3,CW:1,CBS:1,CNC:10,CSJ:7,CJF:3,CB:7</salvage>
@@ -66,17 +66,17 @@
 			<weightDistribution era='2860' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CFM'>
-			<pctOmni>0,0,0,10,25</pctOmni>
-			<pctClan>0,0,10,45,55</pctClan>
-			<pctSL>100,100,90,55,45</pctSL>
+            <!-- Omni percentages: 0,0,0,10,25 -->
+            <!-- Clan percentages: 0,0,10,45,55 -->
+            <!-- Star League percentages: 100,100,90,55,45 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CCC:1,CHH:3,CSR:4,CIH:10,CSV:4,CCO:7,CGS:5,CSA:6,CDS:1,CW:1,CNC:3,CSJ:4,CMG:1,CJF:4,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CGB'>
-			<pctOmni>0,0,0,15,25</pctOmni>
-			<pctClan>15,15,35,45,55</pctClan>
-			<pctSL>85,85,65,55,45</pctSL>
+            <!-- Omni percentages: 0,0,0,15,25 -->
+            <!-- Clan percentages: 15,15,35,45,55 -->
+            <!-- Star League percentages: 85,85,65,55,45 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CSA:10,CHH:10,CCC:3,CIH:5,CSR:1,CDS:1,CW:10,CSV:10,CFM:3,CGS:1,CCO:1,CJF:5</salvage>
@@ -84,25 +84,25 @@
 			<weightDistribution era='2860' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CGS'>
-			<pctOmni>0,0,0,0,0</pctOmni>
-			<pctClan>0,0,20,25,35</pctClan>
-			<pctSL>100,100,80,75,65</pctSL>
+            <!-- Omni percentages: 0,0,0,0,0 -->
+            <!-- Clan percentages: 0,0,20,25,35 -->
+            <!-- Star League percentages: 100,100,80,75,65 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CCC:1,CHH:10,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:5,CW:4,CNC:10,CSJ:1,CMG:3,CJF:5,CB:5</salvage>
 		</faction>
 		<faction key='CHH'>
-			<pctOmni>0,0,0,15,20</pctOmni>
-			<pctClan>0,0,20,35,50</pctClan>
-			<pctSL>100,100,80,65,50</pctSL>
+            <!-- Omni percentages: 0,0,0,15,20 -->
+            <!-- Clan percentages: 0,0,20,35,50 -->
+            <!-- Star League percentages: 100,100,80,65,50 -->
 			<pctClan unitType='Vehicle'>0,0,15,20,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,70</pctSL>
 			<salvage pct='10'>CCC:2,CSR:7,CIH:10,CSV:3,CFM:7,CCO:1,CGS:7,CSA:3,CDS:7,CW:4,CBS:2,CNC:10,CSJ:3,CJF:3,CGB:7,CB:7</salvage>
 		</faction>
 		<faction key='CIH'>
-			<pctOmni>0,0,0,10,25</pctOmni>
-			<pctClan>0,0,15,40,50</pctClan>
-			<pctSL>100,100,85,60,50</pctSL>
+            <!-- Omni percentages: 0,0,0,10,25 -->
+            <!-- Clan percentages: 0,0,15,40,50 -->
+            <!-- Star League percentages: 100,100,85,60,50 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CCC:3,CHH:4,CSR:4,CSV:1,CFM:10,CCO:9,CGS:1,CSA:4,CDS:4,CW:7,CNC:3,CSJ:3,CMG:3,CJF:3,CGB:2,CB:3</salvage>
@@ -110,50 +110,50 @@
 			<weightDistribution era='2860' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
 		<faction key='CJF'>
-			<pctOmni>0,0,5,25,30</pctOmni>
-			<pctClan>0,0,25,40,50</pctClan>
-			<pctSL>100,100,75,60,50</pctSL>
+            <!-- Omni percentages: 0,0,5,25,30 -->
+            <!-- Clan percentages: 0,0,25,40,50 -->
+            <!-- Star League percentages: 100,100,75,60,50 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CCC:2,CHH:3,CSR:5,CIH:5,CSV:5,CFM:8,CCO:5,CGS:3,CSA:3,CDS:3,CW:10,CNC:2,CSJ:3,CMG:2,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CMG' />
 		<faction key='CNC'>
-			<pctOmni>0,0,0,10,20</pctOmni>
-			<pctClan>0,0,10,40,50</pctClan>
-			<pctSL>100,100,90,60,50</pctSL>
+            <!-- Omni percentages: 0,0,0,10,20 -->
+            <!-- Clan percentages: 0,0,10,40,50 -->
+            <!-- Star League percentages: 100,100,90,60,50 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CCC:5,CHH:5,CSR:10,CIH:3,CSV:2,CFM:3,CCO:10,CGS:3,CSA:5,CDS:3,CW:7,CBS:3,CSJ:2,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CDS'>
-			<pctOmni>0,0,0,30,35</pctOmni>
-			<pctClan>0,0,20,40,55</pctClan>
-			<pctSL>100,100,80,60,45</pctSL>
+            <!-- Omni percentages: 0,0,0,30,35 -->
+            <!-- Clan percentages: 0,0,20,40,55 -->
+            <!-- Star League percentages: 100,100,80,60,45 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='12'>CCC:2,CHH:5,CSR:10,CIH:8,CSV:5,CFM:3,CCO:4,CGS:3,CSA:3,CW:4,CNC:4,CSJ:5,CMG:1,CJF:5,CB:8</salvage>
 		</faction>
 		<faction key='CSJ'>
-			<pctOmni>0,0,0,20,30</pctOmni>
-			<pctClan>0,0,15,40,50</pctClan>
-			<pctSL>100,100,85,50,50</pctSL>
+            <!-- Omni percentages: 0,0,0,20,30 -->
+            <!-- Clan percentages: 0,0,15,40,50 -->
+            <!-- Star League percentages: 100,100,85,50,50 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
 		</faction>
 		<faction key='CSR'>
-			<pctOmni>0,0,5,10,30</pctOmni>
-			<pctClan>0,0,25,50,60</pctClan>
-			<pctSL>100,100,75,50,40</pctSL>
+            <!-- Omni percentages: 0,0,5,10,30 -->
+            <!-- Clan percentages: 0,0,25,50,60 -->
+            <!-- Star League percentages: 100,100,75,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CCC:2,CHH:3,CIH:5,CSV:4,CFM:5,CCO:8,CGS:1,CSA:1,CDS:7,CW:7,CNC:10,CSJ:2,CMG:1,CJF:3,CB:8</salvage>
 		</faction>
 		<faction key='CSA'>
-			<pctOmni>0,0,0,10,20</pctOmni>
-			<pctClan>0,0,25,45,55</pctClan>
-			<pctSL>100,100,75,55,45</pctSL>
+            <!-- Omni percentages: 0,0,0,10,20 -->
+            <!-- Clan percentages: 0,0,25,45,55 -->
+            <!-- Star League percentages: 100,100,75,55,45 -->
 			<pctClan unitType='Vehicle'>0,0,15,25,25</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,75,75</pctSL>
 			<salvage pct='10'>CCC:5,CHH:3,CSR:2,CIH:8,CSV:5,CFM:10,CCO:5,CGS:4,CDS:3,CW:5,CNC:8,CSJ:1,CMG:2,CJF:3,CGB:3,CB:5</salvage>
@@ -161,17 +161,17 @@
 			<weightDistribution era='2860' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CSV'>
-			<pctOmni>0,0,0,20,30</pctOmni>
-			<pctClan>5,5,30,45,55</pctClan>
-			<pctSL>95,95,70,55,45</pctSL>
+            <!-- Omni percentages: 0,0,0,20,30 -->
+            <!-- Clan percentages: 5,5,30,45,55 -->
+            <!-- Star League percentages: 95,95,70,55,45 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:5,CBS:1,CNC:1,CSJ:1,CMG:1,CJF:10,CGB:3,CB:1</salvage>
 		</faction>
 		<faction key='CW'>
-			<pctOmni>0,0,0,20,30</pctOmni>
-			<pctClan>0,0,15,40,50</pctClan>
-			<pctSL>95,95,85,60,50</pctSL>
+            <!-- Omni percentages: 0,0,0,20,30 -->
+            <!-- Clan percentages: 0,0,15,40,50 -->
+            <!-- Star League percentages: 95,95,85,60,50 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CHH:3,CCC:4,CIH:10,CSR:8,CSV:8,CFM:2,CGS:2,CCO:1,CSA:4,CDS:3,CNC:8,CSJ:8,CJF:8,CGB:2,CB:6</salvage>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -712,9 +712,9 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>CC:1,MOC:1,CS:3-,LA:4,FS.CMM:4,IS:4,MERC:3,FS:4,TC:1</availability>
+			<availability>IS:4,FS:4,LA:4,CC:1,MERC:3,CS:3-,CIH!Second Line:2!Solahma:1,TC:1,MOC:1</availability>
 			<model name='ASN-21'>
-				<availability>General:8</availability>
+				<availability>IS:8,CIH:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Asshur Fast Reconnaissance Vehicle' unitType='Tank'>
@@ -1189,10 +1189,10 @@
 			</model>
 		</chassis>
 		<chassis name='Cicada' unitType='Mek'>
-			<availability>CC:4,CS:4-,OA:3,LA:4,IS:4,FWL:4,FS:4,MERC:4,Periphery:3,DC:4</availability>
+			<availability>IS:4,FS:4,LA:4,DC:4,FWL:4,CC:4,MERC:4,CS:4-,Periphery:3,OA:3</availability>
 			<model name='CDA-2A'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,Periphery:8</availability>
 			</model>
 			<model name='CDA-2B'>
 				<roles>anti_infantry</roles>
@@ -1714,18 +1714,18 @@
             </model>
         </chassis>
 		<chassis name='Clint IIC' unitType='Mek'>
-			<availability>CSR:6</availability>
+			<availability>CSR:3+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CSR:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:6,MOC:3,CS:3-,OA:3,CLAN:2-,IS:4,NIOPS:3-,FS:6,MERC:4</availability>
+			<availability>IS:4,FS:6,CC:6,MERC:4,CS:3-,MOC:3,OA:3,NIOPS:3-</availability>
 			<model name='CLNT-1-2R'>
 				<availability>CC:1,FS:1</availability>
 			</model>
 			<model name='CLNT-2-3T'>
-				<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,NIOPS:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='CLNT-2-4T'>
 				<availability>CC:4,FS:4</availability>
@@ -1854,9 +1854,9 @@
 			</model>
 		</chassis>
 		<chassis name='Corvis' unitType='Mek'>
-			<availability>CHH:4,CLAN:3</availability>
+			<availability>CGB:2+,CHH!Keshik:4!Front Line:2!Second Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CHH:8</availability>
 			</model>
 		</chassis>
         <chassis name='Corx Mobile Tunnel Miner' unitType='Tank'>
@@ -1867,35 +1867,35 @@
             </model>
         </chassis>
 		<chassis name='Coyotl' unitType='Mek' omni='Clan'>
-			<availability>CSA:4,CHH:4,CDS:4,CLAN:4,CFM:4,CCO:6</availability>
+			<availability>CLAN:2+,CBS:1+,CCO!Keshik:5!Front Line:3,CGB!Keshik:3!Front Line:1,CGS:1+,CIH!Keshik:1!Front Line:1,CJF!Keshik:3!Front Line:1,CMG!Keshik:2,CSJ:1+,CSR!Keshik:3!Front Line:1,CSA!Keshik:3!Front Line:1,CW!Keshik:3!Front Line:1,BAN:0</availability>
 			<model name='A'>
                 <roles>raider</roles>
-				<availability>General:6</availability>
+				<availability>CLAN:4+</availability>
 			</model>
 			<model name='B'>
-				<availability>General:6</availability>
+				<availability>CLAN:5</availability>
 			</model>
 			<model name='Prime'>
-				<availability>General:8</availability>
+				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,CJF:4,CGB:4</availability>
+			<availability>IS:3,MERC:3,CS:5,CLAN:4,CB:3,CGS:5,CIH:3-,Periphery:3,NIOPS:5,BAN!Keshik:6!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
-				<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,NIOPS:0,Periphery.Deep:8,BAN:4-</availability>
 			</model>
 			<model name='CRB-27'>
 				<roles>raider</roles>
-				<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
+				<availability>LA:1+,DC:1+,FWL:1+,CC:1+,CS:8,CLAN:4-,CB:5-,CIH:5-,CSJ:5-,NIOPS:8,BAN:3</availability>
 			</model>
 			<model name='CRB-27b'>
 				<roles>raider</roles>
-				<availability>CC:1+,CLAN:7,FWL:1+,CGS:8,BAN:4</availability>
+				<availability>FWL:1+,CC:1+,CLAN:5+,CBS:8,BAN:3+</availability>
 			</model>
 			<model name='CRB-27sl'>
                 <roles>raider</roles>
-				<availability>LA:2+,CLAN:3,DC:2+</availability>
+				<availability>LA:2+,DC:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
@@ -2061,9 +2061,9 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>CC:4,Periphery.HR:6,CLAN:2,IS:5,Periphery.Deep:5,FS:8,MERC:5,TC:5</availability>
+			<availability>IS:5,FS:8,CC:4,MERC:5,CBS:3+,Periphery.HR:6,TC:5,Periphery.Deep:5</availability>
 			<model name='DV-6M'>
-				<availability>CLAN:4,IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CBS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='DV-6Md'>
 				<availability>FS:3+</availability>
@@ -2164,7 +2164,7 @@
 			</model>
 		</chassis>
 		<chassis name='Enfield' unitType='Mek'>
-			<availability>CMG:6</availability>
+			<availability>CMG:3+</availability>
 			<model name='END-6J-EC'>
 				<roles>urban</roles>
 				<availability>CMG:8</availability>
@@ -2518,10 +2518,13 @@
 			</model>
 		</chassis>
 		<chassis name='Fox' unitType='Mek'>
-			<availability>CDS:6,CW:4,CSJ:4</availability>
+			<availability>CGB:2+,CDS!Keshik:3!Front Line:1,CSJ:1+,CW!Front Line:1!Second Line:1</availability>
 			<model name='CS-1'>
-				<availability>General:8</availability>
+				<availability>CDS:4-,CSJ:8,CW:3-</availability>
 			</model>
+            <model name=''>
+                <availability>CGB:8,CDS:3,CSJ:5+,CW:8</availability>
+            </model>
 		</chassis>
 		<chassis name='Fury Command Tank' unitType='Tank'>
 			<availability>CC:1,CHH:8,CW:8,LA:1,CLAN:6,FWL:1,FS:1,MERC:1,CJF:8,DC:1,CGB:8</availability>
@@ -2623,13 +2626,13 @@
 			</model>
 		</chassis>
 		<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
-			<availability>CSV:7</availability>
+			<availability>CLAN:1+,CB:2+,CFM!Keshik:3!Front Line:1,CIH:2+,CJF:2+,CMG!Keshik:3!Front Line:1,CSA:2+,CSV:2+,BAN:0</availability>
 			<model name=''>
 			    <roles>raider</roles>
-				<availability>CSV:8:2863</availability>
+				<availability>CIH:8</availability>
 			</model>
 			<model name='6'>
-				<availability>CLAN:4</availability>
+				<availability>CLAN:8,CIH:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
@@ -2655,28 +2658,31 @@
 			</model>
 		</chassis>
 		<chassis name='Great Wyrm' unitType='Mek'>
-			<availability>CCC:5,CSV:5,CLAN:3,CFM:5,CSJ:5,CMG:5,CCO:5,CB:5</availability>
+			<availability>CBS:1+,CB:2+,CJF!Second Line:1,CMG!Front Line:2!Second Line:1,CNC!Front Line:1,CSJ:1+,CSA!Keshik:1!Front Line:1!Second Line:1,CW!Front Line:1</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Griffin IIC' unitType='Mek'>
-			<availability>CCC:5,CCO:5,CGB:5,CNC:5,CDS:5,CSJ:5,BAN:2+</availability>
+			<availability>CCC!Keshik:3!Front Line:1,CCO!Keshik:3!Front Line:1,CGB!Keshik:3!Front Line:1,CNC!Keshik:4!Front Line:2!Second Line:1,CDS:2+,CSJ!Keshik:3!Front Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CCC:8,CCO:8,CGB:8,CNC:8,CDS:8,CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>CC:7,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,NIOPS:4,DC:8</availability>
+			<availability>IS:9,DC:8,CC:7,MERC:7,CS:4,CLAN!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,CBS:5,CB:5,CIH:5+,CSJ:5,Periphery:6,TC:7,OA:5,NIOPS:4,Periphery.Deep:6,BAN:4+</availability>
 			<model name='GRF-1N'>
-				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:7,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:8,BAN:1-</availability>
 			</model>
 			<model name='GRF-1S'>
 				<availability>LA:6</availability>
 			</model>
 			<model name='GRF-2N'>
-				<availability>CC:1+,LA:1+,CLAN:6,FWL:1+,FS:1+,BAN:4</availability>
+				<availability>FS:1+,LA:1+,FWL:1+,CC:1+,CLAN:8,BAN:5</availability>
 			</model>
+            <model name='GRF-2N2'>
+                <availability>BAN:2-</availability>
+            </model>
 		</chassis>
 		<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 			<availability>IS:5,MERC:5,Periphery:3</availability>
@@ -2972,12 +2978,12 @@
 			</model>
 		</chassis>
 		<chassis name='Hellhound (Conjurer)' unitType='Mek'>
-			<availability>CHH:6,CIH:6,CDS:4,CLAN:7,CNC:6,CJF:6</availability>
+			<availability>CCO!Keshik:3!Front Line:1,CJF!Keshik:4!Front Line:2!Second Line:1,CSJ!Keshik:3!Front Line:1,CW!Keshik:5!Front Line:1</availability>
 			<model name=''>
-				<availability>CHH:8,General:8,CJF:8</availability>
+				<availability>CCO:8,CJF:5,CW:5</availability>
 			</model>
 			<model name='7'>
-				<availability>CW:4,CLAN:4</availability>
+				<availability>CJF:8,CSJ:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hermes II' unitType='Mek'>
@@ -3033,17 +3039,17 @@
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
-			<availability>CC:2,MOC:1,CHH:4,OA:1,LA:2,CLAN:3,FWL:2,FS:2,CGS:5,DC:2,TC:2</availability>
+			<availability>FS:2,LA:2,DC:2,FWL:2,CC:2,CBS:4+,CGB!Front Line:3!Second Line:2!Solahma:1,CGS:5+,CHH!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CJF:3,CNC!Front Line:3!Second Line:2!Solahma:1,TC:2,MOC:1,OA:1</availability>
 			<model name='HOP-4Bb'>
                 <roles>fire_support</roles>
-				<availability>CLAN:5,BAN:2</availability>
+				<availability>CBS:3,CGB:8,CGS:5,CHH:5,CJF:8,CNC:8</availability>
 			</model>
 			<model name='HOP-4C'>
                 <roles>inf_support</roles>
-				<availability>MOC:8,OA:8,FS:8</availability>
+				<availability>FS:8,CBS:1-,CGS:2-,MOC:8,OA:8</availability>
 			</model>
 			<model name='HOP-4Cb'>
-				<availability>CHH:8,CLAN:2,BAN:2</availability>
+				<availability>CHH:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
@@ -3068,15 +3074,15 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback IIC' unitType='Mek'>
-			<availability>CDS:4,CSR:4,CW:4,CSV:5,CLAN:4,CSJ:5,CJF:4,CGB:4</availability>
+			<availability>CSJ:2+</availability>
 			<model name=''>
-				<availability>CSR:8,General:8</availability>
+				<availability>CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>CC:6,CLAN:2-,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,LA:5,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
+			<availability>IS:5,DC:6,FWL:8,CC:6,CS:5-,CB!Front Line:3!Second Line:2!Solahma:1,CCO!Second Line:3!Solahma:2!Provisional Garrison:1,CSJ:4-,Periphery:5,Periphery.MW:6,Periphery.ME:6,NIOPS:5-,Periphery.Deep:5</availability>
 			<model name='HBK-4G'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CB:8,CCO:8,CSJ:8,Periphery:8,NIOPS:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='HBK-4H'>
 				<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
@@ -3418,15 +3424,15 @@
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
-			<availability>CS:7,CHH:7,CDS:7,CSV:7,CLAN:6,FWL:2,NIOPS:7,FS:6,MERC:2,DC:2</availability>
+			<availability>FS:6,DC:2,FWL:2,MERC:2,CS:7,CLAN:4-,CBS:4,CCO:4,CSR:3-,CSV:3-,NIOPS:7,BAN:3+</availability>
 			<model name='KTO-18'>
 				<availability>FS:5</availability>
 			</model>
 			<model name='KTO-19'>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
+				<availability>CS:8,CLAN:3-,CBS:4-,CB:4-,CCC:4-,CIH:4-,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='KTO-19b'>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CLAN:5,BAN:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Kiso' unitType='Mek'>
@@ -3490,10 +3496,10 @@
 			</model>
 		</chassis>
 		<chassis name='Kyudo' unitType='Mek'>
-			<availability>FWL:2+,FS:2+</availability>
+			<availability>FS:2+,FWL:2+,CBS!Front Line:2!Second Line:1,CMG!Second Line:1,CDS!Secodn Line:1</availability>
 			<model name='KY2-D-02'>
 				<roles>fire_support</roles>
-				<availability>IS:8</availability>
+				<availability>FS:8,FWL:8,CBS:8,CMG:8,CDS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='LRM Carrier' unitType='Tank'>
@@ -3742,10 +3748,10 @@
 			</model>
 		</chassis>
 		<chassis name='Lynx' unitType='Mek'>
-			<availability>CIH:6,LA:2,CLAN:4,FWL:2,CSJ:6,CJF:4,DC:2</availability>
+			<availability>LA:2,DC:2,FWL:2,CLAN!Front Line:3!Second Line:2!Solahma:1,CBS:4+,CB:5+,CCC:4+,CCO:5+,CGS:4+,CIH:4+,CJF:5+,CMG:4+,CNC!Front Line:3!Second Line:1,CSJ:5+,CSR:3+,CW!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,BAN:2+</availability>
 			<model name='C'>
                 <roles>raider</roles>
-				<availability>CCC:6,CW:6,CNC:6,CSJ:8,CJF:6,CGS:6</availability>
+				<availability>CCC!Keshik:8!Front Line:8,CGS:3+,CJF:3+,CNC:1+,CSJ!Keshik:3!Front Line:1,CW:3+</availability>
 			</model>
 			<model name='LNX-8Q'>
                 <roles>raider</roles>
@@ -3753,7 +3759,7 @@
 			</model>
 			<model name='LNX-9Q'>
                 <roles>raider</roles>
-				<availability>CLAN:8,IS:4+</availability>
+				<availability>IS:4+,CLAN:8,CCC:3-,CGS:4-,CJF:4-,CW:3-,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -4340,14 +4346,20 @@
 			</model>
 		</chassis>
 		<chassis name='Naja' unitType='Mek'>
-			<availability>CCC:6,CBS:5,CSV:5,CLAN:4,CMG:5</availability>
+			<availability>CBS!Keshik:1!Front Line:1,CB!Front Line:1,CCC:2+,CSV!Front Line:1</availability>
             <model name=''>
-                <availability>CCC:8,CLAN:6</availability>
+                <availability>CBS:8,CCC:8,CSV:8</availability>
             </model>
-			<model name='KTO-19b-EC'>
-				<availability>CCC:4,CBS:4,CSV:4,CMG:4</availability>
-			</model>
 		</chassis>
+        <chassis name='Night Chanter' unitType='Mek' omni='Clan'>
+            <availability>CCO!Keshik:3</availability>
+            <model name='A'>
+                <availability>CCO:6</availability>
+            </model>
+            <model name='Prime'>
+                <availability>CCO:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Night Hawk' unitType='Mek'>
 			<availability>FS:2+,LA:2+,FWL:2+,CLAN:4+,CBS:5+,CB:5+,CCO:5+,CGB:5+,CJF:5+,CMG:3+,CNC:5+,CSJ:5+,CSR:3+,CW:5+,BAN:3+</availability>
 			<model name='NTK-2Q'>
@@ -4629,14 +4641,18 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:7,CLAN:3,IS:9,NIOPS:7,Periphery.Deep:5,Periphery:5</availability>
-			<model name='PXH-1'>
+			<availability>IS:9,CS:7,CLAN:4+,CB:3+,CCO!Front Line:3!Second Line:2!Solahma:1,CGB:3+,CGS:6+,CIH:5+,Periphery:5,NIOPS:7,Periphery.Deep:5,BAN:4</availability>
+            <model name='C'>
+                <roles>recon</roles>
+                <availability>CGS!Keshik:5!Front Line:3!Second Line:1,CIH!Keshik:8!Front Line:3,CJF!Front Line:5!Second Line:3!Solahma:1</availability>
+            </model>
+            <model name='PXH-1'>
 				<roles>command,recon</roles>
-				<availability>General:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,BAN:5-</availability>
 			</model>
 			<model name='PXH-1-EC'>
                 <roles>command,recon</roles>
-				<availability>CGS:3</availability>
+				<availability>CGS!Front Line:3!Second Line:1</availability>
 			</model>
 			<model name='PXH-1D'>
 				<roles>command,recon</roles>
@@ -4648,15 +4664,15 @@
 			</model>
 			<model name='PXH-1b &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:7,BAN:3</availability>
+				<availability>CLAN:8,CGS:4,CIH:5-,BAN:3</availability>
 			</model>
 			<model name='PXH-1c &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:4,CGS:6</availability>
+				<availability>CGS:3+</availability>
 			</model>
 			<model name='PXH-2'>
 				<roles>command,recon</roles>
-				<availability>CC:1+,MOC:1+,OA:1+,CLAN:3,FWL:1+,BAN:4</availability>
+				<availability>FWL:1+,CC:1+,MOC:1+,OA:1+,BAN:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
@@ -5020,9 +5036,9 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>CC:4-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:4-,BAN:2-</availability>
+			<availability>LA:4-,DC:4-,FWL:4-,CC:4-,MERC:4-,CS:3-,Periphery:4-,NIOPS:3-,Periphery.Deep:4-</availability>
 			<model name='SCP-1N'>
-				<availability>LA:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Scout JumpShip' unitType='Jumpship'>
@@ -5046,7 +5062,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
+			<availability>FS:1-,LA:4-,DC:2,FWL:1-,CS:4,CLAN:4-,CBS:5-,CCC:3-,CCO:3-,CIH!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,CDS:2,NIOPS:4,BAN:2</availability>
 			<model name='STN-3K'>
 				<availability>LA:8,DC:8</availability>
 			</model>
@@ -5057,10 +5073,10 @@
 				<availability>LA:4</availability>
 			</model>
 			<model name='STN-3L'>
-				<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
+				<availability>FS:1+,LA:1+,FWL:1+,MERC:1+,CS:8,CLAN:8,CBS:4-,CCC:4,CFM:3,CGB:4-,CHH:4-,CJF:3-,CDS:4-,CSR:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='STN-3Lb'>
-				<availability>CLAN:6,BAN:3</availability>
+				<availability>CBS:4+,CCC:4+,CFM:4+,CGB:4+,CHH:4+,CJF:4+,CDS:4+,CSR:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
@@ -5079,27 +5095,27 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>CLAN:6,BAN:3+</availability>
+			<availability>CLAN!Keshik:3!Front Line:1,CB!Keshik:4!Front Line:3!Second Line:1,CCC:3+,CCO:2+,CFM:3+,CGB!Keshik:4!Front Line:3!Second Line:1,CHH!Keshik:4!Front Line:3!Second Line:1,CIH:2+,CMG:2+,CNC:2+,CSJ:2+,CSR!Keshik:4!Front Line:3!Second Line:1,CSA!Keshik:4!Front Line:3!Second Line:1,CSV:3+,CW!Keshik:4!Front Line:3!Second Line:1,BAN:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CLAN:8,CGB:4,BAN:8</availability>
 			</model>
 			<model name='2'>
-				<availability>CGB:6</availability>
+				<availability>CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5</availability>
+			<availability>IS:7,LA:6,CS:6-,CLAN:5,CGB!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CGS!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CHH!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CIH:4,CNC!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CSR!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CSA!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CSV!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CW!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,Periphery:5,NIOPS:6-,Periphery.Deep:5,BAN:5</availability>
             <model name='C'>
-                <availability>CSA:6,CCC:6,CSV:6,CFM:6,CGS:6</availability>
+                <availability>CLAN!Front Line:6!Second Line:3,CBS!Keshik:6!Front Line:3,CB!Keshik:6!Front Line:3,CCC!Keshik:8!Front Line:3,CCO!Keshik:8!Front Line:1,CFM!Keshik:8!Front Line:3!Second Line:1,CGS!Front Line:6!Second Line:1,CIH!Keshik:8!Front Line:1,CJF!Keshik:6!Front Line:3!Second Line:1,CMG!Keshik:6!Front Line:3!Second Line:1,CNC!Front Line:6!Second Line:1,CDS!Keshik:6!Front Line:3!Second Line:1,CSJ!Keshik:6!Front Line:3!Second Line:1,BAN!Keshik:3!Front Line:1</availability>
             </model>
 			<model name='SHD-2D'>
 				<availability>FS:10</availability>
 			</model>
 			<model name='SHD-2H'>
-				<availability>General:8,CLAN:5-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8,BAN:2</availability>
 			</model>
 			<model name='SHD-2Hb'>
-				<availability>CLAN:6,FS:2+,BAN:4</availability>
+				<availability>FS:2+,CLAN:4-,CBS:7,CB!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:7,CCC:5,BAN:3+</availability>
 			</model>
 			<model name='SHD-2K'>
 				<availability>DC:9</availability>
@@ -5312,14 +5328,14 @@
 			</model>
 		</chassis>
 		<chassis name='Starslayer' unitType='Mek'>
-			<availability>CSA:2,LA:3+,CNC:2</availability>
+			<availability>LA:3+,CNC!Second Line:1,CSA!Front Line:3!Second Line:2!Solahma:1</availability>
 			<model name='STY-2C'>
 				<roles>raider</roles>
-				<availability>IS:8</availability>
+				<availability>LA:8</availability>
 			</model>
 			<model name='STY-2C-EC'>
                 <roles>raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CNC:8,CSA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stinger LAM Mk I' unitType='Mek'>
@@ -5657,10 +5673,10 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
+			<availability>FWL:8,CC:5,MERC:5,CS:5-,CDS!Front Line:2!Second Line:1,MOC:5,NIOPS:5-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
-				<availability>CC:1+,CS:6,FWL:1+,NIOPS:6</availability>
+				<availability>FWL:1+,CC:1+,CS:6,CDS:8,NIOPS:6</availability>
 			</model>
 			<model name='TBT-5J'>
 				<availability>FWL:4</availability>
@@ -5865,14 +5881,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:4,CS:3,MOC:5,LA:7,CLAN:2-,FWL:7,IS:5,NIOPS:3,CIR:5,TC:5</availability>
+			<availability>IS:5,LA:7,FWL:7,CC:4,CS:3,TC:5,MOC:5,CIR:5,NIOPS:3</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
-				<availability>General:8,FS:4</availability>
+				<availability>IS:8,FS:4,Periphery:8</availability>
 			</model>
 			<model name='VL-5T'>
 				<roles>anti_infantry</roles>
-				<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,TC:2</availability>
+				<availability>IS:2,FS:6,TC:2,MOC:2,CIR:2,PIR:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Vulture' unitType='Dropship'>
@@ -6001,13 +6017,13 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:2-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+			<availability>FS.CMM:5,DC:6,MERC:3,CS:3-,Periphery.DD:2,Periphery.OS:2,TC:2,MOC:1,OA:1,NIOPS:3-</availability>
 			<model name='WTH-0'>
 				<availability>TC:5</availability>
 			</model>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
-				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='WTH-1S'>
 				<roles>fire_support</roles>
@@ -6015,7 +6031,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CS:5-,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,TC:5</availability>
+			<availability>IS:7,FS:8,FWL:10,CS:5-,NIOPS:5-,TC:5,Periphery.Deep:6</availability>
 			<model name='WVR-1R'>
 				<availability>FS:1-</availability>
 			</model>
@@ -6032,25 +6048,25 @@
 			</model>
 			<model name='WVR-6R'>
 				<roles>command,recon</roles>
-				<availability>General:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Wyvern IIC' unitType='Mek'>
-			<availability>CHH:4,CW:4,CLAN:4</availability>
+			<availability>CB:2+,CCC!Front Line:1!Second Line:1</availability>
 			<model name=''>
 				<roles>urban</roles>
-				<availability>CW:8,CLAN:8</availability>
+				<availability>CB:8,CCC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CS:6,CC:6,CIH:4,CLAN:5,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:4</availability>
+			<availability>FS:6,DC:6,CC:6,MERC:5,CS:6,CLAN:3,CBS:4,CB:4,CFM:4,CGB:4-,CHH:4-,CIH:2-,CMG:4-,CNC:4-,CSJ:2,CSA:4-,CSV:3-,CW:4-,TC:4,NIOPS:6,BAN:3</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
-				<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
+				<availability>CS:8,CBS:3-,CB:3-,CCO:3-,CFM:2-,TC:8,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='WVE-5Nb'>
 				<roles>urban</roles>
-				<availability>CLAN:6,CFM:6,CGS:6</availability>
+				<availability>CLAN:8,CBS:6,CB:6,CCO:6,CFM:6,BAN:3+</availability>
 			</model>
 			<model name='WVE-5Nsl'>
 				<availability>LA:2+,FWL:2+</availability>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -617,7 +617,7 @@
 			</model>
 			<model name='ARC-2Rb'>
 				<roles>command,fire_support</roles>
-				<availability>CLAN:4-,CB:3-,BAN:2+</availability>
+				<availability>CLAN:4-,CB:3-,NIOPS:5,BAN:2+</availability>
 			</model>
 			<model name='ARC-2S'>
 				<roles>command,fire_support</roles>

--- a/megamek/data/forcegenerator/2860.xml
+++ b/megamek/data/forcegenerator/2860.xml
@@ -2218,7 +2218,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Mek'>
-			<availability>FS:1+,LA:1+,DC:1+,CS:5,CLAN!Front Line:2!Second Line:1,CBS:3+,CB:3+,CGS:3+,CIH:3+,CJF:3+,CMG:3+,CNC:3+,CSR:3+,CSA:3+,CSV:3+,NIOPS:5</availability>
+			<availability>FS:1+,LA:1+,DC:1+,CS:5,CLAN!Front Line:2!Second Line:1,CBS:3+,CB:3+,CGS:3+,CIH:3+,CJF:3+,CMG:3+,CNC:3+,CSR:3+,CSA:3+,CSV:3+,NIOPS:5,BAN:0</availability>
 			<model name='EXC-B1'>
 				<roles>cavalry,fire_support</roles>
 				<availability>LA:8,CDS:4-</availability>
@@ -5951,7 +5951,7 @@
 				<availability>DC:1+</availability>
 			</model>
 			<model name='WHM-7A'>
-				<availability>CLAN!Second Line:2,CBS:3+,CB!Front Line:2!Second Line:1,CFM!Front Line:2!Second Line:1,CIH:4+,CMG!Front Line:2</availability>
+				<availability>CLAN!Second Line:2,CBS:3+,CB!Front Line:2!Second Line:1,CFM!Front Line:2!Second Line:1,CIH:4+,CMG!Front Line:2,BAN:0</availability>
 			</model>
 		</chassis>
 		<chassis name='Wasp LAM Mk I' unitType='Mek'>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -3107,15 +3107,15 @@
 			</model>
 			<model name='HGN-733'>
                 <roles>command</roles>
-				<availability>CC:6-,LA:6-</availability>
+				<availability>LA:6-,CC:6-</availability>
 			</model>
 			<model name='HGN-733C'>
                 <roles>command</roles>
-				<availability>CC:3,LA:3</availability>
+				<availability>LA:3,CC:3</availability>
 			</model>
 			<model name='HGN-733P'>
                 <roles>command</roles>
-				<availability>CC:3-,LA:3-</availability>
+				<availability>LA:3-,CC:3-</availability>
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
@@ -5396,7 +5396,7 @@
 			</model>
 		</chassis>
 		<chassis name='Spartan' unitType='Mek'>
-			<availability>CS:5,CCO!Front Line:1,CFM!Front Line:2!Second Line:1,CHH!Second Line:1,CIH:4+,BAN:4+    </availability>
+			<availability>CS:5,CCO!Front Line:1,CFM!Front Line:2!Second Line:1,CHH!Second Line:1,CIH:4+,BAN:4+</availability>
 			<model name='C'>
                 <roles>cavalry</roles>
 				<availability>CCO:8,CFM:8,CHH:8</availability>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -5819,7 +5819,7 @@
 			<availability>CC:5-,IS:4-,Periphery:3-,CS:4-,FS.CMM:4-,NIOPS:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
-				<availability>IS:8,MERC:8,CC:8,Periphery:8,Periphery.Deep:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Valkyrie' unitType='Mek'>
@@ -5996,7 +5996,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>IS:10,CS:4-,CIR:4,Periphery:6,NIOPS:4-,Periphery.Deep:6,BAN:1-</availability>
+			<availability>IS:10,CS:4-,Periphery:6,CIR:4,NIOPS:4-,Periphery.Deep:6,BAN:1-</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
 				<availability>IS:8,MERC:8,Periphery:8,BAN:8</availability>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -1765,14 +1765,14 @@
             </model>
         </chassis>
 		<chassis name='Commando IIC' unitType='Mek'>
-			<availability>CHH:3,CIH:3,CLAN:3,CGS:5</availability>
+			<availability>CGS!Keshik:1!Front Line:1</availability>
 			<model name=''>
 				<roles>recon</roles>
-				<availability>CLAN:8</availability>
+				<availability>CGS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>LA:9,CSJ:2,CIR:4,MERC:4,CGS:2</availability>
+			<availability>LA:9,MERC:4,CSJ:2-,CIR:4</availability>
 			<model name='COM-1D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
@@ -1781,7 +1781,7 @@
 			<model name='COM-2D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
-				<availability>LA:8,General:8,Periphery.Deep:8</availability>
+				<availability>LA:8,MERC:8,CSJ:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
@@ -2118,9 +2118,9 @@
 			</model>
 		</chassis>
 		<chassis name='Drift Shag' unitType='Mek'>
-			<availability>CIH:4,CMG:2,CGS:2</availability>
+			<availability>CGS!Keshik:3!Front Line:1,CIH!Keshik:3!Front Line:1,CMG:2+</availability>
             <model name=''>
-                <availability>CLAN:8</availability>
+                <availability>CGS:8,CIH:8,CMG:8</availability>
             </model>
 		</chassis>
 		<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -2304,18 +2304,12 @@
 		    </model>
 		</chassis>
 		<chassis name='Falcon' unitType='Mek'>
-			<availability>CC:1,MOC:1,OA:1,CIH:5,LA:1,CLAN:3,FWL:1,FS:1,MERC:1,CGS:5,TC:1</availability>
+			<availability>FS:1,LA:1,FWL:1,CC:1,MERC:1,CGS!Second Line:4!Solahma:3!Provisional Garrison:2,TC:1,MOC:1,OA:1</availability>
 			<model name='FLC-4N'>
-				<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='FLC-4Nb'>
-				<availability>CLAN:8,BAN:2</availability>
-			</model>
-			<model name='FLC-4Nb-PP'>
-				<availability>BAN:2</availability>
-			</model>
-			<model name='FLC-4Nb-PP2'>
-				<availability>BAN:2</availability>
+				<availability>CGS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Field Artillery' unitType='Infantry'>
@@ -2362,33 +2356,24 @@
 			</model>
 		</chassis>
 		<chassis name='Firefly' unitType='Mek'>
-			<availability>CC:1+,CIH:7,CLAN:7,FS:1+,BAN:6,CB:7</availability>
+			<availability>FS:1+,CC:1+,CLAN!Front Line:3!Second Line:2!Solahma:1,CBS:3+,CB!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CCO!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CGB!Second Line:5!Solahma:4!Provisional Garrison:3,CHH!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:3-,CMG:3-,CNC!Second Line:3!Solahma:2!Provisional Garrison:1,CDS!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CSJ:4+,CSV:4-,CW:3-,BAN:2</availability>
 			<model name='C'>
-				<availability>CLAN:7,BAN:2</availability>
+				<availability>CSJ!Keshik:8!Front Line:8!Second Line:1</availability>
 			</model>
 			<model name='FFL-3A'>
 				<roles>spotter</roles>
-				<availability>CC:8,FS:8</availability>
-			</model>
-			<model name='FFL-3PP'>
-				<availability>BAN:2</availability>
-			</model>
-			<model name='FFL-3PP2'>
-				<availability>BAN:2</availability>
-			</model>
-			<model name='FFL-3PP3'>
-				<availability>BAN:2</availability>
+				<availability>FS:8,CC:8,CSR:3-,BAN:4-</availability>
 			</model>
 			<model name='FFL-3SLE'>
-				<availability>CLAN:5,BAN:3</availability>
+				<availability>CLAN:8,CSJ!Front Line:5!Second Line:8!Solahma:8!Provisional Garrison:8,CSR:5,BAN:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Firestarter' unitType='Mek'>
-			<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
+			<availability>IS:7,LA:8,CS:3,Periphery:7,NIOPS:3,Periphery.Deep:7</availability>
 			<model name='FS9-H'>
                 <roles>anti_infantry,recon</roles>
 				<deployedWith>Vulcan</deployedWith>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='FS9-K'>
                 <roles>anti_infantry,recon</roles>
@@ -3041,7 +3026,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hermes' unitType='Mek'>
-			<availability>MOC:2,CC:1,CS:3,CHH:5,OA:2,CLAN:4,FWL:4,NIOPS:3,CGB:5,DC:1,CB:5</availability>
+			<availability>DC:1,FWL:4,CC:1,CS:3,CLAN!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CBS:2,CB!Second Line:1!Solahma:1!Provisional Garrison:1,CCO:1,CGB!Front Line:1!Second Line:1!Solahma:1!Provisional Garrison:1,CGS:2,CHH:2,CIH!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CNC!Second Line:2!Solahma:2!Provisional Garrison:2,CSR:2,CSA:2,CSV:2,MOC:2,OA:2,NIOPS:3,BAN:4+</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
 				<availability>FWL:8</availability>
@@ -3052,11 +3037,11 @@
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
-				<availability>CS:8,General:1+,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>IS:1+,CS:8,CLAN:4-,CBS!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CB:4,CCC:4,CGS:4,CIH!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CMG:4,CSJ:4,CSV:3-,CW:4-,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='HER-1Sb'>
 				<roles>recon</roles>
-				<availability>CLAN:5,FWL:1+,BAN:3</availability>
+				<availability>FWL:1+,CLAN:3,CBS:3+,CB:4+,CCC:4+,CGS:3+,CIH:4+,CJF:4+,CMG:4+,CSJ:3+,CW:4+,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Highlander IIC' unitType='Mek'>
@@ -3149,13 +3134,13 @@
 			</model>
 		</chassis>
 		<chassis name='Hussar' unitType='Mek'>
-			<availability>CS:4,CIH:9,CSV:9,CLAN:8,NIOPS:4</availability>
+			<availability>CS:4,CLAN!Front Line:3!Second Line:2!Solahma:1,CCO:3+,CGB!Front Line:2!Second Line:1,CGS:3+,CHH:3+,CIH!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CMG!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CNC:3+,CDS:4+,CSR:3+,CSA:3+,CSV:4+,CW!Second Line:3!Solahma:2!Provisional Garrison:1,NIOPS:4,BAN:4+</availability>
 			<model name='HSR-200-D'>
 				<roles>recon</roles>
-				<availability>CS:8,General:8,CLAN:6,NIOPS:8,BAN:8,DC:8</availability>
+				<availability>CS:8,CLAN:4-,CBS:5,CB:4,CGS:5,CIH!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CMG:4,CDS:5,CW:5,NIOPS:8,BAN:4-</availability>
 			</model>
 			<model name='HSR-200-Db'>
-				<availability>CLAN:6,BAN:4</availability>
+				<availability>CLAN:4+,CB:5+,CCC:3,CCO:3,CFM:3,CGB:4,CHH:3,CNC:4,CSJ:5,CSR:4,CSA:4,CSV:4,CW!Second Line:4!Solahma:3!Provisional Garrison:2,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
@@ -3171,10 +3156,10 @@
 			</model>
 		</chassis>
 		<chassis name='Icestorm' unitType='Mek'>
-			<availability>CIH:6+,CW:4</availability>
+            <availability>CIH!Keshik:4!Front Line:3!Second Line:1</availability>
 			<model name=''>
 				<roles>spotter</roles>
-				<availability>CLAN:8</availability>
+				<availability>CIH:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
@@ -3678,25 +3663,25 @@
 			</model>
 		</chassis>
 		<chassis name='Locust IIC' unitType='Mek'>
-			<availability>CHH:6,CW:6,CLAN:6,CJF:6,CGB:6</availability>
+			<availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:2,CFM:3+,CGB!Keshik:4!Front Line:2!Second Line:1,CGS:3+,CHH:3+,CIH!Keshik:4!Front Line:2!Second Line:1,CJF!Keshik:6!Front Line:3!Second Line:1,BAN:2+</availability>
 			<model name=''>
-				<availability>CW:8,General:8</availability>
+				<availability>CLAN:8,CIH:4,CJF:5,CSJ:3,CSA!Front Line:5!Second Line:8,BAN:8</availability>
 			</model>
 			<model name='2'>
-				<availability>CCC:4,CIH:4,CJF:4</availability>
+				<availability>CIH:8,CJF:8</availability>
 			</model>
 			<model name='3'>
-				<availability>General:3</availability>
+				<availability>CSJ!Keshik:8!Front Line:5!Second Line:1,CSA!Keshik:8!Front Line:5!Second Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Locust' unitType='Mek'>
-			<availability>CS:6-,CLAN:3-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:9,CS:6-,CLAN!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CB!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CCC:5,CCO!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CFM:5,CGB!Second Line:5!Solahma:5!Provisional Garrison:5,CGS!Second Line:4!Solahma:4!Provisional Garrison:4,CJF:5,CMG!Second Line:5!Solahma:5!Provisional Garrison:5,CNC:5,CDS:4,CSJ:5,CSR:5,CSA:5,CSV:5,CW:4-,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:4</availability>
 			<model name='C'>
-				<availability>CCC:2,CFM:2</availability>
+				<availability>CCC!Keshik:8!Front Line:3!Second Line:1,CFM!Keshik:8!Front Line:3!Second Line:1,CJF!Keshik:8!Front Line:8!Second Line:1,CSJ!Keshik:5!Front Line:8!Second Line:5,CSV!Keshik:8!Front Line:5,BAN:1+</availability>
 			</model>
 			<model name='LCT-1E'>
 				<roles>recon</roles>
-				<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
+				<availability>IS:4,Periphery:4,Periphery.Deep:4</availability>
 			</model>
 			<model name='LCT-1M'>
 				<roles>recon</roles>
@@ -3708,11 +3693,11 @@
 			</model>
 			<model name='LCT-1V'>
 				<roles>recon</roles>
-				<availability>LA:4,General:8,CLAN:1-,FS:7,BAN:5</availability>
+				<availability>IS:8,FS:7,LA:4</availability>
 			</model>
 			<model name='LCT-1Vb'>
 				<roles>recon</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,CCC!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CFM!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CJF!Front Line:1!Second Line:5!Solahma:5!Provisional Garrison:5,CSJ!Second Line:8!Solahma:8!Provisional Garrison:8,CSV!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -3850,9 +3835,9 @@
 			</model>
 		</chassis>
 		<chassis name='Mandrill' unitType='Mek'>
-			<availability>CFM:6</availability>
+			<availability>CFM!Keshik:4!Front Line:3!Second Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CFM:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
@@ -4157,14 +4142,14 @@
 			</model>
 		</chassis>
 		<chassis name='Mercury' unitType='Mek'>
-			<availability>CS:8,CC:1+,LA:1+,CLAN:1,NIOPS:8,IS:1+,MERC:1+</availability>
+			<availability>IS:1+,CS:8,CLAN!Front Line:3!Second Line:2!Solahma:1,CB!Second Line:2!Solahma:1,CCC!Second Line:3!Solahma:2!Provisional Garrison:1,CCO!Second Line:2!Solahma:1,CGB!Second Line:3!Solahma:2!Provisional Garrison:1,CGS!Second Line:3!Solahma:2!Provisional Garrison:1,CHH!Second Line:3!Solahma:2!Provisional Garrison:1,CIH!Second Line:4!Solahma:3!Provisional Garrison:2,CJF!Second Line:3!Solahma:2!Provisional Garrison:1,CMG!Second Line:3!Solahma:2!Provisional Garrison:1,CSJ!Second Line:1!Solahma:1!Provisional Garrison:1,CW:3-,NIOPS:8,BAN:3</availability>
 			<model name='MCY-98'>
 				<roles>recon</roles>
 				<availability>CC:8</availability>
 			</model>
 			<model name='MCY-99'>
 				<roles>recon</roles>
-				<availability>CS:4,CLAN:8,NIOPS:4,BAN:6</availability>
+				<availability>CS:4,CLAN:8,NIOPS:4,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Minsk' unitType='Mek'>
@@ -4247,22 +4232,22 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>MOC:1,CHH:5,CLAN:6,MERC:4,FS:2,TC:1,CS:6,OA:1,CDS:5,CBS:7,FWL:2,NIOPS:6,CMG:10,CJF:7,CGB:5,DC:2</availability>
+			<availability>FS:2,DC:2,FWL:2,MERC:4,CS:6,CLAN:4+,CBS:3+,CGS:3+,CMG:6+,CW:3+,TC:1,MOC:1,OA:1,NIOPS:6,BAN:2+</availability>
 			<model name='C'>
                 <roles>recon</roles>
-				<availability>CIH:4,CMG:8,CJF:4,CGB:4</availability>
+				<availability>CGB!Keshik:5!Front Line:1,CIH!Keshik:5!Front Line:3,CJF!Keshik:5!Front Line:3!Second Line:1,CMG!Keshik:7!Front Line:3!Second Line:1</availability>
 			</model>
 			<model name='C 2'>
                 <roles>recon</roles>
-				<availability>CMG:4</availability>
+				<availability>CMG!Keshik:5!Front Line:1</availability>
 			</model>
 			<model name='MON-66'>
                 <roles>command,recon</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,IS:1+,BAN:8,Periphery:1+</availability>
+				<availability>IS:1+,CS:8,CLAN:6,CB:5,CCC:4-,CFM:5-,CJF!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CMG:4-,CNC:4-,CSJ:4-,CW!Front Line:6!Second Line:6!Solahma:6!Provisional Garrison:6,Periphery:1+,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='MON-66b'>
 				<roles>command,recon</roles>
-				<availability>CLAN:8,CGS:8,BAN:4</availability>
+				<availability>CLAN:5+,CCC:4,CFM:4,CJF!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CNC:5,CSJ:4,BAN:1</availability>
 			</model>
 			<model name='MON-67'>
 				<roles>command,recon</roles>
@@ -4407,13 +4392,13 @@
 			</model>
 		</chassis>
 		<chassis name='Night Hawk' unitType='Mek'>
-			<availability>CW:6,LA:2+,CLAN:6,FWL:2+,FS:2+,CGS:7,CGB:6</availability>
+			<availability>FS:2+,LA:2+,FWL:2+,CLAN:4+,CBS:5+,CB:5+,CCO:5+,CGB:5+,CJF:5+,CMG:3+,CSJ:5+,CSR:3+,CW:5+,BAN:3+</availability>
 			<model name='NTK-2Q'>
 				<roles>raider</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CLAN:8,BAN:8</availability>
 			</model>
 			<model name='NTK-2Q-EC'>
-				<availability>CSJ:2</availability>
+				<availability>CSJ!Keshik:3!Front Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
@@ -4517,14 +4502,14 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CS:4,CLAN:4-,IS:4,Periphery.Deep:4,NIOPS:4,MERC:4,Periphery:4</availability>
+			<availability>IS:4,MERC:4,CS:4,CLAN!Second Line:2!Solahma:2!Provisional Garrison:2,CBS!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CB!Solahma:1!Provisional Garrison:1,CCO!Second Line:1!Solahma:1!Provisional Garrison:1,CGS!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CJF!Solahma:2!Provisional Garrison:2,CMG!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CSJ!Second Line:1!Solahma:1!Provisional Garrison:1,CW!Front Line:1!Second Line:1!Solahma:2!Provisional Garrison:2,Periphery:4,NIOPS:4,Periphery.Deep:4,BAN:1</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
-				<availability>General:8,CLAN:5-,BAN:6</availability>
+				<availability>IS:8,MERC:8,Periphery:8</availability>
 			</model>
 			<model name='OTT-7Jb'>
 				<roles>recon</roles>
-				<availability>CLAN:6,BAN:4</availability>
+				<availability>CLAN:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
@@ -4595,13 +4580,13 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>CC:3,Periphery.DD:5,FS.RR:4,CLAN:1-,MERC:5,Periphery.OS:5,FS:3,BAN:2,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>FS:3,FS.RR:4,FS.DMM:4,LA:3,DC:10,FWL:3,CC:3,MERC:5,CS:2,CSJ:2-,Periphery:3,Periphery.DD:5,Periphery.OS:5,NIOPS:2,BAN:2</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,TC:8</availability>
 			</model>
 			<model name='PNT-9R'>
 				<roles>fire_support</roles>
-				<availability>CLAN:8,MERC:8,DC:8</availability>
+				<availability>DC:8,MERC:8,CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Paramour Mobile Repair Vehicle' unitType='Tank'>
@@ -4645,13 +4630,13 @@
 			</model>
 		</chassis>
 		<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
-			<availability>CLAN:6,CSJ:8,CGB:6</availability>
+			<availability>CFM:1+,CGS!Keshik:3!Front Line:1,CIH:2+,CNC!Keshik:3!Front Line:1,CDS:2+,CSJ:2+,CW:2+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CFM:8,CGS:8,CIH:8,CW:8</availability>
 			</model>
 			<model name='2'>
 				<roles>fire_support</roles>
-				<availability>CLAN:5</availability>
+				<availability>CNC:8,CDS:8,CSJ:8,CW:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk IIC' unitType='Mek'>
@@ -5275,14 +5260,14 @@
 			</model>
 		</chassis>
 		<chassis name='Sling' unitType='Mek'>
-			<availability>CC:1+,LA:1+,CLAN:1,CSJ:2</availability>
+			<availability>LA:1+,CC:1+,CSJ!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1</availability>
 			<model name='SL-1G'>
 				<roles>spotter</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,CC:8,CSJ:8</availability>
 			</model>
 			<model name='SL-1H'>
 				<roles>spotter</roles>
-				<availability>LA:4</availability>
+				<availability>LA:4,CSJ:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Snowden Mining Station' unitType='Space Station'>
@@ -5334,14 +5319,14 @@
 			</model>
 		</chassis>
 		<chassis name='Spector' unitType='Mek'>
-			<availability>CLAN:2</availability>
+			<availability>CMG:1+</availability>
 			<model name='SPR-4F'>
 			    <roles>specops,raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CMG:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>CC:5,CS:4,OA:2,LA:4,CLAN:1-,IS:4,FWL:7,NIOPS:4,FS:5,MERC:4,TC:2,DC:6</availability>
+			<availability>IS:4,FS:5,DC:6,FWL:7,CC:5,MERC:4,CS:4,CIH!Second Line:2!Solahma:1,CMG!Front Line:3!Second Line:2!Solahma:1,TC:2,OA:2,NIOPS:4</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -5351,7 +5336,7 @@
 				<availability>DC:8</availability>
 			</model>
 			<model name='SDR-5V'>
-				<availability>CLAN:8,IS:8,Periphery.Deep:8,FS:4,Periphery:8</availability>
+				<availability>IS:8,FS:4,CIH:8,CMG:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
@@ -5397,18 +5382,24 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:6,Periphery:6,DC:6</availability>
-			<model name='STG-3G'>
+			<availability>IS:9,DC:6,MERC:6,CS:4-,CLAN!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CBS:4,CB:5,CCC:4,CGS:4,CHH:4,CMG!Front Line:1!Second Line:4!Solahma:4!Provisional Garrison:4,CDS:4,CSR:4,CSA:4,CSV:4,CW:4,Periphery:6,NIOPS:4-,Periphery.Deep:6,BAN:5</availability>
+            <model name='C'>
+                <availability>CCC!Keshik:8!Front Line:1,CHH!Keshik:8!Front Line:8,CIH!Front Line:8!Second Line:1,CSV!Keshik:8!Front Line:1,CW!Keshik:8!Front Line:8!Second Line:1,BAN:2+</availability>
+            </model>
+            <model name='C 2'>
+                <availability>CBS!Keshik:8!Front Line:5,CB!Keshik:5!Front Line:3,BAN:2+</availability>
+            </model>
+            <model name='STG-3G'>
 				<roles>recon</roles>
-				<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
+				<availability>IS:4,CLAN!Solahma:1!Provisional Garrison:3,Periphery:4,Periphery.Deep:4,BAN:2-</availability>
 			</model>
 			<model name='STG-3Gb'>
 				<roles>recon</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,CBS!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CB!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CCC!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CHH!Front Line:1!Second Line:8!Solahma:8!Provisional Garrison:8,CIH:4-,CJF!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CSV!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CW:3-,BAN:5</availability>
 			</model>
 			<model name='STG-3R'>
 				<roles>recon</roles>
-				<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:8,BAN:2-</availability>
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
@@ -5504,15 +5495,12 @@
 			</model>
 		</chassis>
 		<chassis name='Talon' unitType='Mek'>
-			<availability>CLAN:8</availability>
-			<model name='TLN-5V'>
-				<availability>FWL:8,FS:8</availability>
-			</model>
+			<availability>CLAN:5+,CB:4+,CFM:4+,CGS:3+,CHH:3+,CIH:4+,CSR:3+,CW:6+,BAN:3+</availability>
 			<model name='TLN-5W'>
-				<availability>LA:8,CLAN:8</availability>
+				<availability>CLAN:8</availability>
 			</model>
 			<model name='TLN-5W-EC'>
-				<availability>CIH:8</availability>
+				<availability>CIH!Keshik:3!Front Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Texas Battleship' unitType='Warship'>
@@ -5534,12 +5522,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>CSA:2,CS:6,CDS:5,CLAN:4,FWL:2,NIOPS:6,CCO:2,CJF:5,CGB:5</availability>
+			<availability>FWL:2,CS:6,CLAN:4-,CB!Second Line:4!Solahma:4!Provisional Garrison:4,CCC:3-,CGS!Second Line:4!Solahma:4!Provisional Garrison:4,CHH!Second Line:5!Solahma:5!Provisional Garrison:5,CIH:3-,CJF!Second Line:4!Solahma:4!Provisional Garrison:4,CMG!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CW!Front Line:1!Second Line:2!Solahma:4!Provisional Garrison:5,NIOPS:6,BAN:0</availability>
 			<model name='THE-N'>
-				<availability>CS:8,CLAN:6,General:3+,NIOPS:8,BAN:6</availability>
+				<availability>FWL:3+,CS:8,CLAN:8,CB:6,CGB:5-,CIH:7,CJF:6,CMG!Second Line:6!Solahma:6!Provisional Garrison:6,CNC:4-,CDS:4-,CSR:4-,CW:4-,NIOPS:8</availability>
 			</model>
 			<model name='THE-Nb'>
-				<availability>CLAN:6,CGS:7,BAN:4</availability>
+				<availability>CB:6+,CGB:5,CIH:6+,CJF:8+,CMG:6+,CNC:5,CDS:4,CSR:5,CW:6+</availability>
 			</model>
 		</chassis>
 		<chassis name='Thresher' unitType='Mek'>
@@ -5821,17 +5809,17 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech IIC' unitType='Mek'>
-			<availability>CHH:4,CIH:4-,CSR:4,CCO:5,CGS:4</availability>
+			<availability>CLAN!Second Line:3!Solahma:2!Provisional Garrison:1,CIH!Solahma:2!Provisional Garrison:1,CJF!Solahma:2!Provisional Garrison:1,CSJ!Solahma:2!Provisional Garrison:1,CSV!Solahma:2!Provisional Garrison:1,BAN:0</availability>
 			<model name=''>
 				<roles>urban</roles>
 				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>CC:5-,CLAN:1-,IS:4-,Periphery:3-,CS:4-,FS.CMM:4-,NIOPS:4-</availability>
+			<availability>CC:5-,IS:4-,Periphery:3-,CS:4-,FS.CMM:4-,NIOPS:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
-				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,CC:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Valkyrie' unitType='Mek'>
@@ -6008,10 +5996,10 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>CS:4-,CLAN:1-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:4,Periphery:6</availability>
+			<availability>IS:10,CS:4-,CIR:4,Periphery:6,NIOPS:4-,Periphery.Deep:6,BAN:1-</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,BAN:8</availability>
 			</model>
 			<model name='WSP-1D'>
 				<roles>recon</roles>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -610,23 +610,27 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CS:5-,LA:9,IS:7,FWL:9,NIOPS:5-,Periphery.Deep:6,FS:8,Periphery:6,DC:8</availability>
+			<availability>IS:7,FS:8,LA:9,DC:8,FWL:9,CS:5-,CLAN!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CBS:4,CB:4,CCC:4,CFM!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CGS!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CHH:4,CIH:4-,CMG:3,CSV!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,Periphery:6,NIOPS:5-,Periphery.Deep:6,BAN:4</availability>
 			<model name='ARC-2K'>
 				<roles>command,fire_support</roles>
 				<availability>DC:8</availability>
 			</model>
 			<model name='ARC-2R'>
 				<roles>command,fire_support</roles>
-				<availability>LA:7,CLAN:3,IS:8,Periphery.Deep:8,BAN:5,DC:6,Periphery:8</availability>
+				<availability>IS:8,LA:7,DC:6,Periphery:8,NIOPS:4-,Periphery.Deep:8,BAN:8</availability>
 			</model>
 			<model name='ARC-2Rb'>
 				<roles>command,fire_support</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:4-,CB:3-,BAN:2+</availability>
 			</model>
 			<model name='ARC-2S'>
 				<roles>command,fire_support</roles>
 				<availability>LA:6</availability>
 			</model>
+            <model name='C'>
+                <roles>command,fire_support</roles>
+                <availability>CLAN:3+,CBS:1+,CB:2+,CFM!Front Line:3!Second Line:1,CGS!Front Line:3!Second Line:1,CJF!Front Line:3!Second Line:1,CMG:2+,CNC!Front Line:2!Second Line:1,CDS!Front Line:3!Second Line:1,CSJ!Front Line:2,CSR!Front Line:3!Second Line:1,CSV!Front Line:3!Second Line:1,CW!Front Line:3!Second Line:1,BAN:0</availability>
+            </model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
 			<availability>MOC:8,OA:8,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8,BAN:3</availability>
@@ -901,18 +905,18 @@
             </model>
         </chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:1,MERC:1,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:1</availability>
+			<availability>FS:1,LA:2,DC:1,FWL:4,MERC:1,CS:7,CLAN:3+,CCC!Front Line:2!Second Line:1,CGS:4+,CIH:2+,NIOPS:7,BAN:2+</availability>
 			<model name='BL-6-KNT'>
                 <roles>command</roles>
-				<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
+				<availability>FS:2+,FWL:2+,CS:8,CLAN:8,CBS:6-,CCO:4-,CGB:4-,CGS:5-,CNC:4-,CW:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='BL-6b-KNT'>
                 <roles>command</roles>
-				<availability>CS:4,CLAN:7,NIOPS:4,FWL:1+,CGS:8,BAN:4</availability>
+				<availability>FWL:1+,CS:4,CBS:7,CCO:7,CGB:7,CGS:7,CNC:7,CW:7,NIOPS:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
                 <roles>command</roles>
-				<availability>LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+				<availability>FS:8,LA:8,DC:8,FWL:4,MERC:8</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
                 <roles>command</roles>
@@ -944,7 +948,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bombardier' unitType='Mek'>
-			<availability>CLAN:3-,CS:5,IS:2,FWL:3,DC:3,Periphery:2,NIOPS:5,BAN:2</availability>
+			<availability>IS:2,DC:3,FWL:3,CS:5,CLAN:3-,CB:2-,CCO:2-,CIH:4,CMG:4-,CDS:4-,CSR:4-,Periphery:2,NIOPS:5,BAN:0</availability>
 			<model name='BMB-10D'>
 				<roles>fire_support</roles>
 				<availability>IS:8,CS:4-,Periphery:8,NIOPS:0</availability>
@@ -1070,18 +1074,18 @@
             </model>
         </chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>CC:5,CLAN:2,IS:3,MERC:2,Periphery:1,CS:2,NIOPS:2,DC:5</availability>
+			<availability>IS:3,DC:5,CC:5,MERC:2,CS:2,CFM:4+,CDS:3,Periphery:1,NIOPS:2</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
-				<availability>CC:4,FWL:2,DC:1</availability>
+				<availability>DC:1,FWL:2,CC:4</availability>
 			</model>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
-				<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,CC:8,MERC:8,CDS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='CPLT-C1b'>
 				<roles>fire_support</roles>
-				<availability>CC:1+,CLAN:6,DC:1+</availability>
+				<availability>DC:1+,CC:1+,CFM:8</availability>
 			</model>
 			<model name='CPLT-C4'>
 				<roles>fire_support</roles>
@@ -1112,12 +1116,12 @@
 			</model>
 		</chassis>
 		<chassis name='Cestus' unitType='Mek'>
-			<availability>CS:4,LA:1+,CLAN:4,NIOPS:4,IS:1+,FS:3</availability>
+			<availability>IS:1+,FS:3,CS:4,CB!Front Line:2!Second Line:1,CFM!Front Line:2!Second Line:1,NIOPS:4+</availability>
 			<model name='CTS-6Y'>
-				<availability>General:8</availability>
+				<availability>IS:8,CB:8,CFM:5</availability>
 			</model>
 			<model name='CTS-6Y-EC'>
-				<availability>CFM:2</availability>
+				<availability>CFM!Front Line:8!Second Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
@@ -1140,19 +1144,19 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:5,CS:5,CHH:6,LA:5,CLAN:4,IS:4,NIOPS:5,MERC:4,CGB:6</availability>
+			<availability>IS:4,LA:5,CC:5,MERC:4,CS:5,CBS:4-,CCO!Second Line:1,CGB!Second Line:2!Solahma:1,CHH!Front Line:3!Second Line:2!Solahma:1,CDS!Front Line:3!Second Line:2!Solahma:1,NIOPS:5</availability>
 			<model name='C'>
-				<availability>CHH:6,CLAN:8,CGB:6</availability>
+				<availability>CBS!Front Line:3,CCO!Second Line:3,CHH!Front Line:3</availability>
 			</model>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
-				<availability>CC:2+,CS:8,CHH:6,CLAN:4,NIOPS:8,BAN:7,CGB:6</availability>
+				<availability>CC:2+,CS:8,CBS:8,CGB:8,CHH:2-,NIOPS:8</availability>
 			</model>
 			<model name='CHP-1N2'>
-				<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
+				<availability>CS:4,CHH:5</availability>
 			</model>
 			<model name='CHP-1Nb'>
-				<availability>CLAN:5,BAN:3</availability>
+				<availability>CDS:8</availability>
 			</model>
 			<model name='CHP-2N'>
 				<availability>IS:8,NIOPS:0</availability>
@@ -1936,6 +1940,18 @@
 				<availability>CLAN:7,CGS:8,BAN:4</availability>
 			</model>
 		</chassis>
+        <chassis name='Crossbow' unitType='Mek' omni='Clan'>
+            <availability>CSV!Keshik:3</availability>
+            <model name='A'>
+                <availability>CSV:5</availability>
+            </model>
+            <model name='B'>
+                <availability>CSV:6</availability>
+            </model>
+            <model name='Prime'>
+                <availability>CSV:8</availability>
+            </model>
+        </chassis>
         <chassis name='Crosscut' unitType='Mek'>
             <availability>CLAN:4,IS:2,Periphery:1,PIR:4,BAN:4</availability>
             <model name='ED-X1 LoggerMech'>
@@ -1963,9 +1979,9 @@
             </model>
         </chassis>
 		<chassis name='Crusader' unitType='Mek'>
-			<availability>CS:6-,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:8,CS:6-,CLAN!Second Line:1!Solahma:2!Provisional Garrison:2,CBS:3,CB:3,CCC!Front Line:1!Second Line:2!Solahma:2!Provisional Garrison:2,CGS!Front Line:1!Second Line:2!Solahma:2!Provisional Garrison:2,CIH:2,CMG:2,CDS!Front Line:1!Second Line:2!Solahma:2!Provisional Garrison:2,CSJ!Front Line:1!Second Line:2!Solahma:2!Provisional Garrison:2,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:4</availability>
 			<model name='CRD-2R'>
-				<availability>CLAN:7,IS:1+,CGS:8,BAN:4,Periphery:1+</availability>
+				<availability>IS:1+,CLAN:8,Periphery:1+,NIOPS:5,BAN:2+</availability>
 			</model>
 			<model name='CRD-3D'>
 				<availability>FS:5</availability>
@@ -1978,7 +1994,7 @@
 				<availability>CC:9</availability>
 			</model>
 			<model name='CRD-3R'>
-				<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,NIOPS:6-,Periphery.Deep:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
@@ -2252,29 +2268,29 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,IS:5,Periphery:2,TC:3,CS:5,NIOPS:5,DC:6</availability>
+			<availability>IS:5,DC:6,CS:5,Periphery:2,TC:3,MOC:3,NIOPS:5</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Mek'>
-			<availability>CS:5,LA:1+,CLAN:4,NIOPS:5,FS:1+,DC:1+</availability>
+			<availability>FS:1+,LA:1+,DC:1+,CS:5,CLAN!Front Line:2!Second Line:1,CBS:3+,CGS:3+,CIH:3+,CJF:3+,CMG:3+,CNC:3+,CSR:3+,NIOPS:5</availability>
 			<model name='EXC-B1'>
 				<roles>cavalry,fire_support</roles>
-				<availability>LA:8</availability>
+				<availability>LA:8,CDS:4-</availability>
 			</model>
 			<model name='EXC-B2'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CS:8,LA:0,General:8,CLAN:5,NIOPS:8</availability>
+				<availability>FS:8,LA:0,DC:8,CS:8,CLAN:5-,CW:0,NIOPS:8</availability>
 			</model>
 			<model name='EXC-B2b'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CLAN:2+,CGB:3+,CJF:3+,CSJ:3+,CW:4-</availability>
 			</model>
 			<model name='EXC-B2b-EC'>
                 <roles>cavalry,fire_support</roles>
-				<availability>CW:3</availability>
+				<availability>CW!Front Line:2!Second Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -2289,22 +2305,22 @@
 			</model>
 		</chassis>
 		<chassis name='Exterminator' unitType='Mek'>
-			<availability>CS:4,CLAN:5,NIOPS:4</availability>
+			<availability>CS:4,CLAN!Second Line:1,CBS!Front Line:2!Second Line:1,CB!Front Line:2!Second Line:1,CCC!Front Line:2!Second Line:1,CFM!Front Line:2!Second Line:1,CIH:4+,CJF!Second Line:2!Solahma:1,CMG:3+,CDS!Front Line:3!Second Line:2!Solahma:1,CSR:3+,NIOPS:4,BAN:1+</availability>
 			<model name='EXT-4C'>
 			    <roles>specops</roles>
-				<availability>BAN:1</availability>
+				<availability>BAN:8</availability>
 			</model>
 			<model name='EXT-4D'>
 			    <roles>cavalry</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:4</availability>
+				<availability>CS:8,CLAN:8,CFM:4-,CIH:4-,CJF:3-,CDS:3-,CSR:4-,NIOPS:8,BAN:0</availability>
 			</model>
 			<model name='EXT-4Db'>
 			    <roles>cavalry</roles>
-				<availability>CLAN:5,BAN:3</availability>
+				<availability>CFM:8,CIH:5,CJF:4-,CDS:8,CSR:8,NIOPS:3+</availability>
 			</model>
 			<model name='EXT-4Db-EC'>
 			    <roles>cavalry</roles>
-				<availability>CJF:2</availability>
+				<availability>CJF:4+</availability>
 			</model>
 		</chassis>
 	    <chassis name='Factory' unitType='Space Station'>
@@ -2362,10 +2378,10 @@
 			</model>
 		</chassis>
 		<chassis name='Fire Scorpion' unitType='Mek'>
-			<availability>CGS:7</availability>
+			<availability>CGS:2+</availability>
 			<model name=''>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
+				<availability>CGS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Firebee' unitType='Mek'>
@@ -2405,13 +2421,13 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:2,CDS:5,LA:6,CBS:5,FWL:2,NIOPS:5,CJF:7,CGB:5</availability>
+			<availability>LA:6,FWL:2,CS:5,CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CJF!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,Periphery.R:2,NIOPS:5,BAN:3+</availability>
 			<model name='FLS-7K'>
 				<availability>LA:7,FWL:8,Periphery.R:8</availability>
 			</model>
 			<model name='FLS-8K'>
                 <roles>cavalry</roles>
-				<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
+				<availability>LA:2+,CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Flatbed Truck' unitType='Tank'>
@@ -2604,19 +2620,16 @@
 			</model>
 		</chassis>
 		<chassis name='Galahad (Glass Spider)' unitType='Mek'>
-			<availability>CSR:8,CW:8,CLAN:8</availability>
+			<availability>CW!Front Line:2!Second Line:1</availability>
 			<model name=''>
                 <roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:8</availability>
+				<availability>CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Galahad' unitType='Mek'>
-			<availability>CC:1+,LA:1+,CLAN:2,FS:1+</availability>
+			<availability>FS:1+,LA:1+,CC:1+</availability>
 			<model name='GLH-1D'>
-				<availability>IS:8</availability>
-			</model>
-			<model name='GLH-2D'>
-				<availability>CLAN:8</availability>
+				<availability>FS:8,LA:8,CC:8</availability>
 			</model>
 		</chassis>
         <chassis name='Galaport Ground Trailer' unitType='Tank'>
@@ -2741,14 +2754,14 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>CS:7,CHH:8,CSR:8,CLAN:7,IS:6,NIOPS:7,FS:5,MERC:6</availability>
+			<availability>IS:6,FS:5,MERC:6,CS:7,CHH!Front Line:3!Second Line:2!Solahma:1,CSR!Front Line:2!Second Line:1,NIOPS:7</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
-				<availability>CS:8,CLAN:8,IS:2+,NIOPS:8,BAN:8</availability>
+				<availability>IS:2+,CS:8,CHH:8,CSR:8,NIOPS:8</availability>
 			</model>
 			<model name='GLT-4L'>
 				<roles>raider</roles>
-				<availability>FWL:7,NIOPS:0,MERC:7</availability>
+				<availability>FWL:7,MERC:7</availability>
 			</model>
 			<model name='GLT-4P'>
 				<roles>raider</roles>
@@ -2987,11 +3000,11 @@
             </model>
         </chassis>
 		<chassis name='Helepolis' unitType='Mek'>
-			<availability>CLAN:2</availability>
+            <availability>CHH:1-</availability>
 			<model name='HEP-3H'>
 				<roles>mixed_artillery</roles>
 				<deployedWith>Helepolis</deployedWith>
-				<availability>General:8</availability>
+                <availability>CHH:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
@@ -3571,18 +3584,18 @@
 			</model>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>MOC:3,CIH:6,CLAN:5,IS:3,CFM:6,MERC:3,CIR:3,CGS:6,BAN:6,TC:3,CS:6,OA:3,NIOPS:6,DC:4</availability>
+			<availability>IS:3,DC:4,MERC:3,CS:6,CLAN!Front Line:2!Second Line:1,CBS:3+,CB!Front Line:3!Second Line:2!Solahma:1,CCC:4+,CCO!Second Line:1,CFM:4+,CGB:3+,CGS:3+,CIH:4+,CMG:4+,CSV!Front Line:3!Second Line:2!Solahma:1,TC:3,MOC:3,OA:3,CIR:3,NIOPS:6,BAN:0</availability>
 			<model name='C'>
                 <roles>cavalry,anti_aircraft</roles>
-				<availability>CIH:2,CFM:2,CFM.SmJ:6,CB:4,CGB:2</availability>
+				<availability>CB:3+,CFM:3+,CGB:3+,CIH!Keshik:8!Front Line:8!Second Line:5</availability>
 			</model>
 			<model name='C 2'>
                 <roles>cavalry,anti_aircraft</roles>
-				<availability>CIH:2,CFM:1,CFM.SmJ:3,CB:2</availability>
+				<availability>CB:2+,CGM:4+,CIH!Keshik:5!Front Line:3!Second Line:1</availability>
 			</model>
 			<model name='LNC25-01'>
 				<roles>cavalry,anti_aircraft</roles>
-				<availability>CS:8,CLAN:8,IS:4+,NIOPS:8,BAN:6,DC:4+</availability>
+				<availability>IS:4+,CS:8,CLAN:8,CB:3-,CFM:4-,CGB:4-,CIH:3-,NIOPS:8</availability>
 			</model>
 			<model name='LNC25-02'>
 				<roles>anti_aircraft,fire_support</roles>
@@ -3590,7 +3603,7 @@
 			</model>
 			<model name='LNC25-05'>
 				<roles>cavalry,anti_infantry</roles>
-				<availability>CS:4,IS:1,NIOPS:4</availability>
+				<availability>IS:1,CS:4,NIOPS:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Leopard CV' unitType='Dropship'>
@@ -3797,12 +3810,12 @@
 			</model>
 		</chassis>
 		<chassis name='Lupus' unitType='Mek' omni='Clan'>
-			<availability>CDS:3,CBS:3,CSV:3,CLAN:3,CCO:8,CGS:3</availability>
+			<availability>CLAN:2+,CCO!Keshik:4!Front Line:1,CGS:1+,CJF:3+,CSJ!Keshik:3,CSA!Keshik:3!Front Line:1,CW!Keshik:1!Front Line:2,BAN:0</availability>
 			<model name='A'>
 				<availability>CLAN:6</availability>
 			</model>
 			<model name='B'>
-				<availability>CLAN:6</availability>
+				<availability>CLAN:4+</availability>
 			</model>
 			<model name='Prime'>
 				<roles>fire_support</roles>
@@ -3888,18 +3901,18 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>MOC:2+,CS:8,LA:5,CLAN:6,IS:4,NIOPS:8,FS:5,TC:3+,DC:5</availability>
+			<availability>IS:4,FS:5,LA:5,DC:5,CS:8,CLAN!Front Line:3!Second Line:2!Solahma:1,CBS:4+,CCC:4+,CGS:4+,CIH:3+,CMG:3+,CDS:4+,CSJ:4+,TC:3+,MOC:2+,NIOPS:8,BAN:2+</availability>
             <model name='C'>
                 <roles>command</roles>
-                <availability>CLAN:2+</availability>
+                <availability>CLAN:4+,CBS!Keshik:8,CB:3+,CCC:3+,CFM:3+,CGS:3+,CHH:2+,CIH:2+,CJF:4+,CMG:2+,CDS:3+,CSJ:3+,BAN:0</availability>
             </model>
 			<model name='MAD-1R'>
                 <roles>command</roles>
-				<availability>CS:8,MOC:2,CLAN:4,IS:1+,NIOPS:8,MERC:0,BAN:4,TC:2+</availability>
+				<availability>IS:1+,MERC:0,CS:8,CLAN:2-,TC:2+,MOC:2,NIOPS:8,BAN:2+</availability>
 			</model>
 			<model name='MAD-2R'>
                 <roles>command</roles>
-				<availability>CLAN:6,FS:1+,CGS:7,BAN:6</availability>
+				<availability>FS:1+,CLAN:5,CB!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CCO:4,CGB:4,CHH:4,CJF:4,CW:4,BAN:0</availability>
 			</model>
 			<model name='MAD-3D'>
                 <roles>command</roles>
@@ -3907,7 +3920,7 @@
 			</model>
 			<model name='MAD-3R'>
                 <roles>command</roles>
-				<availability>CS:4-,IS:8,TC:8</availability>
+				<availability>IS:8,CS:4-,Periphery:8,BAN:8</availability>
 			</model>
 		</chassis>
         <chassis name='Marco' unitType='Mek'>
@@ -3936,15 +3949,15 @@
 			</model>
 		</chassis>
 		<chassis name='Masauwu' unitType='Mek'>
-			<availability>CSA:4,CCO:6</availability>
+			<availability>CCO!Front Line:2,CSA:3+</availability>
             <model name=''>
-                <availability>General:8</availability>
+                <availability>CCO:8,CSA:8</availability>
             </model>
 		</chassis>
 		<chassis name='Matador' unitType='Mek'>
-			<availability>CSV:6</availability>
+			<availability>CSV!Keshik:3!Front Line:2!Second Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CSV:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Maultier Hover APC' unitType='Tank'>
@@ -4178,15 +4191,11 @@
 			</model>
 		</chassis>
 		<chassis name='Minsk' unitType='Mek'>
-			<availability>CW:3,CJF:3,CGB:5</availability>
+			<availability>CGB!Second Line:1!Solahma:1,CJF!Front Line:1,CW!Front Line:1</availability>
             <model name=''>
                 <roles>command</roles>
-                <availability>CLAN:8</availability>
+                <availability>CGB:8,CJF:8,CW:8</availability>
             </model>
-			<model name='MNK-101'>
-				<roles>command</roles>
-				<availability>CGB:4</availability>
-			</model>
 		</chassis>
 		<chassis name='Mithras Light Tank' unitType='Tank'>
 			<availability>CSA:6,CCC:6,CIH:6,CBS:6,CSV:6,CLAN:6,CFM:6,CGS:6,CCO:6,CB:6</availability>
@@ -4482,18 +4491,21 @@
 			</model>
 		</chassis>
 		<chassis name='Orion IIC' unitType='Mek'>
-			<availability>CW:4</availability>
+			<availability>CW:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CLAN:3,IS:5,Periphery.Deep:4,CIR:5,TC:5,Periphery:4,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-</availability>
+			<availability>IS:5,LA:6,FWL:9,CS:5-,CLAN!Front Line:2!Second Line:1,CBS:3+,CCO!Second Line:1,CFM!Second Line:1,CGB!Second Line:1,CIH:2+,CJF!Second Line:2!Solahma:1,CMG!Front Line:1,CW!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,Periphery.MW:5,Periphery.ME:5,Periphery:4,TC:5,MOC:5,OA:5,CIR:5,NIOPS:5-,Periphery.Deep:4,BAN:2</availability>
 			<model name='ON1-K'>
-				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
+            <model name='ON1-Kb'>
+                <availability>CLAN:8,BAN:0</availability>
+            </model>
 			<model name='ON1-V'>
-				<availability>OA:2,IS:3,TC:3</availability>
+				<availability>IS:3,TC:3,OA:2</availability>
 			</model>
 			<model name='ON1-VA'>
 				<availability>IS:2</availability>
@@ -4513,14 +4525,14 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CS:4,CLAN:4-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,DC:6</availability>
+			<availability>IS:5,DC:6,CS:4,CLAN:4-,CBS:4,CB:3,CCC!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:3,CGS:3,CHH:4,CIH!Keshik:5!Front Line:5!Second Line:5!Solahma:4!Provisional Garrison:4,CMG!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,Periphery:4,NIOPS:4,Periphery.Deep:4,BAN:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
-				<availability>CLAN:3,IS:8,Periphery.Deep:8,MERC:8,BAN:5,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8,BAN:4-</availability>
 			</model>
 			<model name='OSR-2Cb'>
 				<roles>urban</roles>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CLAN:8,BAN:3</availability>
 			</model>
 			<model name='OSR-2L'>
 				<availability>IS:4</availability>
@@ -4544,10 +4556,10 @@
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
-			<availability>CLAN:2-,CS:6,FWL:7,NIOPS:6,Periphery.Deep:4,FS:7,MERC:7,Periphery:4,BAN:3</availability>
+			<availability>FS:7,FWL:7,MERC:7,CS:6,Periphery:4,NIOPS:6,Periphery.Deep:4,BAN:2-</availability>
 			<model name='OTL-4D'>
                 <roles>raider</roles>
-				<availability>CLAN:8,IS:8,Periphery:8,BAN:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Overlord C' unitType='Dropship'>
@@ -4914,10 +4926,10 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman IIC' unitType='Mek'>
-			<availability>CLAN:5</availability>
+			<availability>CGB!Front Line:1,CNC!Front Line:1,CDS!Front Line:1,CSR!Front Line:1,CW!Front Line:1</availability>
 			<model name=''>
                 <roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CNC:8,CDS:8,CSR:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Rifleman II' unitType='Mek'>
@@ -4928,14 +4940,14 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CLAN:3,IS:8-,Periphery.Deep:5,CIR:3,Periphery:5,CS:6-,NIOPS:6-</availability>
+			<availability>IS:8-,CS:6-,CLAN!Second Line:1,CBS!Front Line:1,CB!Front Line:1,CCC!Front Line:1,CFM!Front Line:1,CGS!Front Line:1,CMG!Front Line:1,Periphery:5,CIR:3,NIOPS:6-,Periphery.Deep:5,BAN:3-</availability>
             <model name='C'>
                 <roles>fire_support,anti_aircraft</roles>
-                <availability>CLAN:8,BAN:4</availability>
+                <availability>CLAN:8,BAN:3+</availability>
             </model>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:4-,General:8,BAN:5</availability>
+				<availability>IS:8,MERC:8,Periphery:8,NIOPS:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Riga II Destroyer-Carrier' unitType='Warship'>
@@ -5232,10 +5244,10 @@
 			</model>
 		</chassis>
 		<chassis name='Shootist' unitType='Mek'>
-			<availability>CS:5,LA:1+,CLAN:5,NIOPS:5</availability>
+			<availability>LA:1+,CS:5,CLAN!Front Line:2!Second Line:1,CBS:2+,CB!Front Line:3!Second Line:2!Solahma:1,CCC!Second Line:1,CIH!Second Line:2!Solahma:1,CMG!Second Line:1,NIOPS:5,BAN:0</availability>
 			<model name='ST-8A'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
         <chassis name='Shugosha' unitType='Mek'>
@@ -5374,6 +5386,15 @@
 				<availability>IS:8,FS:4,CIH:8,CMG:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
+        <chassis name='Spirit Walker' unitType='Mek' omni='Clan'>
+            <availability>CCO!Keshik:3,CFM:1+:2868,CGS:1+:2868</availability>
+            <model name='A'>
+                <availability>CCO:3+,CFM:3+,CGS:3+</availability>
+            </model>
+            <model name='Prime'>
+                <availability>CCO:8,CFM:8,CGS:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Stalker' unitType='Mek'>
 			<availability>CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,Periphery:10,CS:6,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
@@ -5566,13 +5587,13 @@
 			</model>
 		</chassis>
 		<chassis name='Thresher' unitType='Mek'>
-			<availability>CHH:6,CDS:4,CSR:4,CLAN:4</availability>
+			<availability>CHH:4+,CDS:3+</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CHH:8,CDS:8</availability>
 			</model>
 			<model name='2'>
 				<roles>fire_support</roles>
-				<availability>CHH:4</availability>
+				<availability>CHH:5</availability>
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
@@ -5633,9 +5654,9 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:9,CS:5-,LA:8,CLAN:4-,IS:7,Periphery.Deep:6,NIOPS:5-,MERC:7,Periphery:6,DC:8</availability>
+			<availability>IS:7,LA:8,DC:8,CC:9,MERC:7,CS:5-,CLAN:5,CB!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CCC:4,CCO!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:3,CFM!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:3,CGS!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,CHH!Keshik:5!Front Line:5!Second Line:5!Solahma:4!Provisional Garrison:4,CIH:4,CMG:4,CNC:4,CDS:4,CSR:4,CSV:4,Periphery:6,NIOPS:5-,Periphery.Deep:6,BAN:5</availability>
 			<model name='C'>
-				<availability>CLAN:2</availability>
+				<availability>CLAN:2+,CBS!Keshik:6!Front Line:1,CCC:3+,CCO:3+,CGS:1+,CHH:3+,CJF:3+,CNC:3+,BAN:0</availability>
 			</model>
 			<model name='TDR-5D'>
 				<availability>FS:4,MERC:2</availability>
@@ -5644,13 +5665,13 @@
 				<availability>CC:2</availability>
 			</model>
 			<model name='TDR-5S'>
-				<availability>IS:8,CLAN:1-,BAN:4,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,BAN:6-</availability>
 			</model>
 			<model name='TDR-5SE'>
 				<availability>MERC.ELH:8,MERC:2</availability>
 			</model>
 			<model name='TDR-5Sb'>
-				<availability>CLAN:6-,BAN:4</availability>
+				<availability>CLAN:4,CB:4-,CIH:4-,CJF:4-,BAN:5</availability>
 			</model>
 			<model name='TDR-5Sd'>
 				<availability>FS:1+</availability>
@@ -5910,13 +5931,13 @@
 			</model>
 		</chassis>
 		<chassis name='Vision Quest' unitType='Mek'>
-			<availability>CSR:5,CNC:7,CB:5</availability>
-			<model name='2'>
-				<availability>CSR:6,CNC:6</availability>
+			<availability>CB!Keshik:3!Front Line:1,CNC!Keshik:4!Front Line:2!Second Line:1</availability>
+			<model name=''>
+				<availability>CB:8,CNC:8</availability>
 			</model>
-			<model name='VQ-1NC'>
-				<availability>CNC:2</availability>
-			</model>
+            <model name='2'>
+                <availability>CNC!Keshik:3</availability>
+            </model>
 		</chassis>
 		<chassis name='Volga Transport' unitType='Warship'>
 			<availability>CS:1,CLAN:2,NIOPS:1</availability>
@@ -5982,12 +6003,12 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:8,LA:9,FWL:9,CS:6-,CLAN:5+,CBS:6+,CCO!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CGB!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CIH:3-,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:5+</availability>
             <model name='C'>
-                <availability>CLAN:2</availability>
+                <availability>CLAN:3+,CBS!Keshik:3!Front Line:1,CB:2+,CGB!Keshik:1!Front Line:1!Second Line:1,CSJ:2+,BAN:0</availability>
             </model>
             <model name='C 3'>
-                <availability>CLAN:3+</availability>
+                <availability>CGB:3+</availability>
             </model>
 			<model name='WHM-6D'>
 				<availability>FS:4</availability>
@@ -5999,17 +6020,17 @@
 				<availability>CC:4</availability>
 			</model>
 			<model name='WHM-6R'>
-				<availability>General:8,CLAN:2,BAN:8</availability>
+				<availability>IS:8,CCC:1-,CFM:1-,CMG:1-,CSJ:1-,Periphery:8,NIOPS:3-,Periphery.Deep:8,BAN:6-</availability>
 			</model>
 			<model name='WHM-6Rb'>
-				<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,BAN:4</availability>
+				<availability>FS:1+,LA:1+,FWL:1+,CC:1+,CLAN:3-,CBS:4-,CMG:4-,NIOPS:6,BAN:5</availability>
 			</model>
 			<model name='WHM-6Rk'>
                 <roles>cavalry</roles>
 				<availability>DC:1+</availability>
 			</model>
 			<model name='WHM-7A'>
-				<availability>CLAN:4</availability>
+				<availability>CLAN!Second Line:2,CBS:3+,CB!Front Line:2!Second Line:1,CFM!Front Line:2!Second Line:1,CIH:4+,CMG!Front Line:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Wasp LAM Mk I' unitType='Mek'>
@@ -6119,12 +6140,15 @@
 			</model>
 		</chassis>
 		<chassis name='Woodsman' unitType='Mek' omni='Clan'>
-			<availability>CW:8</availability>
+			<availability>CW!Keshik:3</availability>
 			<model name='A'>
-				<availability>General:6</availability>
+				<availability>CW:4+</availability>
 			</model>
+            <model name='B'>
+                <availability>CW:3+</availability>
+            </model>
 			<model name='Prime'>
-				<availability>General:8</availability>
+				<availability>CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Wyvern IIC' unitType='Mek'>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -588,18 +588,21 @@
 			</model>
 		</chassis>
 		<chassis name='Annihilator' unitType='Mek'>
-			<availability>CSA:3,CHH:2,CSR:3,CLAN:2,CCO:3,BAN:1,CGB:2</availability>
+			<availability>CB!Front Line:3!Second Line:2!Solahma:1,CCO:3+,CGB:3+,CSA:3+</availability>
 			<model name='ANH-1G'>
-				<availability>CSA:4,CCO:4,BAN:1</availability>
+				<availability>CCO!Second Line:1,CGB!Second Line:1,CSA!Second Line:1</availability>
 			</model>
 			<model name='ANH-1X'>
-				<availability>CLAN:3,BAN:4</availability>
+				<availability>CB:8,CCO!Second Line:1,CGB!Second Line:1,CSA!Second Line:1</availability>
 			</model>
 			<model name='C'>
-				<availability>CLAN:8,BAN:2</availability>
+				<availability>CCO!Keshik:5!Front Line:3!Second Line:1,CGB!Keshik:5!Front Line:3!Second Line:1,CSA!Keshik:5!Front Line:3!Second Line:1</availability>
 			</model>
+            <model name='C &apos;Gausszilla&apos;'>
+                <availability>CCO:1+,CGB:1+,CSA:1+</availability>
+            </model>
 			<model name='C 2'>
-				<availability>CLAN:6,BAN:1</availability>
+				<availability>CCO!Keshik:3!Front Line:1,CGB!Keshik:3!Front Line:1,CSA!Keshik:3!Front Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Aquarius Escort' unitType='Small Craft'>
@@ -733,37 +736,37 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas II' unitType='Mek'>
-			<availability>CLAN:4</availability>
+			<availability>CLAN!Front Line:2!Second Line:1,CBS:2+,CCC!Front Line:1,CIH!Front Line:1,CMG!Front Line:1,CSA!Front Line:1,BAN:0</availability>
 			<model name='AS7-D-H'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CLAN:5</availability>
 			</model>
 			<model name='AS7-D-H2'>
                 <roles>command</roles>
-				<availability>CLAN:4</availability>
+				<availability>CLAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CSV:2,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2,LA:4,NIOPS:4-,CSJ:2,DC:5,CB:2</availability>
+			<availability>IS:3,FS:5,LA:4,DC:5,CS:4-,CLAN:4,CCC:3,CGS:3,CIH:2,CMG:3,CDS:3,CSV:3,TC:1,MOC:1,OA:1,NIOPS:4-,BAN:4-</availability>
 			<model name='AS7-D'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CLAN:3-,CBS:4-,Periphery:8,Periphery.Deep:8,BAN:5-</availability>
 			</model>
 			<model name='AS7-D-DC'>
 				<roles>command</roles>
-				<availability>IS:1,MERC:0,DC:2</availability>
+				<availability>IS:1+,DC:2+,MERC:0,BAN!Front Line:1</availability>
 			</model>
 			<model name='C'>
                 <roles>command</roles>
-				<availability>CW:2,CSV:2,CSJ:2,CB:2</availability>
+				<availability>CB!Front Line:5!Second Line:1,CSJ!Front Line:5!Second Line:1,CSV!Front Line:5!Second Line:1,CW!Front Line:5!Second Line:1,BAN:3+</availability>
 			</model>
 			<model name='C 2'>
                 <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>CLAN!Keshik:5!Front Line:3,CBS!Keshik:5!Front Line:1,CGB!Keshik:5!Front Line:3!Second Line:1,CGS!Keshik:5!Front Line:3!Second Line:1,CHH!Keshik:5!Front Line:3!Second Line:1,CSR!Keshik:5!Front Line:3!Second Line:1,CSA!Keshik:5!Front Line:3!Second Line:1,BAN:2+</availability>
 			</model>
 			<model name='C 3'>
 				<roles>mixed_artillery</roles>
-				<availability>CLAN:2-</availability>
+				<availability>CLAN!Front Line:1,CBS:1+,BAN:0</availability>
 			</model>
 		</chassis>
 		<chassis name='Avatar Heavy Cruiser' unitType='Warship'>
@@ -781,9 +784,9 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,CLAN:3-,IS:7,Periphery.Deep:6,CIR:8,Periphery:6,TC:8,CS:8,OA:8,FWL:10,NIOPS:8</availability>
+			<availability>IS:7,FWL:10,CS:8,Periphery:6,TC:8,MOC:8,OA:8,CIR:8,NIOPS:8,Periphery.Deep:6+,BAN:2</availability>
 			<model name='AWS-8Q'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
 			<model name='AWS-8R'>
 				<availability>CS:2,FWL:4</availability>
@@ -822,14 +825,14 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:6,MOC:6,CLAN:3,IS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,DC:6</availability>
+			<availability>IS:5,LA:7,DC:6,FWL:8,CC:6,CS:8-,CLAN:5-,CFM:4,CGS:5,CMG!Keshik:2!Front Line:3!Second Line:4!Solahma:5!Provisional Garrison:5,CSJ:4-,CW:6-,TC:6,MOC:6,NIOPS:8-,BAN:4,PIR:6</availability>
 			<model name='BLR-1D'>
                 <roles>command</roles>
 				<availability>FS:8:2867</availability>
 			</model>
 			<model name='BLR-1G'>
                 <roles>command</roles>
-				<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
+				<availability>IS:8,FS:6,Periphery:8,Periphery.Deep:8,BAN:5,PIR:8</availability>
 			</model>
 			<model name='BLR-1G-DC'>
 				<roles>command</roles>
@@ -837,15 +840,15 @@
 			</model>
 			<model name='BLR-1Gb'>
                 <roles>command</roles>
-				<availability>CC:1+,CLAN:8,BAN:4</availability>
+				<availability>CC:1+,CLAN:8,BAN:6+</availability>
 			</model>
 			<model name='BLR-1Gbc'>
                 <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>CLAN!Second Line:1,CCO:0,CFM:0,CIH:0,CSJ:0,CSV:0,BAN:0</availability>
 			</model>
 			<model name='BLR-1Gc'>
                 <roles>command</roles>
-				<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,DC:1+</availability>
+				<availability>FS:1+,LA:1+,DC:1+,FWL:1+,CC:1+,BAN:1+</availability>
 			</model>
 			<model name='BLR-1Gd'>
                 <roles>command</roles>
@@ -867,15 +870,15 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
-			<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
+			<availability>CSJ:3+</availability>
 			<model name=''>
-				<availability>CSR:8,General:8</availability>
+				<availability>CSJ:3+</availability>
 			</model>
 			<model name='4'>
-				<availability>General:4</availability>
+				<availability>CSJ:4-</availability>
 			</model>
 			<model name='5'>
-				<availability>General:4</availability>
+				<availability>CSJ:3-</availability>
 			</model>
 		</chassis>
 		<chassis name='Behemoth' unitType='Dropship'>
@@ -1929,15 +1932,15 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>CC:2,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:2,CGS:8,CS:8,CDS:8,CW:10,LA:2,CBS:10,FWL:2,NIOPS:8,CJF:8,CGB:10,DC:2</availability>
+			<availability>FS:2,LA:2,DC:2,FWL:2,CC:2,CS:8,CLAN:3-,CBS:5-,CGS:4-,NIOPS:8,BAN:4-</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:8,NIOPS:0</availability>
 			</model>
 			<model name='CRK-5003-1'>
-				<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>IS:2+,CS:8,CLAN:8,CBS:4-,CB:4-,CCO:4-,CGB:4-,CHH:4-,CW:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='CRK-5003-1b'>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CBS:5,CB:5,CCO:5,CGB:5,CHH:5,CW:5,BAN:3+</availability>
 			</model>
 		</chassis>
         <chassis name='Crossbow' unitType='Mek' omni='Clan'>
@@ -1998,7 +2001,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,CS:3,OA:2,LA:5,CLAN:3,IS:3,FWL:4,NIOPS:3,FS:5,TC:2,DC:5</availability>
+			<availability>IS:3,FS:5,LA:5,DC:5,FWL:4,CC:5,CS:3,TC:2,OA:2,NIOPS:3</availability>
 			<model name='CP-10-HQ'>
                 <roles>command</roles>
 				<availability>IS:2</availability>
@@ -2007,7 +2010,7 @@
 				<availability>IS:3</availability>
 			</model>
 			<model name='CP-10-Z'>
-				<availability>OA:8,IS:8,MERC:8,TC:8</availability>
+				<availability>IS:8,MERC:8,TC:8,OA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
@@ -2115,6 +2118,12 @@
 				<availability>FS:2+</availability>
 			</model>
 		</chassis>
+        <chassis name='Devastator' unitType='Mek'>
+            <availability>CSJ!Front Line:2!Second Line:1</availability>
+            <model name='DVS-2-EC'>
+                <availability>CSJ:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Dictator' unitType='Dropship'>
 			<availability>IS:3</availability>
 			<model name=''>
@@ -2208,17 +2217,14 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>MOC:1,CC:2,CS:7,OA:2,CLAN:2,FWL:3,NIOPS:7,FS:2,MERC:2,TC:2</availability>
+			<availability>FS:2,FWL:3,CC:2,MERC:2,CS:7,CLAN!Front Line:2!Second Line:1,CBS:3+,CGS:3+,CIH:3+,CMG:3+,CSA!Front Line:1,TC:2,MOC:1,OA:2,NIOPS:7,BAN:0</availability>
 			<model name='EMP-5A'>
                 <roles>command</roles>
-				<availability>General:8,BAN:2</availability>
+				<availability>IS:8,Periphery:8,NIOPS:1-</availability>
 			</model>
 			<model name='EMP-6A'>
                 <roles>command</roles>
-				<availability>CC:2+,CS:8,LA:2+,CLAN:8,NIOPS:8,FWL:2+,FS:2+,BAN:6</availability>
-			</model>
-			<model name='EMP-6A-EC'>
-				<availability>CSA:3</availability>
+				<availability>FS:2+,LA:2+,FWL:2+,CC:2+,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Enfield' unitType='Mek'>
@@ -3083,21 +3089,21 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander IIC' unitType='Mek'>
-			<availability>CLAN:6</availability>
+			<availability>CBS:1+,CCC!Keshik:3!Front Line:1,CCO!Keshik:3!Front Line:1,CFM:2+,CDS!Keshik:3!Front Line:1,CSR:2+</availability>
 			<model name=''>
                 <roles>command</roles>
-				<availability>CLAN:8</availability>
+				<availability>CBS:8,CCC:8,CCO:8,CFM:8,CDS:8,CSR:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>CC:2,CS:9,LA:2,CLAN:9,FWL:2,NIOPS:9,IS:1,CFM:10,MERC:1,CJF:10,DC:2</availability>
+			<availability>IS:1,LA:2,DC:2,FWL:2,CC:2,MERC:1,CS:9,CLAN:4+,CCC:3+,CIH:3+,CSV:3+,NIOPS:9+,BAN:2+</availability>
 			<model name='HGN-732'>
                 <roles>command</roles>
-				<availability>CC:2+,CS:8,LA:2+,CLAN:6,FWL:2+,IS:8,NIOPS:8,BAN:8</availability>
+				<availability>IS:8,LA:2+,FWL:2+,CC:2+,CS:8,CLAN:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='HGN-732b'>
                 <roles>command</roles>
-				<availability>CLAN:7,FWL:1+,BAN:4</availability>
+				<availability>FWL:1+,CLAN:6,BAN:1+</availability>
 			</model>
 			<model name='HGN-733'>
                 <roles>command</roles>
@@ -3212,22 +3218,22 @@
 			</model>
 		</chassis>
 		<chassis name='Imp' unitType='Mek'>
-			<availability>CSA:4,CW:4,CLAN:3</availability>
+			<availability>CB!Keshik:1!Front Line:2!Second Line:1,CCO!Keshik:1!Front Line:3!Second Line:1,CGB!Front Line:3!Second Line:1,CSJ!Keshik:1!Front Line:3!Second Line:1,CW!Keshik:1!Front Line:3!Second Line:1</availability>
 			<model name='C'>
                 <roles>command</roles>
-				<availability>CLAN:6</availability>
+				<availability>CB:1+,CCO:1+,CGB!Front Line:8!Second Line:3,CSJ:1+,CW:1+</availability>
 			</model>
 			<model name='IMP-1A'>
                 <roles>command</roles>
-				<availability>CLAN:4</availability>
+				<availability>CB:4-,CCO:4-,CGB:3-,CSJ:4-,CW:4-</availability>
 			</model>
 			<model name='IMP-1B'>
                 <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>CB!Front Line:6!Second Line:6,CCO!Front Line:6!Second Line:1,CGB:6,CSJ!Front Line:6!Second Line:6,CW:6</availability>
 			</model>
 			<model name='IMP-1C'>
                 <roles>command</roles>
-				<availability>CHH:5,CLAN:2</availability>
+				<availability>CB!Front Line:4!Second Line:4,CCO!Front Line:1,CGB:4,CSJ!Front Line:4!Second Line:4,CW:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Indra Infantry Transport' unitType='Tank'>
@@ -3479,10 +3485,10 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CS:6,CLAN:6,IS:2+,FWL:1+,NIOPS:6,MERC:2+,CGS:7,CGB:7</availability>
+			<availability>IS:2+,FWL:1+,MERC:2+,CS:6,CB:3-,CFM:3-,CGB:3-,CGS:2-,CW:3-,NIOPS:6,BAN:1</availability>
 			<model name='KGC-000'>
                 <roles>command</roles>
-				<availability>CS:8,CIH:5,General:2,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
+				<availability>IS:2,CS:8,NIOPS:8,BAN:5</availability>
 			</model>
 			<model name='KGC-0000'>
                 <roles>command</roles>
@@ -3490,11 +3496,7 @@
 			</model>
 			<model name='KGC-000b'>
                 <roles>command</roles>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
-			</model>
-			<model name='KGC-010'>
-                <roles>command</roles>
-				<availability>CLAN:3</availability>
+				<availability>CB:8,CFM:8,CGB:8,CGS:8,CW:8,BAN:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
@@ -3558,9 +3560,9 @@
 			</model>
 		</chassis>
 		<chassis name='Kraken (Bane)' unitType='Mek'>
-			<availability>CSR:7,CLAN:7,CJF:7</availability>
+			<availability>CJF!Front Line:2!Second Line:1,CDS!Front Line:2!Second Line:1,CSR!Front Line:2!Second Line:1,CW!Front Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CJF:8,CDS:8,CSR:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
@@ -3760,7 +3762,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>CC:6,CDS:3-,CSR:3-,IS:7,Periphery.Deep:7,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>IS:7,FS:8,DC:5,FWL:9,CC:6,CS:4,Periphery:7,NIOPS:4,Periphery.Deep:7</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>IS:8,Periphery:8</availability>
@@ -3771,11 +3773,11 @@
 			</model>
 			<model name='LGB-7Q'>
 				<roles>fire_support</roles>
-				<availability>MOC:6,OA:6,IS:6,TC:6,CLAN:6</availability>
+				<availability>IS:6,TC:6,MOC:6,OA:6</availability>
 			</model>
 			<model name='LGB-8C'>
                 <roles>fire_support</roles>
-				<availability>MOC:3,CS:6,OA:3,IS:5,MERC:4,TC:2,CLAN:5</availability>
+				<availability>IS:5,MERC:4,CS:6,TC:2,MOC:3,OA:3</availability>
 			</model>
 		</chassis>
         <chassis name='Luciano White Wolverine' unitType='Tank'>
@@ -3892,12 +3894,12 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder IIC' unitType='Mek'>
-			<availability>CSA:7,CSR:6,CW:6,CLAN:6,CNC:6,CJF:6,CGB:7</availability>
+			<availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS:2+,CB!Keshik:4!Front Line:1,CCO:3+,CGB:3+,CGS!Keshik:5!Front Line:3!Second Line:1,CHH!Keshik:5!Front Line:3!Second Line:2,CIH!Keshik:5!Front Line:2!Second Line:1,CJF:3+,CNC:3+,CSJ:3+,CSR!Keshik:4!Front Line:3!Second Line:1,CSA:2+,CSV:3+,CW!Keshik:5!Front Line:3,BAN!Keshik:1!Front Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8,CJF:8,CGB:8</availability>
+				<availability>CLAN:8,CJF:4,CW:4</availability>
 			</model>
 			<model name='9'>
-				<availability>CSA:4,CSV:4,CLAN:4,CJF:4</availability>
+				<availability>CJF:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
@@ -4416,6 +4418,48 @@
 				<availability>General:8</availability>
 			</model>
 		</chassis>
+        <chassis name='Naga II' unitType='Mek' omni='Clan'>
+            <availability>CW!Front Line:3</availability>
+            <model name='A'>
+                <roles>cavalry</roles>
+                <availability>CW:6</availability>
+            </model>
+            <model name='B'>
+                <roles>cavalry,fire_support</roles>
+                <availability>CW:5</availability>
+            </model>
+            <model name='C'>
+                <roles>cavalry,urban</roles>
+                <availability>CW:6-</availability>
+            </model>
+            <model name='Prime'>
+                <roles>cavalry</roles>
+                <availability>CW:8</availability>
+            </model>
+        </chassis>
+        <chassis name='Naga' unitType='Mek' omni='Clan'>
+            <availability>CW!Front Line:3</availability>
+            <model name='A'>
+                <roles>mixed_artillery</roles>
+                <availability>CW:3+</availability>
+            </model>
+            <model name='B'>
+                <roles>mixed_artillery</roles>
+                <availability>CW:2+</availability>
+            </model>
+            <model name='C'>
+                <roles>missile_artillery</roles>
+                <availability>CW:3+</availability>
+            </model>
+            <model name='D'>
+                <roles>mixed_artillery</roles>
+                <availability>CW:2+</availability>
+            </model>
+            <model name='Prime'>
+                <roles>missile_artillery</roles>
+                <availability>CW:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Naja' unitType='Mek'>
 			<availability>CBS!Front Line:1,CCC:2+,CSV!Front Line:1</availability>
             <model name=''>
@@ -4457,10 +4501,10 @@
 			</model>
 		</chassis>
 		<chassis name='Nightstar' unitType='Mek'>
-			<availability>CSA:6,CS:4,CLAN:4,NIOPS:4</availability>
+			<availability>CS:4,CCO!Front Line:1,NIOPS:4+</availability>
 			<model name='NSR-9J'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CS:8,CCO:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Odin Scout Tank' unitType='Tank'>
@@ -4683,18 +4727,18 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk IIC' unitType='Mek'>
-			<availability>CCC:4,CIH:4,CSR:4,CDS:4,CSV:5,CLAN:3,CFM:4,CGS:3,CCO:4,CB:2</availability>
+			<availability>CFM:2+,CJF!Keshik:2,CSR!Keshik:3!Front Line:1,CSV!Keshik:4!Front Line:3!Second Line:1</availability>
 			<model name=''>
                 <roles>cavalry</roles>
-				<availability>CLAN:8</availability>
+				<availability>CFM:8,CJF:8,CSR:8,CSV:8</availability>
 			</model>
 			<model name='2'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CCC:6,CSR:6,CDS:6,CSV:6,CNC:6,CFM:6,CCO:6</availability>
+				<availability>CSR:5,CSV:5</availability>
 			</model>
 			<model name='9'>
-                <roles>cavalry</roles>
-				<availability>CLAN:2</availability>
+			    <roles>cavalry,fire_support</roles>
+				<availability>CSV:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
@@ -4747,7 +4791,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
-			<availability>CLAN:4,CC:4+,CS:5,LA:3+,FWL:3+,NIOPS:5,FS:3+,BAN:0</availability>
+			<availability>FS:3+,LA:3+,FWL:3+,CC:4+,CS:5,CLAN:1+,CBS:2+,CGS:2+,CIH!Front Line:1,CMG!Front Line:1,CSA!Front Line:1,CSV!Front Line:1,NIOPS:5+,BAN:0</availability>
 			<model name='PLG-3Z'>
 				<availability>IS:8,CLAN:8,NIOPS:8</availability>
 			</model>
@@ -4836,15 +4880,12 @@
 			</model>
 		</chassis>
 		<chassis name='Pulverizer' unitType='Mek'>
-			<availability>CSR:4</availability>
+			<availability>CSR!Second Line:1!Solahma:1</availability>
 			<model name=''>
-				<availability>CSR:8</availability>
-			</model>
-			<model name='PUL-2V'>
-				<availability>General:4</availability>
+				<availability>CSR!Second Line:1</availability>
 			</model>
 			<model name='PUL-3R'>
-				<availability>General:1</availability>
+				<availability>CSR!Solahma:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -4933,10 +4974,10 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman II' unitType='Mek'>
-			<availability>CLAN:4</availability>
+			<availability>CGB!Front Line:2!Second Line:1</availability>
 			<model name='RFL-3N-2'>
 				<roles>anti_aircraft</roles>
-				<availability>General:8</availability>
+				<availability>CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
@@ -5225,12 +5266,12 @@
 			</model>
 		</chassis>
 		<chassis name='Shogun' unitType='Mek'>
-			<availability>CSA:4,CIH:4,CBS:4,CLAN:4,FWL:2+,CCO:4,CB:4</availability>
+			<availability>FWL:2+,CBS:2,CB!Front Line:3!Second Line:2!Solahma:1,CCC!Front Line:2!Second Line:1,CCO!Front Line:3!Second Line:2!Solahma:1,CSA!Front Line:2!Second Line:1</availability>
 			<model name='C'>
-				<availability>CLAN:7</availability>
+				<availability>CBS:2+,CB!Front Line:8,CCC:8,CCO:8,CSA:8</availability>
 			</model>
 			<model name='SHG-2H'>
-				<availability>General:8,CLAN:2-,BAN:6</availability>
+				<availability>FWL:8,CBS:4-,CB:3-</availability>
 			</model>
 		</chassis>
 		<chassis name='Sholagar' unitType='AeroSpaceFighter'>
@@ -5355,15 +5396,19 @@
 			</model>
 		</chassis>
 		<chassis name='Spartan' unitType='Mek'>
-			<availability>CS:5,CHH:4,CFM:5,CCO:4</availability>
+			<availability>CS:5,CCO!Front Line:1,CFM!Front Line:2!Second Line:1,CHH!Second Line:1,CIH:4+,BAN:4+    </availability>
 			<model name='C'>
                 <roles>cavalry</roles>
-				<availability>CLAN:8</availability>
+				<availability>CCO:8,CFM:8,CHH:8</availability>
 			</model>
 			<model name='SPT-N2'>
 				<roles>cavalry,spotter</roles>
-				<availability>IS:8</availability>
+				<availability>CS:8,BAN:3-</availability>
 			</model>
+            <model name='SPT-NF'>
+                <roles>cavalry</roles>
+                <availability>CIH:8,BAN:5</availability>
+            </model>
 		</chassis>
 		<chassis name='Spector' unitType='Mek'>
 			<availability>CMG:1+</availability>
@@ -5396,15 +5441,15 @@
             </model>
         </chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,Periphery:10,CS:6,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>IS:9,FS:7,DC:7,FWL:10,CC:7,CS:6,CLAN:5-,CBS:6-,CCC:4-,CIH:4-,CMG:4-,CSR:4-,Periphery:10,NIOPS:6,Periphery.Deep:10,BAN:3</availability>
 			<model name='STK-3F'>
-				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:8,BAN:5</availability>
 			</model>
 			<model name='STK-3Fb'>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,BAN:3+</availability>
 			</model>
 			<model name='STK-3H'>
-				<availability>MOC:2,OA:2,IS:2,TC:2</availability>
+				<availability>IS:2,TC:2,MOC:2,OA:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -5476,15 +5521,18 @@
 			</model>
 		</chassis>
 		<chassis name='Storm Giant' unitType='Mek'>
-			<availability>CSV:5</availability>
+			<availability>CSV!Keshik:1!Front Line:1</availability>
+            <model name=''>
+                <availability>CSV:8</availability>
+            </model>
 			<model name='2'>
-				<availability>General:5</availability>
+				<availability>CSV:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Striker' unitType='Mek'>
-			<availability>MOC:4,CC:8,CS:4,OA:5,LA:8,PIR:2,NIOPS:4,MERC:5,FS:5,TC:5,DC:5</availability>
+			<availability>FS:5,LA:8,DC:5,CC:8,MERC:5,CS:4,TC:5,MOC:4,OA:5,NIOPS:4,PIR:2</availability>
 			<model name='STC-2C'>
-				<availability>CC:8,General:8</availability>
+				<availability>IS:8,Periphery:8,PIR:8</availability>
 			</model>
 			<model name='STC-2S'>
 				<availability>LA:5</availability>
@@ -5503,9 +5551,9 @@
 			</model>
 		</chassis>
 		<chassis name='Supernova' unitType='Mek'>
-			<availability>CSA:2,CCC:4,CDS:2,CW:4,CNC:7,CGB:3</availability>
+			<availability>CNC:3+,CDS:3+,CSJ:2+</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CNC:8,CDS:8,CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Svantovit Infantry Fighting Vehicle' unitType='Tank'>
@@ -5604,15 +5652,15 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,TC:1+,CS:7,CDS:7,CW:9,CBS:7,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>IS:3,FWL:5,CS:7,CLAN!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,CIH!Keshik:2!Front Line:3!Second Line:4!Solahma:4!Provisional Garrison:4,CSV!Keshik:2!Front Line:3!Second Line:4!Solahma:4!Provisional Garrison:4,TC:1+,NIOPS:7,BAN:4+</availability>
 			<model name='THG-10E'>
 				<availability>FWL:6,DC:6</availability>
 			</model>
 			<model name='THG-11E'>
-				<availability>CS:8,CLAN:6,FWL:2+,IS:2+,NIOPS:8,FS:2+,BAN:8,DC:2+,TC:8</availability>
+				<availability>IS:2+,FS:2+,DC:2+,FWL:2+,CS:8,CLAN:4-,TC:8,NIOPS:8,BAN:5</availability>
 			</model>
 			<model name='THG-11Eb'>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CLAN:6,BAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -5623,19 +5671,16 @@
 			</model>
 		</chassis>
 		<chassis name='Thunder Hawk' unitType='Mek'>
-			<availability>CS:2,LA:1+,CLAN:4,NIOPS:2,DC:1+</availability>
+			<availability>LA:1+,DC:1+,CS:2,CB!Front Line:1,NIOPS:2+</availability>
 			<model name='TDK-7X'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,DC:8,CS:8,CB:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thunder Stallion' unitType='Mek'>
-			<availability>CHH:5</availability>
+			<availability>CHH:2+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
-			</model>
-			<model name='2 &apos;Fire Stallion&apos;'>
-				<availability>CHH:6,CGS:6</availability>
+				<availability>CHH:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
@@ -5900,15 +5945,18 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:5,CC:6,CLAN:2-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,DC:5</availability>
-			<model name='VTR-9A'>
-				<availability>CC:2,CS:2,IS:1,FS:2</availability>
+			<availability>IS:4,FS:9,LA:5,DC:5,FWL:5,CC:6,CS:5-,CBS!Second Line:1,CB!Second Line:1,CCO!Solahma:1,CGB!Second Line:1,CJF!Second Line:1,CNC!Second Line:1,CSJ!Front Line:1,CW!Second Line:1,Periphery:4,Periphery.OS:5,Periphery.HR:5,TC:5,MOC:5,OA:5,CIR:5,NIOPS:5-,Periphery.Deep:4+</availability>
+            <model name='C'>
+                <availability>CBS:8,CB:8,CCO:8,CGB:8,CJF:8,CNC:8,CSJ:8,CW:8</availability>
+            </model>
+            <model name='VTR-9A'>
+				<availability>IS:1,FS:2,CC:2,CS:2</availability>
 			</model>
 			<model name='VTR-9A1'>
-				<availability>CC:2,CS:2,IS:1,FS:2</availability>
+				<availability>IS:1,FS:2,CC:2,CS:2</availability>
 			</model>
 			<model name='VTR-9B'>
-				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
@@ -5991,15 +6039,15 @@
 			</model>
 		</chassis>
 		<chassis name='Wakazashi' unitType='Mek'>
-			<availability>CJF:6</availability>
+			<availability>CJF!Keshik:2!Front Line:2!Second Line:1</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CJF:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Warhammer IIC' unitType='Mek'>
-			<availability>CLAN:6</availability>
+			<availability>CGB!Keshik:5!Front Line:3!Second Line:1,CSA!Keshik:4!Front Line:3!Second Line:1,BAN:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CSA:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -3143,7 +3143,7 @@
 		<chassis name='Hunchback' unitType='Mek'>
 			<availability>IS:5,DC:6,FWL:8,CC:6,CS:5-,CB!Front Line:3!Second Line:2!Solahma:1,CCO!Second Line:3!Solahma:2!Provisional Garrison:1,CSJ:3-,Periphery:5,Periphery.MW:6,Periphery.ME:6,NIOPS:5-,Periphery.Deep:5</availability>
 			<model name='HBK-4G'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CB:8,CCO:8,CSJ:8,Periphery:8,NIOPS:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='HBK-4H'>
 				<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
@@ -3810,7 +3810,7 @@
 			</model>
 		</chassis>
 		<chassis name='Lynx' unitType='Mek'>
-			<availability>LA:1,DC:1,FWL:1,CLAN!Front Line:3!Second Line:2!Solahma:1,CBS:4+,CB:5+,CCC:4+,CCO:5+,CGS:4+,CIH:4+,CJF:4+,CMG:4+,CNC!Front Line:3!Second Line:1,CSJ:5+,CSR!Front Line:2!Second Line:1,CW!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,BAN:2+</availability>
+			<availability>LA:1,DC:1,FWL:1,CLAN!Front Line:3!Second Line:2!Solahma:1,CBS:4+,CB:5+,CCC:4+,CCO:5+,CGS:4+,CIH:4+,CJF:4+,CMG:4+,CNC!Front Line:3!Second Line:1,CSJ:5+,CSR!Front Line:2!Second Line:1,CSA!Keshik:2!Front Line:3!Second Line:2!Solahma:1,CW!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,BAN:2+</availability>
 			<model name='C'>
                 <roles>raider</roles>
 				<availability>CCC!Keshik:8!Front Line:8,CGS:3+,CJF:3+,CNC:1+,CSJ!Keshik:3!Front Line:1,CW:3+</availability>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2865-->
-<ratgen>
+<ratgen
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -955,7 +955,7 @@
 			</model>
 			<model name='BMB-12D'>
 				<roles>fire_support</roles>
-				<availability>CLAN:8,CS:8,FWL:3+,DC:3+,NIOPS:8,BAN:8</availability>
+				<availability>FWL:3+,DC:3+,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
         <chassis name='Brunel Dump Truck' unitType='Tank'>
@@ -2275,7 +2275,7 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Mek'>
-			<availability>FS:1+,LA:1+,DC:1+,CS:5,CLAN!Front Line:2!Second Line:1,CBS:3+,CGS:3+,CIH:3+,CJF:3+,CMG:3+,CNC:3+,CSR:3+,NIOPS:5</availability>
+			<availability>FS:1+,LA:1+,DC:1+,CS:5,CLAN!Front Line:2!Second Line:1,CBS:3+,CGS:3+,CIH:3+,CJF:3+,CMG:3+,CNC:3+,CSR:3+,NIOPS:5,BAN:0</availability>
 			<model name='EXC-B1'>
 				<roles>cavalry,fire_support</roles>
 				<availability>LA:8,CDS:4-</availability>
@@ -3591,7 +3591,7 @@
 			</model>
 			<model name='C 2'>
                 <roles>cavalry,anti_aircraft</roles>
-				<availability>CB:2+,CGM:4+,CIH!Keshik:5!Front Line:3!Second Line:1</availability>
+				<availability>CB:2+,CFM:4+,CIH!Keshik:5!Front Line:3!Second Line:1</availability>
 			</model>
 			<model name='LNC25-01'>
 				<roles>cavalry,anti_aircraft</roles>
@@ -3904,7 +3904,7 @@
 			<availability>IS:4,FS:5,LA:5,DC:5,CS:8,CLAN!Front Line:3!Second Line:2!Solahma:1,CBS:4+,CCC:4+,CGS:4+,CIH:3+,CMG:3+,CDS:4+,CSJ:4+,TC:3+,MOC:2+,NIOPS:8,BAN:2+</availability>
             <model name='C'>
                 <roles>command</roles>
-                <availability>CLAN:4+,CBS!Keshik:8,CB:3+,CCC:3+,CFM:3+,CGS:3+,CHH:2+,CIH:2+,CJF:4+,CMG:2+,CDS:3+,CSJ:3+,BAN:0</availability>
+                <availability>CLAN:4+,CBS!Keshik:8,CB:3+,CCC:3+,CFM:3+,CGS:3+,CHH:2+,CIH:2+,CMG:2+,CDS:3+,CSJ:3+,BAN:0</availability>
             </model>
 			<model name='MAD-1R'>
                 <roles>command</roles>
@@ -6030,7 +6030,7 @@
 				<availability>DC:1+</availability>
 			</model>
 			<model name='WHM-7A'>
-				<availability>CLAN!Second Line:2,CBS:3+,CB!Front Line:2!Second Line:1,CFM!Front Line:2!Second Line:1,CIH:4+,CMG!Front Line:2</availability>
+				<availability>CLAN!Second Line:2,CBS:3+,CB!Front Line:2!Second Line:1,CFM!Front Line:2!Second Line:1,CIH:4+,CMG!Front Line:2,BAN:0</availability>
 			</model>
 		</chassis>
 		<chassis name='Wasp LAM Mk I' unitType='Mek'>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -3896,7 +3896,7 @@
 		<chassis name='Marauder IIC' unitType='Mek'>
 			<availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS:2+,CB!Keshik:4!Front Line:1,CCO:3+,CGB:3+,CGS!Keshik:5!Front Line:3!Second Line:1,CHH!Keshik:5!Front Line:3!Second Line:2,CIH!Keshik:5!Front Line:2!Second Line:1,CJF:3+,CNC:3+,CSJ:3+,CSR!Keshik:4!Front Line:3!Second Line:1,CSA:2+,CSV:3+,CW!Keshik:5!Front Line:3,BAN!Keshik:1!Front Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8,CJF:4,CW:4</availability>
+				<availability>CLAN:8,CJF:4,CW:4,BAN:8</availability>
 			</model>
 			<model name='9'>
 				<availability>CJF:8,CW:8</availability>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2865-->
-<ratgen
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
             <!-- Omni percentages: 0,0 -->

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -621,7 +621,7 @@
 			</model>
 			<model name='ARC-2Rb'>
 				<roles>command,fire_support</roles>
-				<availability>CLAN:4-,CB:3-,BAN:2+</availability>
+				<availability>CLAN:4-,CB:3-,NIOPS:5,BAN:2+</availability>
 			</model>
 			<model name='ARC-2S'>
 				<roles>command,fire_support</roles>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -6,9 +6,9 @@
 >
 	<factions>
 		<faction key='BAN'>
-			<pctOmni>0,0</pctOmni>
-			<pctClan>5,5</pctClan>
-			<pctSL>85,85</pctSL>
+            <!-- Omni percentages: 0,0 -->
+            <!-- Clan percentages: 5,5 -->
+            <!-- Star League percentages: 85,85 -->
 			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS'>
@@ -32,17 +32,17 @@
 			<weightDistribution era='2865' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 		</faction>
 		<faction key='CBS'>
-			<pctOmni>0,0,0,5,10</pctOmni>
-			<pctClan>0,0,0,10,35</pctClan>
-			<pctSL>100,100,100,90,65</pctSL>
+            <!-- Omni percentages: 0,0,0,5,10 -->
+            <!-- Clan percentages: 0,0,0,10,35 -->
+            <!-- Star League percentages: 100,100,100,90,65 -->
 			<pctClan unitType='Vehicle'>0,0,0,5,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,95,85</pctSL>
 			<salvage pct='5'>CHH:5,CCC:5,CDS:1,CW:5,CSV:10,CNC:10,CCO:5,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CB'>
-			<pctOmni>0,0,0,20,30</pctOmni>
-			<pctClan>0,0,0,40,80</pctClan>
-			<pctSL>100,100,100,60,20</pctSL>
+            <!-- Omni percentages: 0,0,0,20,30 -->
+            <!-- Clan percentages: 0,0,0,40,80 -->
+            <!-- Star League percentages: 100,100,100,60,20 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CCC:1,CHH:5,CSR:6,CIH:4,CSV:3,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CMG:1,CJF:4</salvage>
@@ -50,17 +50,17 @@
 			<weightDistribution era='2865' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CCC'>
-			<pctOmni>0,0,0,20,25</pctOmni>
-			<pctClan>0,0,15,40,55</pctClan>
-			<pctSL>100,100,85,60,45</pctSL>
+            <!-- Omni percentages: 0,0,0,20,25 -->
+            <!-- Clan percentages: 0,0,15,40,55 -->
+            <!-- Star League percentages: 100,100,85,60,45 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CHH:2,CSR:2,CIH:3,CSV:2,CFM:2,CCO:10,CGS:2,CSA:3,CDS:1,CW:3,CBS:2,CNC:5,CJF:5,CGB:2,CB:1</salvage>
 		</faction>
 		<faction key='CCO'>
-			<pctOmni>0,0,0,40,50</pctOmni>
-			<pctClan>10,10,15,50,60</pctClan>
-			<pctSL>90,90,85,50,40</pctSL>
+            <!-- Omni percentages: 0,0,0,40,50 -->
+            <!-- Clan percentages: 10,10,15,50,60 -->
+            <!-- Star League percentages: 90,90,85,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,25,25,25</pctClan>
 			<pctSL unitType='Vehicle'>100,100,75,75,75</pctSL>
 			<salvage pct='10'>CHH:1,CCC:10,CIH:10,CSR:8,CSV:2,CFM:8,CGS:1,CSA:3,CDS:3,CW:1,CBS:1,CNC:10,CSJ:7,CJF:3,CB:7</salvage>
@@ -68,17 +68,17 @@
 			<weightDistribution era='2865' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CFM'>
-			<pctOmni>0,0,0,15,40</pctOmni>
-			<pctClan>0,0,10,45,55</pctClan>
-			<pctSL>100,100,90,55,45</pctSL>
+            <!-- Omni percentages: 0,0,0,15,40 -->
+            <!-- Clan percentages: 0,0,10,45,55 -->
+            <!-- Star League percentages: 100,100,90,55,45 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CCC:1,CHH:3,CSR:4,CIH:10,CSV:4,CCO:7,CGS:5,CSA:6,CDS:1,CW:1,CNC:3,CSJ:4,CMG:1,CJF:4,CGB:1,CB:1</salvage>
 		</faction>
 		<faction key='CGB'>
-			<pctOmni>0,0,0,25,40</pctOmni>
-			<pctClan>15,15,35,45,55</pctClan>
-			<pctSL>85,85,65,55,45</pctSL>
+            <!-- Omni percentages: 0,0,0,25,40 -->
+            <!-- Clan percentages: 15,15,35,45,55 -->
+            <!-- Star League percentages: 85,85,65,55,45 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CSA:10,CHH:10,CCC:3,CIH:5,CSR:1,CDS:1,CW:10,CSV:10,CFM:3,CGS:1,CCO:1,CJF:5</salvage>
@@ -86,25 +86,25 @@
 			<weightDistribution era='2865' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CGS'>
-			<pctOmni>0,0,0,5,10</pctOmni>
-			<pctClan>0,0,20,25,35</pctClan>
-			<pctSL>100,100,80,75,65</pctSL>
+            <!-- Omni percentages: 0,0,0,5,10 -->
+            <!-- Clan percentages: 0,0,20,25,35 -->
+            <!-- Star League percentages: 100,100,80,75,65 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CCC:1,CHH:10,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:5,CW:4,CNC:10,CSJ:1,CMG:3,CJF:5,CB:5</salvage>
 		</faction>
 		<faction key='CHH'>
-			<pctOmni>0,0,0,25,30</pctOmni>
-			<pctClan>0,0,20,35,55</pctClan>
-			<pctSL>100,100,80,65,45</pctSL>
+            <!-- Omni percentages: 0,0,0,25,30 -->
+            <!-- Clan percentages: 0,0,20,35,55 -->
+            <!-- Star League percentages: 100,100,80,65,45 -->
 			<pctClan unitType='Vehicle'>0,0,20,25,35</pctClan>
 			<pctSL unitType='Vehicle'>100,100,75,75,65</pctSL>
 			<salvage pct='10'>CCC:2,CSR:7,CIH:10,CSV:3,CFM:7,CCO:1,CGS:7,CSA:3,CDS:7,CW:4,CBS:2,CNC:10,CSJ:3,CJF:3,CGB:7,CB:7</salvage>
 		</faction>
 		<faction key='CIH'>
-			<pctOmni>0,0,0,20,40</pctOmni>
-			<pctClan>0,0,15,45,55</pctClan>
-			<pctSL>100,100,85,55,45</pctSL>
+            <!-- Omni percentages: 0,0,0,20,40 -->
+            <!-- Clan percentages: 0,0,15,45,55 -->
+            <!-- Star League percentages: 100,100,85,55,45 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CCC:3,CHH:4,CSR:4,CSV:1,CFM:10,CCO:9,CGS:1,CSA:4,CDS:4,CW:7,CNC:3,CSJ:3,CMG:3,CJF:3,CGB:2,CB:3</salvage>
@@ -112,50 +112,50 @@
 			<weightDistribution era='2865' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
 		<faction key='CJF'>
-			<pctOmni>0,0,10,35,40</pctOmni>
-			<pctClan>0,0,25,45,55</pctClan>
-			<pctSL>100,100,75,55,45</pctSL>
+            <!-- Omni percentages: 0,0,10,35,40 -->
+            <!-- Clan percentages: 0,0,25,45,55 -->
+            <!-- Star League percentages: 100,100,75,55,45 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CCC:2,CHH:3,CSR:5,CIH:5,CSV:5,CFM:8,CCO:5,CGS:3,CSA:3,CDS:3,CW:10,CNC:2,CSJ:3,CMG:2,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CMG' />
 		<faction key='CNC'>
-			<pctOmni>0,0,5,20,40</pctOmni>
-			<pctClan>0,0,10,45,55</pctClan>
-			<pctSL>100,100,90,55,45</pctSL>
+            <!-- Omni percentages: 0,0,5,20,40 -->
+            <!-- Clan percentages: 0,0,10,45,55 -->
+            <!-- Star League percentages: 100,100,90,55,45 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CCC:5,CHH:5,CSR:10,CIH:3,CSV:2,CFM:3,CCO:10,CGS:3,CSA:5,CDS:3,CW:7,CBS:3,CSJ:2,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CDS'>
-			<pctOmni>0,0,0,40,45</pctOmni>
-			<pctClan>0,0,20,45,55</pctClan>
-			<pctSL>100,100,80,55,45</pctSL>
+            <!-- Omni percentages: 0,0,0,40,45 -->
+            <!-- Clan percentages: 0,0,20,45,55 -->
+            <!-- Star League percentages: 100,100,80,55,45 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='12'>CCC:2,CHH:5,CSR:10,CIH:8,CSV:5,CFM:3,CCO:4,CGS:3,CSA:3,CW:4,CNC:4,CSJ:5,CMG:1,CJF:5,CB:8</salvage>
 		</faction>
 		<faction key='CSJ'>
-			<pctOmni>0,0,0,25,40</pctOmni>
-			<pctClan>0,0,15,45,55</pctClan>
-			<pctSL>100,100,85,45,45</pctSL>
+            <!-- Omni percentages: 0,0,0,25,40 -->
+            <!-- Clan percentages: 0,0,15,45,55 -->
+            <!-- Star League percentages: 100,100,85,45,45 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CMG:2,CJF:3,CB:2</salvage>
 		</faction>
 		<faction key='CSR'>
-			<pctOmni>0,0,10,20,40</pctOmni>
-			<pctClan>10,10,25,55,65</pctClan>
-			<pctSL>90,90,75,45,35</pctSL>
+            <!-- Omni percentages: 0,0,10,20,40 -->
+            <!-- Clan percentages: 10,10,25,55,65 -->
+            <!-- Star League percentages: 90,90,75,45,35 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CCC:2,CHH:3,CIH:5,CSV:4,CFM:5,CCO:8,CGS:1,CSA:1,CDS:7,CW:7,CNC:10,CSJ:2,CMG:1,CJF:3,CB:8</salvage>
 		</faction>
 		<faction key='CSA'>
-			<pctOmni>0,0,0,25,35</pctOmni>
-			<pctClan>0,0,25,45,55</pctClan>
-			<pctSL>100,100,75,55,45</pctSL>
+            <!-- Omni percentages: 0,0,0,25,35 -->
+            <!-- Clan percentages: 0,0,25,45,55 -->
+            <!-- Star League percentages: 100,100,75,55,45 -->
 			<pctClan unitType='Vehicle'>0,0,15,25,25</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,75,75</pctSL>
 			<salvage pct='10'>CCC:5,CHH:3,CSR:2,CIH:8,CSV:5,CFM:10,CCO:5,CGS:4,CDS:3,CW:5,CNC:8,CSJ:1,CMG:2,CJF:3,CGB:3,CB:5</salvage>
@@ -163,17 +163,17 @@
 			<weightDistribution era='2865' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CSV'>
-			<pctOmni>0,0,5,30,40</pctOmni>
-			<pctClan>10,10,35,45,55</pctClan>
-			<pctSL>90,90,65,55,45</pctSL>
+            <!-- Omni percentages: 0,0,5,30,40 -->
+            <!-- Clan percentages: 10,10,35,45,55 -->
+            <!-- Star League percentages: 90,90,65,55,45 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:5,CBS:1,CNC:1,CSJ:1,CMG:1,CJF:10,CGB:3,CB:1</salvage>
 		</faction>
 		<faction key='CW'>
-			<pctOmni>0,0,0,30,40</pctOmni>
-			<pctClan>0,0,15,45,55</pctClan>
-			<pctSL>95,95,85,55,45</pctSL>
+            <!-- Omni percentages: 0,0,0,30,40 -->
+            <!-- Clan percentages: 0,0,15,45,55 -->
+            <!-- Star League percentages: 95,95,85,55,45 -->
 			<pctClan unitType='Vehicle'>0,0,15,15,15</pctClan>
 			<pctSL unitType='Vehicle'>100,100,85,85,85</pctSL>
 			<salvage pct='10'>CHH:3,CCC:4,CIH:10,CSR:8,CSV:8,CFM:2,CGS:2,CCO:1,CSA:4,CDS:3,CNC:8,CSJ:8,CJF:8,CGB:2,CB:6</salvage>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -4723,7 +4723,7 @@
 			</model>
 			<model name='PXH-1b &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:8,CGS:4,CIH:5-,BAN:3</availability>
+				<availability>CLAN:8,CGS:4,CIH:5-,NIOPS:4+,BAN:3</availability>
 			</model>
 			<model name='PXH-1c &apos;Special&apos;'>
 				<roles>command,recon</roles>

--- a/megamek/data/forcegenerator/2865.xml
+++ b/megamek/data/forcegenerator/2865.xml
@@ -716,9 +716,9 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>CC:1,MOC:1,CS:3-,LA:4,FS.CMM:4,IS:4,MERC:3,FS:4,TC:1</availability>
+			<availability>IS:4,FS:4,LA:4,CC:1,MERC:3,CS:3-,CIH!Second Line:2!Solahma:1,TC:1,MOC:1</availability>
 			<model name='ASN-21'>
-				<availability>General:8</availability>
+				<availability>IS:8,CIH:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Asshur Fast Reconnaissance Vehicle' unitType='Tank'>
@@ -881,6 +881,25 @@
 				<availability>General:8</availability>
 			</model>
 		</chassis>
+        <chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
+            <availability>CHH!Keshik:3</availability>
+            <model name='A'>
+                <availability>CHH:4+</availability>
+            </model>
+            <model name='B'>
+                <availability>CHH:5</availability>
+            </model>
+            <model name='C'>
+                <availability>CHH:4</availability>
+            </model>
+            <model name='D'>
+                <availability>CHH:6</availability>
+            </model>
+            <model name='Prime'>
+                <roles>raider</roles>
+                <availability>CHH:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Black Knight' unitType='Mek'>
 			<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:1,MERC:1,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:1</availability>
 			<model name='BL-6-KNT'>
@@ -1196,10 +1215,10 @@
 			</model>
 		</chassis>
 		<chassis name='Cicada' unitType='Mek'>
-			<availability>CC:4,CS:4-,OA:3,LA:4,IS:4,FWL:4,FS:4,MERC:4,Periphery:3,DC:4</availability>
+			<availability>IS:4,FS:4,LA:4,DC:4,FWL:4,CC:4,MERC:4,CS:4-,Periphery:3,OA:3</availability>
 			<model name='CDA-2A'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,Periphery:8</availability>
 			</model>
 			<model name='CDA-2B'>
 				<roles>anti_infantry</roles>
@@ -1721,18 +1740,18 @@
             </model>
         </chassis>
 		<chassis name='Clint IIC' unitType='Mek'>
-			<availability>CSR:6</availability>
+			<availability>CSR:3+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CSR:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:6,MOC:3,CS:3-,OA:3,CLAN:2-,IS:4,NIOPS:3-,FS:6,MERC:4</availability>
+			<availability>IS:4,FS:6,CC:6,MERC:4,CS:3-,MOC:3,OA:3,NIOPS:3-</availability>
 			<model name='CLNT-1-2R'>
 				<availability>CC:1,FS:1</availability>
 			</model>
 			<model name='CLNT-2-3T'>
-				<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,NIOPS:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='CLNT-2-4T'>
 				<availability>CC:4,FS:4</availability>
@@ -1861,9 +1880,9 @@
 			</model>
 		</chassis>
 		<chassis name='Corvis' unitType='Mek'>
-			<availability>CHH:4,CLAN:3</availability>
+			<availability>CGB!Front Line:2!Second Line:1,CHH!Keshik:1!Front Line:4!Second Line:2</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CHH:8</availability>
 			</model>
 		</chassis>
         <chassis name='Corx Mobile Tunnel Miner' unitType='Tank'>
@@ -1874,35 +1893,35 @@
             </model>
         </chassis>
 		<chassis name='Coyotl' unitType='Mek' omni='Clan'>
-			<availability>CSA:5,CHH:5,CDS:5,CLAN:5,CFM:5,CCO:8</availability>
+			<availability>CLAN:2+,CBS:1+,CCO!Keshik:6!Front Line:3,CGB!Keshik:3!Front Line:1,CGS:1+,CJF!Keshik:3!Front Line:1,CMG!Keshik:2,CSJ!Keshik:3!Front Line:1,CSR!Keshik:3!Front Line:1,CSA!Keshik:3!Front Line:1,CW!Keshik:3!Front Line:1,BAN:0</availability>
 			<model name='A'>
                 <roles>raider</roles>
-				<availability>General:6</availability>
+				<availability>CLAN:4+</availability>
 			</model>
 			<model name='B'>
-				<availability>General:6</availability>
+				<availability>CLAN:5</availability>
 			</model>
 			<model name='Prime'>
-				<availability>General:8</availability>
+				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,CJF:4,CGB:4</availability>
+			<availability>IS:3,MERC:3,CS:5,CLAN:4,CB:3,CGS:5,CIH:3-,Periphery:3,NIOPS:5,BAN!Keshik:6!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
-				<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,NIOPS:0,Periphery.Deep:8,BAN:4-</availability>
 			</model>
 			<model name='CRB-27'>
 				<roles>raider</roles>
-				<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
+				<availability>LA:1+,DC:1+,FWL:1+,CC:1+,CS:8,CLAN:4-,CIH:5-,CSJ:5-,NIOPS:8,BAN:3</availability>
 			</model>
 			<model name='CRB-27b'>
 				<roles>raider</roles>
-				<availability>CC:1+,CLAN:7,FWL:1+,CGS:8,BAN:4</availability>
+				<availability>FWL:1+,CC:1+,CLAN:5+,CBS:8,BAN:3+</availability>
 			</model>
 			<model name='CRB-27sl'>
                 <roles>raider</roles>
-				<availability>LA:1+,CLAN:3,DC:1+</availability>
+				<availability>LA:1+,DC:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
@@ -2072,9 +2091,9 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>CC:4,LA:5,Periphery.HR:6,CLAN:2,IS:5,Periphery.Deep:5,FS:8,MERC:5,TC:5,DC:5</availability>
+			<availability>IS:5,FS:8,CC:4,MERC:5,CBS:3+,Periphery.HR:6,TC:5,Periphery.Deep:5</availability>
 			<model name='DV-6M'>
-				<availability>CLAN:4,IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CBS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='DV-6Md'>
 				<availability>FS:2+</availability>
@@ -2187,7 +2206,7 @@
 			</model>
 		</chassis>
 		<chassis name='Enfield' unitType='Mek'>
-			<availability>CMG:6</availability>
+			<availability>CMG:3+</availability>
 			<model name='END-6J-EC'>
 				<roles>urban</roles>
 				<availability>CMG:8</availability>
@@ -2548,10 +2567,13 @@
 			</model>
 		</chassis>
 		<chassis name='Fox' unitType='Mek'>
-			<availability>CDS:6,CW:4,CSJ:4</availability>
+			<availability>CGB:2+,CDS:3+,CSJ!Front Line:1,CW!Front Line:1!Second Line:1</availability>
 			<model name='CS-1'>
-				<availability>General:8</availability>
+				<availability>CDS:4-,CSJ:8,CW:3-</availability>
 			</model>
+            <model name=''>
+                <availability>CGB:8,CDS:3,CSJ:5+,CW:8</availability>
+            </model>
 		</chassis>
 		<chassis name='Fury Command Tank' unitType='Tank'>
 			<availability>CC:1,CHH:8,CW:8,LA:1,CLAN:6,FWL:1,FS:1,MERC:1,CJF:8,DC:1,CGB:8</availability>
@@ -2653,13 +2675,13 @@
 			</model>
 		</chassis>
 		<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
-			<availability>CSV:7,CLAN:5</availability>
+			<availability>CLAN:1+,CBS:2+,CB:2+,CFM!Keshik:4!Front Line:2,CGB!Front Line:1!Second Line:1,CIH!Keshik:3!Front Line:1,CJF:2+,CMG!Keshik:3!Front Line:1,CSJ:2+,CSA:2+,CSV!Keshik:3!Front Line:1,BAN:0</availability>
 			<model name=''>
                 <roles>raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CIH:8</availability>
 			</model>
 			<model name='6'>
-				<availability>CLAN:4</availability>
+				<availability>CLAN:8,CIH:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Gotha' unitType='AeroSpaceFighter'>
@@ -2685,28 +2707,31 @@
 			</model>
 		</chassis>
 		<chassis name='Great Wyrm' unitType='Mek'>
-			<availability>CSA:3,CCC:5,CHH:3,CSV:5,CLAN:3,CFM:5,CSJ:5,CCO:5,CB:5,CGB:3</availability>
+			<availability>CBS:2+,CB!Front Line:1!Second Line:1,CJF!Second Line:1,CMG!Front Line:2!Second Line:1,CNC!Front Line:1,CSJ!Front Line:1,CSA!Keshik:1!Front Line:1!Second Line:1,CW!Front Line:1</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Griffin IIC' unitType='Mek'>
-			<availability>CCC:5,CCO:5,CGB:5,CNC:5,CDS:5,CSJ:5,BAN:2+</availability>
+			<availability>CCC!Keshik:4!Front Line:2!Second Line:1,CCO!Keshik:4!Front Line:3,CGB!Keshik:4!Front Line:3!Second Line:1,CNC!Keshik:4!Front Line:2!Second Line:1,CDS!Keshik:3!Front Line:1,CSJ!Keshik:3!Front Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CCC:8,CCO:8,CGB:8,CNC:8,CDS:8,CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>CC:7,CLAN:3,IS:9,Periphery.Deep:6,MERC:7,TC:7,Periphery:6,CS:4,OA:5,NIOPS:4,DC:8</availability>
+			<availability>IS:9,DC:8,CC:7,MERC:7,CS:4,CLAN!Front Line:3!Second Line:4!Solahma:5!Provisional Garrison:5,CBS:5,CB!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CGS!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,CIH:5+,CMG!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,CNC!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,CSV!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,Periphery:6,TC:7,OA:5,NIOPS:4,Periphery.Deep:6,BAN:4+</availability>
 			<model name='GRF-1N'>
-				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:8,BAN:1-</availability>
 			</model>
 			<model name='GRF-1S'>
 				<availability>LA:6</availability>
 			</model>
 			<model name='GRF-2N'>
-				<availability>CC:1+,LA:1+,CLAN:6,FWL:1+,FS:1+,BAN:4</availability>
+				<availability>FS:1+,LA:1+,FWL:1+,CC:1+,CLAN:8,BAN:5</availability>
 			</model>
+            <model name='GRF-2N2'>
+                <availability>BAN:2-</availability>
+            </model>
 		</chassis>
 		<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 			<availability>IS:5,MERC:5,Periphery:3</availability>
@@ -3002,12 +3027,12 @@
 			</model>
 		</chassis>
 		<chassis name='Hellhound (Conjurer)' unitType='Mek'>
-			<availability>CHH:6,CIH:6,CDS:4,CLAN:7,CNC:6,CJF:6</availability>
+			<availability>CCO!Keshik:3!Front Line:1,CJF!Keshik:4!Front Line:2!Second Line:1,CSJ!Keshik:4!Front Line:1,CW!Keshik:5!Front Line:1</availability>
 			<model name=''>
-				<availability>CHH:8,General:8,CJF:8</availability>
+				<availability>CCO:8,CJF:5,CW:5</availability>
 			</model>
 			<model name='7'>
-				<availability>CW:4,CLAN:4</availability>
+				<availability>CJF:8,CSJ:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hermes II' unitType='Mek'>
@@ -3075,17 +3100,17 @@
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
-			<availability>CC:2,MOC:1,CHH:4,OA:1,LA:2,CLAN:3,FWL:2,FS:2,CGS:5,DC:2,TC:2</availability>
+			<availability>FS:2,LA:2,DC:2,FWL:2,CC:2,CBS:4+,CGB!Front Line:3!Second Line:2!Solahma:1,CGS:5+,CHH!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CJF:3-,CNC!Front Line:3!Second Line:2!Solahma:1,TC:2,MOC:1,OA:1</availability>
 			<model name='HOP-4Bb'>
                 <roles>fire_support</roles>
-				<availability>CLAN:5,BAN:2</availability>
+				<availability>CBS:3,CGB:8,CGS:5,CHH:5,CJF:8,CNC:8</availability>
 			</model>
 			<model name='HOP-4C'>
                 <roles>inf_support</roles>
-				<availability>MOC:8,OA:8,FS:8</availability>
+				<availability>FS:8,CBS:1-,CGS:1-,MOC:8,OA:8</availability>
 			</model>
 			<model name='HOP-4Cb'>
-				<availability>CHH:8,CLAN:2,BAN:2</availability>
+				<availability>CHH!Front Line:3!Second Line:2!Solahma:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
@@ -3110,13 +3135,13 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback IIC' unitType='Mek'>
-			<availability>CDS:4,CSR:4,CW:4,CSV:5,CLAN:4,CSJ:5,CJF:4,CGB:4</availability>
+			<availability>CSJ:2+</availability>
 			<model name=''>
-				<availability>CSR:8,General:8</availability>
+				<availability>CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>CC:6,CLAN:2-,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
+			<availability>IS:5,DC:6,FWL:8,CC:6,CS:5-,CB!Front Line:3!Second Line:2!Solahma:1,CCO!Second Line:3!Solahma:2!Provisional Garrison:1,CSJ:3-,Periphery:5,Periphery.MW:6,Periphery.ME:6,NIOPS:5-,Periphery.Deep:5</availability>
 			<model name='HBK-4G'>
 				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
 			</model>
@@ -3460,15 +3485,15 @@
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
-			<availability>CS:7,CHH:7,CDS:7,CSV:7,CLAN:6,FWL:1,NIOPS:7,FS:6,MERC:1,DC:1</availability>
+			<availability>FS:6,DC:1,FWL:1,MERC:1,CS:7,CLAN:4-,CBS:4,CSR:3-,CSV:3-,NIOPS:7,BAN:3+</availability>
 			<model name='KTO-18'>
 				<availability>FS:6</availability>
 			</model>
 			<model name='KTO-19'>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
+				<availability>CS:8,CLAN:3-,CBS:4-,CCC:4-,CIH:4-,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='KTO-19b'>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CLAN:5,BAN:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Kiso' unitType='Mek'>
@@ -3532,10 +3557,10 @@
 			</model>
 		</chassis>
 		<chassis name='Kyudo' unitType='Mek'>
-			<availability>FWL:1+,FS:1+</availability>
+			<availability>FS:1+,FWL:1+,CBS!Front Line:2!Second Line:1,CMG!Second Line:1,CDS!Second Line:1</availability>
 			<model name='KY2-D-02'>
 				<roles>fire_support</roles>
-				<availability>IS:8</availability>
+				<availability>FS:8,FWL:8,CBS:8,CMG:8,CDS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='LRM Carrier' unitType='Tank'>
@@ -3785,10 +3810,10 @@
 			</model>
 		</chassis>
 		<chassis name='Lynx' unitType='Mek'>
-			<availability>CIH:6,LA:1,CLAN:4,FWL:1,CSJ:6,CJF:4,DC:1</availability>
+			<availability>LA:1,DC:1,FWL:1,CLAN!Front Line:3!Second Line:2!Solahma:1,CBS:4+,CB:5+,CCC:4+,CCO:5+,CGS:4+,CIH:4+,CJF:4+,CMG:4+,CNC!Front Line:3!Second Line:1,CSJ:5+,CSR!Front Line:2!Second Line:1,CW!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,BAN:2+</availability>
 			<model name='C'>
                 <roles>raider</roles>
-				<availability>CCC:6,CW:6,CNC:6,CSJ:8,CJF:6,CGS:6</availability>
+				<availability>CCC!Keshik:8!Front Line:8,CGS:3+,CJF:3+,CNC:1+,CSJ!Keshik:3!Front Line:1,CW:3+</availability>
 			</model>
 			<model name='LNX-8Q'>
                 <roles>raider</roles>
@@ -3796,7 +3821,7 @@
 			</model>
 			<model name='LNX-9Q'>
                 <roles>raider</roles>
-				<availability>CLAN:8,IS:3+</availability>
+				<availability>IS:3+,CLAN:8,CCC:3-,CGS:3-,CJF:4-,CW:3-,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -4383,14 +4408,20 @@
 			</model>
 		</chassis>
 		<chassis name='Naja' unitType='Mek'>
-			<availability>CCC:6,CBS:5,CSV:5,CLAN:3,CMG:5</availability>
+			<availability>CBS!Front Line:1,CCC:2+,CSV!Front Line:1</availability>
             <model name=''>
-                <availability>CCC:8,CLAN:6</availability>
+                <availability>CBS:8,CCC:8,CSV:8</availability>
             </model>
-			<model name='KTO-19b-EC'>
-				<availability>CCC:4,CBS:4,CSV:3,CMG:3</availability>
-			</model>
 		</chassis>
+        <chassis name='Night Chanter' unitType='Mek' omni='Clan'>
+            <availability>CCO:2+,CFM:1+,CHH:1+</availability>
+            <model name='A'>
+                <availability>CCO:6,CFM:6,CHH:8</availability>
+            </model>
+            <model name='Prime'>
+                <availability>CCO:8,CFM:8,CHH:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Night Hawk' unitType='Mek'>
 			<availability>FS:2+,LA:2+,FWL:2+,CLAN:4+,CBS:5+,CB:5+,CCO:5+,CGB:5+,CJF:5+,CMG:3+,CSJ:5+,CSR:3+,CW:5+,BAN:3+</availability>
 			<model name='NTK-2Q'>
@@ -4669,14 +4700,18 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:7,CLAN:3,IS:9,FWL:9,NIOPS:7,Periphery.Deep:5,Periphery:5,CGB:3</availability>
-			<model name='PXH-1'>
+			<availability>IS:9,CS:7,CLAN:4+,CB:3+,CCO!Front Line:3!Second Line:2!Solahma:1,CGB:3+,CGS:6+,CIH!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,Periphery:5,NIOPS:7,Periphery.Deep:5,BAN:4</availability>
+            <model name='C'>
+                <roles>recon</roles>
+                <availability>CGS!Keshik:5!Front Line:3!Second Line:1,CIH!Front Line:8!Second Line:3,CJF!Front Line:5!Second Line:3!Solahma:1</availability>
+            </model>
+            <model name='PXH-1'>
 				<roles>command,recon</roles>
-				<availability>General:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,BAN:5-</availability>
 			</model>
 			<model name='PXH-1-EC'>
                 <roles>command,recon</roles>
-				<availability>CGS:2</availability>
+				<availability>CGS!Front Line:3!Second Line:1</availability>
 			</model>
 			<model name='PXH-1D'>
 				<roles>command,recon</roles>
@@ -4688,15 +4723,15 @@
 			</model>
 			<model name='PXH-1b &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:7,BAN:3</availability>
+				<availability>CLAN:8,CGS:4,CIH:5-,BAN:3</availability>
 			</model>
 			<model name='PXH-1c &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:4,CGS:6</availability>
+				<availability>CGS:3+</availability>
 			</model>
 			<model name='PXH-2'>
 				<roles>command,recon</roles>
-				<availability>CC:1+,MOC:1+,OA:1+,CLAN:3,FWL:1+,BAN:4</availability>
+				<availability>FWL:1+,CC:1+,MOC:1+,OA:1+,BAN:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
@@ -5060,9 +5095,9 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>CC:4-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,Periphery.Deep:4-,MERC:4-,Periphery:4-,DC:4-,BAN:2-</availability>
+			<availability>LA:4-,DC:4-,FWL:4-,CC:4-,MERC:4-,CS:3-,Periphery:4-,NIOPS:3-,Periphery.Deep:4-</availability>
 			<model name='SCP-1N'>
-				<availability>LA:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Scout JumpShip' unitType='Jumpship'>
@@ -5098,7 +5133,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
+			<availability>FS:1-,LA:4-,DC:2,FWL:1-,CS:4,CLAN:4-,CBS:5-,CCC:3-,CCO:3-,CIH!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,CDS:2,NIOPS:4,BAN:2</availability>
 			<model name='STN-3K'>
 				<availability>LA:8,DC:8</availability>
 			</model>
@@ -5109,10 +5144,10 @@
 				<availability>LA:4</availability>
 			</model>
 			<model name='STN-3L'>
-				<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
+				<availability>FS:1+,LA:1+,FWL:1+,MERC:1+,CS:8,CLAN:8,CBS:4-,CCC:4,CFM:3,CGB:4-,CHH:4-,CJF:3-,CDS:4-,CSR:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='STN-3Lb'>
-				<availability>CLAN:5,BAN:3</availability>
+				<availability>CBS:4+,CCC:4+,CFM:4+,CGB:4+,CHH:4+,CJF:4+,CDS:4+,CSR:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
@@ -5131,27 +5166,27 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>CLAN:6,BAN:3+</availability>
+			<availability>CLAN!Keshik:4!Front Line:3!Second Line:1,CBS!Keshik:4!Front Line:1,CCC:3+,CCO:2+,CFM!Keshik:5!Front Line:2!Second Line:1,CGS!Keshik:3!Front Line:1,CIH:2+,CJF!Keshik:3!Front Line:1,CMG:2+,CNC:2+,CDS!Keshik:4!Front Line:2!Second Line:1,CSJ:2+,CSV:3+,BAN:2+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CLAN:8,CGB:4,BAN:8</availability>
 			</model>
 			<model name='2'>
-				<availability>CGB:6</availability>
+				<availability>CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5</availability>
+			<availability>IS:7,LA:6,CS:6-,CLAN!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CBS:5,CB:5,CCC:5,CFM:5,CIH:4,CMG:5,Periphery:5,NIOPS:6-,Periphery.Deep:5,BAN:5</availability>
             <model name='C'>
-                <availability>CSA:6,CCC:6,CSV:6,CFM:6,CGS:6</availability>
+                <availability>CLAN!Front Line:6!Second Line:3,CBS!Keshik:6!Front Line:3,CB!Keshik:6!Front Line:3,CCC!Keshik:3!Front Line:5,CCO!Front Line:8!Second Line:1,CFM!Front Line:8!Second Line:1,CGS!Front Line:6!Second Line:1,CIH!Keshik:8!Front Line:5!Second Line:1,CMG!Keshik:6!Front Line:3!Second Line:1,CNC!Front Line:6!Second Line:1,BAN!Keshik:6!Front Line:1</availability>
             </model>
 			<model name='SHD-2D'>
 				<availability>FS:10</availability>
 			</model>
 			<model name='SHD-2H'>
-				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:5,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8,BAN:2</availability>
 			</model>
 			<model name='SHD-2Hb'>
-				<availability>CLAN:6,FS:1+,BAN:4</availability>
+				<availability>FS:1+,CLAN:4-,CB!Front Line:7!Second Line:7!Solahma:7!Provisional Garrison:7,CCC:5,BAN:3+</availability>
 			</model>
 			<model name='SHD-2K'>
 				<availability>DC:9</availability>
@@ -5364,14 +5399,14 @@
 			</model>
 		</chassis>
 		<chassis name='Starslayer' unitType='Mek'>
-			<availability>CSA:2,LA:3+,CNC:2</availability>
+			<availability>LA:3+,CNC!Second Line:1,CSA!Front Line:3!Second Line:2!Solahma:1</availability>
 			<model name='STY-2C'>
 				<roles>raider</roles>
-				<availability>IS:8</availability>
+				<availability>LA:8</availability>
 			</model>
 			<model name='STY-2C-EC'>
                 <roles>raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CNC:8,CSA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stinger LAM' unitType='Mek'>
@@ -5702,10 +5737,10 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
+			<availability>FWL:8,CC:5,MERC:5,CS:5-,CDS!Front Line:2!Second Line:1,MOC:5,NIOPS:5-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
-				<availability>CC:1+,CS:6,FWL:1+,NIOPS:6</availability>
+				<availability>FWL:1+,CC:1+,CS:6,CDS:8,NIOPS:6</availability>
 			</model>
 			<model name='TBT-5J'>
 				<availability>FWL:4</availability>
@@ -5913,14 +5948,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:4,CS:3,MOC:5,LA:7,CLAN:2-,FWL:7,IS:5,NIOPS:3,CIR:5,TC:5</availability>
+			<availability>IS:5,LA:7,FWL:7,CC:4,CS:3,TC:5,MOC:5,CIR:5,NIOPS:3</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
-				<availability>General:8,FS:4</availability>
+				<availability>IS:8,FS:4,Periphery:8</availability>
 			</model>
 			<model name='VL-5T'>
 				<roles>anti_infantry</roles>
-				<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,TC:2</availability>
+				<availability>IS:2,FS:6,TC:2,MOC:2,CIR:2,PIR:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Vulture' unitType='Dropship'>
@@ -6049,13 +6084,13 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:2-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+			<availability>FS.CMM:5,DC:6,MERC:3,CS:3-,Periphery.DD:2,Periphery.OS:2,TC:2,MOC:1,OA:1,NIOPS:3-</availability>
 			<model name='WTH-0'>
 				<availability>TC:4</availability>
 			</model>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
-				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='WTH-1S'>
 				<roles>fire_support</roles>
@@ -6063,7 +6098,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CS:5-,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,TC:5</availability>
+			<availability>IS:7,FS:8,FWL:10,CS:5-,NIOPS:5-,TC:5,Periphery.Deep:6</availability>
 			<model name='WVR-1R'>
 				<availability>FS:1-</availability>
 			</model>
@@ -6080,7 +6115,7 @@
 			</model>
 			<model name='WVR-6R'>
 				<roles>command,recon</roles>
-				<availability>General:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Woodsman' unitType='Mek' omni='Clan'>
@@ -6093,21 +6128,21 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern IIC' unitType='Mek'>
-			<availability>CHH:4,CW:4,CLAN:4</availability>
+			<availability>CB!Keshik:4!Front Line:1,CCC!Front Line:1!Second Line:2</availability>
 			<model name=''>
 				<roles>urban</roles>
-				<availability>CW:8,CLAN:8</availability>
+				<availability>CB:8,CCC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CS:6,CC:6,CIH:4,CLAN:5,NIOPS:6,CFM:7,FS:6,MERC:5,DC:6,TC:4</availability>
+			<availability>FS:6,DC:6,CC:6,MERC:5,CS:6,CLAN:3,CBS:4,CB:4-,CCC:4-,CGB:4-,CHH:4-,CIH:2-,CMG:4-,CNC:4-,CSJ:2,CSR:4-,CSA:4-,CSV:3-,CW:4-,TC:4,NIOPS:6,BAN:3</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
-				<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
+				<availability>CS:8,CBS:3-,CB:3-,CCO:3-,CFM:2-,TC:8,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='WVE-5Nb'>
 				<roles>urban</roles>
-				<availability>CLAN:5,CFM:6,CGS:6</availability>
+				<availability>CLAN:8,CBS:6,CB:6,CCO:6,CFM:6,BAN:3+</availability>
 			</model>
 			<model name='WVE-5Nsl'>
 				<availability>LA:1+,FWL:1+</availability>

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -601,23 +601,27 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>CC:7,CS:5-,LA:9,IS:8,FWL:9,NIOPS:5-,Periphery.Deep:6,FS:8,Periphery:6</availability>
+			<availability>IS:8,FS:8,LA:9,FWL:9,CC:7,CS:5-,CLAN!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CBS:4,CFM!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CGS!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CIH:4-,CMG:3,Periphery:6,NIOPS:5-,Periphery.Deep:6,BAN:4</availability>
 			<model name='ARC-2K'>
 				<roles>command,fire_support</roles>
 				<availability>DC:8</availability>
 			</model>
 			<model name='ARC-2R'>
 				<roles>command,fire_support</roles>
-				<availability>LA:7,CLAN:3,IS:8,Periphery.Deep:8,BAN:5,DC:6,Periphery:8</availability>
+				<availability>IS:8,LA:7,DC:6,Periphery:8,NIOPS:4-,Periphery.Deep:8,BAN:8</availability>
 			</model>
 			<model name='ARC-2Rb'>
 				<roles>command,fire_support</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:4-,CB:3-,BAN:2+</availability>
 			</model>
 			<model name='ARC-2S'>
 				<roles>command,fire_support</roles>
 				<availability>LA:6</availability>
 			</model>
+            <model name='C'>
+                <roles>command,fire_support</roles>
+                <availability>CLAN!Front Line:3!Second Line:1,CBS:1+,CB:2+,CCO:3+,CIH:3+,CMG:2+,CNC!Front Line:2!Second Line:1,CSJ!Front Line:2,BAN:0</availability>
+            </model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
 			<availability>MOC:8,OA:8,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8,BAN:3</availability>
@@ -993,18 +997,18 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>CHH:8,CSR:8,CSV:8,CLAN:9,CFM:8,FWL.OH:4,FS:1,MERC:1,CGS:10,CS:7,CDS:8,CW:10,CBS:10,LA:2,CNC:10,FWL:4,NIOPS:7,CJF:8,CGB:10,DC:1</availability>
+			<availability>FS:1,LA:2,DC:1,FWL:4,MERC:1,CS:7,CLAN:3+,CBS!Front Line:2!Second Line:1,CCC!Front Line:2!Second Line:1,CGS:4+,CIH:2+,NIOPS:7,BAN:2+</availability>
 			<model name='BL-6-KNT'>
                 <roles>command</roles>
-				<availability>CS:8,CLAN:6,FWL:2+,NIOPS:8,FS:2+,BAN:6</availability>
+				<availability>FS:2+,FWL:2+,CS:8,CLAN:8,CBS:6-,CCO:4-,CGB:4-,CGS:4-,CNC:4-,CW:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='BL-6b-KNT'>
                 <roles>command</roles>
-				<availability>CS:4,CLAN:7,NIOPS:4,CGS:8,BAN:4</availability>
+				<availability>CS:4,CBS:7,CCO:7,CGB:7,CGS:7,CNC:7,CW:7,NIOPS:4</availability>
 			</model>
 			<model name='BL-7-KNT'>
                 <roles>command</roles>
-				<availability>LA:8,FWL:4,MERC:8,FS:8,DC:8</availability>
+				<availability>FS:8,LA:8,DC:8,FWL:4,MERC:8</availability>
 			</model>
 			<model name='BL-7-KNT-L'>
                 <roles>command</roles>
@@ -1036,14 +1040,14 @@
 			</model>
 		</chassis>
 		<chassis name='Bombardier' unitType='Mek'>
-			<availability>CLAN:2-,CS:5,IS:2,Periphery:1,NIOPS:5,BAN:1</availability>
+			<availability>IS:2,CLAN:2-,CS:5,CLAN:3-,CB:2-,CCO:2-,CIH:4,CMG:4-,CDS:4-,CSR:4-,Periphery:1,NIOPS:5,BAN:0</availability>
 			<model name='BMB-10D'>
 				<roles>fire_support</roles>
 				<availability>IS:8,CS:4-,Periphery:8,NIOPS:0</availability>
 			</model>
 			<model name='BMB-12D'>
 				<roles>fire_support</roles>
-				<availability>CLAN:8,CS:8,FWL:2+,DC:2+,NIOPS:8,BAN:8</availability>
+				<availability>FWL:2+,DC:2+,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -1176,18 +1180,18 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>MOC:1,CC:5,CLAN:2,IS:3,MERC:2,CIR:1,Periphery:1,TC:1,CS:2,NIOPS:2,DC:5</availability>
+			<availability>IS:3,DC:5,CC:5,MERC:2,CS:2,CFM:4+,Periphery:1,NIOPS:2</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
-				<availability>CC:4,FWL:2,DC:1</availability>
+				<availability>DC:1,FWL:2,CC:4</availability>
 			</model>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
-				<availability>CC:8,CLAN:4,IS:8,Periphery.Deep:8,MERC:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,CC:8,MERC:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='CPLT-C1b'>
 				<roles>fire_support</roles>
-				<availability>CLAN:6</availability>
+				<availability>CFM:8</availability>
 			</model>
 			<model name='CPLT-C4'>
 				<roles>fire_support</roles>
@@ -1226,12 +1230,12 @@
 			</model>
 		</chassis>
 		<chassis name='Cestus' unitType='Mek'>
-			<availability>CS:4,LA:1+,CLAN:4,NIOPS:4,IS:1+,FS:2</availability>
+			<availability>IS:1+,FS:2,CS:4,CB!Front Line:2!Second Line:1,CFM!Front Line:2!Second Line:1,NIOPS:4+</availability>
 			<model name='CTS-6Y'>
-				<availability>General:8</availability>
+				<availability>IS:8,CB:8,CFM:5</availability>
 			</model>
 			<model name='CTS-6Y-EC'>
-				<availability>CFM:2</availability>
+				<availability>CFM!Front Line:8!Second Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
@@ -1254,13 +1258,13 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>CC:5,CS:5,CHH:6,LA:5,CLAN:4,IS:4,NIOPS:5,MERC:4,FS:4,CGB:6</availability>
+			<availability>IS:4,FS:4,LA:5,CC:5,MERC:4,CS:5,CBS:4-,CCO!Second Line:1,CGB!Second Line:2!Solahma:1,CHH!Front Line:3!Second Line:2!Solahma:1,NIOPS:5</availability>
 			<model name='C'>
-				<availability>CHH:6,CLAN:8,CGB:6</availability>
+				<availability>CBS!Front Line:1,CCO!Second Line:1,CHH:3+</availability>
 			</model>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
-				<availability>CC:2+,CS:8,CHH:6,CLAN:4,NIOPS:8,BAN:7,CGB:6</availability>
+				<availability>CC:2+,CS:8,CBS:8,CGB:8,CHH:2-,NIOPS:8</availability>
 			</model>
 			<model name='CHP-1N2'>
 				<availability>CS:4,CLAN:2,BAN:2,CGB:2</availability>
@@ -2058,15 +2062,15 @@
 			</model>
 		</chassis>
 		<chassis name='Crossbow' unitType='Mek' omni='Clan'>
-			<availability>CBS:4,CSV:6</availability>
+			<availability>CSV:1+</availability>
 			<model name='A'>
-				<availability>General:5</availability>
+                <availability>CSV:5</availability>
 			</model>
 			<model name='B'>
-				<availability>General:6</availability>
+                <availability>CSV:6</availability>
 			</model>
 			<model name='Prime'>
-				<availability>General:8</availability>
+                <availability>CSV:8</availability>
 			</model>
 		</chassis>
         <chassis name='Crosscut' unitType='Mek'>
@@ -2100,9 +2104,9 @@
             </model>
         </chassis>
 		<chassis name='Crusader' unitType='Mek'>
-			<availability>CS:6-,CLAN:5,IS:8,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:8,CS:6-,CLAN!Second Line:1!Solahma:2!Provisional Garrison:2,CBS:3,CB:3,CCC!Front Line:1!Second Line:2!Solahma:2!Provisional Garrison:2,CGS!Front Line:1!Second Line:2!Solahma:2!Provisional Garrison:2,CIH:2,CMG:2,CDS!Front Line:1!Second Line:2!Solahma:2!Provisional Garrison:2,CSJ!Front Line:1!Second Line:2!Solahma:2!Provisional Garrison:2,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:4</availability>
 			<model name='CRD-2R'>
-				<availability>CLAN:7,IS:1+,CGS:8,BAN:4,Periphery:1+</availability>
+				<availability>IS:1+,CLAN:8,Periphery:1+,NIOPS:5,BAN:2+</availability>
 			</model>
 			<model name='CRD-3D'>
 				<availability>FS:5</availability>
@@ -2115,7 +2119,7 @@
 				<availability>CC:9</availability>
 			</model>
 			<model name='CRD-3R'>
-				<availability>General:8,CLAN:2,Periphery.Deep:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,NIOPS:6-,Periphery.Deep:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
@@ -2418,29 +2422,29 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,IS:5,Periphery:2,TC:3,CS:5,NIOPS:5,DC:6</availability>
+			<availability>IS:5,DC:6,CS:5,Periphery:2,TC:3,MOC:3,NIOPS:5</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Mek'>
-			<availability>CS:5,LA:1+,CLAN:4,NIOPS:5,FS:1+,DC:1+</availability>
+			<availability>FS:1+,LA:1+,DC:1+,CS:5,CLAN!Front Line:2!Second Line:1,CBS:3+,CGS:3+,CIH:3+,CJF:3+,CMG:3+,CNC:3+,NIOPS:5,BAN:0</availability>
 			<model name='EXC-B1'>
 				<roles>cavalry,fire_support</roles>
-				<availability>LA:8</availability>
+				<availability>LA:8,CDS:4-</availability>
 			</model>
 			<model name='EXC-B2'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CS:8,LA:0,General:8,CLAN:5,NIOPS:8</availability>
+				<availability>FS:8,LA:0,DC:8,CS:8,CLAN:5-,CW:0,NIOPS:8</availability>
 			</model>
 			<model name='EXC-B2b'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CLAN:2+,CGB:3+,CJF:3+,CSJ:3+,CW:4-</availability>
 			</model>
 			<model name='EXC-B2b-EC'>
                 <roles>cavalry,fire_support</roles>
-				<availability>CW:2</availability>
+				<availability>CW!Front Line:2!Second Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -2455,22 +2459,18 @@
 			</model>
 		</chassis>
 		<chassis name='Exterminator' unitType='Mek'>
-			<availability>CS:4,CLAN:5,NIOPS:4</availability>
+			<availability>CS:4,CLAN!Second Line:1,CBS!Front Line:2!Second Line:1,CCC!Front Line:2!Second Line:1,CFM!Front Line:2!Second Line:1,CIH:4+,CJF!Second Line:2!Solahma:1,CMG:3+,CDS!Front Line:3!Second Line:2!Solahma:1,CSR:3+,NIOPS:4,BAN:1+</availability>
 			<model name='EXT-4C'>
 			    <roles>specops</roles>
-				<availability>BAN:1</availability>
+				<availability>BAN:8</availability>
 			</model>
 			<model name='EXT-4D'>
 			    <roles>cavalry</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:4</availability>
+				<availability>CS:8,CLAN:8,CFM:4-,CIH:4-,CJF:3-,CDS:3-,CSR:4-,NIOPS:8,BAN:0</availability>
 			</model>
 			<model name='EXT-4Db'>
 			    <roles>cavalry</roles>
-				<availability>CLAN:4,BAN:3</availability>
-			</model>
-			<model name='EXT-4Db-EC'>
-			    <roles>cavalry</roles>
-				<availability>CJF:1</availability>
+				<availability>CFM:8,CIH:5,CJF:4-,CDS:8,CSR:8,NIOPS:3+</availability>
 			</model>
 		</chassis>
 	    <chassis name='Factory' unitType='Space Station'>
@@ -2528,10 +2528,10 @@
 			</model>
 		</chassis>
 		<chassis name='Fire Scorpion' unitType='Mek'>
-			<availability>CGS:7</availability>
+			<availability>CGS:2+</availability>
 			<model name=''>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
+				<availability>CGS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Firebee' unitType='Mek'>
@@ -2571,13 +2571,13 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>CHH:5,CSV:7,CLAN:6,CFM:7,CGS:5,CS:5,Periphery.R:2,CDS:5,LA:6,CBS:5,FWL:1,NIOPS:5,CJF:7,CGB:5</availability>
+			<availability>LA:6,FWL:1,CS:5,CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CCO!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:2,CJF!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,Periphery.R:2,NIOPS:5,BAN:3+</availability>
 			<model name='FLS-7K'>
 				<availability>LA:8,FWL:8,Periphery.R:8</availability>
 			</model>
 			<model name='FLS-8K'>
                 <roles>cavalry</roles>
-				<availability>CS:8,LA:2+,CLAN:8,NIOPS:8,BAN:8</availability>
+				<availability>LA:2+,CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Flatbed Truck' unitType='Tank'>
@@ -2770,19 +2770,16 @@
 			</model>
 		</chassis>
 		<chassis name='Galahad (Glass Spider)' unitType='Mek'>
-			<availability>CSR:8,CW:8,CLAN:8</availability>
+			<availability>CW!Front Line:2!Second Line:1</availability>
 			<model name=''>
                 <roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:8</availability>
+				<availability>CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Galahad' unitType='Mek'>
-			<availability>CC:1+,LA:1+,CLAN:2,FS:1+</availability>
+			<availability>FS:1+,LA:1+,CC:1+</availability>
 			<model name='GLH-1D'>
-				<availability>IS:8</availability>
-			</model>
-			<model name='GLH-2D'>
-				<availability>CLAN:8</availability>
+				<availability>FS:8,LA:8,CC:8</availability>
 			</model>
 		</chassis>
         <chassis name='Galaport Ground Trailer' unitType='Tank'>
@@ -2933,21 +2930,21 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine IIC' unitType='Mek'>
-			<availability>CLAN:2-:2889</availability>
+			<availability>CCO!Keshik:3,CSA:1+</availability>
 			<model name=''>
 			    <roles>raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CCO:8,CSA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>CS:7,CHH:8,CSR:8,CLAN:7,IS:6,NIOPS:7,FS:5,MERC:6</availability>
+			<availability>IS:6,FS:5,MERC:6,CS:7,CHH!Front Line:3!Second Line:2!Solahma:1,CSR!Front Line:2!Second Line:1,NIOPS:7</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
-				<availability>CS:8,CLAN:8,IS:2+,NIOPS:8,BAN:8</availability>
+				<availability>IS:2+,CS:8,CHH:8,CSR:8,NIOPS:8</availability>
 			</model>
 			<model name='GLT-4L'>
 				<roles>raider</roles>
-				<availability>FWL:8,NIOPS:0,MERC:8</availability>
+				<availability>FWL:8,MERC:8</availability>
 			</model>
 			<model name='GLT-4P'>
 				<roles>raider</roles>
@@ -3186,11 +3183,11 @@
             </model>
         </chassis>
 		<chassis name='Helepolis' unitType='Mek'>
-			<availability>CLAN:1</availability>
+            <availability>CHH:1-</availability>
 			<model name='HEP-3H'>
 				<roles>mixed_artillery</roles>
 				<deployedWith>Helepolis</deployedWith>
-				<availability>General:8</availability>
+                <availability>CHH:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
@@ -3848,18 +3845,18 @@
 			</model>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>MOC:2,CIH:6,CLAN:5,IS:2,CFM:6,MERC:2,CIR:2,CGS:6,BAN:6,TC:2,CS:6,OA:2,NIOPS:6,DC:4</availability>
+			<availability>IS:2,DC:4,MERC:2,CS:6,CLAN!Front Line:2!Second Line:1,CBS:3+,CB!Front Line:3!Second Line:2!Solahma:1,CCC:4+,CCO!Second Line:1,CFM:4+,CGB:3+,CGS:3+,CIH:4+,CMG:4+,CSV!Front Line:3!Second Line:2!Solahma:1,TC:2,MOC:2,OA:2,CIR:2,NIOPS:6,BAN:0</availability>
 			<model name='C'>
                 <roles>cavalry,anti_aircraft</roles>
-				<availability>CIH:4,CFM:3,CFM.SmJ:8,CB:5,CGB:4</availability>
+				<availability>CB:3+,CFM:3+,CGB:3+,CIH!Keshik:8!Front Line:8!Second Line:5</availability>
 			</model>
 			<model name='C 2'>
                 <roles>cavalry,anti_aircraft</roles>
-				<availability>CIH:3,CFM:2,CFM.SmJ:4,CB:3</availability>
+				<availability>CB:2+,CFM:4+,CIH!Keshik:5!Front Line:3!Second Line:1</availability>
 			</model>
 			<model name='LNC25-01'>
 				<roles>cavalry,anti_aircraft</roles>
-				<availability>CS:8,CLAN:8,IS:3+,NIOPS:8,BAN:6</availability>
+				<availability>IS:3+,CS:8,CLAN:8,CB:3-,CFM:4-,CGB:4-,CIH:3-,NIOPS:8</availability>
 			</model>
 			<model name='LNC25-02'>
 				<roles>anti_aircraft,fire_support</roles>
@@ -4077,12 +4074,12 @@
 			</model>
 		</chassis>
 		<chassis name='Lupus' unitType='Mek' omni='Clan'>
-			<availability>CDS:3,CBS:4,CSV:4,CLAN:3,CCO:8,CGS:4</availability>
+			<availability>CLAN!Keshik:3!Front Line:1,CBS:2+,CB!Keshik:5!Front Line:2,CCC!Keshik:4!Front Line:1,CCO!Keshik:4!Front Line:2,CFM!Keshik:4!Front Line:1,CGB:3+,CGS:2+,CHH:2+,CJF:3+,CNC:3+,CSR:3+,CSA:3+,CW!Keshik:1!Front Line:2,BAN:0</availability>
 			<model name='A'>
 				<availability>CLAN:6</availability>
 			</model>
 			<model name='B'>
-				<availability>CLAN:6</availability>
+				<availability>CLAN:4+</availability>
 			</model>
 			<model name='Prime'>
 				<roles>fire_support</roles>
@@ -4168,18 +4165,18 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>MOC:2+,CS:8,LA:5,CLAN:6,IS:4,NIOPS:8,FS:5,TC:3+,DC:5</availability>
+			<availability>IS:4,FS:5,LA:5,DC:5,CS:8,CLAN!Front Line:3!Second Line:2!Solahma:1,CBS:4+,CGS:4+,CIH:3+,CMG:3+,CDS:4+,TC:3+,MOC:2+,NIOPS:8,BAN:2+</availability>
             <model name='C'>
                 <roles>command</roles>
-                <availability>CLAN:2+</availability>
+                <availability>CLAN:4+,CBS!Keshik:8,CB:3+,CFM:3+,CGS:3+,CHH:2+,CIH:2+,CMG:2+,CDS:3+,BAN:0</availability>
             </model>
 			<model name='MAD-1R'>
                 <roles>command</roles>
-				<availability>CS:8,MOC:1,CLAN:4,NIOPS:8,BAN:4,TC:1+</availability>
+				<availability>CS:8,CLAN:2-,TC:1+,MOC:1,NIOPS:8,BAN:2+</availability>
 			</model>
 			<model name='MAD-2R'>
                 <roles>command</roles>
-				<availability>CLAN:6,FS:1+,CGS:7,BAN:6</availability>
+				<availability>FS:1+,CLAN:5,CCO:4,CGB:4,CHH:4,CJF:4,CW:4,BAN:0</availability>
 			</model>
 			<model name='MAD-3D'>
                 <roles>command</roles>
@@ -4191,7 +4188,7 @@
 			</model>
 			<model name='MAD-3R'>
                 <roles>command</roles>
-				<availability>CS:4-,IS:8,Periphery:8</availability>
+				<availability>IS:8,CS:4-,Periphery:8,BAN:8</availability>
 			</model>
 		</chassis>
         <chassis name='Marco' unitType='Mek'>
@@ -4226,15 +4223,15 @@
 			</model>
 		</chassis>
 		<chassis name='Masauwu' unitType='Mek'>
-			<availability>CSA:4,CCO:6</availability>
+			<availability>CCO!Front Line:2,CSA!Front Line:3!Second Line:2!Solahma:1</availability>
             <model name=''>
-                <availability>General:8</availability>
+                <availability>CCO:8,CSA:8</availability>
             </model>
 		</chassis>
 		<chassis name='Matador' unitType='Mek'>
-			<availability>CSV:6</availability>
+			<availability>CSV!Front Line:3!Second Line:2!Solahma:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CSV:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Maultier Hover APC' unitType='Tank'>
@@ -4468,15 +4465,11 @@
 			</model>
 		</chassis>
 		<chassis name='Minsk' unitType='Mek'>
-			<availability>CW:2,CJF:2,CGB:5</availability>
+			<availability>CGB!Second Line:1!Solahma:1,CJF!Front Line:1,CW!Front Line:1</availability>
             <model name=''>
                 <roles>command</roles>
-                <availability>CLAN:8</availability>
+                <availability>CGB:8,CJF:8,CW:8</availability>
             </model>
-			<model name='MNK-101'>
-				<roles>command</roles>
-				<availability>CGB:2</availability>
-			</model>
 		</chassis>
 		<chassis name='Mithras Light Tank' unitType='Tank'>
 			<availability>CSA:6,CCC:6,CIH:6,CBS:6,CSV:6,CLAN:6,CFM:6,CGS:6,CCO:6,CB:6</availability>
@@ -4808,18 +4801,21 @@
 			</model>
 		</chassis>
 		<chassis name='Orion IIC' unitType='Mek'>
-			<availability>CW:4</availability>
+			<availability>CW:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>MOC:5,CLAN:3,IS:5,Periphery.Deep:4,CIR:5,Periphery:4,TC:5,CS:5-,OA:5,CW:4,LA:6,Periphery.MW:5,Periphery.ME:5,FWL:9,NIOPS:5-</availability>
+			<availability>IS:5,LA:6,FWL:9,CS:5-,CLAN!Front Line:2!Second Line:1,CBS:3+,CCO!Second Line:1,CFM!Second Line:1,CGB!Second Line:1,CIH:2+,CJF!Second Line:2!Solahma:1,CMG!Front Line:1,CW!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,Periphery.MW:5,Periphery.ME:5,Periphery:4,TC:5,MOC:5,OA:5,CIR:5,NIOPS:5-,Periphery.Deep:4,BAN:2</availability>
 			<model name='ON1-K'>
-				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8,BAN:8</availability>
+			</model>
+            <model name='ON1-Kb'>
+                <availability>CLAN:8,BAN:0</availability>
 			</model>
 			<model name='ON1-V'>
-				<availability>OA:2,IS:3,TC:3</availability>
+				<availability>IS:3,TC:3,OA:2</availability>
 			</model>
 			<model name='ON1-VA'>
 				<availability>IS:2</availability>
@@ -4839,14 +4835,14 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>CS:4,CLAN:3-,IS:5,NIOPS:4,Periphery.Deep:4,Periphery:4,DC:6</availability>
+			<availability>IS:5,DC:6,CS:4,CLAN:4-,CBS:4,CB:3,CCC!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:3,CGS:3,CHH:4,CIH!Keshik:5!Front Line:5!Second Line:5!Solahma:4!Provisional Garrison:4,CMG!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,Periphery:4,NIOPS:4,Periphery.Deep:4,BAN:6</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
-				<availability>CLAN:3,IS:8,Periphery.Deep:8,MERC:8,BAN:5,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8,BAN:4-</availability>
 			</model>
 			<model name='OSR-2Cb'>
 				<roles>urban</roles>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CLAN:8,BAN:3</availability>
 			</model>
 			<model name='OSR-2L'>
 				<availability>IS:4</availability>
@@ -4870,10 +4866,10 @@
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
-			<availability>CLAN:1-,CS:6,FWL:7,NIOPS:6,Periphery.Deep:4,FS:7,MERC:7,Periphery:4,BAN:2</availability>
+			<availability>FS:7,FWL:7,MERC:7,CS:6,Periphery:4,NIOPS:6,Periphery.Deep:4,BAN:2-</availability>
 			<model name='OTL-4D'>
                 <roles>raider</roles>
-				<availability>CLAN:8,IS:8,Periphery:8,BAN:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,BAN:8</availability>
 			</model>
 			<model name='OTL-4F'>
 				<availability>FS:4:2871</availability>
@@ -5256,10 +5252,10 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman IIC' unitType='Mek'>
-			<availability>CLAN:5</availability>
+			<availability>CGB!Front Line:1,CNC!Front Line:1,CDS!Front Line:1,CSR!Front Line:1,CW!Front Line:1</availability>
 			<model name=''>
                 <roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CNC:8,CDS:8,CSR:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Rifleman II' unitType='Mek'>
@@ -5270,14 +5266,14 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>CLAN:2,IS:8-,Periphery.Deep:5,CIR:2,Periphery:5,CS:6-,NIOPS:6-</availability>
+			<availability>IS:8-,CS:6-,CLAN!Second Line:1,CBS!Front Line:1,CB!Front Line:1,CCC!Front Line:1,CCO!Solahma:1,CFM!Front Line:1,CMG!Front Line:1,Periphery:5,CIR:2,NIOPS:6-,Periphery.Deep:5,BAN:3-</availability>
             <model name='C'>
                 <roles>fire_support,anti_aircraft</roles>
-                <availability>CLAN:8,BAN:4</availability>
+                <availability>CLAN:8,BAN:3+</availability>
             </model>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:4-,General:8,BAN:5</availability>
+				<availability>IS:8,MERC:8,Periphery:8,NIOPS:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Riga II Destroyer-Carrier' unitType='Warship'>
@@ -5591,10 +5587,10 @@
 			</model>
 		</chassis>
 		<chassis name='Shootist' unitType='Mek'>
-			<availability>CS:5,LA:1+,CLAN:5,NIOPS:5</availability>
+			<availability>LA:1+,CS:5,CLAN!Front Line:2!Second Line:1,CBS:2+,CB!Front Line:3!Second Line:2!Solahma:1,CCC!Second Line:1,CIH!Second Line:2!Solahma:1,CMG!Second Line:1,NIOPS:5,BAN:0</availability>
 			<model name='ST-8A'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
         <chassis name='Shugosha' unitType='Mek'>
@@ -5744,6 +5740,15 @@
 				<availability>IS:8,FS:3,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
+        <chassis name='Spirit Walker' unitType='Mek' omni='Clan'>
+            <availability>CBS:1+,CCO:2+,CFM:2+,CGS:2+,CHH:2+,CJF:1+,CNC:1+,CSJ:1+,CSR:1+,CSA:1+</availability>
+            <model name='A'>
+                <availability>CLAN:3+,CGS:4+</availability>
+            </model>
+            <model name='Prime'>
+                <availability>CLAN:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Stalker' unitType='Mek'>
 			<availability>CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,Periphery:10,CS:6,LA:9,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
@@ -5926,21 +5931,24 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CIH:4,CLAN:6,CCO:7,BAN:5,CDS:7,CW:7,CSJ:7,CJF:10,CGB:7,CB:5</availability>
+			<availability>CHH:1+:2875,CJF!Keshik:3</availability>
+            <model name='A'>
+                <availability>CHH:4,CJF:4</availability>
+            </model>
 			<model name='B'>
 				<roles>fire_support</roles>
-				<availability>CDS:4,CNC:5,CLAN:6,CJF:7,CGB:4</availability>
+				<availability>CHH:5,CJF:5</availability>
 			</model>
 			<model name='C'>
-				<availability>CLAN:5,CJF:6,CGB:4</availability>
+				<availability>CHH:3+,CJF:3+</availability>
 			</model>
 			<model name='D'>
 			    <roles>raider</roles>
-				<availability>CNC:6,CLAN:5,CSJ:3,CGS:4,CGB:4</availability>
+				<availability>CHH:6,CJF:6</availability>
 			</model>
 			<model name='Prime'>
 				<roles>raider</roles>
-				<availability>CDS:9,CLAN:8,CJF:9</availability>
+				<availability>CHH:8,CJF:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thor Artillery Vehicle' unitType='Tank'>
@@ -5964,13 +5972,13 @@
 			</model>
 		</chassis>
 		<chassis name='Thresher' unitType='Mek'>
-			<availability>CHH:6,CDS:4,CSR:4,CLAN:4</availability>
+			<availability>CHH:4+,CDS!Keshik:4!Front Line:2!Second Line:1</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CHH:8,CDS:8</availability>
 			</model>
 			<model name='2'>
 				<roles>fire_support</roles>
-				<availability>CHH:4</availability>
+				<availability>CHH:5</availability>
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
@@ -6031,9 +6039,9 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>CC:9,CS:5-,CLAN:4-,IS:8,Periphery.Deep:6,NIOPS:5-,FS:7,MERC:8,Periphery:6</availability>
+			<availability>IS:8,FS:7,MERC:8,CC:9,CS:5-,CLAN:4,CBS:5,CB!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CCO!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:3,CFM!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:3,CGB!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,CGS!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,CJF:5,CSJ:5,CSA:5,CW:5,Periphery:6,NIOPS:5-,Periphery.Deep:6,BAN:5</availability>
 			<model name='C'>
-				<availability>CLAN:1</availability>
+				<availability>CLAN:2+,CBS!Keshik:6!Front Line:1,CB:3+,CCC:3+,CCO:3+,CGS:1+,CHH:3+,CJF:3+,CNC:3+,CSA:3+,BAN:0</availability>
 			</model>
 			<model name='TDR-5D'>
 				<availability>FS:4,MERC:2</availability>
@@ -6042,7 +6050,7 @@
 				<availability>CC:2</availability>
 			</model>
 			<model name='TDR-5S'>
-				<availability>IS:8,CLAN:1-,BAN:4,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,BAN:6-</availability>
 			</model>
 			<model name='TDR-5SE'>
 				<availability>MERC.ELH:8,MERC:2</availability>
@@ -6051,7 +6059,7 @@
 				<availability>LA:6</availability>
 			</model>
 			<model name='TDR-5Sb'>
-				<availability>CLAN:5-,BAN:4</availability>
+				<availability>CLAN:4,CB:4-,CIH:4-,CJF:4-,BAN:5</availability>
 			</model>
 			<model name='TDR-5Sd'>
 				<availability>FS:1+</availability>
@@ -6340,12 +6348,12 @@
 			</model>
 		</chassis>
 		<chassis name='Vision Quest' unitType='Mek'>
-			<availability>CSR:4,CNC:8,CB:4</availability>
-			<model name='2'>
-				<availability>CSR:8,CNC:8</availability>
-			</model>
-			<model name='VQ-1NC'>
-				<availability>CNC:1</availability>
+			<availability>CB!Keshik:1!Front Line:3!Second Line:1,CNC!Keshik:4!Front Line:2!Second Line:1,CSR:1+</availability>
+            <model name=''>
+                <availability>CB:8,CNC:8</availability>
+            </model>
+            <model name='2'>
+				<availability>CNC:1+,CSR:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Volga Transport' unitType='Warship'>
@@ -6412,12 +6420,12 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>CS:6-,LA:9,CLAN:5,IS:8,FWL:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:8,LA:9,FWL:9,CS:6-,CLAN:5+,CBS:6+,CCO!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CGB!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CIH:3-,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:5+</availability>
             <model name='C'>
-                <availability>CLAN:1</availability>
+                <availability>CLAN:3+,CBS!Keshik:3!Front Line:1,CB:2+,CGB!Keshik:1!Front Line:1!Second Line:1,CSJ:2+,BAN:0</availability>
             </model>
 			<model name='C 3'>
-				<availability>CLAN:3</availability>
+				<availability>CGB:3+</availability>
 			</model>
 			<model name='WHM-6D'>
 				<availability>FS:4</availability>
@@ -6429,17 +6437,17 @@
 				<availability>CC:4</availability>
 			</model>
 			<model name='WHM-6R'>
-				<availability>General:8,CLAN:1,BAN:8</availability>
+				<availability>IS:8,CMG:1-,CSJ:1-,Periphery:8,NIOPS:3-,Periphery.Deep:8,BAN:6-</availability>
 			</model>
 			<model name='WHM-6Rb'>
-				<availability>CC:1+,LA:1+,CLAN:4,FWL:1+,FS:1+,BAN:4</availability>
+				<availability>FS:1+,LA:1+,FWL:1+,CC:1+,CLAN:3-,CBS:4-,CMG:4-,NIOPS:6,BAN:5</availability>
 			</model>
 			<model name='WHM-6Rk'>
                 <roles>cavalry</roles>
 				<availability>DC:1+</availability>
 			</model>
 			<model name='WHM-7A'>
-				<availability>CLAN:4</availability>
+				<availability>CLAN!Second Line:2,CBS:3+,CB!Front Line:2!Second Line:1,CFM!Front Line:2!Second Line:1,CIH:4+,CMG!Front Line:2,BAN:0</availability>
 			</model>
 		</chassis>
 		<chassis name='Wasp LAM Mk I' unitType='Mek'>
@@ -6553,12 +6561,15 @@
 			</model>
 		</chassis>
 		<chassis name='Woodsman' unitType='Mek' omni='Clan'>
-			<availability>CW:8</availability>
+			<availability>CW!Keshik:4!Front Line:2</availability>
 			<model name='A'>
-				<availability>General:6</availability>
+				<availability>CW:4+</availability>
 			</model>
+            <model name='B'>
+                <availability>CW:3+</availability>
+            </model>
 			<model name='Prime'>
-				<availability>General:8</availability>
+				<availability>CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Wyvern IIC' unitType='Mek'>

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2870-->
-<ratgen>
+<ratgen
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -579,18 +579,21 @@
 			</model>
 		</chassis>
 		<chassis name='Annihilator' unitType='Mek'>
-			<availability>CSA:3,CHH:2,CSR:3,CLAN:2,CCO:3,BAN:1,CGB:2</availability>
+			<availability>CB!Front Line:3!Second Line:2!Solahma:1,CCO:3+,CGB:3+,CSA:3+</availability>
 			<model name='ANH-1G'>
-				<availability>CSA:4,CCO:4,BAN:1</availability>
+				<availability>CCO!Second Line:1,CGB!Second Line:1,CSA!Second Line:1</availability>
 			</model>
 			<model name='ANH-1X'>
-				<availability>CLAN:3,BAN:4</availability>
+				<availability>CB:8,CCO!Second Line:1,CGB!Second Line:1,CSA!Second Line:1</availability>
 			</model>
 			<model name='C'>
-				<availability>CLAN:8,BAN:2</availability>
+				<availability>CCO!Keshik:5!Front Line:3!Second Line:1,CGB!Keshik:5!Front Line:3!Second Line:1,CSA!Keshik:5!Front Line:3!Second Line:1</availability>
 			</model>
+            <model name='C &apos;Gausszilla&apos;'>
+                <availability>CCO:1+,CGB:1+,CSA:1+</availability>
+            </model>
 			<model name='C 2'>
-				<availability>CLAN:6,BAN:1</availability>
+				<availability>CCO!Keshik:3!Front Line:1,CGB!Keshik:3!Front Line:1,CSA!Keshik:3!Front Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Aquarius Escort' unitType='Small Craft'>
@@ -738,25 +741,25 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas II' unitType='Mek'>
-			<availability>CLAN:4</availability>
+			<availability>CLAN!Front Line:2!Second Line:1,CBS:2+,CCC!Front Line:1,CIH!Front Line:1,CMG!Front Line:1,CSA!Front Line:1,BAN:0</availability>
 			<model name='AS7-D-H'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CLAN:5</availability>
 			</model>
 			<model name='AS7-D-H2'>
                 <roles>command</roles>
-				<availability>CLAN:4</availability>
+				<availability>CLAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>MOC:1,CSV:2-,IS:3,FS:5,TC:1,CS:4-,OA:1,CW:2-,LA:4,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
+			<availability>IS:3,FS:5,LA:4,DC:5,CS:4-,CLAN:4,CCC:3,CGS:3,CIH:2,CMG:3,CDS:3,CSV:3,TC:1,MOC:1,OA:1,NIOPS:4-,BAN:4-</availability>
 			<model name='AS7-D'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CLAN:3-,CBS:4-,Periphery:8,Periphery.Deep:8,BAN:5-</availability>
 			</model>
 			<model name='AS7-D-DC'>
 				<roles>command</roles>
-				<availability>IS:1,MERC:0,DC:2</availability>
+				<availability>IS:1+,DC:2+,MERC:0,BAN!Front Line:1</availability>
 			</model>
 			<model name='AS7-RS'>
                 <roles>command</roles>
@@ -764,15 +767,15 @@
 			</model>
 			<model name='C'>
                 <roles>command</roles>
-				<availability>CW:2-,CSV:2-,CSJ:2-,CB:2</availability>
+				<availability>CB!Front Line:5!Second Line:1,CSJ!Second Line:1,CSV!Front Line:5!Second Line:1,CW!Second Line:5,BAN:3+</availability>
 			</model>
 			<model name='C 2'>
                 <roles>command</roles>
-				<availability>CLAN:2-</availability>
+				<availability>CLAN!Keshik:5!Front Line:3,CBS!Keshik:5!Front Line:1,CGB!Keshik:5!Front Line:3!Second Line:1,CGS!Keshik:5!Front Line:3!Second Line:1,CHH!Keshik:5!Front Line:3!Second Line:1,CNC!Keshik:5!Front Line:3!Second Line:1,CSJ!Keshik:5!Front Line:5,CSR!Keshik:5!Front Line:3!Second Line:1,CSA!Keshik:5!Front Line:3!Second Line:1,CW!Keshik:5!Front Line:5,BAN:2+</availability>
 			</model>
 			<model name='C 3'>
 				<roles>mixed_artillery</roles>
-				<availability>CLAN:2-</availability>
+				<availability>CLAN!Front Line:1,CBS:1+,CIH!Second Line:1,CJF!Second Line:1,CMG!Second Line:1,CSJ!Second Line:1,CW!Second Line:1,BAN:0</availability>
 			</model>
 		</chassis>
 		<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
@@ -805,9 +808,9 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,CLAN:2-,IS:7,Periphery.Deep:7,CIR:8,Periphery:7,TC:8,CS:8,OA:8,FWL:10,NIOPS:8</availability>
+			<availability>IS:7,FWL:10,CS:8,Periphery:7,TC:8,MOC:8,OA:8,CIR:8,NIOPS:8,Periphery.Deep:7+,BAN:1</availability>
 			<model name='AWS-8Q'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
 			<model name='AWS-8R'>
 				<availability>CS:2,FWL:4</availability>
@@ -914,14 +917,14 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:6,MOC:6,CLAN:3,IS:5,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,DC:6</availability>
+			<availability>IS:5,LA:7,DC:6,FWL:8,CC:6,CS:8-,CLAN:5-,CFM:4,CGS:5,CMG!Keshik:2!Front Line:3!Second Line:4!Solahma:5!Provisional Garrison:5,CSJ:4-,CW:6-,TC:6,MOC:6,NIOPS:8-,BAN:4,PIR:6</availability>
 			<model name='BLR-1D'>
                 <roles>command</roles>
 				<availability>FS:8</availability>
 			</model>
 			<model name='BLR-1G'>
                 <roles>command</roles>
-				<availability>IS:8,Periphery.Deep:8,FS:6,BAN:8,Periphery:8</availability>
+				<availability>IS:8,FS:6,Periphery:8,Periphery.Deep:8,BAN:5,PIR:8</availability>
 			</model>
 			<model name='BLR-1G-DC'>
 				<roles>command</roles>
@@ -929,15 +932,15 @@
 			</model>
 			<model name='BLR-1Gb'>
                 <roles>command</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,BAN:6+</availability>
 			</model>
 			<model name='BLR-1Gbc'>
                 <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>CLAN!Second Line:1,CCO:0,CFM:0,CIH:0,CSJ:0,CSV:0,BAN:0</availability>
 			</model>
 			<model name='BLR-1Gc'>
                 <roles>command</roles>
-				<availability>CLAN:4</availability>
+				<availability>BAN:1+</availability>
 			</model>
 			<model name='BLR-1Gd'>
                 <roles>command</roles>
@@ -959,15 +962,15 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
-			<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
+			<availability>CSJ:3+</availability>
 			<model name=''>
-				<availability>CSR:8,General:8</availability>
+				<availability>CSJ:3+</availability>
 			</model>
 			<model name='4'>
-				<availability>General:4</availability>
+				<availability>CSJ:4-</availability>
 			</model>
 			<model name='5'>
-				<availability>General:4</availability>
+				<availability>CSJ:3-</availability>
 			</model>
 		</chassis>
 		<chassis name='Behemoth' unitType='Dropship'>
@@ -2050,15 +2053,15 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>CC:1,CHH:10,CSR:8,CSV:8,CLAN:9,CFM:8,FS:1,CGS:8,CS:8,CDS:8,CW:10,LA:1,CBS:10,FWL:1,NIOPS:8,CJF:8,CGB:10,DC:1</availability>
+			<availability>FS:1,LA:1,FWL:1,DC:1,CC:1,CS:8,CLAN:3-,CBS:5-,CGS:4-,NIOPS:8,BAN:4-</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:8,NIOPS:0</availability>
 			</model>
 			<model name='CRK-5003-1'>
-				<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>IS:2+,CS:8,CLAN:8,CBS:4-,CB:4-,CCO:4-,CGB:4-,CHH:4-,CW:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='CRK-5003-1b'>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CBS:5,CB:5,CCO:5,CGB:5,CHH:5,CW:5,BAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Crossbow' unitType='Mek' omni='Clan'>
@@ -2123,7 +2126,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,CLAN:3,IS:3,FS:5,Periphery:2,CS:3,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>IS:3,FS:5,LA:5,DC:5,FWL:4,CC:5,CS:3,Periphery:2,NIOPS:3</availability>
 			<model name='CP-10-HQ'>
                 <roles>command</roles>
 				<availability>IS:2</availability>
@@ -2132,7 +2135,7 @@
 				<availability>IS:3</availability>
 			</model>
 			<model name='CP-10-Z'>
-				<availability>OA:8,IS:8,MERC:8,TC:8</availability>
+				<availability>IS:8,MERC:8,TC:8,OA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
@@ -2257,6 +2260,12 @@
 				<availability>FS:1+</availability>
 			</model>
 		</chassis>
+        <chassis name='Devastator' unitType='Mek'>
+            <availability>CSJ!Front Line:2!Second Line:1</availability>
+            <model name='DVS-2-EC'>
+                <availability>CSJ:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Dictator' unitType='Dropship'>
 			<availability>IS:2</availability>
 			<model name=''>
@@ -2350,17 +2359,14 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>CC:1,CS:7,OA:1,CLAN:2,CNC:2,FWL:2,NIOPS:7,FS:1,MERC:1,TC:1</availability>
+			<availability>FS:1,FWL:2,CC:1,MERC:1,CS:7,CLAN!Front Line:2!Second Line:1,CBS:3+,CGS:3+,CIH:3+,CSA!Front Line:1,TC:1,OA:1,NIOPS:7,BAN:0</availability>
 			<model name='EMP-5A'>
                 <roles>command</roles>
-				<availability>General:8,BAN:3</availability>
+				<availability>IS:8,Periphery:8,NIOPS:1-</availability>
 			</model>
 			<model name='EMP-6A'>
                 <roles>command</roles>
-				<availability>CC:2+,CS:8,LA:2+,CLAN:8,NIOPS:8,FWL:2+,FS:2+,BAN:6</availability>
-			</model>
-			<model name='EMP-6A-EC'>
-				<availability>CSA:2</availability>
+				<availability>FS:2+,LA:2+,FWL:2+,CC:2+,CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Enforcer' unitType='Mek'>
@@ -2825,6 +2831,23 @@
                 <availability>LA:8,FWL:8</availability>
             </model>
         </chassis>
+        <chassis name='Gladiator-B (Executioner-B)' unitType='Mek' omni='Clan'>
+            <availability>CLAN:1+,CBS:1+:2876,CB!Keshik:3,CFM:1+:2876,CGB!Keshik:2,CGS:1+:2876,CIH:0,CMG:0,CSR!Keshik:2,BAN:0</availability>
+            <model name='A'>
+                <availability>CLAN:6</availability>
+            </model>
+            <model name='B'>
+                <roles>fire_support</roles>
+                <availability>CLAN:3+</availability>
+            </model>
+            <model name='C'>
+                <roles>fire_support</roles>
+                <availability>CLAN:4+</availability>
+            </model>
+            <model name='Prime'>
+                <availability>CLAN:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
 			<availability>CC:1,LA:2,FS.CH:7,FS:6,MERC:3,CIR:4,Periphery:3,DC:2</availability>
 			<model name=''>
@@ -3279,33 +3302,33 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander IIC' unitType='Mek'>
-			<availability>CLAN:7</availability>
+			<availability>CBS!Keshik:2,CCC!Keshik:3!Front Line:1,CCO!Keshik:3!Front Line:1,CFM:2+,CDS!Keshik:3!Front Line:1,CSR:2+</availability>
 			<model name=''>
                 <roles>command</roles>
-				<availability>CLAN:8</availability>
+				<availability>CBS:8,CCC:8,CCO:8,CFM:8,CDS:8,CSR:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>CC:2,CS:9,LA:2,CLAN:9,NIOPS:9,IS:1,CFM:10,CJF:10,DC:2</availability>
+			<availability>IS:1,LA:2,DC:2,CC:2,CS:9,CLAN:4+,CCC:3+,CIH:3+,CSV:3+,NIOPS:9+,BAN:2+</availability>
 			<model name='HGN-732'>
                 <roles>command</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,FWL:1+,FS:8,BAN:8</availability>
+				<availability>FS:8,FWL:1+,CS:8,CLAN:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='HGN-732b'>
                 <roles>command</roles>
-				<availability>CLAN:7,FWL:1+,BAN:4</availability>
+				<availability>FWL:1+,CLAN:6,BAN:1+</availability>
 			</model>
 			<model name='HGN-733'>
                 <roles>command</roles>
-				<availability>CC:8,LA:8</availability>
+				<availability>LA:8,CC:8</availability>
 			</model>
 			<model name='HGN-733C'>
                 <roles>command</roles>
-				<availability>CC:4,LA:4</availability>
+				<availability>LA:4,CC:4</availability>
 			</model>
 			<model name='HGN-733P'>
                 <roles>command</roles>
-				<availability>CC:4,LA:4</availability>
+				<availability>LA:4,CC:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
@@ -3411,22 +3434,22 @@
 			</model>
 		</chassis>
 		<chassis name='Imp' unitType='Mek'>
-			<availability>CSA:4,CW:4,CLAN:3</availability>
+			<availability>CB!Keshik:1!Front Line:2!Second Line:1,CCO!Keshik:1!Front Line:3!Second Line:1,CGB!Front Line:3!Second Line:1,CSJ!Keshik:1!Front Line:3!Second Line:1,CW!Keshik:1!Front Line:3!Second Line:1</availability>
 			<model name='C'>
                 <roles>command</roles>
-				<availability>CLAN:8</availability>
+				<availability>CB:1+,CCO:1+,CGB!Front Line:8!Second Line:3,CSJ:2+,CW:1+</availability>
 			</model>
 			<model name='IMP-1A'>
                 <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>CB:4-,CCO:4-,CGB:3-,CSJ:4-,CW:4-</availability>
 			</model>
 			<model name='IMP-1B'>
                 <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>CB!Front Line:6!Second Line:6,CCO!Front Line:6!Second Line:1,CGB:6,CSJ!Front Line:6!Second Line:6,CW:6</availability>
 			</model>
 			<model name='IMP-1C'>
                 <roles>command</roles>
-				<availability>CHH:5,CLAN:2</availability>
+				<availability>CB!Front Line:4!Second Line:4,CCO!Front Line:1,CGB:4,CSJ!Front Line:4!Second Line:4,CW:4</availability>
 			</model>
 		</chassis>
         <chassis name='Ina-du Swamp Skimmer' unitType='Tank'>
@@ -3707,10 +3730,10 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CS:6,CLAN:6,IS:2+,FWL:1+,NIOPS:6,MERC:2+,CGS:7,CGB:7</availability>
+			<availability>IS:2+,FWL:1+,MERC:2+,CS:6,CB:3-,CFM:3-,CGB:3-,CGS:2-,CW:3-,NIOPS:6,BAN:1</availability>
 			<model name='KGC-000'>
                 <roles>command</roles>
-				<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
+				<availability>CS:8,NIOPS:8,BAN:5</availability>
 			</model>
 			<model name='KGC-0000'>
                 <roles>command</roles>
@@ -3718,29 +3741,25 @@
 			</model>
 			<model name='KGC-000b'>
                 <roles>command</roles>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
-			</model>
-			<model name='KGC-010'>
-                <roles>command</roles>
-				<availability>CLAN:3</availability>
+				<availability>CB:8,CFM:8,CGB:8,CGS:8,CW:8,BAN:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
-			<availability>CSJ:5,CGB:5</availability>
+			<availability>CSR!Keshik:3</availability>
 			<model name='A'>
-				<availability>General:6</availability>
+				<availability>CSR:6</availability>
 			</model>
 			<model name='B'>
-				<availability>General:7</availability>
+				<availability>CSR:4+</availability>
 			</model>
 			<model name='C'>
-				<availability>General:5,CGB:5</availability>
+				<availability>CSR:4</availability>
 			</model>
 			<model name='D'>
-				<availability>General:6,CGB:6</availability>
+				<availability>CSR:6</availability>
 			</model>
 			<model name='Prime'>
-				<availability>General:8</availability>
+				<availability>CSR:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
@@ -3819,9 +3838,9 @@
 			</model>
 		</chassis>
 		<chassis name='Kraken (Bane)' unitType='Mek'>
-			<availability>CSR:7,CLAN:7,CJF:7</availability>
+			<availability>CJF!Front Line:2!Second Line:1,CDS!Front Line:2!Second Line:1,CSR!Front Line:2!Second Line:1,CW!Front Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CJF:8,CDS:8,CSR:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
@@ -4024,7 +4043,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>CC:6,CDS:3-,CSR:3-,IS:7,Periphery.Deep:7,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>IS:7,FS:8,DC:5,FWL:9,CC:6,CS:4,Periphery:7,NIOPS:4,Periphery.Deep:7</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>IS:8,Periphery:8</availability>
@@ -4035,11 +4054,11 @@
 			</model>
 			<model name='LGB-7Q'>
 				<roles>fire_support</roles>
-				<availability>MOC:6,OA:6,IS:6,TC:6,CLAN:6</availability>
+				<availability>IS:6,TC:6,MOC:6,OA:6</availability>
 			</model>
 			<model name='LGB-8C'>
                 <roles>fire_support</roles>
-				<availability>MOC:2,CS:6,OA:2,IS:4,MERC:3,TC:2,CLAN:4</availability>
+				<availability>IS:4,MERC:3,CS:6,TC:2,MOC:2,OA:2</availability>
 			</model>
 		</chassis>
         <chassis name='Luciano White Wolverine' unitType='Tank'>
@@ -4156,12 +4175,12 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder IIC' unitType='Mek'>
-			<availability>CSA:7,CSR:6,CW:6,CLAN:6,CNC:6,CJF:6,CGB:7</availability>
+			<availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:3!Front Line:1,CB!Keshik:4!Front Line:1,CCO:3+,CGB:3+,CGS!Keshik:5!Front Line:3!Second Line:1,CHH!Keshik:5!Front Line:3!Second Line:2,CIH!Keshik:5!Front Line:2!Second Line:1,CJF:3+,CNC:3+,CSJ!Keshik:5!Front Line:3!Second Line:1,CSR!Keshik:4!Front Line:3!Second Line:1,CSA:2+,CSV:3+,CW!Keshik:5!Front Line:3,BAN!Keshik:1!Front Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8,CJF:8,CGB:8</availability>
+				<availability>CLAN:8,CJF:4,CW:4</availability>
 			</model>
 			<model name='9'>
-				<availability>CSA:4,CSV:4,CLAN:4,CJF:4</availability>
+				<availability>CJF:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
@@ -4682,27 +4701,46 @@
 				<availability>General:8</availability>
 			</model>
 		</chassis>
+        <chassis name='Naga II' unitType='Mek' omni='Clan'>
+            <availability>CHH:1+,CW!Front Line:2!Second Line:1</availability>
+            <model name='A'>
+                <roles>cavalry</roles>
+                <availability>CHH:6,CW:6</availability>
+            </model>
+            <model name='B'>
+                <roles>cavalry,fire_support</roles>
+                <availability>CHH:5,CW:5</availability>
+            </model>
+            <model name='C'>
+                <roles>cavalry,urban</roles>
+                <availability>CHH:6-,CW:6-</availability>
+            </model>
+            <model name='Prime'>
+                <roles>cavalry</roles>
+                <availability>CHH:8,CW:8</availability>
+            </model>
+        </chassis>
         <chassis name='Naga' unitType='Mek' omni='Clan'>
-            <availability>CW:3,CHH:2</availability>
+            <availability>CHH!Front Line:1,CW!Front Line:1</availability>
             <model name='A'>
                 <roles>mixed_artillery</roles>
-                <availability>CLAN:4</availability>
+                <availability>CHH:3+,CW:3+</availability>
             </model>
             <model name='B'>
                 <roles>mixed_artillery</roles>
-                <availability>CLAN:6</availability>
+                <availability>CHH:2+,CW:2+</availability>
             </model>
             <model name='C'>
                 <roles>missile_artillery</roles>
-                <availability>CLAN:4</availability>
+                <availability>CHH:3+,CW:3+</availability>
             </model>
             <model name='D'>
                 <roles>mixed_artillery</roles>
-                <availability>CLAN:4</availability>
+                <availability>CHH:2+,CW:2+</availability>
             </model>
             <model name='Prime'>
                 <roles>missile_artillery</roles>
-                <availability>CLAN:8</availability>
+                <availability>CHH:8,CW:8</availability>
             </model>
         </chassis>
 		<chassis name='Naja' unitType='Mek'>
@@ -4746,10 +4784,10 @@
 			</model>
 		</chassis>
 		<chassis name='Nightstar' unitType='Mek'>
-			<availability>CSA:6,CS:4,CLAN:4,NIOPS:4</availability>
+			<availability>CS:4,CCO!Front Line:1,NIOPS:4+</availability>
 			<model name='NSR-9J'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CS:8,CCO:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Odin Scout Tank' unitType='Tank'>
@@ -4985,18 +5023,18 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk IIC' unitType='Mek'>
-			<availability>CCC:4,CIH:4,CSR:4,CDS:4,CSV:5,CLAN:3,CFM:4,CGS:2,CCO:4,CB:2</availability>
+			<availability>CFM!Keshik:3!Front Line:1,CJF!Keshik:3!Front Line:1,CSR:3+,CSV!Keshik:4!Front Line:3!Second Line:1</availability>
 			<model name=''>
                 <roles>cavalry</roles>
-				<availability>CLAN:8</availability>
+				<availability>CFM:8,CJF:8,CSR:8,CSV:8</availability>
 			</model>
 			<model name='2'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CCC:6,CSR:6,CDS:6,CSV:6,CNC:6,CFM:6,CCO:6</availability>
+				<availability>CSR:5,CSV:5</availability>
 			</model>
 			<model name='9'>
-                <roles>cavalry</roles>
-				<availability>CLAN:2</availability>
+			    <roles>cavalry,fire_support</roles>
+				<availability>CSV:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk LAM Mk I' unitType='Mek'>
@@ -5049,7 +5087,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
-			<availability>CLAN:4,CC:2+,CS:5,LA:2+,FWL:2+,NIOPS:5,FS:2+,BAN:0</availability>
+			<availability>FS:2+,LA:2+,FWL:2+,CC:2+,CS:5,CLAN:1+,CBS:2+,CGS:2+,CIH!Front Line:1,CMG!Front Line:1,CSR!Front Line:1,CSA!Front Line:1,CSV!Front Line:1,NIOPS:5+,BAN:0</availability>
 			<model name='PLG-3Z'>
 				<availability>IS:8,CLAN:8,NIOPS:8</availability>
 			</model>
@@ -5150,15 +5188,9 @@
 			</model>
 		</chassis>
 		<chassis name='Pulverizer' unitType='Mek'>
-			<availability>CSR:4</availability>
+			<availability>CSR!Solahma:1</availability>
 			<model name=''>
 				<availability>CSR:8</availability>
-			</model>
-			<model name='PUL-2V'>
-				<availability>General:2</availability>
-			</model>
-			<model name='PUL-3R'>
-				<availability>General:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
@@ -5256,13 +5288,6 @@
 			<model name=''>
                 <roles>fire_support,anti_aircraft</roles>
 				<availability>CGB:8,CNC:8,CDS:8,CSR:8,CW:8</availability>
-			</model>
-		</chassis>
-		<chassis name='Rifleman II' unitType='Mek'>
-			<availability>CLAN:4</availability>
-			<model name='RFL-3N-2'>
-				<roles>anti_aircraft</roles>
-				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
@@ -5568,12 +5593,12 @@
 			</model>
 		</chassis>
 		<chassis name='Shogun' unitType='Mek'>
-			<availability>CSA:4,CIH:4,CBS:4,CLAN:4,FWL:1+,CCO:4,CB:4</availability>
+			<availability>FWL:1+,CBS:2,CB!Front Line:3!Second Line:2!Solahma:1,CCC!Front Line:2!Second Line:1,CCO!Front Line:3!Second Line:2!Solahma:1,CSA!Front Line:2!Second Line:1</availability>
 			<model name='C'>
-				<availability>CLAN:8</availability>
+				<availability>CBS:2+,CB!Front Line:8,CCC:8,CCO:8,CSA:8</availability>
 			</model>
 			<model name='SHG-2H'>
-				<availability>General:8,CLAN:1-,BAN:6</availability>
+				<availability>FWL:8,CBS:4-,CB:3-</availability>
 			</model>
 		</chassis>
 		<chassis name='Sholagar' unitType='AeroSpaceFighter'>
@@ -5716,15 +5741,19 @@
 			</model>
 		</chassis>
 		<chassis name='Spartan' unitType='Mek'>
-			<availability>CS:5,CHH:4,CFM:6,CCO:4</availability>
+			<availability>CS:5,CCO!Front Line:1,CFM!Front Line:2!Second Line:1,CHH!Second Line:1,CIH:3+,BAN:4+</availability>
 			<model name='C'>
                 <roles>cavalry</roles>
-				<availability>CLAN:8</availability>
+				<availability>CCO:8,CFM:8,CHH:8</availability>
 			</model>
 			<model name='SPT-N2'>
 				<roles>cavalry,spotter</roles>
-				<availability>IS:8</availability>
+				<availability>CS:8,BAN:3-</availability>
 			</model>
+            <model name='SPT-NF'>
+                <roles>cavalry</roles>
+                <availability>CIH:8,BAN:5</availability>
+            </model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
 			<availability>IS:3,FS:5,DC:6,FWL:7,CC:5,MERC:4,CS:4,TC:2,OA:2,NIOPS:4</availability>
@@ -5750,18 +5779,18 @@
             </model>
         </chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>CC:7,CLAN:6,IS:9,Periphery.Deep:10,FS:7,Periphery:10,CS:6,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>IS:9,FS:7,DC:7,FWL:10,CC:7,CS:6,CLAN:5-,CBS:6-,CCC:4-,CIH:4-,CJF:4-,CMG:4-,CSR:4-,CW:4-,Periphery:10,NIOPS:6,Periphery.Deep:10,BAN:3</availability>
 			<model name='STK-3F'>
-				<availability>IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:8,BAN:5</availability>
 			</model>
 			<model name='STK-3Fb'>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,BAN:3+</availability>
 			</model>
 			<model name='STK-3H'>
-				<availability>MOC:2,OA:2,IS:2,TC:2</availability>
+				<availability>IS:2,TC:2,MOC:2,OA:2</availability>
 			</model>
 			<model name='STK-4N'>
-				<availability>MOC:2,OA:2,IS:2,TC:2</availability>
+				<availability>IS:2,TC:2,MOC:2,OA:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -5829,15 +5858,18 @@
 			</model>
 		</chassis>
 		<chassis name='Storm Giant' unitType='Mek'>
-			<availability>CSV:6</availability>
+			<availability>CSV!Keshik:1!Front Line:1</availability>
+            <model name=''>
+                <availability>CSV:8</availability>
+            </model>
 			<model name='2'>
-				<availability>General:6</availability>
+				<availability>CSV:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Striker' unitType='Mek'>
-			<availability>MOC:3,CC:8,CS:4,OA:4,LA:6,PIR:2,NIOPS:4,MERC:4,FS:4,TC:4,DC:4</availability>
+			<availability>FS:4,LA:6,DC:4,CC:8,MERC:4,CS:4,TC:4,MOC:3,OA:4,NIOPS:4,PIR:2</availability>
 			<model name='STC-2C'>
-				<availability>CC:8,General:8</availability>
+				<availability>IS:8,Periphery:8,PIR:8</availability>
 			</model>
 			<model name='STC-2S'>
 				<availability>LA:5</availability>
@@ -5859,9 +5891,9 @@
 			</model>
 		</chassis>
 		<chassis name='Supernova' unitType='Mek'>
-			<availability>CSA:3,CCC:5,CDS:3,CW:5,CNC:8,CLAN:2,CGB:4</availability>
+			<availability>CNC!Keshik:4!Front Line:2!Second Line:1,CDS:3+,CSJ!Front Line:2</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CNC:8,CDS:8,CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Svantovit Infantry Fighting Vehicle' unitType='Tank'>
@@ -5989,15 +6021,15 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>CHH:7,CSV:9,CLAN:8,IS:3,CFM:10,FS:2,TC:1+,CS:7,CDS:7,CW:9,CBS:7,CNC:7,FWL:5,NIOPS:7,CJF:9,CGB:9</availability>
+			<availability>IS:3,FS:2,FWL:5,CS:7,CLAN!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,CIH!Keshik:2!Front Line:3!Second Line:4!Solahma:4!Provisional Garrison:4,CSV!Keshik:2!Front Line:3!Second Line:4!Solahma:4!Provisional Garrison:4,TC:1+,NIOPS:7,BAN:4+</availability>
 			<model name='THG-10E'>
 				<availability>FWL:8,DC:8</availability>
 			</model>
 			<model name='THG-11E'>
-				<availability>CS:8,CLAN:6,FWL:1+,IS:1+,NIOPS:8,FS:1+,BAN:8,DC:1+,TC:8</availability>
+				<availability>IS:1+,FS:1+,DC:1+,FWL:1+,CS:8,CLAN:4-,TC:8,NIOPS:8,BAN:5</availability>
 			</model>
 			<model name='THG-11Eb'>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CLAN:6,BAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -6008,19 +6040,19 @@
 			</model>
 		</chassis>
 		<chassis name='Thunder Hawk' unitType='Mek'>
-			<availability>CS:2,LA:1+,CLAN:4,NIOPS:2,DC:1+</availability>
+			<availability>LA:1+,DC:1+,CS:2,CB!Front Line:1,NIOPS:2+</availability>
 			<model name='TDK-7X'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,DC:8,CS:8,CB:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thunder Stallion' unitType='Mek'>
-			<availability>CHH:5</availability>
+			<availability>CHH:3+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CHH:8</availability>
 			</model>
 			<model name='2 &apos;Fire Stallion&apos;'>
-				<availability>CHH:6,CGS:6</availability>
+				<availability>CHH!Keshik:3!Front Line:2!Second Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
@@ -6317,15 +6349,18 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:5,CC:6,CLAN:1-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,DC:5</availability>
-			<model name='VTR-9A'>
-				<availability>CC:2,CS:2,IS:1,FS:2</availability>
+			<availability>IS:4,FS:9,LA:5,DC:5,FWL:5,CC:6,CS:5-,CBS!Second Line:1,CB!Second Line:1,CCO!Solahma:1,CGB!Second Line:1,CJF!Second Line:1,CNC!Second Line:1,CSJ!Second Line:1,CW!Second Line:1,Periphery:4,Periphery.OS:5,Periphery.HR:5,TC:5,MOC:5,OA:5,CIR:5,NIOPS:5-,Periphery.Deep:4+</availability>
+            <model name='C'>
+                <availability>CBS:8,CB:8,CCO:8,CGB:8,CJF:8,CNC:8,CSJ:8,CW:8</availability>
+            </model>
+            <model name='VTR-9A'>
+				<availability>IS:1,FS:2,CC:2,CS:2</availability>
 			</model>
 			<model name='VTR-9A1'>
-				<availability>CC:2,CS:2,IS:1,FS:2</availability>
+				<availability>IS:1,FS:2,CC:2,CS:2</availability>
 			</model>
 			<model name='VTR-9B'>
-				<availability>General:8,CLAN:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
@@ -6408,15 +6443,15 @@
 			</model>
 		</chassis>
 		<chassis name='Wakazashi' unitType='Mek'>
-			<availability>CJF:6</availability>
+			<availability>CJF!Keshik:2!Front Line:2!Second Line:1</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CJF:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Warhammer IIC' unitType='Mek'>
-			<availability>CLAN:6</availability>
+			<availability>CGB!Keshik:5!Front Line:3!Second Line:1,CSA!Keshik:4!Front Line:3!Second Line:1,BAN:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CSA:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2870-->
-<ratgen
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
             <!-- Omni percentages: 0,0 -->

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -2541,7 +2541,7 @@
 			</model>
 		</chassis>
 		<chassis name='Firefly' unitType='Mek'>
-			<availability>FS:1+,CC:1+,CLAN!Front Line:3!Second Line:2!Solahma:1,CBS:3+,CB!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CCO!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CFM!Second Line:3!Solahma:2!Provisional Garrison:1,CGB!Second Line:5!Solahma:4!Provisional Garrison:3,CHH!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:3-,CNC!Second Line:3!Solahma:2!Provisional Garrison:1,CDS!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CSJ:4+,CSV:4-,CW:3-,BAN:2</availability>
+			<availability>FS:1+,CC:1+,CLAN!Front Line:3!Second Line:2!Solahma:1,CBS:3+,CB!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CCO!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CFM!Second Line:3!Solahma:2!Provisional Garrison:1,CGB!Second Line:5!Solahma:4!Provisional Garrison:3,CHH!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:3-,CNC!Second Line:3!Solahma:2!Provisional Garrison:1,CDS!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CSJ:4+,CSR:4+,CSV:4-,CW:3-,BAN:2</availability>
 			<model name='C'>
 				<availability>CSJ!Keshik:8!Front Line:8!Second Line:1</availability>
 			</model>
@@ -3255,7 +3255,7 @@
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
-				<availability>CS:8,CLAN:4-,CBS!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CB:4,CCC:4,CGS:4,CIH!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CJF:3-,CSJ:4,CSV:3-,CW:4-,NIOPS:8,BAN:5-</availability>
+				<availability>CS:8,CLAN:4-,CBS!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CB:4,CCC:4,CGS:4,CIH!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CJF:3-,CSJ:4,CSV:3-,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='HER-1Sb'>
 				<roles>recon</roles>
@@ -4548,11 +4548,11 @@
 			</model>
 			<model name='MON-66'>
 				<roles>command,recon</roles>
-				<availability>CS:8,CLAN:6,CB:5,CCC:4-,CFM:5-,CJF!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CNC:4-,CSJ:4-,CW!Front Line:6!Second Line:6!Solahma:6!Provisional Garrison:6,NIOPS:8,BAN:5-</availability>
+				<availability>CS:8,CLAN:6,CB:5,CCC:4-,CCO:4-,CFM:5-,CJF!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CNC:4-,CSJ:4-,CW!Front Line:6!Second Line:6!Solahma:6!Provisional Garrison:6,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='MON-66b'>
 				<roles>command,recon</roles>
-				<availability>CLAN:5+,CCC:4,CFM:4,CJF!Second Line:4!Solahma:3!Provisional Garrison:2,CNC:5,CSJ:4,BAN:1</availability>
+				<availability>CLAN:5+,CCC:4,CCO:4,CFM:4,CJF!Second Line:4!Solahma:3!Provisional Garrison:2,CNC:5,CSJ:4,BAN:1</availability>
 			</model>
 			<model name='MON-67'>
 				<roles>command,recon</roles>

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -5041,7 +5041,7 @@
 			</model>
 			<model name='PXH-1b &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:8,CGS:4,CIH:5-,BAN:3</availability>
+				<availability>CLAN:8,CGS:4,CIH:5-,NIOPS:4+,BAN:3</availability>
 			</model>
 			<model name='PXH-1c &apos;Special&apos;'>
 				<roles>command,recon</roles>

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -813,13 +813,13 @@
 			</model>
 		</chassis>
 		<chassis name='Baboon (Howler)' unitType='Mek'>
-			<availability>CSR:3,CJF:3</availability>
+			<availability>CFM!Keshik:3</availability>
 			<model name=''>
 				<roles>fire_support</roles>
-				<availability>CSV:8,CLAN:8,CJF:8</availability>
+				<availability>CFM:8</availability>
 			</model>
 			<model name='4'>
-				<availability>CLAN:3,CJF:3</availability>
+				<availability>CFM:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
@@ -1898,14 +1898,14 @@
             </model>
         </chassis>
 		<chassis name='Commando IIC' unitType='Mek'>
-			<availability>CHH:3,CIH:3,CLAN:3,CGS:5</availability>
+			<availability>CGS!Front Line:2!Second Line:1</availability>
 			<model name=''>
 				<roles>recon</roles>
-				<availability>CLAN:8</availability>
+				<availability>CGS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>LA:9,CSJ:2,CIR:4,MERC:4,CGS:2</availability>
+			<availability>LA:9,MERC:4,CSJ:1-,CIR:4</availability>
 			<model name='COM-1D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
@@ -1914,7 +1914,7 @@
 			<model name='COM-2D'>
 				<roles>recon</roles>
 				<deployedWith>Commando</deployedWith>
-				<availability>LA:8,General:8,Periphery.Deep:8</availability>
+				<availability>LA:8,MERC:8,CSJ:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
@@ -2190,23 +2190,23 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>CHH:4,CCC:6,CLAN:3,BAN:2,CGB:9,CB:6</availability>
+			<availability>CCC!Keshik:3,CGB:1+:2875</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
-				<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
+				<availability>CCC:5-,CGB:5-</availability>
 			</model>
 			<model name='B'>
-				<availability>CHH:6,CDS:6,CW:5,CSV:4,General:5,CGB:5,CB:6</availability>
+				<availability>CCC:6,CGB:6</availability>
 			</model>
 			<model name='C'>
 				<roles>fire_support</roles>
-				<availability>CSA:4,CHH:8,CIH:6,CDS:6,CW:5,CNC:4,General:5,CCO:4,CGB:4</availability>
+				<availability>CCC:5,CGB:5</availability>
 			</model>
 			<model name='D'>
-				<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:7,CNC:8,General:6,CCO:5,CGB:8</availability>
+				<availability>CCC:6+,CGB:6+</availability>
 			</model>
 			<model name='Prime'>
-				<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:6,General:6,CCO:5,CGB:9,CB:5</availability>
+				<availability>CCC:8,CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
@@ -2291,9 +2291,9 @@
 			</model>
 		</chassis>
 		<chassis name='Drift Shag' unitType='Mek'>
-			<availability>CIH:4,CGS:2</availability>
+			<availability>CGS!Keshik:3!Front Line:1,CIH!Keshik:3!Front Line:1</availability>
             <model name=''>
-                <availability>CLAN:8</availability>
+                <availability>CGS:8,CIH:8</availability>
             </model>
 		</chassis>
 		<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -2489,18 +2489,12 @@
             </model>
 		</chassis>
 		<chassis name='Falcon' unitType='Mek'>
-			<availability>CC:1,MOC:1,OA:1,CIH:5,LA:1,CLAN:3,FWL:1,FS:1,MERC:1,CGS:5,TC:1</availability>
+			<availability>FS:1,LA:1,FWL:1,CC:1,MERC:1,CGS!Second Line:4!Solahma:3!Provisional Garrison:2,TC:1,MOC:1,OA:1</availability>
 			<model name='FLC-4N'>
-				<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='FLC-4Nb'>
-				<availability>CLAN:8,BAN:2</availability>
-			</model>
-			<model name='FLC-4Nb-PP'>
-				<availability>BAN:2</availability>
-			</model>
-			<model name='FLC-4Nb-PP2'>
-				<availability>BAN:2</availability>
+				<availability>CGS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Field Artillery' unitType='Infantry'>
@@ -2547,33 +2541,24 @@
 			</model>
 		</chassis>
 		<chassis name='Firefly' unitType='Mek'>
-			<availability>CC:1+,CIH:7,CLAN:7,FS:1+,BAN:6,CB:7</availability>
+			<availability>FS:1+,CC:1+,CLAN!Front Line:3!Second Line:2!Solahma:1,CBS:3+,CB!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CCO!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CFM!Second Line:3!Solahma:2!Provisional Garrison:1,CGB!Second Line:5!Solahma:4!Provisional Garrison:3,CHH!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:3-,CNC!Second Line:3!Solahma:2!Provisional Garrison:1,CDS!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CSJ:4+,CSV:4-,CW:3-,BAN:2</availability>
 			<model name='C'>
-				<availability>CLAN:8,BAN:2</availability>
+				<availability>CSJ!Keshik:8!Front Line:8!Second Line:1</availability>
 			</model>
 			<model name='FFL-3A'>
 				<roles>spotter</roles>
-				<availability>CC:8,FS:8</availability>
-			</model>
-			<model name='FFL-3PP'>
-				<availability>BAN:2</availability>
-			</model>
-			<model name='FFL-3PP2'>
-				<availability>BAN:2</availability>
-			</model>
-			<model name='FFL-3PP3'>
-				<availability>BAN:2</availability>
+				<availability>FS:8,CC:8,BAN:3-</availability>
 			</model>
 			<model name='FFL-3SLE'>
-				<availability>CLAN:5,BAN:3</availability>
+				<availability>CLAN:8,CSJ!Front Line:5!Second Line:8!Solahma:8!Provisional Garrison:8,BAN:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Firestarter' unitType='Mek'>
-			<availability>CS:3,LA:8,IS:7,NIOPS:3,Periphery.Deep:7,Periphery:7</availability>
+			<availability>IS:7,LA:8,CS:3,Periphery:7,NIOPS:3,Periphery.Deep:7</availability>
 			<model name='FS9-H'>
                 <roles>anti_infantry,recon</roles>
 				<deployedWith>Vulcan</deployedWith>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='FS9-K'>
                 <roles>anti_infantry,recon</roles>
@@ -3259,7 +3244,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hermes' unitType='Mek'>
-			<availability>MOC:1,CC:1,CS:3,CHH:5,OA:1,CLAN:4,FWL:3,NIOPS:3,CGB:5,DC:1,CB:5</availability>
+			<availability>DC:1,FWL:3,CC:1,CS:3,CLAN!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CBS:2,CB!Second Line:1!Solahma:1!Provisional Garrison:1,CCO:1,CGB!Front Line:1!Second Line:1!Solahma:1!Provisional Garrison:1,CGS:2,CHH:2,CIH!Second Line:4!Solahma:3!Provisional Garrison:2,CJF!Second Line:2!Solahma:2!Provisional Garrison:2,CNC!Second Line:2!Solahma:2!Provisional Garrison:2,CDS!Second Line:3!Solahma:3!Provisional Garrison:3,CSR:2,CSA:2,CSV:2,MOC:1,OA:1,NIOPS:3,BAN:4+</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
 				<availability>FWL:8</availability>
@@ -3270,11 +3255,11 @@
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>CS:8,CLAN:4-,CBS!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CB:4,CCC:4,CGS:4,CIH!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CJF:3-,CSJ:4,CSV:3-,CW:4-,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='HER-1Sb'>
 				<roles>recon</roles>
-				<availability>CLAN:5,FWL:1+,BAN:3</availability>
+				<availability>FWL:1+,CLAN:3,CBS:3+,CB:4+,CCC:4+,CGS:3+,CIH:4+,CJF:5+,CMG:4+,CSJ:3+,CW:4+,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
@@ -3383,13 +3368,13 @@
 			</model>
 		</chassis>
 		<chassis name='Hussar' unitType='Mek'>
-			<availability>CS:4,CIH:9,CSV:9,CLAN:8,NIOPS:4</availability>
+			<availability>CS:4,CLAN!Front Line:3!Second Line:2!Solahma:1,CCO:3+,CGB!Front Line:2!Second Line:1,CGS:3+,CHH:3+,CIH!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CNC:3+,CDS:4+,CSR:3+,CSA:3+,CSV:4+,CW!Second Line:3!Solahma:2!Provisional Garrison:1,NIOPS:4,BAN:4+</availability>
 			<model name='HSR-200-D'>
 				<roles>recon</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>CS:8,CLAN:4-,CBS:5,CB:4,CGS:5,CIH!Second Line:4!Solahma:4!Provisional Garrison:4,CW:5,NIOPS:8,BAN:4-</availability>
 			</model>
 			<model name='HSR-200-Db'>
-				<availability>CLAN:6,BAN:4</availability>
+				<availability>CLAN:4+,CB:5+,CCC:3,CCO:3,CFM:3,CGB:4,CHH:3,CNC:4,CDS:4,CSJ:5,CSR:4,CSA:4,CSV:4,CW!Second Line:4!Solahma:3!Provisional Garrison:2,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
@@ -3405,10 +3390,10 @@
 			</model>
 		</chassis>
 		<chassis name='Icestorm' unitType='Mek'>
-			<availability>CIH:6+,CW:4</availability>
+            <availability>CIH!Keshik:4!Front Line:3!Second Line:1</availability>
 			<model name=''>
 				<roles>spotter</roles>
-				<availability>CLAN:8</availability>
+				<availability>CIH:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ignis Infantry Support Tank' unitType='Tank'>
@@ -3977,25 +3962,25 @@
 			</model>
 		</chassis>
 		<chassis name='Locust IIC' unitType='Mek'>
-			<availability>CHH:6,CW:6,CLAN:6,CJF:6,CGB:6</availability>
+			<availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:2,CFM:3+,CGB!Keshik:4!Front Line:2!Second Line:1,CGS:3+,CHH:3+,CIH!Keshik:4!Front Line:2!Second Line:1,CJF!Keshik:6!Front Line:3!Second Line:1,BAN:2+</availability>
 			<model name=''>
-				<availability>CW:8,General:8</availability>
+				<availability>CLAN:8,CIH:4,CJF:5,CSJ:3,CSA!Front Line:5!Second Line:8,BAN:8</availability>
 			</model>
 			<model name='2'>
-				<availability>CCC:4,CIH:4,CJF:4</availability>
+				<availability>CIH:8,CJF:8</availability>
 			</model>
 			<model name='3'>
-				<availability>General:3</availability>
+				<availability>CSJ!Keshik:8!Front Line:5!Second Line:1,CSA!Keshik:8!Front Line:5!Second Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Locust' unitType='Mek'>
-			<availability>CS:6-,CLAN:2-,IS:9,NIOPS:6-,Periphery.Deep:6,Periphery:6</availability>
+			<availability>IS:9,CS:6-,CLAN!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CB!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CCO!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CFM:5,CGB!Second Line:5!Solahma:5!Provisional Garrison:5,CGS!Second Line:4!Solahma:4!Provisional Garrison:4,CJF:4-,CNC:5,CDS:4,CSJ:5,CSR:5,CSA:5,CSV:5,CW:4-,Periphery:6,NIOPS:6-,Periphery.Deep:6,BAN:4</availability>
 			<model name='C'>
-				<availability>CCC:2,CFM:2</availability>
+				<availability>CCC!Front Line:8!Second Line:1,CFM!Keshik:8!Front Line:5!Second Line:1,CJF!Front Line:8!Second Line:5,CSJ!Keshik:5!Front Line:8!Second Line:5,CSV!Keshik:8!Front Line:5,BAN:2+</availability>
 			</model>
 			<model name='LCT-1E'>
 				<roles>recon</roles>
-				<availability>IS:4,Periphery.Deep:4,Periphery:4</availability>
+				<availability>IS:4,Periphery:4,Periphery.Deep:4</availability>
 			</model>
 			<model name='LCT-1M'>
 				<roles>recon</roles>
@@ -4007,11 +3992,11 @@
 			</model>
 			<model name='LCT-1V'>
 				<roles>recon</roles>
-				<availability>LA:4,General:8,CLAN:1-,FS:7,BAN:5</availability>
+				<availability>IS:8,FS:7,LA:4</availability>
 			</model>
 			<model name='LCT-1Vb'>
 				<roles>recon</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,CFM!Front Line:1!Second Line:8!Solahma:8!Provisional Garrison:8,CJF:3-,CSJ!Second Line:8!Solahma:8!Provisional Garrison:8,CSV!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -4149,9 +4134,9 @@
 			</model>
 		</chassis>
 		<chassis name='Mandrill' unitType='Mek'>
-			<availability>CFM:6</availability>
+			<availability>CFM!Keshik:4!Front Line:3!Second Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CFM:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
@@ -4466,14 +4451,14 @@
 			</model>
 		</chassis>
 		<chassis name='Mercury' unitType='Mek'>
-			<availability>CS:8,CC:1+,LA:1+,CLAN:1,NIOPS:8,IS:1+,MERC:1+</availability>
+			<availability>IS:1+,CS:8,CLAN!Front Line:3!Second Line:2!Solahma:1,CB!Second Line:2!Solahma:1,CCC!Second Line:3!Solahma:2!Provisional Garrison:1,CCO!Second Line:2!Solahma:1,CGB!Second Line:3!Solahma:2!Provisional Garrison:1,CGS!Second Line:3!Solahma:2!Provisional Garrison:1,CHH!Second Line:3!Solahma:2!Provisional Garrison:1,CIH!Second Line:4!Solahma:3!Provisional Garrison:2,CJF!Second Line:3!Solahma:2!Provisional Garrison:1,CSJ!Second Line:1!Solahma:1!Provisional Garrison:1,CW:3-,NIOPS:8,BAN:3</availability>
 			<model name='MCY-98'>
 				<roles>recon</roles>
 				<availability>CC:8</availability>
 			</model>
 			<model name='MCY-99'>
 				<roles>recon</roles>
-				<availability>CS:4,CLAN:8,NIOPS:4,BAN:6</availability>
+				<availability>CS:4,CLAN:8,NIOPS:4,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Minsk' unitType='Mek'>
@@ -4556,18 +4541,18 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>MOC:1,CHH:5,CLAN:6,MERC:4,FS:1,TC:1,CS:6,OA:1,CDS:5,CBS:7,FWL:1,NIOPS:6,CJF:7,CGB:5,DC:1</availability>
+			<availability>FS:1,DC:1,FWL:1,MERC:4,CS:6,CLAN:4+,CBS:3+,CGS:3+,CW:3+,TC:1,MOC:1,OA:1,NIOPS:6,BAN:2+</availability>
 			<model name='C'>
                 <roles>recon</roles>
-				<availability>CIH:4,CJF:4,CGB:4</availability>
+				<availability>CGB!Keshik:5!Front Line:1,CIH!Keshik:5!Front Line:3,CJF!Keshik:5!Front Line:3!Second Line:1</availability>
 			</model>
 			<model name='MON-66'>
 				<roles>command,recon</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>CS:8,CLAN:6,CB:5,CCC:4-,CFM:5-,CJF!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CNC:4-,CSJ:4-,CW!Front Line:6!Second Line:6!Solahma:6!Provisional Garrison:6,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='MON-66b'>
 				<roles>command,recon</roles>
-				<availability>CLAN:8,CGS:8,BAN:4</availability>
+				<availability>CLAN:5+,CCC:4,CFM:4,CJF!Second Line:4!Solahma:3!Provisional Garrison:2,CNC:5,CSJ:4,BAN:1</availability>
 			</model>
 			<model name='MON-67'>
 				<roles>command,recon</roles>
@@ -4731,13 +4716,13 @@
 			</model>
 		</chassis>
 		<chassis name='Night Hawk' unitType='Mek'>
-			<availability>CW:6,LA:2+,CLAN:6,FWL:2+,FS:2+,CGS:7,CGB:6</availability>
+			<availability>FS:2+,LA:2+,FWL:2+,CLAN:4+,CBS:5+,CB:5+,CCO:5+,CGB:5+,CJF:5+,CSJ:5+,CSR:3+,CW:5+,BAN:3+</availability>
 			<model name='NTK-2Q'>
 				<roles>raider</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,CLAN:8,BAN:8</availability>
 			</model>
 			<model name='NTK-2Q-EC'>
-				<availability>CSJ:1</availability>
+				<availability>CSJ!Keshik:3!Front Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Nightshade ECM VTOL' unitType='VTOL'>
@@ -4862,14 +4847,14 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>CS:4,CLAN:4-,IS:4,Periphery.Deep:4,NIOPS:4,MERC:4,Periphery:4</availability>
+			<availability>IS:4,MERC:4,CS:4,CLAN!Second Line:2!Solahma:2!Provisional Garrison:2,CBS!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CB!Solahma:1!Provisional Garrison:1,CCO!Second Line:1!Solahma:1!Provisional Garrison:1,CGS!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CJF:2-,CSJ!Second Line:1!Solahma:1!Provisional Garrison:1,CW!Front Line:1!Second Line:1!Solahma:2!Provisional Garrison:2,Periphery:4,NIOPS:4,Periphery.Deep:4,BAN:1</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
-				<availability>General:8,CLAN:5-,BAN:6</availability>
+				<availability>IS:8,MERC:8,Periphery:8</availability>
 			</model>
 			<model name='OTT-7Jb'>
 				<roles>recon</roles>
-				<availability>CLAN:5,BAN:4</availability>
+				<availability>CLAN:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
@@ -4939,13 +4924,13 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>CC:3,Periphery.DD:5,FS.RR:4,CLAN:1-,MERC:5,Periphery.OS:5,FS:3,BAN:2,Periphery:3,CS:2,LA:3,FS.DMM:4,FWL:3,NIOPS:2,DC:10</availability>
+			<availability>FS:3,FS.RR:4,FS.DMM:4,LA:3,DC:10,FWL:3,CC:3,MERC:5,CS:2,CSJ:1-,Periphery:3,Periphery.DD:5,Periphery.OS:5,NIOPS:2,BAN:2</availability>
 			<model name='PNT-8Z'>
 				<availability>CC:8,LA:8,TC:8</availability>
 			</model>
 			<model name='PNT-9R'>
 				<roles>fire_support</roles>
-				<availability>CLAN:8,MERC:8,DC:8</availability>
+				<availability>DC:8,MERC:8,CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Partisan Heavy Tank' unitType='Tank'>
@@ -4982,13 +4967,13 @@
 			</model>
 		</chassis>
 		<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
-			<availability>CLAN:6,CSJ:8,CGB:6</availability>
+			<availability>CFM:1+,CGS:3+,CIH:2+,CNC!Keshik:3!Front Line:1,CDS:2+,CSJ:2+,CW:2+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CFM:8,CGS:8,CIH:8,CW:8</availability>
 			</model>
 			<model name='2'>
 				<roles>fire_support</roles>
-				<availability>CLAN:5</availability>
+				<availability>CNC:8,CDS:8,CSJ:8,CW:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk IIC' unitType='Mek'>
@@ -5661,10 +5646,10 @@
 			</model>
 		</chassis>
 		<chassis name='Sling' unitType='Mek'>
-			<availability>CC:1+,LA:1+,CLAN:1,CSJ:2</availability>
+			<availability>LA:1+,CC:1+,CSJ!Second Line:3!Solahma:2!Provisional Garrison:1</availability>
 			<model name='SL-1G'>
 				<roles>spotter</roles>
-				<availability>General:8</availability>
+				<availability>LA:8,CC:8,CSJ:8</availability>
 			</model>
 			<model name='SL-1H'>
 				<roles>spotter</roles>
@@ -5729,15 +5714,8 @@
 				<availability>IS:8</availability>
 			</model>
 		</chassis>
-		<chassis name='Spector' unitType='Mek'>
-			<availability>CLAN:2</availability>
-			<model name='SPR-4F'>
-                <roles>specops,raider</roles>
-				<availability>CLAN:8</availability>
-			</model>
-		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>CC:5,CS:4,OA:2,CLAN:1-,IS:3,FWL:7,NIOPS:4,MERC:4,FS:5,TC:2,DC:6</availability>
+			<availability>IS:3,FS:5,DC:6,FWL:7,CC:5,MERC:4,CS:4,TC:2,OA:2,NIOPS:4</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8</availability>
@@ -5747,7 +5725,7 @@
 				<availability>DC:8</availability>
 			</model>
 			<model name='SDR-5V'>
-				<availability>CLAN:8,IS:8,Periphery.Deep:8,FS:3,Periphery:8</availability>
+				<availability>IS:8,FS:3,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
@@ -5796,18 +5774,24 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>CS:4-,CLAN:2-,IS:9,NIOPS:4-,Periphery.Deep:6,MERC:7,Periphery:6,DC:6</availability>
-			<model name='STG-3G'>
+			<availability>IS:9,DC:6,MERC:7,CS:4-,CLAN!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CBS:4,CB:5,CCC:4,CFM!Second Line:4!Solahma:4!Provisional Garrison:4,CGS:4,CHH:4,CNC!Second Line:4!Solahma:4!Provisional Garrison:4,CDS:4,CSR:4,CSA:4,CSV:4,CW:4,Periphery:6,NIOPS:4-,Periphery.Deep:6,BAN:5</availability>
+            <model name='C'>
+                <availability>CCC!Keshik:8!Front Line:1,CHH!Keshik:8!Front Line:8,CIH!Front Line:8!Second Line:1,CSV!Keshik:8!Front Line:1,CW!Keshik:8!Front Line:8!Second Line:1,BAN!Keshik:3!Front Line:1</availability>
+            </model>
+            <model name='C 2'>
+                <availability>CBS!Keshik:8!Front Line:5,CB!Keshik:5!Front Line:3,BAN!Keshik:3!Front Line:1</availability>
+            </model>
+            <model name='STG-3G'>
 				<roles>recon</roles>
-				<availability>CLAN:2-,IS:4,Periphery.Deep:4,BAN:3,Periphery:4</availability>
+				<availability>IS:4,CLAN!Provisional Garrison:3,Periphery:4,Periphery.Deep:4,BAN:2-</availability>
 			</model>
 			<model name='STG-3Gb'>
 				<roles>recon</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,CBS!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CB!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CCC!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CHH!Front Line:1!Second Line:8!Solahma:8!Provisional Garrison:8,CIH:3-,CJF!Second Line:8!Solahma:8!Provisional Garrison:8,CSV!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CW:3-,BAN:5</availability>
 			</model>
 			<model name='STG-3R'>
 				<roles>recon</roles>
-				<availability>IS:8,Periphery.Deep:8,BAN:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:8,BAN:2-</availability>
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
@@ -5910,15 +5894,12 @@
 			</model>
 		</chassis>
 		<chassis name='Talon' unitType='Mek'>
-			<availability>CLAN:8</availability>
-			<model name='TLN-5V'>
-				<availability>FWL:8,FS:8</availability>
-			</model>
+			<availability>CLAN:5+,CB:4+,CFM:4+,CGS:3+,CHH:3+,CIH:4+,CSR:3+,CW:6+,BAN:3+</availability>
 			<model name='TLN-5W'>
-				<availability>LA:8,CLAN:8</availability>
+				<availability>CLAN:8</availability>
 			</model>
 			<model name='TLN-5W-EC'>
-				<availability>CIH:6</availability>
+				<availability>CIH!Keshik:3!Front Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Texas Battleship' unitType='Warship'>
@@ -5962,12 +5943,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>CSA:2,CS:6,CDS:5,CLAN:4,FWL:2,NIOPS:6,CCO:2,CJF:5,CGB:5</availability>
+			<availability>FWL:2,CS:6,CLAN:4-,CB!Second Line:4!Solahma:4!Provisional Garrison:4,CCC:3-,CGS!Second Line:4!Solahma:4!Provisional Garrison:4,CHH!Second Line:5!Solahma:5!Provisional Garrison:5,CIH:3-,CJF!Solahma:4!Provisional Garrison:4,CSJ:3-,CW!Front Line:1!Second Line:2!Solahma:4!Provisional Garrison:5,NIOPS:6,BAN:0</availability>
 			<model name='THE-N'>
-				<availability>CS:8,CLAN:6,General:2+,NIOPS:8,BAN:6</availability>
+				<availability>FWL:2+,CS:8,CLAN:8,CB:6,CGB:5-,CIH:7,CJF:6,CNC:4-,CDS:4-,CSR:4-,CW:4-,NIOPS:8</availability>
 			</model>
 			<model name='THE-Nb'>
-				<availability>CLAN:6,CGS:7,BAN:4</availability>
+				<availability>CB:6+,CGB:5,CIH:6+,CJF:8+,CNC:5,CDS:4,CSR:5,CW:6+</availability>
 			</model>
 		</chassis>
 		<chassis name='Thresher' unitType='Mek'>
@@ -6208,19 +6189,19 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>CCC:8:2890,CSR:6:2890,CJF:6:2890</availability>
+			<availability>CCC!Keshik:3!Front Line:1,CJF:1+:2891</availability>
 			<model name='A'>
-				<availability>CLAN:5,CJF:6</availability>
+				<availability>CCC:5+,CJF:5+</availability>
 			</model>
 			<model name='B'>
-				<availability>CLAN:7</availability>
+				<availability>CCC:6,CJF:6</availability>
 			</model>
 			<model name='D'>
 				<roles>fire_support</roles>
-				<availability>CLAN:4</availability>
+				<availability>CCC:5,CJF:5</availability>
 			</model>
 			<model name='Prime'>
-				<availability>CLAN:8,CJF:9</availability>
+				<availability>CCC:8,CJF:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Union C' unitType='Dropship'>
@@ -6281,17 +6262,17 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech IIC' unitType='Mek'>
-			<availability>CHH:4,CIH:4-,CSR:4,CCO:5,CGS:4</availability>
+			<availability>CLAN!Second Line:3!Solahma:2!Provisional Garrison:1,CIH!Solahma:2!Provisional Garrison:1,CJF!Solahma:2!Provisional Garrison:1,CSJ!Solahma:2!Provisional Garrison:1,CSV!Solahma:2!Provisional Garrison:1,BAN:0</availability>
 			<model name=''>
 				<roles>urban</roles>
 				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>CC:5-,CLAN:1-,IS:4-,Periphery:3-,CS:4-,NIOPS:4-</availability>
+			<availability>CC:5-,IS:4-,Periphery:3-,CS:4-,NIOPS:4-</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
-				<availability>CC:8,General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Valkyrie' unitType='Mek'>
@@ -6468,10 +6449,10 @@
 			</model>
 		</chassis>
 		<chassis name='Wasp' unitType='Mek'>
-			<availability>CS:4-,CLAN:1-,IS:10,NIOPS:4-,Periphery.Deep:6,CIR:3,Periphery:6</availability>
+			<availability>IS:10,CS:4-,Periphery:6,CIR:3,NIOPS:4-,Periphery.Deep:6,BAN:1-</availability>
 			<model name='WSP-1A'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,BAN:8</availability>
 			</model>
 			<model name='WSP-1D'>
 				<roles>recon</roles>

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -2053,7 +2053,7 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>FS:1,LA:1,FWL:1,DC:1,CC:1,CS:8,CLAN:3-,CBS:5-,CGS:4-,NIOPS:8,BAN:4-</availability>
+			<availability>FS:1,LA:1,DC:1,FWL:1,CC:1,CS:8,CLAN:3-,CBS:5-,CGS:4-,NIOPS:8,BAN:4-</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:8,NIOPS:0</availability>
 			</model>
@@ -4177,7 +4177,7 @@
 		<chassis name='Marauder IIC' unitType='Mek'>
 			<availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:3!Front Line:1,CB!Keshik:4!Front Line:1,CCO:3+,CGB:3+,CGS!Keshik:5!Front Line:3!Second Line:1,CHH!Keshik:5!Front Line:3!Second Line:2,CIH!Keshik:5!Front Line:2!Second Line:1,CJF:3+,CNC:3+,CSJ!Keshik:5!Front Line:3!Second Line:1,CSR!Keshik:4!Front Line:3!Second Line:1,CSA:2+,CSV:3+,CW!Keshik:5!Front Line:3,BAN!Keshik:1!Front Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8,CJF:4,CW:4</availability>
+				<availability>CLAN:8,CJF:4,CW:4,BAN:8</availability>
 			</model>
 			<model name='9'>
 				<availability>CJF:8,CW:8</availability>

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -6,9 +6,9 @@
 >
 	<factions>
 		<faction key='BAN'>
-			<pctOmni>0,0</pctOmni>
-			<pctClan>5,5</pctClan>
-			<pctSL>85,85</pctSL>
+            <!-- Omni percentages: 0,0 -->
+            <!-- Clan percentages: 5,5 -->
+            <!-- Star League percentages: 85,85 -->
 			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS'>
@@ -32,17 +32,17 @@
 			<weightDistribution era='2870' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 		</faction>
 		<faction key='CBS'>
-			<pctOmni>0,0,0,5,10</pctOmni>
-			<pctClan>0,0,0,10,40</pctClan>
-			<pctSL>100,100,100,90,60</pctSL>
+            <!-- Omni percentages: 0,0,0,5,10 -->
+            <!-- Clan percentages: 0,0,0,10,40 -->
+            <!-- Star League percentages: 100,100,100,90,60 -->
 			<pctClan unitType='Vehicle'>0,0,0,10,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,90,80</pctSL>
 			<salvage pct='5'>CHH:5,CCC:5,CSR:3,CIH:10,CSV:10,CFM:10,CCO:5,CDS:1,CW:5,CNC:10,CSJ:10,CJF:10,CB:10</salvage>
 		</faction>
 		<faction key='CB'>
-			<pctOmni>0,0,0,30,50</pctOmni>
-			<pctClan>0,0,0,40,80</pctClan>
-			<pctSL>100,100,100,60,20</pctSL>
+            <!-- Omni percentages: 0,0,0,30,50 -->
+            <!-- Clan percentages: 0,0,0,40,80 -->
+            <!-- Star League percentages: 100,100,100,60,20 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CCC:1,CHH:5,CSR:6,CIH:4,CSV:3,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CJF:4</salvage>
@@ -50,36 +50,35 @@
 			<weightDistribution era='2870' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CCC'>
-			<pctOmni>0,0,0,40,50</pctOmni>
-			<pctClan>0,0,20,50,60</pctClan>
-			<pctSL>100,100,80,50,40</pctSL>
+            <!-- Omni percentages: 0,0,0,40,50 -->
+            <!-- Clan percentages: 0,0,20,50,60 -->
+            <!-- Star League percentages: 100,100,80,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CHH:2,CSR:3,CIH:3,CSV:3,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CJF:5,CGB:2,CB:3</salvage>
 		</faction>
 		<faction key='CCO'>
-			<pctOmni>4,4,5,50,60</pctOmni>
-			<pctClan>15,15,15,50,60</pctClan>
-			<pctSL>85,85,85,50,40</pctSL>
+            <!-- Omni percentages: 4,4,5,50,60 -->
+            <!-- Clan percentages: 15,15,15,50,60 -->
+            <!-- Star League percentages: 85,85,85,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
-			<salvage pct='10'>
-				CHH:1,CCC:3,CIH:2,CSR:5,CSV:3,CFM:2,CGS:1,CSA:3,CDS:1,CW:1,CBS:1,CNC:10,CSJ:3,CJF:10,CB:7</salvage>
+			<salvage pct='10'>CHH:1,CCC:3,CIH:2,CSR:5,CSV:3,CFM:2,CGS:1,CSA:3,CDS:1,CW:1,CBS:1,CNC:10,CSJ:3,CJF:10,CB:7</salvage>
 			<weightDistribution era='2870' unitType='Mek'>2,3,4,2</weightDistribution>
 			<weightDistribution era='2870' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CFM'>
-			<pctOmni>0,0,0,20,50</pctOmni>
-			<pctClan>0,0,10,50,60</pctClan>
-			<pctSL>100,100,90,50,40</pctSL>
+            <!-- Omni percentages: 0,0,0,20,50 -->
+            <!-- Clan percentages: 0,0,10,50,60 -->
+            <!-- Star League percentages: 100,100,90,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CCC:5,CHH:10,CSR:10,CIH:10,CSV:4,CCO:5,CGS:5,CSA:10,CDS:5,CW:5,CBS:5,CNC:10,CSJ:10,CJF:10,CGB:1,CB:5</salvage>
 		</faction>
 		<faction key='CGB'>
-			<pctOmni>0,0,10,40,50</pctOmni>
-			<pctClan>20,20,40,50,60</pctClan>
-			<pctSL>80,80,60,50,40</pctSL>
+            <!-- Omni percentages: 0,0,10,40,50 -->
+            <!-- Clan percentages: 20,20,40,50,60 -->
+            <!-- Star League percentages: 80,80,60,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CSA:10,CHH:10,CCC:3,CIH:5,CSR:1,CDS:1,CW:10,CSV:10,CFM:3,CGS:1,CCO:1,CJF:5</salvage>
@@ -87,25 +86,25 @@
 			<weightDistribution era='2870' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CGS'>
-			<pctOmni>0,0,0,10,30</pctOmni>
-			<pctClan>0,0,20,30,40</pctClan>
-			<pctSL>100,100,80,70,60</pctSL>
+            <!-- Omni percentages: 0,0,0,10,30 -->
+            <!-- Clan percentages: 0,0,20,30,40 -->
+            <!-- Star League percentages: 100,100,80,70,60 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CCC:1,CHH:4,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:3,CNC:10,CSJ:1,CJF:5,CB:5</salvage>
 		</faction>
 		<faction key='CHH'>
-			<pctOmni>0,0,0,30,40</pctOmni>
-			<pctClan>0,0,25,40,60</pctClan>
-			<pctSL>100,100,75,60,40</pctSL>
+            <!-- Omni percentages: 0,0,0,30,40 -->
+            <!-- Clan percentages: 0,0,25,40,60 -->
+            <!-- Star League percentages: 100,100,75,60,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,30,40</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,60</pctSL>
 			<salvage pct='10'>CCC:2,CSR:3,CIH:5,CSV:3,CFM:10,CCO:2,CGS:5,CSA:5,CDS:8,CW:1,CBS:2,CNC:10,CSJ:5,CJF:8,CGB:7,CB:7</salvage>
 		</faction>
 		<faction key='CIH'>
-			<pctOmni>0,0,0,40,50</pctOmni>
-			<pctClan>0,0,20,50,60</pctClan>
-			<pctSL>100,100,80,50,40</pctSL>
+            <!-- Omni percentages: 0,0,0,40,50 -->
+            <!-- Clan percentages: 0,0,20,50,60 -->
+            <!-- Star League percentages: 100,100,80,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CSV:3,CFM:7,CCO:3,CGS:3,CSA:3,CDS:5,CW:10,CBS:3,CNC:7,CSJ:3,CJF:3,CGB:2,CB:7</salvage>
@@ -113,49 +112,49 @@
 			<weightDistribution era='2870' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
 		<faction key='CJF'>
-			<pctOmni>0,0,20,40,50</pctOmni>
-			<pctClan>0,0,30,50,60</pctClan>
-			<pctSL>100,100,70,50,40</pctSL>
+            <!-- Omni percentages: 0,0,20,40,50 -->
+            <!-- Clan percentages: 0,0,30,50,60 -->
+            <!-- Star League percentages: 100,100,70,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CCC:2,CHH:3,CSR:10,CIH:5,CSV:10,CFM:10,CCO:4,CGS:5,CSA:5,CDS:3,CW:10,CBS:5,CNC:2,CSJ:5,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CNC'>
-			<pctOmni>0,0,10,30,50</pctOmni>
-			<pctClan>0,0,20,50,60</pctClan>
-			<pctSL>100,100,80,50,40</pctSL>
+            <!-- Omni percentages: 0,0,10,30,50 -->
+            <!-- Clan percentages: 0,0,20,50,60 -->
+            <!-- Star League percentages: 100,100,80,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CCC:5,CHH:8,CSR:10,CIH:3,CSV:1,CFM:3,CCO:10,CGS:3,CSA:5,CDS:2,CW:3,CBS:3,CSJ:2,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CDS'>
-			<pctOmni>0,0,0,50,60</pctOmni>
-			<pctClan>0,0,25,50,60</pctClan>
-			<pctSL>100,100,75,50,40</pctSL>
+            <!-- Omni percentages: 0,0,0,50,60 -->
+            <!-- Clan percentages: 0,0,25,50,60 -->
+            <!-- Star League percentages: 100,100,75,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='12'>CCC:1,CHH:5,CSR:10,CIH:6,CSV:5,CFM:5,CCO:4,CGS:3,CSA:5,CW:3,CNC:5,CSJ:5,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CSJ'>
-			<pctOmni>0,0,10,30,50</pctOmni>
-			<pctClan>0,0,20,50,60</pctClan>
-			<pctSL>100,100,80,40,40</pctSL>
+            <!-- Omni percentages: 0,0,10,30,50 -->
+            <!-- Clan percentages: 0,0,20,50,60 -->
+            <!-- Star League percentages: 100,100,80,40,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CJF:3,CB:2</salvage>
 		</faction>
 		<faction key='CSR'>
-			<pctOmni>10,10,20,30,50</pctOmni>
-			<pctClan>20,20,30,60,70</pctClan>
-			<pctSL>80,80,70,40,30</pctSL>
+            <!-- Omni percentages: 10,10,20,30,50 -->
+            <!-- Clan percentages: 20,20,30,60,70 -->
+            <!-- Star League percentages: 80,80,70,40,30 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CCC:1,CHH:2,CIH:2,CSV:4,CFM:3,CCO:5,CGS:1,CSA:1,CDS:3,CW:5,CNC:10,CSJ:2,CJF:3,CB:8</salvage>
 		</faction>
 		<faction key='CSA'>
-			<pctOmni>0,0,10,40,50</pctOmni>
-			<pctClan>10,10,30,50,60</pctClan>
-			<pctSL>90,90,70,50,40</pctSL>
+            <!-- Omni percentages: 0,0,10,40,50 -->
+            <!-- Clan percentages: 10,10,30,50,60 -->
+            <!-- Star League percentages: 90,90,70,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,70,70</pctSL>
 			<salvage pct='10'>CCC:7,CHH:2,CSR:3,CIH:3,CSV:3,CFM:7,CCO:7,CGS:4,CDS:3,CW:3,CNC:10,CSJ:1,CJF:3,CGB:3,CB:7</salvage>
@@ -163,17 +162,17 @@
 			<weightDistribution era='2870' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CSV'>
-			<pctOmni>0,0,20,40,50</pctOmni>
-			<pctClan>20,20,40,50,60</pctClan>
-			<pctSL>80,80,60,50,40</pctSL>
+            <!-- Omni percentages: 0,0,20,40,50 -->
+            <!-- Clan percentages: 20,20,40,50,60 -->
+            <!-- Star League percentages: 80,80,60,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:5,CBS:1,CNC:1,CSJ:1,CJF:10,CGB:3,CB:1</salvage>
 		</faction>
 		<faction key='CW'>
-			<pctOmni>0,0,0,40,50</pctOmni>
-			<pctClan>0,0,20,50,60</pctClan>
-			<pctSL>95,95,80,50,40</pctSL>
+            <!-- Omni percentages: 0,0,0,40,50 -->
+            <!-- Clan percentages: 0,0,20,50,60 -->
+            <!-- Star League percentages: 95,95,80,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CHH:1,CCC:2,CIH:10,CSR:10,CSV:3,CFM:3,CGS:2,CSA:3,CDS:2,CNC:7,CSJ:7,CJF:7,CGB:2,CB:3</salvage>

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -707,9 +707,9 @@
 			</model>
 		</chassis>
 		<chassis name='Assassin' unitType='Mek'>
-			<availability>CC:1,MOC:1,CS:3-,LA:4,FS.CMM:4,IS:4,MERC:3,FS:4,TC:1</availability>
+			<availability>IS:4,FS:4,LA:4,CC:1,MERC:3,CS:3-,TC:1,MOC:1</availability>
 			<model name='ASN-21'>
-				<availability>General:8</availability>
+				<availability>IS:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Asshur Artillery Spotter' unitType='Tank'>
@@ -898,15 +898,15 @@
 			</model>
 		</chassis>
 		<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
-			<availability>CCC:5,CBS:5,CSV:6,CGS:5</availability>
+			<availability>CSV!Keshik:3</availability>
 			<model name='A'>
-				<availability>General:6</availability>
+				<availability>CSV:5</availability>
 			</model>
 			<model name='B'>
-				<availability>CBS:8,General:6</availability>
+				<availability>CSV:4+</availability>
 			</model>
 			<model name='Prime'>
-				<availability>General:8</availability>
+				<availability>CSV:8</availability>
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
@@ -974,22 +974,22 @@
 			</model>
 		</chassis>
 		<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
-			<availability>CHH:8,CLAN:5,CFM:7,CGS:7,CCO:7,BAN:5,CSA:7,CDS:7,CW:7,CBS:4,CJF:7,CGB:7</availability>
+			<availability>CHH!Keshik:2,CSA:1+:2871</availability>
 			<model name='A'>
-				<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
+                <availability>CHH:4+,CSA:4+</availability>
 			</model>
 			<model name='B'>
-				<availability>CW:5,CNC:7,General:6,CJF:8,CGB:6</availability>
+                <availability>CHH:5,CSA:5</availability>
 			</model>
 			<model name='C'>
-				<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
+                <availability>CHH:4,CSA:4</availability>
 			</model>
 			<model name='D'>
-				<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
+                <availability>CHH:6,CSA:6</availability>
 			</model>
 			<model name='Prime'>
 			    <roles>raider</roles>
-				<availability>CW:7,CSV:7,General:6,CJF:8,CGB:7</availability>
+                <availability>CHH:8,CSA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
@@ -1329,10 +1329,10 @@
 			</model>
 		</chassis>
 		<chassis name='Cicada' unitType='Mek'>
-			<availability>CC:4,CS:4-,OA:2,LA:4,IS:4,FWL:4,FS:4,MERC:4,Periphery:2,DC:4</availability>
+			<availability>IS:4,FS:4,LA:4,DC:4,FWL:4,CC:4,MERC:4,CS:4-,Periphery:2,OA:2</availability>
 			<model name='CDA-2A'>
 				<roles>recon</roles>
-				<availability>General:8</availability>
+				<availability>IS:8,Periphery:8</availability>
 			</model>
 			<model name='CDA-2B'>
 				<roles>anti_infantry</roles>
@@ -1854,18 +1854,18 @@
             </model>
         </chassis>
 		<chassis name='Clint IIC' unitType='Mek'>
-			<availability>CSR:6</availability>
+			<availability>CSR:3+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CSR:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
-			<availability>CC:6,MOC:2,CS:3-,OA:2,CLAN:1-,IS:4,NIOPS:3-,FS:6,MERC:4</availability>
+			<availability>IS:4,FS:6,CC:6,MERC:4,CS:3-,MOC:2,OA:2,NIOPS:3-</availability>
 			<model name='CLNT-1-2R'>
 				<availability>CC:1,FS:1</availability>
 			</model>
 			<model name='CLNT-2-3T'>
-				<availability>CLAN:8,IS:8,Periphery.Deep:8,NIOPS:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,NIOPS:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='CLNT-2-4T'>
 				<availability>CC:4,FS:4</availability>
@@ -2001,9 +2001,9 @@
 			</model>
 		</chassis>
 		<chassis name='Corvis' unitType='Mek'>
-			<availability>CHH:4,CLAN:3</availability>
+			<availability>CGB!Front Line:1!Second Line:1!Solahma:1,CHH!Keshik:1!Front Line:4!Second Line:2</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CHH:8</availability>
 			</model>
 		</chassis>
         <chassis name='Corx Mobile Tunnel Miner' unitType='Tank'>
@@ -2014,35 +2014,35 @@
             </model>
         </chassis>
 		<chassis name='Coyotl' unitType='Mek' omni='Clan'>
-			<availability>CSA:5,CHH:5,CDS:5,CLAN:5,CFM:5,CCO:8</availability>
+			<availability>CLAN!Keshik:3!Front Line:1,CBS!Keshik:2,CB:2+,CCC:2+,CCO!Keshik:5!Front Line:3!Second Line:1,CFM:2+,CGS:1+,CHH!Front Line:2,CIH:2+,CMG!Keshik:2,CNC:2+,BAN:0</availability>
 			<model name='A'>
                 <roles>raider</roles>
-				<availability>General:6</availability>
+				<availability>CLAN:4+</availability>
 			</model>
 			<model name='B'>
-				<availability>General:6</availability>
+				<availability>CLAN:5</availability>
 			</model>
 			<model name='Prime'>
-				<availability>General:8</availability>
+				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>CHH:4,CSR:4,CLAN:5,IS:3,CFM:4,MERC:3,CGS:6,Periphery:3,CS:5,CDS:6,CW:6,CBS:6,NIOPS:5,CJF:4,CGB:4</availability>
+			<availability>IS:3,MERC:3,CS:5,CLAN:4,CB:3,CCC:4-,CFM:5-,CGB!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:4,CGS:5,CHH:4-,CIH:3-,CMG:4-,CNC:3,CDS:4-,CSA:4-,CSV:3,CW:4-,Periphery:3,NIOPS:5,BAN!Keshik:6!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
-				<availability>IS:8,Periphery.Deep:8,NIOPS:0,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,NIOPS:0,Periphery.Deep:8,BAN:4-</availability>
 			</model>
 			<model name='CRB-27'>
 				<roles>raider</roles>
-				<availability>CS:8,CC:1+,LA:1+,CLAN:6,NIOPS:8,FWL:1+,BAN:8,DC:1+</availability>
+				<availability>LA:1+,DC:1+,FWL:1+,CC:1+,CS:8,CLAN:4-,CIH:5-,NIOPS:8,BAN:3</availability>
 			</model>
 			<model name='CRB-27b'>
 				<roles>raider</roles>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CLAN:5+,CBS:8,BAN:3+</availability>
 			</model>
 			<model name='CRB-27sl'>
                 <roles>raider</roles>
-				<availability>LA:1+,CLAN:3,DC:1+</availability>
+				<availability>LA:1+,DC:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
@@ -2245,9 +2245,9 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>CC:4,Periphery.HR:6,CLAN:2,IS:5,Periphery.Deep:5,FS:8,MERC:5,TC:5</availability>
+			<availability>IS:5,FS:8,CC:4,MERC:5,CBS:3+,Periphery.HR:6,TC:5,Periphery.Deep:5</availability>
 			<model name='DV-6M'>
-				<availability>CLAN:4,IS:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,CBS:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='DV-6Md'>
 				<availability>FS:1+</availability>
@@ -2733,10 +2733,13 @@
 			</model>
 		</chassis>
 		<chassis name='Fox' unitType='Mek'>
-			<availability>CDS:6,CW:3,CSJ:3</availability>
+			<availability>CGB!Front Line:1!Second Line:1,CDS:3+</availability>
 			<model name='CS-1'>
-				<availability>General:8</availability>
+				<availability>CDS:4-</availability>
 			</model>
+            <model name=''>
+                <availability>CGB:8,CDS:3</availability>
+            </model>
 		</chassis>
 		<chassis name='Fury Command Tank' unitType='Tank'>
 			<availability>CHH:7,CW:7,CLAN:5,CJF:7,CGB:7</availability>
@@ -2852,13 +2855,13 @@
 			</model>
 		</chassis>
 		<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
-			<availability>CSV:7,CLAN:5</availability>
+			<availability>CLAN:2+,CCC:1+,CCO:1+,CFM!Keshik:4!Front Line:2,CGS:1+,CHH!Front Line:1,CIH!Keshik:3!Front Line:1,CMG!Keshik:3!Front Line:1,CDS:1+,CSR:1+,CSV:3+,CW:1+,BAN:0</availability>
 			<model name=''>
                 <roles>raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CIH:8</availability>
 			</model>
 			<model name='6'>
-				<availability>CLAN:4</availability>
+				<availability>CLAN:8,CIH:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Goth' unitType='AeroSpaceFighter'>
@@ -2896,28 +2899,31 @@
 			</model>
 		</chassis>
 		<chassis name='Great Wyrm' unitType='Mek'>
-			<availability>CSA:3,CCC:5,CHH:3,CSV:5,CLAN:3,CFM:5,CSJ:5,CCO:5,CB:5,CGB:3</availability>
+			<availability>CBS:2+,CB!Front Line:1!Second Line:1,CJF!Second Line:1,CMG!Front Line:2!Second Line:1,CNC!Second Line:1,CSJ!Second Line:1,CSA!Front Line:1!Second Line:1,CW!Second Line:1</availability>
 			<model name=''>
 				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Griffin IIC' unitType='Mek'>
-			<availability>CCC:5-,CCO:5-,CGB:5-,CNC:5-,CDS:5-,CSJ:5-,BAN:2+</availability>
+			<availability>CCC!Keshik:4!Front Line:2!Second Line:1,CCO!Keshik:4!Front Line:3,CGB!Keshik:4!Front Line:3!Second Line:1,CNC!Keshik:4!Front Line:2!Second Line:1,CDS!Keshik:3!Front Line:1,CSJ!Keshik:3!Front Line:1,BAN:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CCC:8,CCO:8,CGB:8,CNC:8,CDS:8,CSJ:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>CC:7,MOC:5,CLAN:3,IS:9,Periphery.Deep:6,MERC:8,TC:7,Periphery:6,CS:4,OA:4,NIOPS:4,DC:8</availability>
+			<availability>IS:9,DC:8,CC:7,MERC:8,CS:4,CLAN!Front Line:3!Second Line:4!Solahma:5!Provisional Garrison:5,CBS:5,CB!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CGS!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,CIH!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CMG!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,CNC!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,Periphery:6,TC:7,MOC:5,OA:4,NIOPS:4,Periphery.Deep:6,BAN:4+</availability>
 			<model name='GRF-1N'>
-				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:8,BAN:1-</availability>
 			</model>
 			<model name='GRF-1S'>
 				<availability>LA:6</availability>
 			</model>
 			<model name='GRF-2N'>
-				<availability>CLAN:6,BAN:4</availability>
+				<availability>CLAN:8,BAN:5</availability>
 			</model>
+            <model name='GRF-2N2'>
+                <availability>BAN:2-</availability>
+            </model>
 		</chassis>
 		<chassis name='Guardian Fighter' unitType='Conventional Fighter'>
 			<availability>IS:5,MERC:5,Periphery:3</availability>
@@ -3220,12 +3226,12 @@
 			</model>
 		</chassis>
 		<chassis name='Hellhound (Conjurer)' unitType='Mek'>
-			<availability>CHH:6,CIH:6,CDS:4,CLAN:7,CNC:6,CJF:6</availability>
+			<availability>CCO!Keshik:3!Front Line:1,CJF!Keshik:4!Front Line:2!Second Line:1,CSJ!Keshik:4!Front Line:1,CW!Keshik:5!Front Line:1</availability>
 			<model name=''>
-				<availability>CHH:8,General:8,CJF:8</availability>
+				<availability>CCO:8,CJF:5,CW:5</availability>
 			</model>
 			<model name='7'>
-				<availability>CW:4,CLAN:4</availability>
+				<availability>CJF:8,CSJ:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hermes II' unitType='Mek'>
@@ -3306,17 +3312,17 @@
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
-			<availability>CC:1,MOC:1,CHH:4,OA:1,LA:1,CLAN:3,FWL:1,FS:1,CGS:5,DC:1,TC:2</availability>
+			<availability>FS:1,LA:1,DC:1,FWL:1,CC:1,CBS:4+,CGB!Front Line:3!Second Line:2!Solahma:1,CGS:5+,CHH!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CJF:3-,CNC!Front Line:3!Second Line:2!Solahma:1,TC:2,MOC:1,OA:1</availability>
 			<model name='HOP-4Bb'>
                 <roles>fire_support</roles>
-				<availability>CLAN:5,BAN:2</availability>
+				<availability>CBS:8,CGB:8,CGS:8,CHH:5,CJF:8,CNC:8</availability>
 			</model>
 			<model name='HOP-4C'>
                 <roles>inf_support</roles>
-				<availability>MOC:8,OA:8,FS:8</availability>
+				<availability>FS:8,MOC:8,OA:8</availability>
 			</model>
 			<model name='HOP-4Cb'>
-				<availability>CHH:8,CLAN:2,BAN:2</availability>
+				<availability>CHH!Front Line:3!Second Line:2!Solahma:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
@@ -3341,15 +3347,15 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback IIC' unitType='Mek'>
-			<availability>CDS:4,CSR:4,CW:4,CSV:5,CLAN:4,CSJ:5,CJF:4,CGB:4</availability>
+			<availability>CSJ:2+</availability>
 			<model name=''>
-				<availability>CSR:8,General:8</availability>
+				<availability>CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>CC:6,CLAN:2-,IS:5,Periphery.Deep:5,Periphery:5,CS:5-,Periphery.MW:6,Periphery.ME:6,FWL:8,NIOPS:5-,DC:6</availability>
+			<availability>IS:5,DC:6,FWL:8,CC:6,CS:5-,Periphery:5,Periphery.MW:6,Periphery.ME:6,NIOPS:5-,Periphery.Deep:5</availability>
 			<model name='HBK-4G'>
-				<availability>General:8,Periphery.Deep:8,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,NIOPS:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='HBK-4H'>
 				<availability>IS:2,FWL:3,FS:3,MERC:3,Periphery:3</availability>
@@ -3741,15 +3747,15 @@
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
-			<availability>CS:7,CHH:7,CDS:7,CSV:7,CLAN:6,FWL:1,NIOPS:7,FS:6,MERC:1,DC:1</availability>
+			<availability>FS:6,DC:1,FWL:1,MERC:1,CS:7,CLAN:4-,CBS:4,CIH:3-,CSR:3-,CSV:3-,NIOPS:7,BAN:3+</availability>
 			<model name='KTO-18'>
 				<availability>FS:6</availability>
 			</model>
 			<model name='KTO-19'>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
+				<availability>CS:8,CLAN:3-,CBS:4-,CB:4-,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='KTO-19b'>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CLAN:5,BAN:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
@@ -3828,10 +3834,10 @@
 			</model>
 		</chassis>
 		<chassis name='Kyudo' unitType='Mek'>
-			<availability>FWL:1+,FS:1+</availability>
+			<availability>FS:1+,FWL:1+,CBS!Front Line:2!Second Line:1,CMG!Second Line:1</availability>
 			<model name='KY2-D-02'>
 				<roles>fire_support</roles>
-				<availability>IS:8</availability>
+				<availability>FS:8,FWL:8,CBS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='LRM Carrier' unitType='Tank'>
@@ -4084,10 +4090,10 @@
 			</model>
 		</chassis>
 		<chassis name='Lynx' unitType='Mek'>
-			<availability>CIH:6,LA:1,CLAN:4,FWL:1,CSJ:6,CJF:4,DC:1</availability>
+			<availability>LA:1,DC:1,FWL:1,CLAN!Front Line:3!Second Line:2!Solahma:1,CB!Second Line:1!Solahma:1!Provisional Garrison:1,CCO:5+,CGS:4+,CIH!Keshik:2!Front Line:3!Second Line:2!Solahma:1,CJF:4+,CMG:4+,CNC!Front Line:3!Second Line:1,CSJ:5+,CSR!Front Line:2!Second Line:1,CSA!Keshik:2!Front Line:3!Second Line:2!Solahma:1,CSV!Second Line:2!Solahma:1,CW:3+,BAN:2+</availability>
 			<model name='C'>
                 <roles>raider</roles>
-				<availability>CCC:6,CW:6,CNC:6,CSJ:8,CJF:6,CGS:6</availability>
+				<availability>CCC:8,CGS:8,CJF:8,CNC:8,CSJ:3+,CW:8</availability>
 			</model>
 			<model name='LNX-8Q'>
                 <roles>raider</roles>
@@ -4095,7 +4101,7 @@
 			</model>
 			<model name='LNX-9Q'>
                 <roles>raider</roles>
-				<availability>CLAN:8,IS:2+</availability>
+				<availability>IS:2+,CLAN:8,CCC:0,CGS:8,CJF:0,CNC:0,CSJ:3-,CW:0,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -4707,14 +4713,20 @@
             </model>
         </chassis>
 		<chassis name='Naja' unitType='Mek'>
-			<availability>CCC:6,CBS:5,CSV:5,CLAN:2</availability>
+			<availability>CBS!Front Line:1,CCC!Front Line:2!Second Line:1,CSV!Front Line:1</availability>
             <model name=''>
-                <availability>CCC:8,CLAN:6</availability>
+                <availability>CBS:8,CCC:8,CSV:8</availability>
             </model>
-			<model name='KTO-19b-EC'>
-				<availability>CCC:3,CBS:3,CSV:2</availability>
-			</model>
 		</chassis>
+        <chassis name='Night Chanter' unitType='Mek' omni='Clan'>
+            <availability>CLAN:1+,CCO:3+,CGB!Keshik:1!Front Line:1,CNC:2+,CSA!Front Line:1</availability>
+            <model name='A'>
+                <availability>CLAN:6,CGS:4</availability>
+            </model>
+            <model name='Prime'>
+                <availability>CLAN:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Night Hawk' unitType='Mek'>
 			<availability>FS:2+,LA:2+,FWL:2+,CLAN:4+,CBS:5+,CB:5+,CCO:5+,CGB:5+,CJF:5+,CSJ:5+,CSR:3+,CW:5+,BAN:3+</availability>
 			<model name='NTK-2Q'>
@@ -5006,14 +5018,18 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>CS:7,CLAN:2,IS:9,NIOPS:7,Periphery.Deep:4,Periphery:4</availability>
-			<model name='PXH-1'>
+			<availability>IS:9,CS:7,CLAN:4+,CB:3+,CCO!Front Line:3!Second Line:2!Solahma:1,CGB:3+,CGS:6+,CIH!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CSA!Keshik:3!Front Line:3!Second Line:2!Solahma:1,Periphery:4,NIOPS:7,Periphery.Deep:4,BAN:4</availability>
+            <model name='C'>
+                <roles>recon</roles>
+                <availability>CGS!Keshik:5!Front Line:3!Second Line:1,CIH!Front Line:8!Second Line:3,CJF!Front Line:5!Second Line:3!Solahma:1</availability>
+            </model>
+            <model name='PXH-1'>
 				<roles>command,recon</roles>
-				<availability>General:8,BAN:6,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,BAN:5-</availability>
 			</model>
 			<model name='PXH-1-EC'>
                 <roles>command,recon</roles>
-				<availability>CGS:1</availability>
+				<availability>CGS!Front Line:3!Second Line:1</availability>
 			</model>
 			<model name='PXH-1D'>
 				<roles>command,recon</roles>
@@ -5025,15 +5041,15 @@
 			</model>
 			<model name='PXH-1b &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:7,BAN:3</availability>
+				<availability>CLAN:8,CGS:4,CIH:5-,BAN:3</availability>
 			</model>
 			<model name='PXH-1c &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:4,CGS:6</availability>
+				<availability>CGS:3+</availability>
 			</model>
 			<model name='PXH-2'>
 				<roles>command,recon</roles>
-				<availability>CLAN:3,BAN:4</availability>
+				<availability>BAN:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
@@ -5428,9 +5444,9 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>CC:4-,CS:3-,LA:4-,FWL:4-,NIOPS:3-,Periphery.Deep:4-,FS:3-,MERC:4-,Periphery:4-,DC:4-,BAN:2-</availability>
+			<availability>FS:3-,LA:4-,DC:4-,FWL:4-,CC:4-,MERC:4-,CS:3-,Periphery:4-,NIOPS:3-,Periphery.Deep:4-</availability>
 			<model name='SCP-1N'>
-				<availability>LA:8,General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Scout JumpShip' unitType='Jumpship'>
@@ -5469,7 +5485,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>CSV:5,CLAN:6,CFM:7,FS:1-,CGS:5,CS:4,CDS:5,CW:5,LA:4-,CBS:5,FWL:1-,NIOPS:4,CJF:7,CGB:7,DC:2</availability>
+			<availability>FS:1-,LA:4-,DC:2,FWL:1-,CS:4,CLAN:4-,CBS:5-,CCC:3-,CCO:3-,CDS:2,NIOPS:4,BAN:2</availability>
 			<model name='STN-3K'>
 				<availability>LA:8,DC:8</availability>
 			</model>
@@ -5480,10 +5496,10 @@
 				<availability>LA:4</availability>
 			</model>
 			<model name='STN-3L'>
-				<availability>CS:8,LA:1+,CLAN:6,NIOPS:8,FWL:1+,FS:1+,MERC:1+,BAN:8</availability>
+				<availability>FS:1+,LA:1+,FWL:1+,MERC:1+,CS:8,CLAN:8,CBS:4-,CCC:4,CFM:3,CGB:4-,CHH:4-,CJF:3-,CDS:4-,CSR:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='STN-3Lb'>
-				<availability>CLAN:4,BAN:3</availability>
+				<availability>CBS:4+,CCC:4+,CFM:4+,CGB:4+,CHH:4+,CJF:4+,CDS:4+,CSR:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
@@ -5502,27 +5518,27 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>CLAN:6-,BAN:3+</availability>
+			<availability>CLAN!Keshik:4!Front Line:3!Second Line:1,CBS!Keshik:4!Front Line:1,CCC:3+,CCO:2+,CFM!Keshik:5!Front Line:2!Second Line:1,CGS!Keshik:3!Front Line:1,CIH!Keshik:3!Front Line:1,CJF!Keshik:3!Front Line:1,CMG:2+,CSJ:2+,BAN:2+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CLAN:8,CGB:4,BAN:8</availability>
 			</model>
 			<model name='2'>
-				<availability>CGB:6</availability>
+				<availability>CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>CS:6-,LA:6,CLAN:3,IS:7,NIOPS:6-,Periphery.Deep:5,BAN:4,Periphery:5</availability>
+			<availability>IS:7,LA:6,CS:6-,CLAN!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CBS:5,CCC:5,CIH!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CMG:5,Periphery:5,NIOPS:6-,Periphery.Deep:5,BAN:5</availability>
             <model name='C'>
-                <availability>CSA:6,CCC:6,CSV:6,CFM:6,CGS:6</availability>
+                <availability>CLAN!Front Line:6!Second Line:3,CBS!Keshik:6!Front Line:3,CCC!Keshik:3!Front Line:5,CCO!Front Line:8!Second Line:1,CFM!Front Line:8!Second Line:1,CGS!Front Line:6!Second Line:1,CIH!Front Line:8!Second Line:3,CMG!Keshik:6!Front Line:3!Second Line:1,CNC!Front Line:6!Second Line:1,BAN!Keshik:6!Front Line:1</availability>
             </model>
 			<model name='SHD-2D'>
 				<availability>FS:10</availability>
 			</model>
 			<model name='SHD-2H'>
-				<availability>General:8,CLAN:4-,Periphery.Deep:8,BAN:5,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8,BAN:2</availability>
 			</model>
 			<model name='SHD-2Hb'>
-				<availability>CLAN:5,FS:1+,BAN:4</availability>
+				<availability>FS:1+,CLAN:4-,CCC:5,BAN:3+</availability>
 			</model>
 			<model name='SHD-2K'>
 				<availability>DC:9</availability>
@@ -5756,14 +5772,10 @@
 			</model>
 		</chassis>
 		<chassis name='Starslayer' unitType='Mek'>
-			<availability>CSA:1,LA:3+,CNC:1</availability>
+			<availability>LA:3+</availability>
 			<model name='STY-2C'>
 				<roles>raider</roles>
-				<availability>IS:8</availability>
-			</model>
-			<model name='STY-2C-EC'>
-                <roles>raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>LA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stinger LAM' unitType='Mek'>
@@ -6139,10 +6151,10 @@
 			</model>
 		</chassis>
 		<chassis name='Trebuchet' unitType='Mek'>
-			<availability>CC:5,MOC:5,CS:5-,FWL:8,NIOPS:5-,MERC:5</availability>
+			<availability>FWL:8,CC:5,MERC:5,CS:5-,CDS!Second Line:2!Solahma:1,MOC:5,NIOPS:5-</availability>
 			<model name='TBT-3C'>
 				<roles>fire_support</roles>
-				<availability>CS:6,NIOPS:6</availability>
+				<availability>CS:6,CDS:8,NIOPS:6</availability>
 			</model>
 			<model name='TBT-5J'>
 				<availability>FWL:4</availability>
@@ -6366,14 +6378,14 @@
 			</model>
 		</chassis>
 		<chassis name='Vulcan' unitType='Mek'>
-			<availability>CC:4,CS:3,MOC:5,LA:7,CLAN:1-,FWL:7,IS:5,NIOPS:3,CIR:5,TC:5</availability>
+			<availability>IS:5,LA:7,FWL:7,CC:4,CS:3,TC:5,MOC:5,CIR:5,NIOPS:3</availability>
 			<model name='VL-2T'>
 				<roles>anti_infantry</roles>
-				<availability>General:8,FS:4</availability>
+				<availability>IS:8,FS:4,Periphery:8</availability>
 			</model>
 			<model name='VL-5T'>
 				<roles>anti_infantry</roles>
-				<availability>MOC:2,PIR:2,IS:2,FS:6,CIR:2,TC:2</availability>
+				<availability>IS:2,FS:6,TC:2,MOC:2,CIR:2,PIR:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Vulture' unitType='Dropship'>
@@ -6506,13 +6518,13 @@
 			</model>
 		</chassis>
 		<chassis name='Whitworth' unitType='Mek'>
-			<availability>MOC:1,CS:3-,Periphery.DD:2,OA:1,FS.CMM:5,CLAN:1-,NIOPS:3-,MERC:3,Periphery.OS:2,DC:6,TC:2</availability>
+			<availability>FS.CMM:5,DC:6,MERC:3,CS:3-,Periphery.DD:2,Periphery.OS:2,TC:2,MOC:1,OA:1,NIOPS:3-</availability>
 			<model name='WTH-0'>
 				<availability>TC:2</availability>
 			</model>
 			<model name='WTH-1'>
 				<roles>fire_support</roles>
-				<availability>General:8,Periphery.Deep:8,MERC:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='WTH-1S'>
 				<roles>fire_support</roles>
@@ -6520,7 +6532,7 @@
 			</model>
 		</chassis>
 		<chassis name='Wolverine' unitType='Mek'>
-			<availability>CS:5-,IS:7,Periphery.Deep:6,FWL:10,NIOPS:5-,FS:8,TC:5</availability>
+			<availability>IS:7,FS:8,FWL:10,CS:5-,NIOPS:5-,TC:5,Periphery.Deep:6</availability>
 			<model name='WVR-1R'>
 				<availability>FS:1-</availability>
 			</model>
@@ -6537,7 +6549,7 @@
 			</model>
 			<model name='WVR-6R'>
 				<roles>command,recon</roles>
-				<availability>General:8,Periphery:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Woodsman' unitType='Mek' omni='Clan'>
@@ -6550,21 +6562,21 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern IIC' unitType='Mek'>
-			<availability>CHH:4,CW:4,CLAN:4</availability>
+			<availability>CB!Keshik:4!Front Line:1,CCC!Front Line:1!Second Line:2</availability>
 			<model name=''>
 				<roles>urban</roles>
-				<availability>CW:8,CLAN:8</availability>
+				<availability>CB:8,CCC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>CS:6,CC:6,CIH:4,CLAN:5,NIOPS:6,CFM:6,FS:6,MERC:5,DC:6,TC:4</availability>
+			<availability>FS:6,DC:6,CC:6,MERC:5,CS:6,CLAN:3,CBS:4,CB:4-,CCC:4-,CCO:3-,CGB:4-,CHH:4-,CIH:2-,CMG:4-,CNC:4-,CSJ:2,CSR:4-,CSA:4-,CSV:3-,CW:4-,TC:4,NIOPS:6,BAN:3</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
-				<availability>CS:8,CLAN:5,NIOPS:8,CFM:5,BAN:7,TC:8</availability>
+				<availability>CS:8,CBS:3-,CB:3-,CCO:2-,CFM:2-,TC:8,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='WVE-5Nb'>
 				<roles>urban</roles>
-				<availability>CLAN:5,CFM:6,CGS:6</availability>
+				<availability>CLAN:8,CBS:6,CB:6,CCO:6,CFM:6,BAN:3+</availability>
 			</model>
 			<model name='WVE-5Nsl'>
 				<availability>LA:1+,FWL:1+</availability>

--- a/megamek/data/forcegenerator/2870.xml
+++ b/megamek/data/forcegenerator/2870.xml
@@ -612,7 +612,7 @@
 			</model>
 			<model name='ARC-2Rb'>
 				<roles>command,fire_support</roles>
-				<availability>CLAN:4-,CB:3-,BAN:2+</availability>
+				<availability>CLAN:4-,CB:3-,NIOPS:5,BAN:2+</availability>
 			</model>
 			<model name='ARC-2S'>
 				<roles>command,fire_support</roles>

--- a/megamek/data/forcegenerator/2900.xml
+++ b/megamek/data/forcegenerator/2900.xml
@@ -592,7 +592,7 @@
 			</model>
 		</chassis>
 		<chassis name='Archer' unitType='Mek'>
-			<availability>IS:7,FWL:6,CC:6,MERC:6,CS!A:3!B:3!C:4!D:5!F:6,Periphery:5,TC:6,NIOPS:5,HL:3,Periphery.Deep:3</availability>
+			<availability>IS:7,FWL:6,CC:6,MERC:6,CS!A:3!B:3!C:4!D:5!F:6,CLAN!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CBS:4,CFM!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CGS!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CIH:4-,CSV!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,Periphery:5,TC:6,NIOPS:5,HL:3,Periphery.Deep:3,BAN:4</availability>
             <model name='ARC-1A'>
                 <roles>fire_support</roles>
                 <availability>Periphery:2-,TC:1-,NIOPS:0,HL:8-,Periphery.Deep:8,PIR:6-</availability>
@@ -603,16 +603,20 @@
 			</model>
 			<model name='ARC-2R'>
 				<roles>command,fire_support</roles>
-				<availability>IS:8,LA:7,DC:6,Periphery:8,HL:8,Periphery.Deep:2+,PIR:8</availability>
+				<availability>IS:8,LA:7,DC:6,Periphery:8,NIOPS:4-,HL:8,Periphery.Deep:2+,PIR:8,BAN:8</availability>
 			</model>
             <model name='ARC-2Rb'>
                 <roles>command,fire_support</roles>
-                <availability>NIOPS:6+</availability>
+                <availability>CLAN:4-,CB:3-,NIOPS:6+,BAN:2+</availability>
             </model>
 			<model name='ARC-2S'>
 				<roles>command,fire_support</roles>
 				<availability>LA:8+</availability>
 			</model>
+            <model name='C'>
+                <roles>command,fire_support</roles>
+                <availability>CLAN!Front Line:3!Second Line:1,CBS:1+,CB:2+,CIH:3+,CNC!Front Line:2!Second Line:1,CSJ!Front Line:2,BAN:0</availability>
+            </model>
 		</chassis>
 		<chassis name='Ares Assault Craft' unitType='Small Craft'>
 			<availability>MOC:8,OA:8,CLAN:4,IS:8,MERC:7,Periphery:8,TC:8,BAN:3</availability>
@@ -1004,14 +1008,14 @@
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
-			<availability>FS:2+,LA:1+,FWL:2+,DC:2+,MERC:1+,CS:8,CLAN:8,CHH:7,CSR:7,CSV:7,CFM:7,CGS:9,CDS:7,CW:9,CBS:9,CNC:9,CJF:7,CGB:9,NIOPS:7</availability>
+			<availability>FS:2+,LA:1+,FWL:2+,DC:2+,MERC:1+,CS:8,CLAN:3+,CBS!Front Line:2!Second Line:1,CCC!Front Line:2!Second Line:1,CCO!Front Line:2!Second Line:1,CGS:4+,CIH:2+,NIOPS:7,BAN:2+</availability>
 			<model name='BL-6-KNT'>
                 <roles>command</roles>
-				<availability>CS:7,CLAN:6,NIOPS:8,BAN:6</availability>
+				<availability>CS:7,CLAN:8,CBS:6-,CCO:4-,CGB:4-,CGS:4-,CNC:4-,CW:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='BL-6b-KNT'>
                 <roles>command</roles>
-				<availability>CS:4+,CLAN:7,CGS:8,NIOPS:4+,BAN:4+</availability>
+				<availability>CS:4+,CBS:7,CCO:7,CGB:7,CGS:7,CNC:7,CW:7,NIOPS:4+</availability>
 			</model>
 			<model name='BL-7-KNT'>
                 <roles>command</roles>
@@ -1049,14 +1053,14 @@
 			</model>
 		</chassis>
 		<chassis name='Bombardier' unitType='Mek'>
-			<availability>IS:2-,MERC:2,CS:5,CLAN:2-,Periphery:1,NIOPS:5,HL:1+,BAN:1</availability>
+			<availability>IS:2-,MERC:2,CS:5,CLAN:3-,CB:2-,CCO:2-,CIH:4,CDS:4-,CSR:4-,Periphery:1,NIOPS:5,HL:1+,BAN:0</availability>
 			<model name='BMB-10D'>
 				<roles>fire_support</roles>
 				<availability>IS:8,CS:5,Periphery:8,NIOPS:0,HL:8</availability>
 			</model>
 			<model name='BMB-12D'>
 				<roles>fire_support</roles>
-				<availability>CS:8+,CLAN:8,NIOPS:8,BAN:8</availability>
+				<availability>CS:8+,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Boomerang Spotter Plane' unitType='Conventional Fighter'>
@@ -1067,7 +1071,7 @@
 			</model>
 		</chassis>
 		<chassis name='Bowman' unitType='Mek'>
-			<availability>CHH:5:2923</availability>
+			<availability>CHH!Second Line:3!Solahma:2!Provisional Garrison:1</availability>
 			<model name='4'>
 				<roles>missile_artillery</roles>
 				<availability>CHH:8</availability>
@@ -1200,18 +1204,18 @@
 			</model>
 		</chassis>
 		<chassis name='Catapult' unitType='Mek'>
-			<availability>IS:3+,FS:4+,LA:2+,DC:4+,CC:5+,MERC:2+,CS:3-,CLAN:1-,Periphery:1+,Periphery.HR:2+,Periphery.CM:2+,NIOPS:2</availability>
+			<availability>IS:3+,FS:4+,LA:2+,DC:4+,CC:5+,MERC:2+,CS:3-,CFM:4+,Periphery:1+,Periphery.HR:2+,Periphery.CM:2+,NIOPS:2</availability>
 			<model name='CPLT-A1'>
 				<roles>fire_support</roles>
 				<availability>CC:4</availability>
 			</model>
 			<model name='CPLT-C1'>
 				<roles>fire_support</roles>
-				<availability>IS:8,DC:7,CLAN:4-,Periphery:8,HL:8,Periphery.Deep:8,BAN:6</availability>
+				<availability>IS:8,DC:7,Periphery:8,HL:8,Periphery.Deep:8</availability>
 			</model>
 			<model name='CPLT-C1b'>
 				<roles>fire_support</roles>
-				<availability>CLAN:6,NIOPS:2+</availability>
+				<availability>CFM:8,NIOPS:2+</availability>
 			</model>
 			<model name='CPLT-C4'>
 				<roles>fire_support</roles>
@@ -1247,12 +1251,12 @@
 			</model>
 		</chassis>
 		<chassis name='Cestus' unitType='Mek'>
-			<availability>CS:5+,CLAN:3,NIOPS:4+</availability>
+			<availability>CS:5+,CFM!Front Line:2!Second Line:1,NIOPS:4+</availability>
 			<model name='CTS-6Y'>
-				<availability>CS:8,CLAN:8,NIOPS:8</availability>
+				<availability>CS:8,NIOPS:8</availability>
 			</model>
 			<model name='CTS-6Y-EC'>
-				<availability>CFM:1</availability>
+				<availability>CFM:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Chaeronea' unitType='AeroSpaceFighter'>
@@ -1275,19 +1279,16 @@
 			</model>
 		</chassis>
 		<chassis name='Champion' unitType='Mek'>
-			<availability>FS:3,LA:2,FWL:2,DC:2,CC:1,MERC:2,CS:4,CLAN:3,CHH:5,CGB:5,NIOPS:5</availability>
+			<availability>FS:3,LA:2,FWL:2,DC:2,CC:1,MERC:2,CS:4,CBS:4-,CCO!Second Line:1,CGB!Second Line:2!Solahma:1,CHH!Front Line:3!Second Line:2!Solahma:1,NIOPS:5</availability>
 			<model name='C'>
-				<availability>CLAN:8,CHH:6,CGB:6</availability>
+				<availability>CBS!Front Line:1,CCO:8,CHH:3+</availability>
 			</model>
 			<model name='CHP-1N'>
 				<roles>recon</roles>
-				<availability>CS:8,CLAN:3,CHH:5,CGB:5,NIOPS:8,BAN:6</availability>
+				<availability>CS:8,CBS:8,CGB:8,CHH:2-,NIOPS:8</availability>
 			</model>
 			<model name='CHP-1N2'>
-				<availability>CS:5,CLAN:1,BAN:2</availability>
-			</model>
-			<model name='CHP-1Nb'>
-				<availability>CLAN:4,BAN:2</availability>
+				<availability>CS:5</availability>
 			</model>
 			<model name='CHP-2N'>
 				<availability>IS:8,CS:3-,NIOPS:0</availability>
@@ -1997,15 +1998,15 @@
 			</model>
 		</chassis>
 		<chassis name='Crossbow' unitType='Mek' omni='Clan'>
-			<availability>CBS:4,CSV:6</availability>
+			<availability>CSR:1+,CSV:2+</availability>
 			<model name='A'>
-				<availability>CBS:5,CSV:5</availability>
+				<availability>CSR:5,CSV:5</availability>
 			</model>
 			<model name='B'>
-				<availability>CBS:6,CSV:6</availability>
+				<availability>CSR:6,CSV:6</availability>
 			</model>
 			<model name='Prime'>
-				<availability>CBS:8,CSV:8</availability>
+				<availability>CSR:8,CSV:8</availability>
 			</model>
 		</chassis>
         <chassis name='Crosscut' unitType='Mek'>
@@ -2043,9 +2044,9 @@
             </model>
         </chassis>
 		<chassis name='Crusader' unitType='Mek'>
-			<availability>IS:6,LA:5,FWL:5,CS!F:6!D:4!C:3,CLAN:5-,Periphery:5,NIOPS:6-,HL:4+,Periphery.Deep:4+</availability>
+			<availability>IS:6,LA:5,FWL:5,CS!F:6!D:4!C:3,CLAN!Second Line:1!Solahma:2!Provisional Garrison:2,CBS:3,CB:3,CCC!Front Line:1!Second Line:2!Solahma:2!Provisional Garrison:2,CGS!Front Line:1!Second Line:2!Solahma:2!Provisional Garrison:2,CIH:2,CDS!Front Line:1!Second Line:2!Solahma:2!Provisional Garrison:2,CSJ!Front Line:1!Second Line:2!Solahma:2!Provisional Garrison:2,Periphery:5,NIOPS:6-,HL:4+,Periphery.Deep:4+,BAN:4</availability>
 			<model name='CRD-2R'>
-				<availability>CLAN:7,CGS:8,BAN:4+</availability>
+				<availability>CLAN:8,NIOPS:5,BAN:2+</availability>
 			</model>
 			<model name='CRD-3D'>
 				<availability>FS:8+</availability>
@@ -2058,7 +2059,7 @@
 				<availability>CC:8+</availability>
 			</model>
 			<model name='CRD-3R'>
-				<availability>IS:8,FS:7,DC:6,CC:6,CLAN:1-,Periphery:8,HL:8,Periphery.Deep:8,BAN:5</availability>
+				<availability>IS:8,MERC:8,FS:7,DC:6,CC:6,Periphery:8,NIOPS:6-,HL:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
@@ -2398,21 +2399,21 @@
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Dropship'>
-			<availability>MOC:3,IS:5,FS:4,Periphery:2,TC:3,CS:5,NIOPS:5,DC:6</availability>
+			<availability>IS:5,FS:4,DC:6,CS:5,Periphery:2,TC:3,MOC:3,NIOPS:5</availability>
 			<model name='(2786)'>
 				<roles>troop_carrier</roles>
 				<availability>General:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Excalibur' unitType='Mek'>
-			<availability>CS:6,CLAN:4-,NIOPS:5,BAN:4</availability>
+			<availability>CS:6,CLAN!Front Line:2!Second Line:1,CBS:3+,CGS:3+,CIH:3+,CNC:3+,CW!Second Line:2!Solahma:1,NIOPS:5,BAN:0</availability>
 			<model name='EXC-B2'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CS:8,CLAN:4,NIOPS:8,BAN:8</availability>
+				<availability>CS:8,CLAN:5-,NIOPS:8</availability>
 			</model>
 			<model name='EXC-B2b'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CLAN:7,CGS:8,BAN:4+</availability>
+				<availability>CLAN:3+,CBS:2+,CGS:2+,CIH:2+,CNC:2+,CW:3-</availability>
 			</model>
 		</chassis>
 		<chassis name='Explorer JumpShip' unitType='Jumpship'>
@@ -2427,18 +2428,18 @@
 			</model>
 		</chassis>
 		<chassis name='Exterminator' unitType='Mek'>
-			<availability>CS:5,CLAN:4,NIOPS:4</availability>
+			<availability>CS:5,CLAN!Second Line:1,CBS!Front Line:2!Second Line:1,CCC!Front Line:2!Second Line:1,CFM!Front Line:2!Second Line:1,CIH:4+,CJF!Second Line:2!Solahma:1,CDS!Front Line:3!Second Line:2!Solahma:1,CSR!Front Line:3!Second Line:2!Solahma:1,NIOPS:4,BAN:1+</availability>
 			<model name='EXT-4C'>
 			    <roles>specops</roles>
-				<availability>BAN:1</availability>
+				<availability>BAN:8</availability>
 			</model>
 			<model name='EXT-4D'>
 			    <roles>cavalry</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:4</availability>
+				<availability>CS:8,CLAN:8,CFM:4-,CIH:4-,CJF:3-,CDS:3-,CSR:4-,NIOPS:8,BAN:0</availability>
 			</model>
 			<model name='EXT-4Db'>
 			    <roles>cavalry</roles>
-				<availability>CLAN:3,BAN:2</availability>
+				<availability>CFM:8,CIH:5,CJF:4-,CDS:8,CSR:8,NIOPS:3+</availability>
 			</model>
 		</chassis>
 	    <chassis name='Factory' unitType='Space Station'>
@@ -2607,10 +2608,10 @@
 			</model>
 		</chassis>
 		<chassis name='Fire Scorpion' unitType='Mek'>
-			<availability>CGS:7</availability>
+			<availability>CGS:2+</availability>
 			<model name=''>
                 <roles>urban</roles>
-				<availability>CLAN:8</availability>
+				<availability>CGS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Firebee' unitType='Mek'>
@@ -2644,7 +2645,7 @@
 			</model>
 		</chassis>
 		<chassis name='Flashman' unitType='Mek'>
-			<availability>LA:4+,CS:8,CLAN:5,CHH:4,CSV:6,CFM:6,CGS:4,CDS:4,CBS:4,CJF:6,CGB:4,Periphery.R:2+,NIOPS:5</availability>
+			<availability>LA:4+,CS:8,CLAN!Keshik:4!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CCO!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:2,CW!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:2,Periphery.R:2+,NIOPS:5,BAN:3+</availability>
 			<model name='FLS-7K'>
 				<availability>LA:8,Periphery.R:8</availability>
 			</model>
@@ -2885,16 +2886,10 @@
 			</model>
 		</chassis>
 		<chassis name='Galahad (Glass Spider)' unitType='Mek'>
-			<availability>CSR:7,CW:8,CLAN:7</availability>
+			<availability>CW!Front Line:2!Second Line:1</availability>
 			<model name=''>
                 <roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:8</availability>
-			</model>
-		</chassis>
-		<chassis name='Galahad' unitType='Mek'>
-			<availability>CLAN:2-</availability>
-			<model name='GLH-2D'>
-				<availability>CLAN:8</availability>
+				<availability>CW:8</availability>
 			</model>
 		</chassis>
         <chassis name='Galaport Ground Trailer' unitType='Tank'>
@@ -3060,9 +3055,9 @@
             </model>
 		</chassis>
 		<chassis name='Grizzly' unitType='Mek'>
-			<availability>CHH:2,CGB:3</availability>
+			<availability>CLAN!Front Line:1,CCO!Solahma:1,CGB!Front Line:3,CHH!Second Line:1,CIH!Second Line:1,CJF:0,CNC:0,CSJ!Second Line:1,CSR!Second Line:1,CSA:0,CSV:0,CW!Second Line:1,BAN:0</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
         <chassis name='Guard' unitType='Mek'>
@@ -3080,17 +3075,17 @@
 			</model>
 		</chassis>
 		<chassis name='Guillotine IIC' unitType='Mek'>
-			<availability>CLAN:2-</availability>
+			<availability>CCO:1+</availability>
 			<model name=''>
                 <roles>raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CCO:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Guillotine' unitType='Mek'>
-			<availability>IS:3+,LA:4+,FWL:4+,DC:4+,CC:4+,CS:6,CLAN:5,CHH:7,CSR:7,Periphery:3+,HL:2+,NIOPS:7,Periphery.Deep:1+</availability>
+			<availability>IS:3+,LA:4+,FWL:4+,DC:4+,CC:4+,CS:6,CHH!Second Line:1,CSR!Second Line:1,Periphery:3+,HL:2+,NIOPS:7,Periphery.Deep:1+</availability>
 			<model name='GLT-3N'>
 				<roles>raider</roles>
-				<availability>CS:8,CLAN:8,NIOPS:8,BAN:8</availability>
+				<availability>CS:8,CHH:8,CSR:8,NIOPS:8</availability>
 			</model>
 			<model name='GLT-4L'>
 				<roles>raider</roles>
@@ -3325,11 +3320,11 @@
             </model>
         </chassis>
 		<chassis name='Helepolis' unitType='Mek'>
-			<availability>CLAN:1</availability>
+            <availability>CHH:1-</availability>
 			<model name='HEP-3H'>
 				<roles>mixed_artillery</roles>
 				<deployedWith>Helepolis</deployedWith>
-				<availability>CLAN:8</availability>
+                <availability>CHH:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hellcat II' unitType='AeroSpaceFighter'>
@@ -4023,18 +4018,18 @@
 			</model>
 		</chassis>
 		<chassis name='Lancelot' unitType='Mek'>
-			<availability>DC:2+,CS:7,CLAN:5,CFM:6,CIH:6,CGS:6,TC:1+,MOC:1+,OA:1+,CIR:1+,NIOPS:6,BAN:6</availability>
+			<availability>DC:2+,CS:7,CLAN!Front Line:2!Second Line:1,CBS:3+,CB!Front Line:3!Second Line:2!Solahma:1,CCC:4+,CCO!Second Line:1,CFM:4+,CGB:3+,CGS:3+,CIH:4+,CSV!Front Line:3!Second Line:2!Solahma:1,CW!Front Line:1!Second Line:2,TC:1+,MOC:1+,OA:1+,CIR:1+,NIOPS:6,BAN:0</availability>
 			<model name='C'>
                 <roles>cavalry,anti_aircraft</roles>
-				<availability>CIH:4,CB:6,CGB:4</availability>
+				<availability>CB:3+,CFM:3+,CGB:3+,CIH!Keshik:8!Front Line:8!Second Line:5</availability>
 			</model>
 			<model name='C 2'>
                 <roles>cavalry,anti_aircraft</roles>
-				<availability>CIH:3,CB:4</availability>
+				<availability>CB:2+,CFM:4+,CIH!Keshik:5!Front Line:3!Second Line:1</availability>
 			</model>
 			<model name='LNC25-01'>
 				<roles>cavalry,anti_aircraft</roles>
-				<availability>CS:8,CLAN:8,NIOPS:8,BAN:6</availability>
+				<availability>CS:8,CLAN:8,CB:3-,CFM:4-,CGB:4-,CIH:3-,NIOPS:8</availability>
 			</model>
 			<model name='LNC25-02'>
 				<roles>anti_aircraft,fire_support</roles>
@@ -4178,16 +4173,16 @@
 			</model>
 		</chassis>
 		<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
-			<availability>CHH:8,CLAN:5</availability>
+			<availability>CLAN:1+:2928,CHH!Keshik:3,CGB:1+:2927,CJF:1+:2927</availability>
 			<model name='A'>
 				<roles>fire_support</roles>
-				<availability>General:7,CGB:8</availability>
+				<availability>CLAN:6</availability>
 			</model>
 			<model name='B'>
-				<availability>CHH:6,CDS:6,CW:4,General:5,CJF:7,CGB:5</availability>
+				<availability>CLAN:4</availability>
 			</model>
 			<model name='Prime'>
-				<availability>General:8,CJF:9,CGB:9</availability>
+				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Lola III Destroyer' unitType='Warship'>
@@ -4262,12 +4257,12 @@
 			</model>
 		</chassis>
 		<chassis name='Lupus' unitType='Mek' omni='Clan'>
-			<availability>CDS:3,CBS:4,CSV:4,CLAN:3,CCO:8,CGS:4</availability>
+			<availability>CLAN!Keshik:3!Front Line:1,CBS:2+,CB!Keshik:5!Front Line:2,CCC!Keshik:4!Front Line:2,CCO!Keshik:4!Front Line:2,CFM!Keshik:4!Front Line:1,CGB:3+,CGS:2+,CHH:2+,CJF!Front Line:2!Second Line:1,CNC:3+,CSR!Keshik:4!Front Line:2!Second Line:1,CSA:3+,CSV:3+,CW!Keshik:1!Front Line:2,BAN:0</availability>
 			<model name='A'>
 				<availability>CLAN:6</availability>
 			</model>
 			<model name='B'>
-				<availability>CLAN:6</availability>
+				<availability>CLAN:4+</availability>
 			</model>
 			<model name='Prime'>
 				<roles>fire_support</roles>
@@ -4308,21 +4303,21 @@
             </model>
 		</chassis>
 		<chassis name='Mad Cat (Timber Wolf)' unitType='Mek' omni='Clan'>
-			<availability>CW:8</availability>
+			<availability>CGB:1+:2949,CJF:1+:2949,CSJ:1+:2949,CW!Keshik:3</availability>
 			<model name='A'>
-				<availability>CDS:8,CW:6,General:7,CJF:8,CGB:8</availability>
+				<availability>CGB:4+,CJF:4+,CSJ:4+,CW:4+</availability>
 			</model>
 			<model name='B'>
-				<availability>CHH:7,CDS:7,CW:5,General:6,CJF:7,CGB:7</availability>
+				<availability>CGB:3,CJF:3,CSJ:3,CW:3</availability>
 			</model>
 			<model name='C'>
-				<availability>CW:4,General:5,CJF:6,CGB:5</availability>
+				<availability>CGB:6,CJF:6,CSJ:6,CW:6</availability>
 			</model>
 			<model name='D'>
-				<availability>CIH:5,CW:2,CSV:3,CNC:3,General:4,CSJ:3,CB:5</availability>
+				<availability>CGB:3,CJF:3,CSJ:3,CW:3</availability>
 			</model>
 			<model name='Prime'>
-				<availability>CSA:8,CCC:8,CDS:9,CSV:8,CNC:8,General:8,CGS:8,CCO:8,CJF:9,CGB:9</availability>
+				<availability>CGB:8,CJF:8,CSJ:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Magi Infantry Support Vehicle' unitType='Tank'>
@@ -4390,18 +4385,18 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
-			<availability>IS:4+,FWL:3+,MERC:3+,CS:8,CLAN:5,Periphery:1+,TC:3+,NIOPS:8,HL:1+,Periphery.Deep:0</availability>
+			<availability>IS:4+,FWL:3+,MERC:3+,CS:8,CLAN!Front Line:3!Second Line:2!Solahma:1,CBS:4+,CGS:4+,CIH:3+,Periphery:1+,TC:3+,NIOPS:8,HL:1+,Periphery.Deep:0,BAN:2+</availability>
             <model name='C'>
                 <roles>command</roles>
-                <availability>CLAN:2</availability>
+                <availability>CLAN:4+,CBS!Keshik:8,CB:3+,CFM:3+,CGS:3+,CHH:2+,CIH:2+,BAN:0</availability>
             </model>
 			<model name='MAD-1R'>
                 <roles>command</roles>
-				<availability>CS:8+,CLAN:3,NIOPS:8,BAN:4</availability>
+				<availability>CS:8+,CLAN:2-,NIOPS:8,BAN:2+</availability>
 			</model>
 			<model name='MAD-2R'>
                 <roles>command</roles>
-				<availability>CLAN:5,CGS:6,BAN:5</availability>
+				<availability>CLAN:5,CCO:4,CGB:4,CHH:4,CJF:4,CW:4,BAN:0</availability>
 			</model>
 			<model name='MAD-3D'>
                 <roles>command</roles>
@@ -4417,7 +4412,7 @@
 			</model>
 			<model name='MAD-3R'>
                 <roles>command</roles>
-				<availability>IS:8,FS:6,FWL:4,CC:6,CS:4,Periphery:8,HL:8,NIOPS:6</availability>
+				<availability>IS:8,FS:6,FWL:4,CC:6,CS:4,Periphery:8,HL:8,NIOPS:6,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Marksman Artillery Vehicle' unitType='Tank'>
@@ -4443,15 +4438,15 @@
 			</model>
 		</chassis>
 		<chassis name='Masauwu' unitType='Mek'>
-			<availability>CSA:4,CCO:6</availability>
+			<availability>CCO!Second Line:1,CSA!Front Line:3!Second Line:2!Solahma:1</availability>
             <model name=''>
-                <availability>General:8</availability>
+                <availability>CCO:8,CSA:8</availability>
             </model>
 		</chassis>
 		<chassis name='Matador' unitType='Mek'>
-			<availability>CSV:6</availability>
+			<availability>CSV!Front Line:3!Second Line:2!Solahma:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CSV:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Maultier Hover APC' unitType='Tank'>
@@ -4765,10 +4760,10 @@
 			</model>
 		</chassis>
 		<chassis name='Minsk' unitType='Mek'>
-			<availability>CGB:4-</availability>
+			<availability>CGB!Second Line:1!Solahma:1,CJF!Front Line:1,CW!Second Line:1</availability>
             <model name=''>
                 <roles>command</roles>
-                <availability>CLAN:8</availability>
+                <availability>CGB:8,CJF:8,CW:8</availability>
             </model>
 		</chassis>
 		<chassis name='Mithras Light Tank' unitType='Tank'>
@@ -5155,13 +5150,13 @@
 			</model>
 		</chassis>
 		<chassis name='Orion IIC' unitType='Mek'>
-			<availability>CW:4</availability>
+			<availability>CW:1+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Orion' unitType='Mek'>
-			<availability>IS:3+,FWL:7+,CC:4+,MERC:4+,CS!C:5!D:3!F:3,CLAN:3-,CW:4,Periphery:4+,Periphery.MW:5,Periphery.ME:5,MOC:5+,OA:3+,CIR:4+,NIOPS:5-,HL:2,Periphery.Deep:3</availability>
+			<availability>IS:3+,FWL:7+,CC:4+,MERC:4+,CS!C:5!D:3!F:3,CLAN!Front Line:2!Second Line:1,CBS:3+,CCO!Second Line:1,CFM!Second Line:1,CGB!Second Line:1,CIH:2+,CJF!Second Line:2!Solahma:1,CW!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,Periphery:4+,Periphery.MW:5,Periphery.ME:5,MOC:5+,OA:3+,CIR:4+,NIOPS:5-,HL:2,Periphery.Deep:3,BAN:2</availability>
             <model name='ON1-C'>
                 <availability>Periphery.CM:1-,Periphery.MW:2-,Periphery.ME:2-,HL:5-,Periphery.Deep:8</availability>
             </model>
@@ -5169,8 +5164,11 @@
                 <availability>Periphery.CM:2-,Periphery.MW:3-,Periphery.ME:3-,HL:6-,Periphery.Deep:5</availability>
             </model>
 			<model name='ON1-K'>
-				<availability>IS:7,FWL:8,CC:8,MERC:8,CS:8,CLAN:8,Periphery:8,Periphery.MW:4+,Periphery.ME:4+,HL:6,Periphery.Deep:1+</availability>
+				<availability>IS:7,FWL:8,CC:8,MERC:8,CS:8,Periphery:8,Periphery.MW:4+,Periphery.ME:4+,HL:6,Periphery.Deep:1+,BAN:8</availability>
 			</model>
+            <model name='ON1-Kb'>
+                <availability>CLAN:8,BAN:0</availability>
+            </model>
 			<model name='ON1-V'>
 				<availability>IS:6,FWL:5,MH:3,TC:3</availability>
 			</model>
@@ -5189,14 +5187,14 @@
 			</model>
 		</chassis>
 		<chassis name='Ostroc' unitType='Mek'>
-			<availability>IS:5,CS!F:6!D:5!C:4,CLAN:3-,Periphery:4,NIOPS:4-,HL:2,Periphery.Deep:2+,PIR:5</availability>
+			<availability>IS:5,CS!F:6!D:5!C:4,CLAN:4-,CBS:4,CB:3,CCC!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:3,CGS:3,CHH:4,CIH!Keshik:5!Front Line:5!Second Line:5!Solahma:4!Provisional Garrison:4,Periphery:4,NIOPS:4-,HL:2,Periphery.Deep:2+,BAN:6,PIR:5</availability>
 			<model name='OSR-2C'>
 				<roles>urban</roles>
-				<availability>IS:8,CLAN:2,Periphery:8,HL:6,Periphery.Deep:8,BAN:4</availability>
+				<availability>IS:8,Periphery:8,HL:6,Periphery.Deep:8,BAN:4-</availability>
 			</model>
 			<model name='OSR-2Cb'>
 				<roles>urban</roles>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CLAN:8,BAN:3</availability>
 			</model>
 			<model name='OSR-2L'>
 				<availability>IS:6,Periphery:6</availability>
@@ -5223,10 +5221,10 @@
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
-			<availability>IS:4,CS:2,Periphery:3,NIOPS:6-,HL:1,Periphery.Deep:1+,BAN:2,PIR:4</availability>
+			<availability>IS:4,CS:2,Periphery:3,NIOPS:6-,HL:1,Periphery.Deep:1+,BAN:2-,PIR:4</availability>
 			<model name='OTL-4D'>
                 <roles>raider</roles>
-				<availability>IS:8,Periphery:8,HL:8,BAN:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8,HL:8,BAN:8</availability>
 			</model>
 			<model name='OTL-4F'>
 				<availability>FS:3+</availability>
@@ -5616,10 +5614,10 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman IIC' unitType='Mek'>
-			<availability>CLAN:5</availability>
+			<availability>CGB!Front Line:1,CNC!Front Line:1,CDS!Front Line:1,CSR!Front Line:1,CW!Front Line:1!Second Line:1</availability>
 			<model name=''>
                 <roles>fire_support,anti_aircraft</roles>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CNC:8,CDS:8,CSR:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Rifleman II' unitType='Mek'>
@@ -5630,10 +5628,10 @@
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
-			<availability>IS:4,CLAN:2,Periphery:5,NIOPS:6-,CIR:2,HL:3,Periphery.Deep:3+</availability>
+			<availability>IS:4,CLAN!Second Line:1,CBS!Front Line:1,CB!Front Line:1,CCC!Front Line:1,CCO!Solahma:1,CW!Solahma:1,Periphery:5,NIOPS:6-,CIR:2,HL:3,Periphery.Deep:3+,BAN:3-</availability>
             <model name='C'>
                 <roles>fire_support,anti_aircraft</roles>
-                <availability>CLAN:8,BAN:4</availability>
+                <availability>CLAN:8,BAN:3+</availability>
             </model>
             <model name='RFL-1N'>
                 <roles>anti_aircraft</roles>
@@ -5645,7 +5643,7 @@
             </model>
 			<model name='RFL-3N'>
 				<roles>fire_support,anti_aircraft</roles>
-				<availability>IS:8,CLAN:3-,Periphery:8,HL:8,Periphery.Deep:8,BAN:4</availability>
+				<availability>IS:8,MERC:8,Periphery:8,HL:8,Periphery.Deep:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Riga II Destroyer-Carrier' unitType='Warship'>
@@ -6013,7 +6011,7 @@
 			</model>
 		</chassis>
 		<chassis name='Shootist' unitType='Mek'>
-			<availability>CS:5,CLAN:4,NIOPS:5</availability>
+			<availability>CS:5,CLAN!Front Line:2!Second Line:1,CBS:2+,CB!Front Line:3!Second Line:2!Solahma:1,CCC!Second Line:1,CFM!Second Line:2!Solahma:1,CIH!Second Line:2!Solahma:1,CW!Second Line:2!Solahma:1,NIOPS:5,BAN:0</availability>
 			<model name='ST-8A'>
                 <roles>command</roles>
 				<availability>CS:8,CLAN:8,NIOPS:8</availability>
@@ -6162,6 +6160,15 @@
 				<availability>IS:8,DC:7,Periphery:8,HL:8</availability>
 			</model>
 		</chassis>
+        <chassis name='Spirit Walker' unitType='Mek' omni='Clan'>
+            <availability>CBS:1+,CB:1+,CCC:1+,CCO:2+,CFM:2+,CGS:2+,CHH!Front Line:1,CJF!Front Line:1,CNC:2+,CSJ:2+,CSR!Front Line:1,CSA:1+</availability>
+            <model name='A'>
+                <availability>CLAN:3+,CGS:4+</availability>
+            </model>
+            <model name='Prime'>
+                <availability>CLAN:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Stalker' unitType='Mek'>
 			<availability>CC:7,HL:8,CLAN:5,IS:9,Periphery.Deep:9,FS:7,Periphery:10,CS:6,LA:9,FWL:10,NIOPS:6,DC:7</availability>
 			<model name='STK-3F'>
@@ -6353,21 +6360,24 @@
 			</model>
 		</chassis>
 		<chassis name='Thor (Summoner)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7,CIH:4,CLAN:6,CCO:7,BAN:5,CDS:7,CW:7,CSJ:7,CJF:10,CGB:7,CB:5</availability>
+			<availability>CFM:1+,CHH:2+,CJF!Keshik:3!Front Line:1</availability>
+            <model name='A'>
+                <availability>CFM:4,CHH:4,CJF:4</availability>
+            </model>
 			<model name='B'>
 				<roles>fire_support</roles>
-				<availability>CDS:4,CNC:5,CLAN:6,CJF:7,CGB:4</availability>
+				<availability>CFM:5,CHH:5,CJF:5</availability>
 			</model>
 			<model name='C'>
-				<availability>CLAN:5,CJF:6,CGB:4</availability>
+				<availability>CFM:3+,CHH:3+,CJF:3+</availability>
 			</model>
 			<model name='D'>
                 <roles>raider</roles>
-				<availability>CNC:6,CLAN:5,CSJ:3,CGS:4,CGB:4</availability>
+				<availability>CFM:6,CHH:6,CJF:6</availability>
 			</model>
 			<model name='Prime'>
 				<roles>raider</roles>
-				<availability>CDS:9,CLAN:8,CJF:9</availability>
+				<availability>CFM:8,CHH:8,CJF:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thor Artillery Vehicle' unitType='Tank'>
@@ -6391,13 +6401,13 @@
 			</model>
 		</chassis>
 		<chassis name='Thresher' unitType='Mek'>
-			<availability>CHH:6,CDS:4,CSR:4,CLAN:4</availability>
+			<availability>CHH:4+,CDS!Keshik:4!Front Line:2!Second Line:1</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CHH:8,CDS:8</availability>
 			</model>
 			<model name='2'>
 				<roles>fire_support</roles>
-				<availability>CHH:4</availability>
+				<availability>CHH:5</availability>
 			</model>
 		</chassis>
 		<chassis name='Thrush' unitType='AeroSpaceFighter'>
@@ -6458,15 +6468,15 @@
 			</model>
 		</chassis>
 		<chassis name='Thunderbolt' unitType='Mek'>
-			<availability>IS:5+,LA:7+,FWL:4+,DC:4+,CC:7+,MERC:8+,CS!C:6!D:5!F:5,CLAN:4-,Periphery:4+,Periphery.R:5+,TC:5+,NIOPS:5-,HL:4+,Periphery.Deep:2+</availability>
+			<availability>IS:5+,LA:7+,FWL:4+,DC:4+,CC:7+,MERC:8+,CS!C:6!D:5!F:5,CLAN:4,CBS:5,CB!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CCO!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:3,CFM!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:3,CGB!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,CGS!Keshik:5!Front Line:5!Second Line:4!Solahma:4!Provisional Garrison:4,CSJ:5,CSA:5,CW:5,Periphery:4+,Periphery.R:5+,TC:5+,NIOPS:5-,HL:4+,Periphery.Deep:2+,BAN:5</availability>
 			<model name='C'>
-				<availability>CLAN:1</availability>
+				<availability>CLAN:2+,CBS!Keshik:6!Front Line:1,CB:3+,CCC:3+,CCO:3+,CFM!Keshik:3!Front Line:1,CGS:1+,CHH:3+,CJF:3+,CNC:3+,CSA:3+,CW:3+,BAN:0</availability>
 			</model>
 			<model name='TDR-5D'>
 				<availability>FS:3,MERC:3</availability>
 			</model>
 			<model name='TDR-5S'>
-				<availability>IS:8,LA:6,Periphery:8,HL:8,BAN:3</availability>
+				<availability>IS:8,LA:6,Periphery:8,HL:8,BAN:6-</availability>
 			</model>
 			<model name='TDR-5SE'>
 				<availability>MERC.ELH:8,MERC:5+</availability>
@@ -6475,7 +6485,7 @@
 				<availability>LA:7+</availability>
 			</model>
 			<model name='TDR-5Sb'>
-				<availability>CLAN:4-,BAN:3</availability>
+				<availability>CLAN:4,CB:4-,CIH:4-,CJF:4-,BAN:5</availability>
 			</model>
 		</chassis>
 		<chassis name='Tigress Close Patrol Craft' unitType='Small Craft'>
@@ -6842,9 +6852,12 @@
 			</model>
 		</chassis>
 		<chassis name='Vision Quest' unitType='Mek'>
-			<availability>CSR:3,CNC:8,CB:3</availability>
-			<model name='2'>
-				<availability>CSR:8,CNC:8</availability>
+			<availability>CB!Keshik:1!Front Line:3!Second Line:1,CNC!Keshik:1!Front Line:3!Second Line:2!Solahma:1,CSR:1+</availability>
+            <model name=''>
+                <availability>CB:8,CNC:8</availability>
+            </model>
+            <model name='2'>
+				<availability>CNC:1+,CSR:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Volga Transport' unitType='Warship'>
@@ -6918,9 +6931,12 @@
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>
-			<availability>IS:5,FS:6,LA:5,FWL:5,DC:6,CC:5,MERC:5,CS!A:3!B:4!C:4!D:5!F:5,CLAN:4,Periphery:5+,NIOPS:6-,HL:3+,Periphery.Deep:2+,PIR:5</availability>
-			<model name='C 3'>
-				<availability>CLAN:4</availability>
+			<availability>IS:5,FS:6,LA:5,FWL:5,DC:6,CC:5,MERC:5,CS!A:3!B:4!C:4!D:5!F:5,CLAN:5+,CBS:6+,CCO!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CGB!Keshik:5!Front Line:5!Second Line:4!Solahma:3!Provisional Garrison:2,CIH:3-,CJF!Keshik:4!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CW!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,Periphery:5+,NIOPS:6-,HL:3+,Periphery.Deep:2+,BAN:5+,PIR:5</availability>
+            <model name='C'>
+                <availability>CLAN:3+,CBS!Keshik:3!Front Line:1,CB:2+,CGB!Keshik:1!Front Line:1!Second Line:1,CSJ:2+,CW:4+,BAN:0</availability>
+            </model>
+            <model name='C 3'>
+				<availability>CGB:3+</availability>
 			</model>
 			<model name='WHM-6D'>
 				<availability>FS:7+,Periphery.HR:3+,PIR:0</availability>
@@ -6932,13 +6948,13 @@
 				<availability>CC:8+</availability>
 			</model>
 			<model name='WHM-6R'>
-				<availability>IS:8,FS:6,DC:6,CC:7,Periphery:8,CLAN:1-,HL:8,Periphery.Deep:8,BAN:8</availability>
+				<availability>IS:8,FS:6,DC:6,CC:7,Periphery:8,CSJ:1-,HL:8,Periphery.Deep:8,BAN:6-</availability>
 			</model>
 			<model name='WHM-6Rb'>
-				<availability>CLAN:4,BAN:4</availability>
+				<availability>CLAN:3-,CBS:4-,BAN:5</availability>
 			</model>
 			<model name='WHM-7A'>
-				<availability>CLAN:3</availability>
+				<availability>CLAN!Second Line:2,CBS:3+,CB!Front Line:2!Second Line:1,CIH:4+,BAN:0</availability>
 			</model>
 		</chassis>
 		<chassis name='Wasp LAM' unitType='Mek'>
@@ -7049,12 +7065,15 @@
 			</model>
 		</chassis>
 		<chassis name='Woodsman' unitType='Mek' omni='Clan'>
-			<availability>CW:8</availability>
+			<availability>CW!Keshik:5!Front Line:3</availability>
 			<model name='A'>
-				<availability>General:6</availability>
+				<availability>CW:4+</availability>
+			</model>
+            <model name='B'>
+                <availability>CW:3+</availability>
 			</model>
 			<model name='Prime'>
-				<availability>General:8</availability>
+				<availability>CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Wyvern IIC' unitType='Mek'>

--- a/megamek/data/forcegenerator/2900.xml
+++ b/megamek/data/forcegenerator/2900.xml
@@ -6,9 +6,9 @@
 >
 	<factions>
 		<faction key='BAN'>
-			<pctOmni>0,0</pctOmni>
-			<pctClan>5,5</pctClan>
-			<pctSL>85,85</pctSL>
+            <!-- Omni percentages: 0,0 -->
+            <!-- Clan percentages: 5,5 -->
+            <!-- Star League percentages: 85,85 -->
 			<salvage pct='10'>CCC:2,CHH:2,CSR:2,CIH:2,CSV:2,CFM:2,CCO:2,CGS:2,CSA:2,CDS:2,CW:2,CBS:1,CNC:2,CSJ:2,CJF:2,CGB:2,CB:5</salvage>
 		</faction>
 		<faction key='BoS'>
@@ -32,17 +32,17 @@
 			<weightDistribution era='2900' unitType='AeroSpaceFighter'>1,1,1</weightDistribution>
 		</faction>
 		<faction key='CBS'>
-			<pctOmni>0,0,0,5,10</pctOmni>
-			<pctClan>0,0,0,10,40</pctClan>
-			<pctSL>100,100,100,90,60</pctSL>
+            <!-- Omni percentages: 0,0,0,5,10 -->
+            <!-- Clan percentages: 0,0,0,10,40 -->
+            <!-- Star League percentages: 100,100,100,90,60 -->
 			<pctClan unitType='Vehicle'>0,0,0,10,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,100,90,80</pctSL>
 			<salvage pct='5'>CHH:5,CCC:5,CSR:3,CIH:10,CSV:10,CFM:10,CCO:5,CDS:1,CW:5,CNC:10,CSJ:10,CJF:10,CB:10</salvage>
 		</faction>
 		<faction key='CB'>
-			<pctOmni>0,0,0,30,50</pctOmni>
-			<pctClan>0,0,0,40,80</pctClan>
-			<pctSL>100,100,100,60,20</pctSL>
+            <!-- Omni percentages: 0,0,0,30,50 -->
+            <!-- Clan percentages: 0,0,0,40,80 -->
+            <!-- Star League percentages: 100,100,100,60,20 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CCC:1,CHH:5,CSR:6,CIH:4,CSV:3,CFM:3,CCO:5,CGS:3,CSA:4,CDS:4,CW:4,CBS:3,CNC:10,CSJ:1,CJF:4</salvage>
@@ -50,17 +50,17 @@
 			<weightDistribution era='2900' unitType='Tank'>4,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CCC'>
-			<pctOmni>0,0,0,40,50</pctOmni>
-			<pctClan>0,0,20,50,60</pctClan>
-			<pctSL>100,100,80,50,40</pctSL>
+            <!-- Omni percentages: 0,0,0,40,50 -->
+            <!-- Clan percentages: 0,0,20,50,60 -->
+            <!-- Star League percentages: 100,100,80,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CHH:2,CSR:3,CIH:3,CSV:3,CFM:3,CCO:7,CGS:2,CSA:7,CDS:1,CW:7,CBS:2,CNC:10,CJF:5,CGB:2,CB:3</salvage>
 		</faction>
 		<faction key='CCO'>
-			<pctOmni>4,4,5,50,60</pctOmni>
-			<pctClan>15,15,15,50,60</pctClan>
-			<pctSL>85,85,85,50,40</pctSL>
+            <!-- Omni percentages: 4,4,5,50,60 -->
+            <!-- Clan percentages: 15,15,15,50,60 -->
+            <!-- Star League percentages: 85,85,85,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CHH:1,CCC:3,CIH:2,CSR:5,CSV:3,CFM:2,CGS:1,CSA:3,CDS:1,CW:1,CBS:1,CNC:10,CSJ:3,CJF:10,CB:7</salvage>
@@ -68,17 +68,17 @@
 			<weightDistribution era='2900' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CFM'>
-			<pctOmni>0,0,0,20,50</pctOmni>
-			<pctClan>0,5,10,50,60</pctClan>
-			<pctSL>100,100,90,50,40</pctSL>
+            <!-- Omni percentages: 0,0,0,20,50 -->
+            <!-- Clan percentages: 0,5,10,50,60 -->
+            <!-- Star League percentages: 100,100,90,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CCC:5,CHH:10,CSR:10,CIH:10,CSV:4,CCO:5,CGS:5,CSA:10,CDS:5,CW:5,CBS:5,CNC:10,CSJ:10,CJF:10,CGB:1,CB:5</salvage>
 		</faction>
 		<faction key='CGB'>
-			<pctOmni>0,0,10,40,50</pctOmni>
-			<pctClan>20,20,40,50,60</pctClan>
-			<pctSL>80,80,60,50,40</pctSL>
+            <!-- Omni percentages: 0,0,10,40,50 -->
+            <!-- Clan percentages: 20,20,40,50,60 -->
+            <!-- Star League percentages: 80,80,60,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CSA:10,CHH:10,CCC:3,CIH:5,CSR:1,CDS:1,CW:10,CSV:10,CFM:3,CGS:1,CCO:1,CJF:5</salvage>
@@ -86,25 +86,25 @@
 			<weightDistribution era='2900' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CGS'>
-			<pctOmni>0,0,0,10,30</pctOmni>
-			<pctClan>0,0,20,30,40</pctClan>
-			<pctSL>100,100,80,70,60</pctSL>
+            <!-- Omni percentages: 0,0,0,10,30 -->
+            <!-- Clan percentages: 0,0,20,30,40 -->
+            <!-- Star League percentages: 100,100,80,70,60 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CCC:1,CHH:4,CSR:1,CIH:5,CSV:4,CFM:10,CCO:1,CSA:8,CDS:4,CW:3,CNC:10,CSJ:1,CJF:5,CB:5</salvage>
 		</faction>
 		<faction key='CHH'>
-			<pctOmni>0,0,0,30,40</pctOmni>
-			<pctClan>0,0,25,40,60</pctClan>
-			<pctSL>100,100,75,60,40</pctSL>
+            <!-- Omni percentages: 0,0,0,30,40 -->
+            <!-- Clan percentages: 0,0,25,40,60 -->
+            <!-- Star League percentages: 100,100,75,60,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,30,40</pctClan>
 			<pctSL unitType='Vehicle'>100,100,70,70,60</pctSL>
 			<salvage pct='10'>CCC:2,CSR:3,CIH:5,CSV:3,CFM:10,CCO:2,CGS:5,CSA:5,CDS:8,CW:1,CBS:2,CNC:10,CSJ:5,CJF:8,CGB:7,CB:7</salvage>
 		</faction>
 		<faction key='CIH'>
-			<pctOmni>0,0,0,40,50</pctOmni>
-			<pctClan>0,0,20,50,60</pctClan>
-			<pctSL>100,100,80,50,40</pctSL>
+            <!-- Omni percentages: 0,0,0,40,50 -->
+            <!-- Clan percentages: 0,0,20,50,60 -->
+            <!-- Star League percentages: 100,100,80,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CCC:2,CHH:3,CSR:3,CSV:3,CFM:7,CCO:3,CGS:3,CSA:3,CDS:5,CW:10,CBS:3,CNC:7,CSJ:3,CJF:3,CGB:2,CB:7</salvage>
@@ -112,49 +112,49 @@
 			<weightDistribution era='2900' unitType='Tank'>5,2,3,1</weightDistribution>
 		</faction>
 		<faction key='CJF'>
-			<pctOmni>0,0,20,40,50</pctOmni>
-			<pctClan>10,10,30,50,60</pctClan>
-			<pctSL>90,90,70,50,40</pctSL>
+            <!-- Omni percentages: 0,0,20,40,50 -->
+            <!-- Clan percentages: 10,10,30,50,60 -->
+            <!-- Star League percentages: 90,90,70,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,10,10,10</pctClan>
 			<pctSL unitType='Vehicle'>100,100,90,90,90</pctSL>
 			<salvage pct='10'>CCC:2,CHH:3,CSR:10,CIH:5,CSV:10,CFM:10,CCO:4,CGS:5,CSA:5,CDS:3,CW:10,CBS:5,CNC:2,CSJ:5,CGB:1,CB:2</salvage>
 		</faction>
 		<faction key='CNC'>
-			<pctOmni>0,0,10,30,50</pctOmni>
-			<pctClan>0,0,20,50,60</pctClan>
-			<pctSL>100,100,80,50,40</pctSL>
+            <!-- Omni percentages: 0,0,10,30,50 -->
+            <!-- Clan percentages: 0,0,20,50,60 -->
+            <!-- Star League percentages: 100,100,80,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CCC:5,CHH:8,CSR:10,CIH:3,CSV:1,CFM:3,CCO:10,CGS:3,CSA:5,CDS:2,CW:3,CBS:3,CSJ:2,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CDS'>
-			<pctOmni>0,0,0,50,60</pctOmni>
-			<pctClan>0,0,25,50,60</pctClan>
-			<pctSL>100,100,75,50,40</pctSL>
+            <!-- Omni percentages: 0,0,0,50,60 -->
+            <!-- Clan percentages: 0,0,25,50,60 -->
+            <!-- Star League percentages: 100,100,75,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='12'>CCC:1,CHH:5,CSR:10,CIH:6,CSV:5,CFM:5,CCO:4,CGS:3,CSA:5,CW:3,CNC:5,CSJ:5,CJF:5,CB:10</salvage>
 		</faction>
 		<faction key='CSJ'>
-			<pctOmni>0,0,10,30,50</pctOmni>
-			<pctClan>0,0,20,50,60</pctClan>
-			<pctSL>100,100,80,40,40</pctSL>
+            <!-- Omni percentages: 0,0,10,30,50 -->
+            <!-- Clan percentages: 0,0,20,50,60 -->
+            <!-- Star League percentages: 100,100,80,40,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CHH:5,CSR:2,CIH:7,CSV:3,CFM:7,CCO:10,CGS:2,CSA:2,CDS:5,CW:7,CNC:5,CJF:3,CB:2</salvage>
 		</faction>
 		<faction key='CSR'>
-			<pctOmni>10,10,20,30,50</pctOmni>
-			<pctClan>20,20,30,60,70</pctClan>
-			<pctSL>80,80,70,40,30</pctSL>
+            <!-- Omni percentages: 10,10,20,30,50 -->
+            <!-- Clan percentages: 20,20,30,60,70 -->
+            <!-- Star League percentages: 80,80,70,40,30 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CCC:1,CHH:2,CIH:3,CSV:3,CFM:5,CCO:5,CGS:1,CSA:2,CDS:3,CW:5,CNC:10,CSJ:2,CJF:5,CB:8</salvage>
 		</faction>
 		<faction key='CSA'>
-			<pctOmni>0,0,10,40,50</pctOmni>
-			<pctClan>10,10,30,50,60</pctClan>
-			<pctSL>90,90,70,50,40</pctSL>
+            <!-- Omni percentages: 0,0,10,40,50 -->
+            <!-- Clan percentages: 10,10,30,50,60 -->
+            <!-- Star League percentages: 90,90,70,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,30,30</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,70,70</pctSL>
 			<salvage pct='10'>CCC:7,CHH:2,CSR:3,CIH:3,CSV:3,CFM:7,CCO:7,CGS:4,CDS:3,CW:3,CNC:10,CSJ:1,CJF:3,CGB:3,CB:7</salvage>
@@ -162,17 +162,17 @@
 			<weightDistribution era='2900' unitType='Tank'>3,1,3,2</weightDistribution>
 		</faction>
 		<faction key='CSV'>
-			<pctOmni>0,0,20,40,50</pctOmni>
-			<pctClan>20,20,40,50,60</pctClan>
-			<pctSL>80,80,60,50,40</pctSL>
+            <!-- Omni percentages: 0,0,20,40,50 -->
+            <!-- Clan percentages: 20,20,40,50,60 -->
+            <!-- Star League percentages: 80,80,60,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CCC:1,CHH:1,CSR:3,CIH:4,CFM:4,CCO:1,CGS:2,CSA:6,CDS:4,CW:5,CBS:1,CNC:1,CSJ:1,CJF:10,CGB:3,CB:1</salvage>
 		</faction>
 		<faction key='CW'>
-			<pctOmni>0,0,0,40,50</pctOmni>
-			<pctClan>5,5,20,50,60</pctClan>
-			<pctSL>95,95,80,50,40</pctSL>
+            <!-- Omni percentages: 0,0,0,40,50 -->
+            <!-- Clan percentages: 5,5,20,50,60 -->
+            <!-- Star League percentages: 95,95,80,50,40 -->
 			<pctClan unitType='Vehicle'>0,0,20,20,20</pctClan>
 			<pctSL unitType='Vehicle'>100,100,80,80,80</pctSL>
 			<salvage pct='10'>CHH:1,CCC:2,CIH:10,CSR:10,CSV:3,CFM:3,CGS:2,CSA:3,CDS:2,CNC:7,CSJ:7,CJF:7,CGB:2,CB:3</salvage>

--- a/megamek/data/forcegenerator/2900.xml
+++ b/megamek/data/forcegenerator/2900.xml
@@ -909,15 +909,15 @@
 			</model>
 		</chassis>
 		<chassis name='Battle Cobra' unitType='Mek' omni='Clan'>
-			<availability>CCC:5,CBS:5,CSV:6,CGS:5</availability>
+			<availability>CSV:2+,CCC:1+,CFM:1+,CJF:1+,CSR:1+</availability>
 			<model name='A'>
-				<availability>General:6</availability>
+				<availability>CLAN:5</availability>
 			</model>
 			<model name='B'>
-				<availability>CBS:8,General:6</availability>
+				<availability>CLAN:4+</availability>
 			</model>
 			<model name='Prime'>
-				<availability>General:8</availability>
+				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
@@ -985,22 +985,22 @@
 			</model>
 		</chassis>
 		<chassis name='Black Hawk (Nova)' unitType='Mek' omni='Clan'>
-			<availability>CHH:8,CLAN:5,CFM:7,CGS:7,CCO:7,BAN:5,CSA:7,CDS:7,CW:7,CBS:4,CJF:7,CGB:7</availability>
+			<availability>CFM:1+,CGB:1+,CHH:2+,CSA!Keshik:2</availability>
 			<model name='A'>
-				<availability>CDS:8,CNC:8,General:7,CJF:9,CGB:8</availability>
+				<availability>CFM:4+,CGB:4+,CHH:4+,CSA:4+</availability>
 			</model>
 			<model name='B'>
-				<availability>CW:5,CNC:7,General:6,CJF:8,CGB:6</availability>
+				<availability>CFM:5,CGB:5,CHH:5,CSA:5</availability>
 			</model>
 			<model name='C'>
-				<availability>CHH:6,CW:3,CSV:4,General:5,CSJ:4,CJF:6</availability>
+				<availability>CFM:4,CGB:4,CHH:4,CSA:4</availability>
 			</model>
 			<model name='D'>
-				<availability>CHH:6,CW:3,CNC:5,General:4,CJF:6</availability>
+				<availability>CFM:6,CGB:6,CHH:6,CSA:6</availability>
 			</model>
 			<model name='Prime'>
                 <roles>raider</roles>
-				<availability>CW:7,CSV:7,General:6,CJF:8,CGB:7</availability>
+				<availability>CFM:8,CGB:8,CHH:8,CSA:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Black Knight' unitType='Mek'>
@@ -1788,9 +1788,9 @@
             </model>
         </chassis>
 		<chassis name='Clint IIC' unitType='Mek'>
-			<availability>CSR:6</availability>
+			<availability>CSR:3+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CSR:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Clint' unitType='Mek'>
@@ -1944,9 +1944,9 @@
 			</model>
 		</chassis>
 		<chassis name='Corvis' unitType='Mek'>
-			<availability>CHH:4,CLAN:3</availability>
+			<availability>CGB!Second Line:1!Solahma:1,CHH!Front Line:4!Second Line:2</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CHH:8</availability>
 			</model>
 		</chassis>
         <chassis name='Corx Mobile Tunnel Miner' unitType='Tank'>
@@ -1957,35 +1957,31 @@
 			</model>
 		</chassis>
 		<chassis name='Coyotl' unitType='Mek' omni='Clan'>
-			<availability>CSA:5,CHH:4,CDS:4,CLAN:4,CFM:5,CCO:8</availability>
+			<availability>CLAN!Keshik:3!Front Line:1,CBS!Front Line:1,CB!Front Line:1,CCC:2+,CCO!Keshik:5!Front Line:3!Second Line:1,CFM:2+,CGS:1+,CHH!Front Line:1,CIH!Keshik:1!Front Line:1,CJF:3+,CNC!Keshik:1!Front Line:1,CSA!Front Line:1,CW:2+,BAN:0</availability>
 			<model name='A'>
                 <roles>raider</roles>
-				<availability>General:6</availability>
+				<availability>CLAN:4+</availability>
 			</model>
 			<model name='B'>
-				<availability>General:6</availability>
+				<availability>CLAN:5</availability>
 			</model>
 			<model name='Prime'>
-				<availability>General:8</availability>
+				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Crab' unitType='Mek'>
-			<availability>IS:3+,FS:4+,LA:4+,MERC:4+,CS!A:8!B:7!C:7!D:7!F:7,CLAN:5,CHH:4,CSR:4,CJF:4,CGB:4,CFM:4,CGS:6,CDS:6,CW:6,CBS:6,Periphery:2+,NIOPS:5,HL:0,Periphery.Deep:0,PIR:2+</availability>
+			<availability>IS:3+,FS:4+,LA:4+,MERC:4+,CS!A:8!B:7!C:7!D:7!F:7,CLAN:4-,CBS:4,CCO:4,CFM:5-,CGB!Keshik:2!Front Line:2!Second Line:2!Solahma:3!Provisional Garrison:4,CGS:5,CIH:3-,CNC:3,CSJ:3,CSR:4,CSV:3,Periphery:2+,NIOPS:5,HL:0,Periphery.Deep:0,BAN!Keshik:6!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,PIR:2+</availability>
 			<model name='CRB-20'>
 				<roles>raider</roles>
-				<availability>IS:8,CS!B:1!C:2!D:3!F:8,Periphery:8,NIOPS:0,PIR:8</availability>
+				<availability>IS:8,CS!B:1!C:2!D:3!F:8,Periphery:8,NIOPS:0,BAN:4-,PIR:8</availability>
 			</model>
 			<model name='CRB-27'>
 				<roles>raider</roles>
-				<availability>CS!A:8!B:7!C:6!D:1,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>CS!A:8!B:7!C:6!D:1,CLAN:4-,CIH:5-,NIOPS:8,BAN:3</availability>
 			</model>
 			<model name='CRB-27b'>
 				<roles>raider</roles>
-				<availability>CS!A:4,CLAN:7,CGS:8,BAN:4</availability>
-			</model>
-			<model name='CRB-27sl'>
-                <roles>raider</roles>
-				<availability>CLAN:2</availability>
+				<availability>CS!A:4,CLAN:5+,CBS:8,BAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
@@ -2199,12 +2195,12 @@
 			</model>
 		</chassis>
 		<chassis name='Dervish' unitType='Mek'>
-			<availability>IS:3+,FS!A:6!B:5!C:1!F:3,MERC:2+,CLAN:1,Periphery:2,Periphery.OS:3,Periphery.HR:3,HL:3,Periphery.Deep:5,PIR:3</availability>
+			<availability>IS:3+,FS!A:6!B:5!C:1!F:3,MERC:2+,Periphery:2,Periphery.OS:3,Periphery.HR:3,HL:3,Periphery.Deep:5,PIR:3</availability>
             <model name='DV-1S'>
                 <availability>FS!F:8,Periphery:2-,TC:1-,HL:5,Periphery.Deep:5,PIR:2-</availability>
             </model>
 			<model name='DV-6M'>
-				<availability>IS:8,FS!A:8!B:8!C:8,CLAN:8,Periphery:4+,HL:3+,Periphery.Deep:2+,PIR:8</availability>
+				<availability>IS:8,FS!A:8!B:8!C:8,Periphery:4+,HL:3+,Periphery.Deep:2+,PIR:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Devil' unitType='Mek'>
@@ -2241,22 +2237,22 @@
 			</model>
 		</chassis>
 		<chassis name='Dragonfly (Viper)' unitType='Mek' omni='Clan'>
-			<availability>CFM:7</availability>
+			<availability>CLAN:1+:2942,CCC:1+:2941,CFM!Keshik:3,CIH:1+:2941,BAN:0</availability>
 			<model name='A'>
-				<availability>CDS:8,General:6,CJF:8,CGB:6</availability>
+				<availability>CLAN:6+</availability>
 			</model>
 			<model name='B'>
-				<availability>CDS:6,CW:5,CSV:5,CNC:5,General:4,CSJ:3,CJF:6,CGB:3</availability>
+				<availability>CLAN:5+,CGS:6+</availability>
 			</model>
 			<model name='C'>
                 <roles>recon,anti_infantry</roles>
-				<availability>CDS:6,CW:5,General:5,CFM:6,CJF:6,CGB:6,CB:6</availability>
+				<availability>CLAN:4-</availability>
 			</model>
 			<model name='D'>
-				<availability>CHH:7,CCC:7,CIH:7,CSR:7,CFM:7,CGS:7,CSA:7,CDS:8,CBS:7,General:6,CJF:8,CGB:7,CB:7</availability>
+				<availability>CLAN:5,CGS:4</availability>
 			</model>
 			<model name='Prime'>
-				<availability>CDS:9,General:8,CJF:9,CGB:9</availability>
+				<availability>CLAN:8,CGS:7</availability>
 			</model>
 		</chassis>
 		<chassis name='Dragonstar Passenger Transport' unitType='Small Craft'>
@@ -2467,21 +2463,21 @@
 			</model>
 		</chassis>
 		<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
-			<availability>CW:6</availability>
+			<availability>CIH!Keshik:3,CW:1+:2949</availability>
 			<model name='A'>
-				<availability>General:6</availability>
+				<availability>CIH:5-,CW:5-</availability>
 			</model>
 			<model name='B'>
-				<availability>General:5</availability>
+				<availability>CIH:6,CW:6</availability>
 			</model>
 			<model name='C'>
-				<availability>General:4</availability>
+				<availability>CIH:5,CW:5</availability>
 			</model>
 			<model name='D'>
-				<availability>General:4</availability>
+				<availability>CIH:5+,CW:5+</availability>
 			</model>
 			<model name='Prime'>
-				<availability>General:8</availability>
+				<availability>CIH:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ferret Light Scout VTOL' unitType='VTOL'>
@@ -2852,10 +2848,13 @@
 			</model>
 		</chassis>
 		<chassis name='Fox' unitType='Mek'>
-			<availability>CDS:6</availability>
+			<availability>CGB!Second Line:1!Solahma:1,CDS:3+</availability>
 			<model name='CS-1'>
-				<availability>General:8</availability>
+				<availability>CDS:4-</availability>
 			</model>
+            <model name=''>
+                <availability>CGB:8,CDS:3</availability>
+            </model>
 		</chassis>
 		<chassis name='Fury Command Tank' unitType='Tank'>
 			<availability>CHH:6,CW:6,CLAN:4,CJF:6,CGB:6</availability>
@@ -2981,19 +2980,19 @@
 			</model>
 		</chassis>
 		<chassis name='Goshawk (Vapor Eagle)' unitType='Mek'>
-			<availability>CSV:7,CLAN:5</availability>
+			<availability>CLAN:2+,CCO:1+,CFM!Keshik:4!Second Line:2,CGS:1+,CHH!Front Line:1,CIH:3+,CSR:1+,CSV:3+,CW:3+,BAN:0</availability>
 			<model name=''>
                 <roles>raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CIH:8</availability>
 			</model>
 			<model name='2'>
-				<availability>CLAN:4:2912</availability>
+				<availability>CLAN!Keshik:8!Front Line:3!Second Line:1,CBS:5,CIH!Keshik:6!Front Line:3!Second Line:1</availability>
 			</model>
 			<model name='5'>
-				<availability>CLAN:3:2922</availability>
+				<availability>CLAN:5,CBS:8</availability>
 			</model>
 			<model name='6'>
-				<availability>CLAN:4</availability>
+				<availability>CLAN!Keshik:1!Front Line:3!Second Line:8,CBS:8,CGB:8,CIH:4-</availability>
 			</model>
 		</chassis>
 		<chassis name='Goth' unitType='AeroSpaceFighter'>
@@ -3031,21 +3030,21 @@
 			</model>
 		</chassis>
 		<chassis name='Great Wyrm' unitType='Mek'>
-			<availability>CSA:3,CCC:5,CHH:3,CSV:5,CLAN:3,CFM:5,CSJ:5,CCO:5,CB:5,CGB:3</availability>
+			<availability>CBS:2+,CB!Front Line:1!Second Line:1,CJF!Second Line:1,CNC!Second Line:1,CSJ!Second Line:1,CSA!Front Line:1!Second Line:1,CW!Second Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CBS:8,CB:8,CJF:8,CNC:8,CSJ:8,CSA:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Griffin IIC' unitType='Mek'>
-			<availability>CBS:4,CB:5-,CCC:5-,CCO:4-,CFM:4,CGB:5-,CGS:4,CIH:5-,CJF:5-,CNC:5-,CDS:4-,CSJ:5-,CW:5-,BAN:2+</availability>
+			<availability>CCC!Keshik:4!Front Line:2!Second Line:1,CCO!Keshik:4!Front Line:3,CGB!Keshik:4!Front Line:3!Second Line:1,CNC!Keshik:4!Front Line:2!Second Line:1,CDS!Keshik:3!Front Line:1,CSJ!Keshik:3!Front Line:1,BAN:2+</availability>
 			<model name=''>
-				<availability>CBS:8,CB:8,CCC:8,CCO:8,CGB:8,CJF:8,CNC:8,CDS:8,CSJ:8,CW:8,BAN:8</availability>
+				<availability>CCC:8,CCO:8,CGB:8,CNC:8,CDS:8,CSJ:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Griffin' unitType='Mek'>
-			<availability>IS:6+,LA:8+,FWL:5+,CC:4+,MERC:7+,CS:4-,CLAN:3,Periphery:4+,TC:6+,NIOPS:4,HL:2+,Periphery.Deep:2+,PIR:5+</availability>
+			<availability>IS:6+,LA:8+,FWL:5+,CC:4+,MERC:7+,CS:4-,CLAN!Front Line:3!Second Line:4!Solahma:5!Provisional Garrison:5,CBS:5,CB!Front Line:1!Second Line:3!Solahma:4!Provisional Garrison:5,CGS!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,CIH!Keshik:3!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CNC!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,CW!Front Line:1!Second Line:3!Solahma:4!Provisional Garrison:5,Periphery:4+,TC:6+,NIOPS:4,HL:2+,Periphery.Deep:2+,BAN:4+,PIR:5+</availability>
 			<model name='GRF-1N'>
-				<availability>IS:8,LA:5,CLAN:3-,Periphery:8,HL:8,Periphery.Deep:8,PIR:8,BAN:5</availability>
+				<availability>IS:8,LA:5,Periphery:8,HL:8,Periphery.Deep:8,PIR:8,BAN:1-</availability>
 			</model>
             <model name='GRF-1RG'>
                 <availability>LA!A:1</availability>
@@ -3054,8 +3053,11 @@
 				<availability>LA:7</availability>
 			</model>
 			<model name='GRF-2N'>
-				<availability>CLAN:6,BAN:4</availability>
+				<availability>CLAN:8,BAN:5</availability>
 			</model>
+            <model name='GRF-2N2'>
+                <availability>BAN:2-</availability>
+            </model>
 		</chassis>
 		<chassis name='Grizzly' unitType='Mek'>
 			<availability>CHH:2,CGB:3</availability>
@@ -3363,12 +3365,12 @@
 			</model>
 		</chassis>
 		<chassis name='Hellhound (Conjurer)' unitType='Mek'>
-			<availability>CHH:6,CIH:6,CDS:4,CLAN:6,CNC:6,CJF:6</availability>
+			<availability>CCO!Keshik:3!Front Line:1,CJF!Keshik:4!Front Line:2!Second Line:1,CSJ!Keshik:4!Front Line:1,CW!Keshik:5!Front Line:1</availability>
 			<model name=''>
-				<availability>CHH:8,General:8,CJF:8</availability>
+				<availability>CCO:8,CJF:5,CW:5</availability>
 			</model>
 			<model name='7'>
-				<availability>CW:4,CLAN:4</availability>
+				<availability>CJF:8,CSJ:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hermes II' unitType='Mek'>
@@ -3445,13 +3447,13 @@
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
-			<availability>CLAN:3,CHH:4,CGS:4</availability>
+			<availability>CBS:4+,CGB!Front Line:3!Second Line:2!Solahma:1,CGS:5+,CHH!Keshik:1!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CJF:3-,CNC!Front Line:3!Second Line:2!Solahma:1</availability>
 			<model name='HOP-4Bb'>
                 <roles>fire_support</roles>
-				<availability>CLAN:4,BAN:2</availability>
+				<availability>CBS:8,CGB:8,CGS:8,CHH:5,CJF:8,CNC:8</availability>
 			</model>
 			<model name='HOP-4Cb'>
-				<availability>CHH:8,CLAN:2,BAN:2</availability>
+				<availability>CHH!Front Line:3!Second Line:2!Solahma:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Hornet' unitType='Mek'>
@@ -3476,16 +3478,16 @@
 			</model>
 		</chassis>
 		<chassis name='Hunchback IIC' unitType='Mek'>
-			<availability>CDS:4,CSR:4,CW:4,CSV:5,CLAN:4,CSJ:5,CJF:4,CGB:4</availability>
+			<availability>CSJ!Front Line:2!Second Line:1</availability>
 			<model name=''>
-				<availability>CSR:8,General:8</availability>
+				<availability>CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Hunchback' unitType='Mek'>
-			<availability>IS:4+,FS:4,LA:4,FWL:5+,DC:5+,CC:5+,MERC:5,CS:4,CLAN:1-,Periphery:3+,Periphery.ME:4+,Periphery.MW:4+,NIOPS:5-,HL:2+,Periphery.Deep:1+,PIR:4+</availability>
+			<availability>IS:4+,FS:4,LA:4,FWL:5+,DC:5+,CC:5+,MERC:5,CS:4,Periphery:3+,Periphery.ME:4+,Periphery.MW:4+,NIOPS:5-,HL:2+,Periphery.Deep:1+,PIR:4+</availability>
 			<model name='HBK-4G'>
                 <roles>urban</roles>
-				<availability>IS:7+,LA:8,FWL:8,DC:8+,CC:8+,MERC:8+,CLAN:8,Periphery:7+,HL:5+,Periphery.Deep:5+,PIR:8</availability>
+				<availability>IS:7+,LA:8,FWL:8,DC:8+,CC:8+,MERC:8+,Periphery:7+,HL:5+,Periphery.Deep:5+,PIR:8</availability>
 			</model>
 			<model name='HBK-4H'>
 				<availability>IS:7,LA:6,FWL:4,DC:6,CC:5,MERC:6-,CS:3,Periphery:7,HL:8,Periphery.Deep:8,PIR:5</availability>
@@ -3918,15 +3920,15 @@
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
-			<availability>FS:4+,CS!A:7!B:5!C:4!D:3,CLAN:5,CHH:6,CDS:6,CSV:6,Periphery.HR:2+,Periphery.OS:1+,NIOPS:6+</availability>
+			<availability>FS:4+,CS!A:7!B:5!C:4!D:3,CLAN:4-,CBS:4,CGS:3-,CIH:3-,CSR:3-,CSV:3-,Periphery.HR:2+,Periphery.OS:1+,NIOPS:6+,BAN:3+</availability>
 			<model name='KTO-18'>
 				<availability>FS:8</availability>
 			</model>
 			<model name='KTO-19'>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:7</availability>
+				<availability>CS:8,CLAN:3-,CBS:4-,CB:4-,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='KTO-19b'>
-				<availability>CS!A:2,CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CS!A:2,CLAN:5,BAN:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Kirghiz' unitType='AeroSpaceFighter' omni='Clan'>
@@ -4273,14 +4275,14 @@
 			</model>
 		</chassis>
 		<chassis name='Lynx' unitType='Mek'>
-			<availability>CIH:5,CLAN:3,CSJ:5,CJF:3</availability>
+			<availability>CLAN!Front Line:2!Second Line:2!Solahma:1,CCO:5+,CFM!Front Line:3!Second Line:2!Solahma:1,CGB!Front Line:3!Second Line:2!Solahma:1,CGS:4+,CIH!Keshik:2!Front Line:3!Second Line:2!Solahma:1,CJF:4+,CNC!Front Line:3!Second Line:1,CDS!Front Line:3!Second Line:2!Solahma:1,CSJ!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CSV!Second Line:2!Solahma:1,CW!Front Line:3!Second Line:1,BAN:2+</availability>
 			<model name='C'>
                 <roles>raider</roles>
-				<availability>CCC:6,CW:5,CNC:6,CSJ:8,CJF:5,CGS:5</availability>
+				<availability>CCC:8,CGS:8,CJF:8,CNC:8,CSJ:3+,CW:8</availability>
 			</model>
 			<model name='LNX-9Q'>
                 <roles>raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CLAN:8,CCC:0,CGS:0,CJF:0,CNC:0,CSJ:3-,CW:0,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Lyonesse Escort' unitType='Small Craft'>
@@ -5035,14 +5037,20 @@
 			</model>
 		</chassis>
 		<chassis name='Naja' unitType='Mek'>
-			<availability>CCC:5,CBS:4,CSV:4</availability>
+			<availability>CBS!Front Line:1,CCC!Front Line:2!Second Line:1,CSV!Front Line:1</availability>
             <model name=''>
-                <availability>CCC:8,CBS:6,CSV:6</availability>
+                <availability>CBS:8,CCC:8,CSV:8</availability>
             </model>
-			<model name='KTO-19b-EC'>
-				<availability>CCC:2,CBS:2</availability>
-			</model>
 		</chassis>
+        <chassis name='Night Chanter' unitType='Mek' omni='Clan'>
+            <availability>CLAN:1+,CCO!Front Line:3!Second Line:1,CGB!Keshik:1!Front Line:1,CGS:2+,CHH!Front Line:1,CIH!Front Line:1,CJF!Front Line:1,CNC:2+,CSJ!Front Line:1,CSR!Front Line:1,CSA!Front Line:1</availability>
+            <model name='A'>
+                <availability>CLAN:6,CGS:4</availability>
+            </model>
+            <model name='Prime'>
+                <availability>CLAN:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Night Hawk' unitType='Mek'>
 			<availability>CLAN:4+,CBS:5+,CB:5+,CCO:5+,CGB:5+,CJF:5+,CSR:3+,CW:5+,BAN:3+</availability>
 			<model name='NTK-2Q'>
@@ -5122,15 +5130,15 @@
 			</model>
 		</chassis>
 		<chassis name='Omni-Corvis' unitType='Mek'>
-			<availability>CHH:4,CSR:3</availability>
+			<availability>CHH!Keshik:3,CSR:1+:2923</availability>
 			<model name='A'>
-				<availability>General:6</availability>
+				<availability>CHH:4+,CSR:4+</availability>
 			</model>
 			<model name='B'>
-				<availability>General:6</availability>
+				<availability>CHH:5,CSR:5</availability>
 			</model>
 			<model name='Prime'>
-				<availability>General:8</availability>
+				<availability>CHH:8,CSR:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ontos Heavy Tank' unitType='Tank'>
@@ -5374,11 +5382,19 @@
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk' unitType='Mek'>
-			<availability>IS:5,FS!A:6!B:6!C:6!D:5!F:5,LA:6,DC!A:6!B:6!C:6!D:5!F:5,CC!A:6!B:6!C:6!D:5!F:5,MERC:8+,CS:6-,CLAN:2,Periphery:4,NIOPS:7,HL:2+,Periphery.Deep:2+,PIR:6+</availability>
-			<model name='PXH-1'>
+			<availability>IS:5,FS!A:6!B:6!C:6!D:5!F:5,LA:6,DC!A:6!B:6!C:6!D:5!F:5,CC!A:6!B:6!C:6!D:5!F:5,MERC:8+,CS:6-,CLAN:4+,CB:3+,CCO!Front Line:3!Second Line:2!Solahma:1,CGB:3+,CGS:6+,CHH!Keshik:3!Front Line:3!Second Line:2!Solahma:1,CIH!Front Line:3!Second Line:3!Solahma:2!Provisional Garrison:1,CSA!Keshik:3!Front Line:3!Second Line:2!Solahma:1,Periphery:4,NIOPS:7,HL:2+,Periphery.Deep:2+,BAN:4,PIR:6+</availability>
+            <model name='C'>
+                <roles>recon</roles>
+                <availability>CGS!Keshik:5!Front Line:3!Second Line:1,CIH!Front Line:3!Second Line:8,CJF!Front Line:5!Second Line:3!Solahma:1</availability>
+            </model>
+            <model name='PXH-1'>
 				<roles>command,recon</roles>
-				<availability>IS:8,FS:5,DC:6,Periphery:8,HL:8,NIOPS:5,Periphery.Deep:8,PIR:8,BAN:6</availability>
+				<availability>IS:8,FS:5,DC:6,Periphery:8,HL:8,NIOPS:5,Periphery.Deep:8,PIR:8,BAN:5-</availability>
 			</model>
+            <model name='PXH-1-EC'>
+                <roles>command,recon</roles>
+                <availability>CGS!Front Line:3!Second Line:1</availability>
+            </model>
 			<model name='PXH-1D'>
 				<roles>command,recon</roles>
 				<availability>FS!A:8!B:7!C:4,Periphery.HR:2+,Periphery.OS:1+</availability>
@@ -5389,15 +5405,11 @@
 			</model>
 			<model name='PXH-1b &apos;Special&apos;'>
 				<roles>command,recon</roles>
-				<availability>CLAN:7,NIOPS:3+,BAN:3</availability>
-			</model>
-			<model name='PXH-1c &apos;Special&apos;'>
-				<roles>command,recon</roles>
-				<availability>CLAN:4,CGS:6</availability>
+				<availability>CLAN:8,CGS:4,CIH:5-,NIOPS:3+,BAN:3</availability>
 			</model>
 			<model name='PXH-2'>
 				<roles>command,recon</roles>
-				<availability>CLAN:2,NIOPS:6+,BAN:3</availability>
+				<availability>BAN:1+</availability>
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
@@ -5699,26 +5711,26 @@
             </model>
         </chassis>
 		<chassis name='Ryoken (Stormcrow)' unitType='Mek' omni='Clan'>
-			<availability>CHH:7:2930,CSR:8:2930,CDS:8:2930,CBS:7:2930,CSV:5:2930,CLAN:6:2930,CSJ:7:2930,CJF:8:2930</availability>
+			<availability>CLAN:1+:2932,CBS:1+:2933,CFM:1+:2933,CGB:1+:2931,CGS:1+:2933,CIH:1+:2933,CJF:1+:2931,CSJ:1+:2931,CSR!Keshik:3,BAN:0</availability>
 			<model name='A'>
                 <roles>cavalry</roles>
-				<availability>CDS:9,CW:5,CSV:8,CLAN:6,CSJ:7,CJF:5,CGB:5</availability>
+				<availability>CLAN:4</availability>
 			</model>
 			<model name='B'>
                 <roles>cavalry</roles>
-				<availability>CDS:8,CW:3,CLAN:6,CJF:4,CGB:4</availability>
+				<availability>CLAN:5+,CSJ:6+</availability>
 			</model>
 			<model name='C'>
                 <roles>cavalry</roles>
-				<availability>CSR:6,CBS:6,CLAN:5,CGB:7</availability>
+				<availability>CLAN:3,CGS:4+</availability>
 			</model>
 			<model name='D'>
                 <roles>fire_support</roles>
-				<availability>CDS:8,CW:3,CSV:6,CNC:6,CLAN:5,CSJ:6,CJF:4,CGB:4</availability>
+				<availability>CLAN:6-,CGS:4-,CSJ:4-</availability>
 			</model>
 			<model name='Prime'>
                 <roles>cavalry</roles>
-				<availability>CDS:5,CW:8,CSV:5,CNC:8,CLAN:7,CSJ:8,CJF:9,CGB:9</availability>
+				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='S 2772 Airplane' unitType='Conventional Fighter'>
@@ -5845,9 +5857,9 @@
 			</model>
 		</chassis>
 		<chassis name='Scorpion' unitType='Mek'>
-			<availability>IS:3-,FWL:4-,CC:4-,MERC:4-,Periphery:4,TC:4-,NIOPS:3-,HL:3,Periphery.Deep:4,PIR:5-,BAN:1-</availability>
+			<availability>IS:3-,FWL:4-,CC:4-,MERC:4-,Periphery:4,TC:4-,NIOPS:3-,HL:3,Periphery.Deep:4,PIR:5-</availability>
 			<model name='SCP-1N'>
-				<availability>IS:8,Periphery:8,HL:8,Periphery.Deep:8,PIR:8,BAN:8</availability>
+				<availability>IS:8,Periphery:8,HL:8,Periphery.Deep:8,PIR:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Scout JumpShip' unitType='Jumpship'>
@@ -5886,7 +5898,7 @@
 			</model>
 		</chassis>
 		<chassis name='Sentinel' unitType='Mek'>
-			<availability>LA:8-,CS!A:7!B:6!C:5!D:4,CLAN:5,CSV:4,CFM:6,CGS:4,CDS:4,CW:4,CBS:4,CJF:6,CGB:6,Periphery.R:4,CIR:3,NIOPS:4-,HL:3+,Periphery.Deep:2+,PIR:3</availability>
+			<availability>LA:8-,CS!A:7!B:6!C:5!D:4,CLAN:4-,CBS:5-,CCC:3-,CCO:3-,CDS:2,Periphery.R:4,CIR:3,NIOPS:4-,HL:3+,Periphery.Deep:2+,BAN:2,PIR:3</availability>
 			<model name='STN-3K'>
 				<availability>LA:8,Periphery.R:8,CIR:8,HL:8,Periphery.Deep:8,PIR:8</availability>
 			</model>
@@ -5897,10 +5909,10 @@
 				<availability>LA:3</availability>
 			</model>
 			<model name='STN-3L'>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>CS:8,CLAN:8,CBS:4-,CCC:4,CFM:3,CGB:4-,CHH:4-,CJF:3-,CDS:4-,CSR:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='STN-3Lb'>
-				<availability>CLAN:3,BAN:2</availability>
+				<availability>CBS:4+,CCC:4+,CFM:4+,CGB:4+,CHH:4+,CJF:4+,CDS:4+,CSR:4+</availability>
 			</model>
 		</chassis>
 		<chassis name='Seydlitz' unitType='AeroSpaceFighter'>
@@ -5919,18 +5931,18 @@
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk IIC' unitType='Mek'>
-			<availability>CLAN:6-,BAN:3+</availability>
+			<availability>CLAN!Keshik:4!Front Line:3!Second Line:1,CBS!Keshik:4!Front Line:1,CCC:3+,CCO:2+,CFM!Keshik:5!Front Line:2!Second Line:1,CGB:4+,CGS!Keshik:3!Front Line:1,CHH!Keshik:3!Front Line:3!Second Line:1,CIH:3+,CJF!Keshik:3!Front Line:1,CNC:2+,CDS!Keshik:4!Front Line:2!Second Line:1,CSJ:2+,CSA:3+,BAN!Keshik:3!Front Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CLAN:8,CGB:4,BAN:8</availability>
 			</model>
 			<model name='2'>
-				<availability>CSA:6,CCC:6,CIH:6,CGB:6,CB:6</availability>
+				<availability>CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Shadow Hawk' unitType='Mek'>
-			<availability>IS:7,LA:6,FWL:6,CC!A:7!B:7!C:7!D:6!F:6,CS:6-,CLAN:2,NIOPS:6-,Periphery:5,HL:4+,Periphery.Deep:4+,PIR:6,BAN:3</availability>
+			<availability>IS:7,LA:6,FWL:6,CC!A:7!B:7!C:7!D:6!F:6,CS:6-,CLAN!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CBS:5,CIH!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,NIOPS:6-,Periphery:5,HL:4+,Periphery.Deep:4+,PIR:6,BAN:5</availability>
             <model name='C'>
-                <availability>CSA:6,CCC:6,CSV:6,CFM:6,CGS:6</availability>
+                <availability>CLAN!Front Line:6!Second Line:3,CBS!Keshik:6!Front Line:3,CCC!Front Line:5!Second Line:1,CCO!Front Line:8!Second Line:1,CFM!Front Line:8!Second Line:1,CGS!Front Line:6!Second Line:1,CIH!Front Line:1!Second Line:3,CNC!Front Line:6!Second Line:3!Solahma:1,CSA!Front Line:6!Second Line:3!Solahma:1,CW!Second Line:4,BAN!Keshik:6!Front Line:3!Second Line:1</availability>
             </model>
             <model name='SHD-1R'>
                 <availability>IS:2-,LA:1-,MERC:3-,CS:0,Periphery:2-,TC:1-,MOC:1-,NIOPS:0,HL:5-,Periphery.Deep:6,PIR:2-</availability>
@@ -5939,10 +5951,10 @@
 				<availability>FS:8+</availability>
 			</model>
 			<model name='SHD-2H'>
-				<availability>IS:8,FS:6,DC:6,MERC!A:8!B:8!C:8!D:6!F:6,CLAN:3-,Periphery:8,HL:6,Periphery.Deep:3+,PIR:8,BAN:4</availability>
+				<availability>IS:8,FS:6,DC:6,MERC!A:8!B:8!C:8!D:6!F:6,Periphery:8,HL:6,Periphery.Deep:3+,PIR:8</availability>
 			</model>
 			<model name='SHD-2Hb'>
-				<availability>CLAN:5,NIOPS:8,BAN:4</availability>
+				<availability>CLAN:4-,CB:3-,CCC:5,CW:3-,NIOPS:8,BAN!Front Line:3!Second Line:2!Solahma:1</availability>
 			</model>
 			<model name='SHD-2K'>
 				<availability>DC:8+</availability>
@@ -7046,21 +7058,21 @@
 			</model>
 		</chassis>
 		<chassis name='Wyvern IIC' unitType='Mek'>
-			<availability>CHH:4,CW:4,CLAN:4</availability>
+			<availability>CB!Keshik:4!Front Line:1,CCC!Front Line:1!Second Line:2</availability>
 			<model name=''>
 				<roles>urban</roles>
-				<availability>CW:8,CLAN:8</availability>
+				<availability>CB:8,CCC:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Wyvern' unitType='Mek'>
-			<availability>IS:4-,CC:3,CS!A:5!B:5!C:5!D:5!F:6,CLAN:4,CIH:3,CFM:5,Periphery:3,HL:1+,Periphery.Deep:0,NIOPS:6,PIR:2+</availability>
+			<availability>IS:4-,CC:3,CS!A:5!B:5!C:5!D:5!F:6,CLAN:4-,CBS:4,CCO:3-,CFM:3,CGS:3,CIH:2-,CJF:3,CDS:3,CSJ:2,CSV:3-,Periphery:3,HL:1+,Periphery.Deep:0,NIOPS:6,BAN:3,PIR:2+</availability>
 			<model name='WVE-5N'>
 				<roles>urban</roles>
-				<availability>CS!A:8!B:7!C:6!D:3!F:1,CLAN:4,CFM:5,NIOPS:8,BAN:6</availability>
+				<availability>CS!A:8!B:7!C:6!D:3!F:1,CBS:3-,CB:3-,CCO:2-,CFM:2-,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='WVE-5Nb'>
 				<roles>urban</roles>
-				<availability>CLAN:4,CFM:5,CGS:5</availability>
+				<availability>CLAN:8,CBS:6,CB:6,CCO:6,CFM:6,BAN:3+</availability>
 			</model>
 			<model name='WVE-6N'>
 				<roles>urban</roles>

--- a/megamek/data/forcegenerator/2900.xml
+++ b/megamek/data/forcegenerator/2900.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2900-->
-<ratgen
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
->
+<ratgen>
 	<factions>
 		<faction key='BAN'>
             <!-- Omni percentages: 0,0 -->

--- a/megamek/data/forcegenerator/2900.xml
+++ b/megamek/data/forcegenerator/2900.xml
@@ -1,6 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!-- Era 2900-->
-<ratgen>
+<ratgen
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="forceGeneratorSchema.xsd"
+>
 	<factions>
 		<faction key='BAN'>
 			<pctOmni>0,0</pctOmni>

--- a/megamek/data/forcegenerator/2900.xml
+++ b/megamek/data/forcegenerator/2900.xml
@@ -808,13 +808,13 @@
 			</model>
 		</chassis>
 		<chassis name='Baboon (Howler)' unitType='Mek'>
-			<availability>CSR:3,CJF:3</availability>
+			<availability>CFM:2+</availability>
 			<model name=''>
 				<roles>fire_support</roles>
-				<availability>CSV:8,CLAN:8,CJF:8</availability>
+				<availability>CFM:8</availability>
 			</model>
 			<model name='4'>
-				<availability>CLAN:4,CJF:4</availability>
+				<availability>CFM:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Badger (C) Tracked Transport' unitType='Tank' omni='Clan'>
@@ -1832,14 +1832,14 @@
             </model>
         </chassis>
 		<chassis name='Commando IIC' unitType='Mek'>
-			<availability>CHH:3,CIH:3,CLAN:3,CGS:5</availability>
+			<availability>CGS!Front Line:2!Second Line:1</availability>
 			<model name=''>
 				<roles>recon</roles>
-				<availability>CLAN:8</availability>
+				<availability>CGS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Commando' unitType='Mek'>
-			<availability>LA:8+,MERC:3+,CSJ:2,CGS:2,Periphery:3+,TC:6+,CIR:4,Periphery.R:4,Periphery.DD:4,Periphery.ME:4+,Periphery.Deep:5</availability>
+			<availability>LA:8+,MERC:3+,Periphery:3+,Periphery.R:4,Periphery.DD:4,Periphery.ME:4+,CIR:4,Periphery.Deep:5,TC:6+</availability>
             <model name='COM-1A'>
                 <availability>CIR:6-,Periphery.R:3-,Periphery.DD:3-,Periphery.Deep:8</availability>
             </model>
@@ -1850,7 +1850,7 @@
 			</model>
 			<model name='COM-2D'>
 				<roles>recon</roles>
-				<availability>LA:8,MERC:8,CSJ:8,CGS:8,Periphery:8,Periphery.R:8+,HL:8,Periphery.Deep:2+</availability>
+				<availability>LA:8,MERC:8,Periphery:8,Periphery.R:8+,HL:8,Periphery.Deep:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Condor Heavy Hover Tank' unitType='Tank'>
@@ -2144,23 +2144,23 @@
 			</model>
 		</chassis>
 		<chassis name='Dasher (Fire Moth)' unitType='Mek' omni='Clan'>
-			<availability>CHH:4,CCC:6,CLAN:3,BAN:2,CGB:9,CB:6</availability>
+			<availability>CCC:1+,CGB!Keshik:3!Front Line:1</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
-				<availability>CSA:2,CIH:4,CDS:5,CSV:2,General:3,CCO:2,CJF:4,CGB:2,CB:4</availability>
+				<availability>CCC:5-,CGB:5-</availability>
 			</model>
 			<model name='B'>
-				<availability>CHH:6,CDS:6,CW:5,CSV:4,General:5,CGB:5,CB:6</availability>
+				<availability>CCC:6,CGB:6</availability>
 			</model>
 			<model name='C'>
 				<roles>fire_support</roles>
-				<availability>CSA:4,CHH:8,CIH:6,CDS:6,CW:5,CNC:4,General:5,CCO:4,CGB:4</availability>
+				<availability>CCC:5,CGB:5</availability>
 			</model>
 			<model name='D'>
-				<availability>CSA:4,CHH:8,CIH:7,CDS:4,CW:7,CNC:8,General:6,CCO:5,CGB:8</availability>
+				<availability>CCC:6+,CGB:6+</availability>
 			</model>
 			<model name='Prime'>
-				<availability>CSA:7,CHH:8,CCC:7,CIH:7,CDS:7,CNC:6,General:6,CCO:5,CGB:9,CB:5</availability>
+				<availability>CCC:8,CGB:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Demolisher Heavy Tank' unitType='Tank'>
@@ -2208,9 +2208,9 @@
 			</model>
 		</chassis>
 		<chassis name='Devil' unitType='Mek'>
-			<availability>CSR:4</availability>
+			<availability>CIH:1+:2912,CSR!keshik:3</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CIH:8,CSR:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Dictator' unitType='Dropship'>
@@ -2266,9 +2266,9 @@
 			</model>
 		</chassis>
 		<chassis name='Drift Shag' unitType='Mek'>
-			<availability>CIH:4,CGS:2</availability>
+			<availability>CGS!Keshik:3!Front Line:1,CIH!Keshik:3!Front Line:1</availability>
             <model name=''>
-                <availability>CLAN:8</availability>
+                <availability>CGS:8,CIH:8</availability>
             </model>
 		</chassis>
 		<chassis name='Dromedary Water Transport' unitType='Tank'>
@@ -2461,18 +2461,9 @@
 		    </model>
 		</chassis>
 		<chassis name='Falcon' unitType='Mek'>
-			<availability>MERC:1,CS:1,CLAN:2,CIH:4,CGS:4</availability>
+			<availability>MERC:1,CS:1</availability>
 			<model name='FLC-4N'>
-				<availability>MERC:8,CS:8,BAN:8</availability>
-			</model>
-			<model name='FLC-4Nb'>
-				<availability>CLAN:8,BAN:2</availability>
-			</model>
-			<model name='FLC-4Nb-PP'>
-				<availability>BAN:2</availability>
-			</model>
-			<model name='FLC-4Nb-PP2'>
-				<availability>BAN:2</availability>
+				<availability>MERC:8,CS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Fenris (Ice Ferret)' unitType='Mek' omni='Clan'>
@@ -2636,21 +2627,12 @@
 			</model>
 		</chassis>
 		<chassis name='Firefly' unitType='Mek'>
-			<availability>CIH:7,CLAN:6,BAN:5,CB:6</availability>
+			<availability>CLAN!Front Line:3!Second Line:2!Solahma:1,CBS:3+,CB!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CCO!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CFM!Second Line:3!Solahma:2!Provisional Garrison:1,CGB!Second Line:5!Solahma:4!Provisional Garrison:3,CGS!Second Line:3!Solahma:2!Provisional Garrison:1,CHH!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CIH:3-,CNC!Second Line:3!Solahma:2!Provisional Garrison:1,CDS!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CSJ:4+,CSR:4+,CSV:4-,CW:3-,BAN:1</availability>
 			<model name='C'>
-				<availability>CLAN:8,BAN:2</availability>
-			</model>
-			<model name='FFL-3PP'>
-				<availability>BAN:1</availability>
-			</model>
-			<model name='FFL-3PP2'>
-				<availability>BAN:1</availability>
-			</model>
-			<model name='FFL-3PP3'>
-				<availability>BAN:1</availability>
+				<availability>CSJ!Keshik:8!Front Line:8!Second Line:1</availability>
 			</model>
 			<model name='FFL-3SLE'>
-				<availability>CLAN:4,BAN:2</availability>
+				<availability>CLAN:8,CSJ!Front Line:5!Second Line:8!Solahma:8!Provisional Garrison:8,BAN:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Firestarter' unitType='Mek'>
@@ -3401,7 +3383,7 @@
 			</model>
 		</chassis>
 		<chassis name='Hermes' unitType='Mek'>
-			<availability>FWL:5+,DC:2+,CC:3+,CS:3+,CLAN:3,CGB:5,CB:5,CHH:5,NIOPS:3</availability>
+			<availability>DC:2+,FWL:5+,CC:3+,CS:3+,CLAN!Second Line:2!Solahma:2!Provisional Garrison:2,CBS:2,CB!Second Line:1!Solahma:1!Provisional Garrison:1,CCC!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CCO!Front Line:1!Second Line:1!Solahma:1!Provisional Garrison:1,CFM!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CGB!Front Line:1!Second Line:1!Solahma:1!Provisional Garrison:1,CGS:2,CHH:2,CIH!Second Line:4!Solahma:3!Provisional Garrison:2,CDS!Second Line:3!Solahma:3!Provisional Garrison:3,CSJ!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CSR:2,CSA:2,CSV:2,CW!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,NIOPS:3,BAN:4+</availability>
 			<model name='HER-1A'>
 				<roles>recon</roles>
 				<availability>FWL:8,DC:8,CC:8</availability>
@@ -3412,11 +3394,11 @@
 			</model>
 			<model name='HER-1S'>
 				<roles>recon</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>CS:8,CLAN:4-,CBS!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CB:4,CCC:4,CGS:4,CJF:3-,CSJ:4,CSV:3-,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='HER-1Sb'>
 				<roles>recon</roles>
-				<availability>CLAN:4,BAN:2</availability>
+				<availability>CLAN:3,CBS:3+,CB:4+,CCC:4+,CGS:3+,CIH:5,CJF:5+,CSJ:3+,CW:4+,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Hetzer Wheeled Assault Gun' unitType='Tank'>
@@ -3535,13 +3517,13 @@
 			</model>
 		</chassis>
 		<chassis name='Hussar' unitType='Mek'>
-			<availability>CS:5+,CLAN:7,CIH:8,CSV:8,NIOPS:4</availability>
+			<availability>CS:5+,CLAN!Front Line:3!Second Line:2!Solahma:1,CCO:3+,CFM!Second Line:3!Solahma:2!Provisional Garrison:1,CGB!Front Line:2!Second Line:1,CHH:3+,CIH!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CNC:3+,CDS:4+,CSR:3+,CSA:3+,CSV:4+,CW!Second Line:3!Solahma:2!Provisional Garrison:1,NIOPS:4,BAN:4+</availability>
 			<model name='HSR-200-D'>
 				<roles>recon</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>CS:8,CLAN:4-,CBS:5,CB:4,CGS:5,CIH!Second Line:4!Solahma:4!Provisional Garrison:4,CW:5,NIOPS:8,BAN:4-</availability>
 			</model>
 			<model name='HSR-200-Db'>
-				<availability>CLAN:5,BAN:3</availability>
+				<availability>CLAN:4,CBS:4+,CB:5+,CCC:3,CCO:3,CFM:3,CGS:4+,CHH:3,CIH:4+,CJF:5+,CSJ:5,CW:6+,BAN:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Hydaspes' unitType='AeroSpaceFighter'>
@@ -3557,10 +3539,10 @@
 			</model>
 		</chassis>
 		<chassis name='Icestorm' unitType='Mek'>
-			<availability>CIH:6+,CW:4</availability>
+            <availability>CIH!Keshik:4!Front Line:3!Second Line:1</availability>
 			<model name=''>
 				<roles>spotter</roles>
-				<availability>CLAN:8</availability>
+				<availability>CIH:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Imp' unitType='Mek'>
@@ -3997,26 +3979,26 @@
 			</model>
 		</chassis>
 		<chassis name='Koshi (Mist Lynx)' unitType='Mek' omni='Clan'>
-			<availability>CSA:4,CW:4,CSJ:7,CCO:4</availability>
+			<availability>CLAN:1+:2927,CBS:1+:2928,CFM:1+:2928,CGS:1+:2928,CIH:1+:2928,CSR:1+:2928,CSJ!Keshik:3,BAN:0</availability>
 			<model name='A'>
 				<roles>recon,spotter</roles>
-				<availability>CIH:6,CDS:7,CW:6,CSV:6,General:5,CGB:7</availability>
+				<availability>CLAN:4-</availability>
 			</model>
 			<model name='B'>
 				<roles>recon</roles>
-				<availability>CSA:6,CIH:6,CDS:6,CW:5,General:5,CSJ:4,CGS:6,CCO:4,CGB:6</availability>
+				<availability>CLAN:7+</availability>
 			</model>
 			<model name='C'>
 				<roles>recon</roles>
-				<availability>CDS:3,CW:4,CSV:2,General:4,CGB:5,CB:5</availability>
+				<availability>CLAN:5+</availability>
 			</model>
 			<model name='D'>
 				<roles>recon</roles>
-				<availability>CSA:4,CDS:5,CW:2,CNC:2,General:3,CCO:2,CJF:2,CGB:3</availability>
+				<availability>CLAN:5</availability>
 			</model>
 			<model name='Prime'>
 				<roles>recon</roles>
-				<availability>CDS:9,CNC:6,General:8,CGB:9</availability>
+				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Kraken (Bane)' unitType='Mek'>
@@ -4156,21 +4138,21 @@
 			</model>
 		</chassis>
 		<chassis name='Locust IIC' unitType='Mek'>
-			<availability>CHH:6,CW:6,CLAN:6,CJF:6,CGB:6</availability>
+			<availability>CLAN!Keshik:5!Front Line:3!Second Line:1,CBS!Keshik:5!Front Line:2,CFM:3+,CGB!Keshik:4!Front Line:2!Second Line:1,CGS:3+,CHH:3+,CIH!Keshik:4!Front Line:2!Second Line:1,CJF!Keshik:6!Front Line:3!Second Line:1,BAN!Keshik:3!Front Line:1</availability>
 			<model name=''>
-				<availability>CW:8,General:8</availability>
+				<availability>CLAN:8,CIH:4,CJF:5,CSJ:3,CSA!Front Line:5!Second Line:8,BAN:8</availability>
 			</model>
 			<model name='2'>
-				<availability>CCC:4,CIH:4,CJF:4</availability>
+				<availability>CIH:8,CJF:8</availability>
 			</model>
 			<model name='3'>
-				<availability>General:3</availability>
+				<availability>CSJ!Keshik:8!Front Line:5!Second Line:1,CSA!Keshik:8!Front Line:5!Second Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Locust' unitType='Mek'>
-			<availability>IS:9,FS:7,LA:8,FWL:6,DC:7,CC:8,MERC:7,CS:2,CLAN:2-,Periphery:6,NIOPS:6-,HL:4,Periphery.Deep:5</availability>
+			<availability>IS:9,FS:7,LA:8,FWL:6,DC:7,CC:8,MERC:7,CS:2,CLAN!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CB!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CCO!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CFM:5,CGB!Second Line:5!Solahma:5!Provisional Garrison:5,CGS!Second Line:4!Solahma:4!Provisional Garrison:4,CJF:4-,CNC:5,CDS:4,CSR:5,CSA:5,CSV:5,CW:4-,Periphery:6,NIOPS:6-,HL:4,Periphery.Deep:5,BAN:4</availability>
 			<model name='C'>
-				<availability>CCC:2,CFM:2</availability>
+				<availability>CCC!Front Line:8!Second Line:1,CFM!Keshik:8!Front Line:5!Second Line:1,CJF!Front Line:8!Second Line:5,CSJ!Keshik:5!Front Line:8!Second Line:5,CSV!Keshik:8!Front Line:5,BAN:2+</availability>
 			</model>
 			<model name='LCT-1E'>
 				<roles>recon</roles>
@@ -4186,11 +4168,11 @@
 			</model>
 			<model name='LCT-1V'>
 				<roles>recon</roles>
-				<availability>IS:8,LA:7,Periphery:8,BAN:4</availability>
+				<availability>IS:8,LA:7,Periphery:8</availability>
 			</model>
 			<model name='LCT-1Vb'>
 				<roles>recon</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,CFM!Front Line:1!Second Line:8!Solahma:8!Provisional Garrison:8,CJF:3-,CSJ!Second Line:8!Solahma:8!Provisional Garrison:8,CSV!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Loki (Hellbringer)' unitType='Mek' omni='Clan'>
@@ -4378,9 +4360,9 @@
 			</model>
 		</chassis>
 		<chassis name='Mandrill' unitType='Mek'>
-			<availability>CFM:6</availability>
+			<availability>CFM!Keshik:4!Front Line:3!Second Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CFM:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Manta Fast Attack Submarine' unitType='Naval'>
@@ -4774,10 +4756,10 @@
 			</model>
 		</chassis>
 		<chassis name='Mercury' unitType='Mek'>
-			<availability>CS:9+,NIOPS:8</availability>
+			<availability>CS:9+,CLAN!Front Line:3!Second Line:2!Solahma:1,CB!Second Line:2!Solahma:1,CCC!Second Line:3!Solahma:2!Provisional Garrison:1,CCO!Second Line:2!Solahma:1,CGB!Second Line:3!Solahma:2!Provisional Garrison:1,CGS!Second Line:3!Solahma:2!Provisional Garrison:1,CHH!Second Line:3!Solahma:2!Provisional Garrison:1,CIH!Second Line:4!Solahma:3!Provisional Garrison:2,CJF!Second Line:3!Solahma:2!Provisional Garrison:1,CSJ!Second Line:1!Solahma:1!Provisional Garrison:1,CW:3-,NIOPS:8,BAN:3</availability>
 			<model name='MCY-99'>
 				<roles>recon</roles>
-				<availability>CS:8,CLAN:8,NIOPS:4,BAN:6</availability>
+				<availability>CS:8,CLAN:8,NIOPS:4,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Minsk' unitType='Mek'>
@@ -4856,18 +4838,18 @@
 			</model>
 		</chassis>
 		<chassis name='Mongoose' unitType='Mek'>
-			<availability>FS:2+,LA:1+,FWL:1+,DC:2+,CC:1+,MERC:1+,CS:5+,CLAN:6,CHH:5,CGB:5,CDS:5,TC:1+,MOC:1+,OA:1+,NIOPS:6</availability>
+			<availability>FS:2+,LA:1+,FWL:1+,DC:2+,CC:1+,MERC:1+,CS:5+,CLAN!Keshik:3!Front Line:3!Second Line:2!Solahma:1,CCC:4+,CCO!Front Line:4!Second Line:3!Solahma:2!Provisional Garrison:1,CFM:4+,CIH:4+,CDS:4+,CSR:4+,CSV:4+,TC:1+,MOC:1+,OA:1+,NIOPS:6,BAN:2+</availability>
 			<model name='C'>
                 <roles>recon</roles>
-				<availability>CIH:4,CJF:4,CGB:4</availability>
+				<availability>CGB!Keshik:5!Front Line:1,CIH!Keshik:5!Front Line:3,CJF!Keshik:5!Front Line:3!Second Line:1</availability>
 			</model>
 			<model name='MON-66'>
 				<roles>command,recon</roles>
-				<availability>CS:5,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>CS:5,CLAN:6,CB:5,CCC:4-,CCO:5-,CFM:5-,CJF!Front Line:3!Second Line:3!Solahma:3!Provisional Garrison:3,CNC:4-,CSJ:4-,CW!Front Line:6!Second Line:6!Solahma:6!Provisional Garrison:6,NIOPS:8,BAN:5-</availability>
 			</model>
 			<model name='MON-66b'>
 				<roles>command,recon</roles>
-				<availability>CLAN:8,CGS:8,BAN:4</availability>
+				<availability>CLAN:5+,CCC:4,CCO:4,CFM:4,CJF!Second Line:4!Solahma:3!Provisional Garrison:2,CNC:5,CSJ:4,BAN:1</availability>
 			</model>
 			<model name='MON-67'>
 				<roles>command,recon</roles>
@@ -5062,11 +5044,14 @@
 			</model>
 		</chassis>
 		<chassis name='Night Hawk' unitType='Mek'>
-			<availability>CW:5,CLAN:5,CGS:6,CGB:5</availability>
+			<availability>CLAN:4+,CBS:5+,CB:5+,CCO:5+,CGB:5+,CJF:5+,CSR:3+,CW:5+,BAN:3+</availability>
 			<model name='NTK-2Q'>
 				<roles>raider</roles>
-				<availability>CLAN:8</availability>
+				<availability>CLAN:8,BAN:8</availability>
 			</model>
+            <model name='NTK-2Q-EC'>
+                <availability>CSJ!Front Line:3!Second Line:1</availability>
+            </model>
 		</chassis>
 		<chassis name='Nightlord Battleship' unitType='Warship'>
 			<availability>CSR:1</availability>
@@ -5219,14 +5204,14 @@
 			</model>
 		</chassis>
 		<chassis name='Ostscout' unitType='Mek'>
-			<availability>IS:1+,FWL:2+,CC:2+,CS:3,CLAN:4-,Periphery:3+,HL:1+,NIOPS:4,Periphery.Deep:0</availability>
+			<availability>IS:1+,FWL:2+,CC:2+,CS:3,CLAN!Second Line:2!Solahma:2!Provisional Garrison:2,CBS!Front Line:2!Second Line:2!Solahma:2!Provisional Garrison:2,CB!Solahma:1!Provisional Garrison:1,CCO!Second Line:1!Solahma:1!Provisional Garrison:1,CJF:2-,CSJ!Second Line:1!Solahma:1!Provisional Garrison:1,CW!Front Line:1!Second Line:1!Solahma:2!Provisional Garrison:2,Periphery:3+,HL:1+,NIOPS:4,Periphery.Deep:0,BAN:1</availability>
 			<model name='OTT-7J'>
 				<roles>recon</roles>
-				<availability>IS:8,CLAN:4-,Periphery:8,BAN:5</availability>
+				<availability>IS:8,Periphery:8</availability>
 			</model>
 			<model name='OTT-7Jb'>
 				<roles>recon</roles>
-				<availability>CLAN:5,BAN:4</availability>
+				<availability>CLAN:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ostsol' unitType='Mek'>
@@ -5302,7 +5287,7 @@
 			</model>
 		</chassis>
 		<chassis name='Panther' unitType='Mek'>
-			<availability>FS:2+,FS.RR:5+,FS.DMM:5+,LA:1+,DC:8+,CC:2+,MERC:3+,CS:3-,Periphery:3,Periphery.DD:5,Periphery.OS:5,HL:1,NIOPS:2,BAN:1</availability>
+			<availability>FS:2+,FS.RR:5+,FS.DMM:5+,LA:1+,DC:8+,CC:2+,MERC:3+,CS:3-,Periphery:3,Periphery.DD:5,Periphery.OS:5,HL:1,NIOPS:2</availability>
 			<model name='PNT-8Z'>
 				<availability>DC:1-,CS:8,Periphery:2-,Periphery.DD:4-,Periphery.OS:4-,HL:8,Periphery.Deep:8,PIR:5</availability>
 			</model>
@@ -5345,13 +5330,13 @@
 			</model>
 		</chassis>
 		<chassis name='Peregrine (Horned Owl)' unitType='Mek'>
-			<availability>CLAN:6,CSJ:8,CGB:6</availability>
+			<availability>CFM:1+,CGS:3+,CIH:2+,CNC!Keshik:3!Front Line:1,CDS:2+,CSJ:2+,CW:2+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CFM:8,CGS:8,CIH:8,CW:8</availability>
 			</model>
 			<model name='2'>
 				<roles>fire_support</roles>
-				<availability>CLAN:5</availability>
+				<availability>CNC:8,CDS:8,CSJ:8,CW:6</availability>
 			</model>
 		</chassis>
         <chassis name='Phoenix' unitType='Mek'>
@@ -6091,10 +6076,10 @@
 			</model>
 		</chassis>
 		<chassis name='Sling' unitType='Mek'>
-			<availability>CLAN:1,CSJ:2,BAN:1</availability>
+			<availability>CSJ!Solahma:2!Provisional Garrison:1</availability>
 			<model name='SL-1G'>
 				<roles>spotter</roles>
-				<availability>CLAN:8,BAN:8</availability>
+				<availability>CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Snowden Mining Station' unitType='Space Station'>
@@ -6151,15 +6136,8 @@
 				<availability>IS:8</availability>
 			</model>
 		</chassis>
-		<chassis name='Spector' unitType='Mek'>
-			<availability>CLAN:2</availability>
-			<model name='SPR-4F'>
-			    <roles>specops,raider</roles>
-				<availability>CLAN:8</availability>
-			</model>
-		</chassis>
 		<chassis name='Spider' unitType='Mek'>
-			<availability>IS:2+,FS:3+,FWL:4+,DC:4+,MERC:1+,CS:1,CLAN:1-,Periphery:1+,Periphery.MW:2+,Periphery.ME:2+,NIOPS:4,HL:1+,Periphery.Deep:0,PIR:2+</availability>
+			<availability>IS:2+,FS:3+,FWL:4+,DC:4+,MERC:1+,CS:1,Periphery:1+,Periphery.MW:2+,Periphery.ME:2+,NIOPS:4,HL:1+,Periphery.Deep:0,PIR:2+</availability>
 			<model name='SDR-5D'>
 				<roles>anti_infantry</roles>
 				<availability>FS:8-</availability>
@@ -6169,7 +6147,7 @@
 				<availability>DC:5-</availability>
 			</model>
 			<model name='SDR-5V'>
-				<availability>IS:8,DC:7,CLAN:8,Periphery:8,HL:8</availability>
+				<availability>IS:8,DC:7,Periphery:8,HL:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Stalker' unitType='Mek'>
@@ -6211,18 +6189,24 @@
 			</model>
 		</chassis>
 		<chassis name='Stinger' unitType='Mek'>
-			<availability>IS:9,FS:7,LA:8,FWL:8,DC:7,CC:8,MERC:6,CS:3,CLAN:2-,Periphery:6,NIOPS:4-,HL:4,Periphery.Deep:5</availability>
-			<model name='STG-3G'>
+			<availability>IS:9,FS:7,LA:8,FWL:8,DC:7,CC:8,MERC:6,CS:3,CLAN:4,CB:5,CCO!Front Line:5!Second Line:5!Solahma:5!Provisional Garrison:5,CFM!Second Line:4!Solahma:4!Provisional Garrison:4,CGB!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CIH!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,CJF:3-,CNC!Second Line:4!Solahma:4!Provisional Garrison:4,CSJ!Front Line:4!Second Line:4!Solahma:4!Provisional Garrison:4,Periphery:6,NIOPS:4-,HL:4,Periphery.Deep:5,BAN:5</availability>
+            <model name='C'>
+                <availability>CCC!Keshik:8!Front Line:1,CHH!Keshik:8!Front Line:8,CIH!Front Line:8!Second Line:1,CSV!Keshik:8!Front Line:8,CW!Keshik:8!Front Line:8!Second Line:1,BAN!Keshik:3!Front Line:1</availability>
+            </model>
+            <model name='C 2'>
+                <availability>CBS!Keshik:8!Front Line:5,CB!Keshik:5!Front Line:3,BAN!Keshik:3!Front Line:1</availability>
+            </model>
+            <model name='STG-3G'>
 				<roles>recon</roles>
-				<availability>IS:4,FS:5,LA:2,DC:5,CC:5,MERC:6,CS:7,Periphery:4,HL:2,Periphery.Deep:4,BAN:2</availability>
+				<availability>IS:4,FS:5,LA:2,DC:5,CC:5,MERC:6,CS:7,Periphery:4,HL:2,Periphery.Deep:4,BAN:1-</availability>
 			</model>
 			<model name='STG-3Gb'>
 				<roles>recon</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,CBS!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CB!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CCC!Front Line:8!Second Line:8!Solahma:8!Provisional Garrison:8,CHH!Front Line:1!Second Line:8!Solahma:8!Provisional Garrison:8,CIH:3-,CSV!Front Line:1!Second Line:8!Solahma:8!Provisional Garrison:8,CW:3-,BAN:5</availability>
 			</model>
 			<model name='STG-3R'>
 				<roles>recon</roles>
-				<availability>IS:7,LA:5,CC:8,MERC:8,CS:8,Periphery:8,HL:6,Periphery.Deep:7,BAN:8</availability>
+				<availability>IS:7,LA:5,CC:8,MERC:8,CS:8,Periphery:8,HL:6,Periphery.Deep:7,BAN:1-</availability>
 			</model>
 		</chassis>
 		<chassis name='Stingray' unitType='AeroSpaceFighter'>
@@ -6331,12 +6315,12 @@
             </model>
         </chassis>
 		<chassis name='Talon' unitType='Mek'>
-			<availability>CLAN:7</availability>
+			<availability>CLAN:4+,CBS:5+,CGB:5+,CGS:3+,CHH:3+,CNC:5+,CDS:5+,CSR:3+,CSA:5+,CSV:5+,CW:5+,BAN:3+</availability>
 			<model name='TLN-5W'>
 				<availability>CLAN:8</availability>
 			</model>
 			<model name='TLN-5W-EC'>
-				<availability>CIH:5</availability>
+				<availability>CIH!Front Line:3!Second Line:1</availability>
 			</model>
 		</chassis>
         <chassis name='Talos' unitType='Mek'>
@@ -6386,12 +6370,12 @@
 			</model>
 		</chassis>
 		<chassis name='Thorn' unitType='Mek'>
-			<availability>CS:7+,CLAN:4,CSA:2,CCO:2,NIOPS:6</availability>
+			<availability>CS:7+,CLAN:3-,CBS:4-,CCO:4-,CFM:4-,CGB:4-,CHH!Second Line:5!Solahma:5!Provisional Garrison:5,CJF!Solahma:4!Provisional Garrison:4,CNC:4-,CDS:4-,CSA:4-,CSV:4-,CW!Front Line:1!Second Line:2!Solahma:4!Provisional Garrison:5,NIOPS:6,BAN:0</availability>
 			<model name='THE-N'>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:6</availability>
+				<availability>CS:8,CLAN:8,CB:4-,CGB:5-,CIH:7,CJF:6,CNC:4-,CDS:4-,CSR:4-,CW:4-,NIOPS:8</availability>
 			</model>
 			<model name='THE-Nb'>
-				<availability>CLAN:4,CGS:5,BAN:2</availability>
+				<availability>CB:4,CGB:5,CIH:6+,CJF:8+,CNC:5,CDS:4,CSR:5,CW:6+</availability>
 			</model>
 		</chassis>
 		<chassis name='Thresher' unitType='Mek'>
@@ -6657,23 +6641,23 @@
 			</model>
 		</chassis>
 		<chassis name='Uller (Kit Fox)' unitType='Mek' omni='Clan'>
-			<availability>CCC:8,CSR:6,CJF:6</availability>
+			<availability>CCC!Keshik:3!Front Line:1,CJF!Keshik:5!Front Line:3</availability>
 			<model name='A'>
-				<availability>CLAN:5,CJF:6</availability>
+				<availability>CCC:5+,CJF:5+</availability>
 			</model>
 			<model name='B'>
-				<availability>CLAN:7</availability>
+				<availability>CCC:6,CJF:6</availability>
 			</model>
 			<model name='D'>
 				<roles>fire_support</roles>
-				<availability>CLAN:4</availability>
+				<availability>CCC:5,CJF:5</availability>
 			</model>
 			<model name='Prime'>
-				<availability>CLAN:8,CJF:9</availability>
+				<availability>CCC:8,CJF:8</availability>
 			</model>
             <model name='V'>
                 <roles>mixed_artillery</roles>
-                <availability>CLAN:2-:2921</availability>
+                <availability>CJF!Front Line:1</availability>
             </model>
 		</chassis>
 		<chassis name='Union C' unitType='Dropship'>
@@ -6734,17 +6718,17 @@
 			</model>
 		</chassis>
 		<chassis name='UrbanMech IIC' unitType='Mek'>
-			<availability>CHH:4,CIH:4-,CSR:4,CCO:5,CGS:4</availability>
+			<availability>CLAN!Second Line:3!Solahma:2!Provisional Garrison:1,CIH!Provisional Garrison:1,CJF!Solahma:2!Provisional Garrison:1,CSJ!Solahma:2!Provisional Garrison:1,CSV!Solahma:2!Provisional Garrison:1,BAN:1-</availability>
 			<model name=''>
 				<roles>urban</roles>
-				<availability>CLAN:8</availability>
+				<availability>CLAN:8,BAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='UrbanMech' unitType='Mek'>
-			<availability>IS:3-,CC:4,CS:4-,CLAN:1-,Periphery:4-,NIOPS:4-,HL:1,Periphery.Deep:3,PIR:2</availability>
+			<availability>IS:3-,CC:4,CS:4-,Periphery:4-,NIOPS:4-,HL:1,Periphery.Deep:3,PIR:2</availability>
 			<model name='UM-R60'>
 				<roles>urban</roles>
-				<availability>IS:8,CC:7,CLAN:8,Periphery:8,HL:8,NIOPS:8,Periphery.Deep:8,PIR:8</availability>
+				<availability>IS:8,CC:7,Periphery:8,HL:8,NIOPS:8,Periphery.Deep:8,PIR:8</availability>
 			</model>
 			<model name='UM-R60L'>
 				<roles>urban</roles>

--- a/megamek/data/forcegenerator/2900.xml
+++ b/megamek/data/forcegenerator/2900.xml
@@ -570,18 +570,21 @@
 			</model>
 		</chassis>
 		<chassis name='Annihilator' unitType='Mek'>
-			<availability>CSA:3,CHH:2,CSR:3,CLAN:2,CCO:3,BAN:1,CGB:2</availability>
+			<availability>CB!Front Line:3!Second Line:2!Solahma:1,CCO:3+,CGB:3+,CSA:3+</availability>
 			<model name='ANH-1G'>
-				<availability>CSA:4,CCO:4,BAN:1</availability>
+				<availability>CCO!Second Line:1,CGB!Second Line:1,CSA!Second Line:1</availability>
 			</model>
 			<model name='ANH-1X'>
-				<availability>CLAN:2,BAN:3</availability>
+				<availability>CB:8,CCO!Second Line:1,CGB!Second Line:1,CSA!Second Line:1</availability>
 			</model>
 			<model name='C'>
-				<availability>CLAN:8,BAN:2</availability>
+				<availability>CCO!Keshik:5!Front Line:3!Second Line:1,CGB!Keshik:5!Front Line:3!Second Line:1,CSA!Keshik:5!Front Line:3!Second Line:1</availability>
 			</model>
+            <model name='C &apos;Gausszilla&apos;'>
+                <availability>CCO:1+,CGB:1+,CSA:1+</availability>
+            </model>
 			<model name='C 2'>
-				<availability>CLAN:6,BAN:1</availability>
+				<availability>CCO!Keshik:3!Front Line:1,CGB!Keshik:3!Front Line:1,CSA!Keshik:3!Front Line:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Aquarius Escort' unitType='Small Craft'>
@@ -733,25 +736,25 @@
 			</model>
 		</chassis>
 		<chassis name='Atlas II' unitType='Mek'>
-			<availability>CLAN:4</availability>
+			<availability>CLAN!Front Line:2!Second Line:1,CBS:2+,CCC!Front Line:1,CIH!Front Line:1,CSA!Front Line:1,BAN:0</availability>
 			<model name='AS7-D-H'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CLAN:5</availability>
 			</model>
 			<model name='AS7-D-H2'>
                 <roles>command</roles>
-				<availability>CLAN:4</availability>
+				<availability>CLAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Atlas' unitType='Mek'>
-			<availability>CSV:2-,IS:3,FS:5,Periphery:1,CS:4-,CW:2-,LA:4,NIOPS:4-,CSJ:2-,DC:5,CB:2-</availability>
+			<availability>IS:3,FS:5,LA:4,DC:5,CS:4-,CLAN:4,CCC:3,CGS:3,CIH:2,CDS:3,CSV:3,Periphery:1,NIOPS:4-,Periphery.Deep:0,HL:1+,BAN:4-</availability>
 			<model name='AS7-D'>
                 <roles>command</roles>
-				<availability>HL:6,General:8,Periphery.Deep:7</availability>
+				<availability>IS:8,CLAN:3-,CBS:4-,Periphery:8,HL:6,BAN:5-</availability>
 			</model>
 			<model name='AS7-D-DC'>
 				<roles>command</roles>
-				<availability>IS:1,MERC:0,DC:2</availability>
+				<availability>IS:1+,DC:2+,MERC:0,BAN!Front Line:1</availability>
 			</model>
 			<model name='AS7-RS'>
                 <roles>command</roles>
@@ -759,15 +762,15 @@
 			</model>
 			<model name='C'>
                 <roles>command</roles>
-				<availability>CW:1-,CSV:1-,CFM:2-,CSJ:1-,CGS:2-,CB:1-</availability>
+				<availability>CB!Front Line:5!Second Line:1,CSJ!Second Line:1,CSV!Front Line:5!Second Line:1,CW!Second Line:5,BAN:3+</availability>
 			</model>
 			<model name='C 2'>
                 <roles>command</roles>
-				<availability>CLAN:2-</availability>
+				<availability>CLAN!Keshik:5!Front Line:3,CGB!Keshik:5!Front Line:3!Second Line:1,CGS!Keshik:5!Front Line:3!Second Line:1,CHH!Keshik:5!Front Line:3!Second Line:1,CNC!Keshik:5!Front Line:3!Second Line:1,CDS!Keshik:5!Front Line:3!Second Line:1,CSJ!Keshik:5!Front Line:5,CSR!Keshik:5!Front Line:3!Second Line:1,CSA!Keshik:5!Front Line:3!Second Line:1,CW!Keshik:5!Front Line:5,BAN:2+</availability>
 			</model>
 			<model name='C 3'>
 				<roles>mixed_artillery</roles>
-				<availability>CLAN:2-</availability>
+				<availability>CLAN!Second Line:1,CBS:1+,CB!Front Line:1,CCO!Front Line:1,CFM!Front Line:1,CGB!Front Line:1,CGS!Front Line:1,CHH!Front Line:1,CNC!Front Line:1,CDS!Front Line:1,CSA!Front Line:1,CSV!Front Line:1,BAN:0</availability>
 			</model>
 		</chassis>
 		<chassis name='Avar' unitType='AeroSpaceFighter' omni='Clan'>
@@ -800,12 +803,12 @@
 			</model>
 		</chassis>
 		<chassis name='Awesome' unitType='Mek'>
-			<availability>MOC:8,HL:5,CLAN:2-,IS:7,Periphery.Deep:6,CIR:8,Periphery:7,TC:8,CS:8,OA:8,FWL:10,NIOPS:8</availability>
+			<availability>IS:7,FWL:10,CS:8,Periphery:7,TC:8,MOC:8,OA:8,CIR:8,NIOPS:8,Periphery.Deep:6+,HL:5+</availability>
 			<model name='AWS-8Q'>
-				<availability>HL:6,General:8,Periphery.Deep:7,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:7,HL:6</availability>
 			</model>
 			<model name='AWS-8R'>
-				<availability>CS:2,IS:2,FWL:4</availability>
+				<availability>IS:2,FWL:4,CS:2</availability>
 			</model>
 			<model name='AWS-8T'>
 				<availability>IS:2,CIR:2</availability>
@@ -925,14 +928,14 @@
 			</model>
 		</chassis>
 		<chassis name='BattleMaster' unitType='Mek'>
-			<availability>CC:6,MOC:6,HL:4,CLAN:3,IS:5,Periphery:4,TC:6,CS:8-,LA:7,PIR:6,FWL:8,NIOPS:8-,DC:6</availability>
+			<availability>IS:5,LA:7,DC:6,FWL:8,CC:6,CS:8-,CLAN:5-,CFM:4,CGS:5,CSJ:4-,CW:6-,Periphery:4,TC:6,MOC:6,NIOPS:8-,HL:4,BAN:4,PIR:6</availability>
 			<model name='BLR-1D'>
                 <roles>command</roles>
 				<availability>FS:8</availability>
 			</model>
 			<model name='BLR-1G'>
                 <roles>command</roles>
-				<availability>HL:6,IS:8,Periphery.Deep:7,FS:6,BAN:8,Periphery:8</availability>
+				<availability>IS:8,FS:6,Periphery:8,Periphery.Deep:7,HL:6,BAN:5,PIR:8</availability>
 			</model>
 			<model name='BLR-1G-DC'>
 				<roles>command</roles>
@@ -940,15 +943,15 @@
 			</model>
 			<model name='BLR-1Gb'>
                 <roles>command</roles>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,BAN:6+</availability>
 			</model>
 			<model name='BLR-1Gbc'>
                 <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>CLAN!Second Line:1,CCO:0,CFM:0,CIH:0,CSJ:0,CSV:0,BAN:0</availability>
 			</model>
 			<model name='BLR-1Gc'>
                 <roles>command</roles>
-				<availability>CLAN:3</availability>
+				<availability>BAN:1+</availability>
 			</model>
 			<model name='BLR-2C'>
                 <roles>command</roles>
@@ -970,15 +973,15 @@
 			</model>
 		</chassis>
 		<chassis name='Behemoth (Stone Rhino)' unitType='Mek'>
-			<availability>CHH:3,CSR:3,CLAN:3,CSJ:5,CGS:3</availability>
+			<availability>CSJ:3+</availability>
 			<model name=''>
-				<availability>CSR:8,General:8</availability>
+				<availability>CSJ:3+</availability>
 			</model>
 			<model name='4'>
-				<availability>General:4</availability>
+				<availability>CSJ:4-</availability>
 			</model>
 			<model name='5'>
-				<availability>General:4</availability>
+				<availability>CSJ:3-</availability>
 			</model>
 		</chassis>
 		<chassis name='Behemoth' unitType='Dropship'>
@@ -1047,9 +1050,9 @@
             </model>
 		</chassis>
 		<chassis name='Blood Kite' unitType='Mek'>
-			<availability>CBS:6</availability>
+			<availability>CBS!Keshik:3</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CBS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Bombardier' unitType='Mek'>
@@ -1986,15 +1989,15 @@
 			</model>
 		</chassis>
 		<chassis name='Crockett' unitType='Mek'>
-			<availability>CC:1,CHH:9,CSR:7,CSV:7,CLAN:8,CFM:7,FS:1,CGS:7,CS:8,CDS:7,CW:9,LA:1,CBS:9,FWL:1,NIOPS:8,CJF:7,CGB:9,DC:1</availability>
+			<availability>FS:1,LA:1,DC:1,FWL:1,CC:1,CS:8,CLAN:3-,CBS:5-,CGS:4-,NIOPS:8,BAN:4-</availability>
 			<model name='CRK-5003-0'>
 				<availability>IS:8,NIOPS:0</availability>
 			</model>
 			<model name='CRK-5003-1'>
-				<availability>CS:8,General:2+,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>IS:2+,CS:8,CLAN:8,CBS:4-,CB:4-,CCO:4-,CGB:4-,CHH:4-,CW:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='CRK-5003-1b'>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
+				<availability>CBS:5,CB:5,CCO:5,CGB:5,CHH:5,CW:5,BAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Crossbow' unitType='Mek' omni='Clan'>
@@ -2063,7 +2066,7 @@
 			</model>
 		</chassis>
 		<chassis name='Cyclops' unitType='Mek'>
-			<availability>CC:5,CLAN:2,IS:3,FS:5,Periphery:2,CS:3,LA:5,FWL:4,NIOPS:3,DC:5</availability>
+			<availability>IS:3,FS:5,LA:5,DC:5,FWL:4,CC:5,CS:3,Periphery:2,NIOPS:3</availability>
 			<model name='CP-10-HQ'>
                 <roles>command</roles>
 				<availability>IS:2</availability>
@@ -2072,7 +2075,7 @@
 				<availability>IS:3</availability>
 			</model>
 			<model name='CP-10-Z'>
-				<availability>General:8</availability>
+				<availability>IS:8,MERC:8,Periphery:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Cyrano Gunship' unitType='VTOL'>
@@ -2204,6 +2207,12 @@
 				<availability>IS:8,FS!A:8!B:8!C:8,Periphery:4+,HL:3+,Periphery.Deep:2+,PIR:8</availability>
 			</model>
 		</chassis>
+        <chassis name='Devastator' unitType='Mek'>
+            <availability>CSJ!Front Line:2!Second Line:1</availability>
+            <model name='DVS-2-EC'>
+                <availability>CSJ:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Devil' unitType='Mek'>
 			<availability>CIH:1+:2912,CSR!keshik:3</availability>
 			<model name=''>
@@ -2330,14 +2339,14 @@
 			</model>
 		</chassis>
 		<chassis name='Emperor' unitType='Mek'>
-			<availability>CC:1,CS:7,OA:1,CLAN:2,CNC:2,FWL:2,NIOPS:7,FS:1,MERC:1,TC:1</availability>
+			<availability>FS:1,FWL:2,CC:1,MERC:1,CS:7,CLAN!Front Line:2!Second Line:1,CBS:3+,CGS:3+,CIH:3+,CSA!Front Line:1,TC:1,OA:1,NIOPS:7,BAN:0</availability>
 			<model name='EMP-5A'>
                 <roles>command</roles>
-				<availability>General:8,BAN:3</availability>
+				<availability>IS:8,Periphery:8,NIOPS:1-</availability>
 			</model>
 			<model name='EMP-6A'>
                 <roles>command</roles>
-				<availability>CS:8,CLAN:8,NIOPS:8,BAN:6</availability>
+				<availability>CS:8,CLAN:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Enforcer' unitType='Mek'>
@@ -2948,6 +2957,23 @@
                 <availability>MERC:8,Periphery.DD:8,HL!A:8!B:6!C:1,Periphery.Deep!A:8!B:6!C:1,PIR:8</availability>
             </model>
         </chassis>
+        <chassis name='Gladiator-B (Executioner-B)' unitType='Mek' omni='Clan'>
+            <availability>CLAN:1+,CB!Keshik:3!Front Line:1,CCO:2+,CFM:2+,CGB!Front Line:1,CGS!Keshik:1!Front Line:1,CJF!Keshik:1!Front Line:1,CDS!Keshik:1!Front Line:1,CSJ!Front Line:1,CSR!Front Line:1,CW:2+,BAN:0</availability>
+            <model name='A'>
+                <availability>CLAN:6</availability>
+            </model>
+            <model name='B'>
+                <roles>fire_support</roles>
+                <availability>CLAN:3+</availability>
+            </model>
+            <model name='C'>
+                <roles>fire_support</roles>
+                <availability>CLAN:4+</availability>
+            </model>
+            <model name='Prime'>
+                <availability>CLAN:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Goblin Medium Tank' unitType='Tank'>
 			<availability>CC:1,HL:1,LA:2,FS.CH:7,FS:6,MERC:3,CIR:4,Periphery:3,DC:2</availability>
 			<model name=''>
@@ -3412,33 +3438,33 @@
 			</model>
 		</chassis>
 		<chassis name='Highlander IIC' unitType='Mek'>
-			<availability>CLAN:7</availability>
+			<availability>CBS!Keshik:2,CCC!Keshik:3!Front Line:1,CCO!Keshik:3!Front Line:1,CFM:2+,CDS!Keshik:3!Front Line:1,CSR:2+</availability>
 			<model name=''>
                 <roles>command</roles>
-				<availability>CLAN:8</availability>
+				<availability>CBS:8,CCC:8,CCO:8,CFM:8,CDS:8,CSR:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Highlander' unitType='Mek'>
-			<availability>CC:2,CS:9,LA:2,CLAN:8,NIOPS:9,CFM:9,CJF:9,DC:1</availability>
+			<availability>LA:2,DC:1,CC:2,CS:9,CLAN:4+,CCC:3+,CIH:3+,CSV:3+,NIOPS:9+,BAN:2+</availability>
 			<model name='HGN-732'>
                 <roles>command</roles>
-				<availability>CS:8,CLAN:6,NIOPS:8,BAN:8</availability>
+				<availability>CS:8,CLAN:4-,NIOPS:8,BAN:8</availability>
 			</model>
 			<model name='HGN-732b'>
                 <roles>command</roles>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CLAN:6,BAN:1+</availability>
 			</model>
 			<model name='HGN-733'>
                 <roles>command</roles>
-				<availability>CC:8,LA:8,DC:8</availability>
+				<availability>LA:8,DC:8,CC:8</availability>
 			</model>
 			<model name='HGN-733C'>
                 <roles>command</roles>
-				<availability>CC:4,LA:4</availability>
+				<availability>LA:4,CC:4</availability>
 			</model>
 			<model name='HGN-733P'>
                 <roles>command</roles>
-				<availability>CC:4,LA:4</availability>
+				<availability>LA:4,CC:4</availability>
 			</model>
 		</chassis>
 		<chassis name='Hoplite' unitType='Mek'>
@@ -3543,22 +3569,22 @@
 			</model>
 		</chassis>
 		<chassis name='Imp' unitType='Mek'>
-			<availability>CSA:4,CW:4,CLAN:3</availability>
+			<availability>CB!Keshik:1!Front Line:2!Second Line:1,CCO!Keshik:1!Front Line:3!Second Line:1,CGB!Front Line:3!Second Line:1,CSJ!Keshik:1!Front Line:3!Second Line:1,CW!Keshik:1!Front Line:3!Second Line:1</availability>
 			<model name='C'>
                 <roles>command</roles>
-				<availability>CLAN:8</availability>
+				<availability>CB!Keshik:1!Front Line:2,CCO:2+,CGB!Front Line:8!Second Line:3,CSJ:2+,CW:1+</availability>
 			</model>
 			<model name='IMP-1A'>
                 <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>CB:4-,CCO:3-,CW:4-</availability>
 			</model>
 			<model name='IMP-1B'>
                 <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>CB!Front Line:6!Second Line:6,CGB:6,CW:6</availability>
 			</model>
 			<model name='IMP-1C'>
                 <roles>command</roles>
-				<availability>CHH:5,CLAN:2</availability>
+				<availability>CGB:4,CSJ:4-,CW:4</availability>
 			</model>
 		</chassis>
         <chassis name='Ina-du Swamp Skimmer' unitType='Tank'>
@@ -3878,10 +3904,10 @@
 			</model>
 		</chassis>
 		<chassis name='King Crab' unitType='Mek'>
-			<availability>CS:6,CLAN:5,IS:2+,FWL:1+,NIOPS:6,MERC:2+,CGS:6,CGB:6</availability>
+			<availability>IS:2+,FWL:1+,MERC:2+,CS:6,CB:3-,CFM:3-,CGB:3-,CGS:2-,CW:3-,NIOPS:6,BAN:1</availability>
 			<model name='KGC-000'>
                 <roles>command</roles>
-				<availability>CS:8,CIH:5,CLAN:6,NIOPS:8,BAN:8,CB:5</availability>
+				<availability>CS:8,NIOPS:8,BAN:5</availability>
 			</model>
 			<model name='KGC-0000'>
                 <roles>command</roles>
@@ -3889,29 +3915,25 @@
 			</model>
 			<model name='KGC-000b'>
                 <roles>command</roles>
-				<availability>CLAN:7,CGS:8,BAN:4</availability>
-			</model>
-			<model name='KGC-010'>
-                <roles>command</roles>
-				<availability>CLAN:2</availability>
+				<availability>CB:8,CFM:8,CGB:8,CGS:8,CW:8,BAN:2+</availability>
 			</model>
 		</chassis>
 		<chassis name='Kingfisher' unitType='Mek' omni='Clan'>
-			<availability>CSJ:5,CGB:5</availability>
+			<availability>CGB:1+,CSJ:1+,CSR:2+</availability>
 			<model name='A'>
-				<availability>General:6</availability>
+				<availability>CGB:6,CSJ:6,CSR:6</availability>
 			</model>
 			<model name='B'>
-				<availability>General:7</availability>
+				<availability>CGB:4+,CSJ:4+,CSR:4+</availability>
 			</model>
 			<model name='C'>
-				<availability>General:5,CGB:5</availability>
+				<availability>CGB:4,CSJ:4,CSR:4</availability>
 			</model>
 			<model name='D'>
-				<availability>General:6,CGB:6</availability>
+				<availability>CGB:6,CSJ:6,CSR:6</availability>
 			</model>
 			<model name='Prime'>
-				<availability>General:8</availability>
+				<availability>CGB:8,CSJ:8,CSR:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Kintaro' unitType='Mek'>
@@ -3999,9 +4021,9 @@
 			</model>
 		</chassis>
 		<chassis name='Kraken (Bane)' unitType='Mek'>
-			<availability>CSR:6,CLAN:6,CJF:6</availability>
+			<availability>CJF!Front Line:2!Second Line:1,CDS!Front Line:2!Second Line:1,CSR!Front Line:2!Second Line:1,CW!Front Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CJF:8,CDS:8,CSR:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Ku Wheeled Assault Tank' unitType='Tank'>
@@ -4207,7 +4229,7 @@
 			</model>
 		</chassis>
 		<chassis name='Longbow' unitType='Mek'>
-			<availability>CC:6,HL:5,CDS:2-,CSR:2-,IS:7,Periphery.Deep:6,FS:8,Periphery:7,CS:4,FWL:9,NIOPS:4,DC:5</availability>
+			<availability>IS:7,FS:8,DC:5,FWL:9,CC:6,CS:4,Periphery:7,NIOPS:4,Periphery.Deep:6,HL:5</availability>
 			<model name='LGB-0W'>
 				<roles>fire_support</roles>
 				<availability>IS:8,Periphery:8</availability>
@@ -4218,11 +4240,11 @@
 			</model>
 			<model name='LGB-7Q'>
 				<roles>fire_support</roles>
-				<availability>MOC:6,OA:6,IS:6,TC:6,Periphery:4,CLAN:6</availability>
+				<availability>IS:6,Periphery:4,TC:6,MOC:6,OA:6</availability>
 			</model>
 			<model name='LGB-8C'>
                 <roles>fire_support</roles>
-				<availability>MOC:2,CS:6,OA:2,IS:4,MERC:3,Periphery:2,TC:1,CLAN:5</availability>
+				<availability>IS:4,MERC:3,CS:6,Periphery:2,TC:1,MOC:2,OA:2</availability>
 			</model>
 		</chassis>
         <chassis name='Luciano White Wolverine' unitType='Tank'>
@@ -4334,22 +4356,22 @@
 			</model>
 		</chassis>
 		<chassis name='Man O&apos; War (Gargoyle)' unitType='Mek' omni='Clan'>
-			<availability>CW:7:2945</availability>
+			<availability>CLAN:1+,CBS:1+:2949,CB:1+:2948,CCO!Keshik:2,CFM:1+:2949,CGS:1+:2949,CIH!Keshik:2,CJF!Keshik:2,CSV!Keshik:2,CW!Keshik:3,BAN:0</availability>
 			<model name='A'>
 			    <roles>cavalry</roles>
-				<availability>CW:7</availability>
+				<availability>CLAN:3+</availability>
 			</model>
 			<model name='B'>
                 <roles>cavalry</roles>
-				<availability>CLAN:5</availability>
+				<availability>CLAN:4+</availability>
 			</model>
 			<model name='C'>
                 <roles>cavalry</roles>
-				<availability>CW:5</availability>
+				<availability>CLAN:3+</availability>
 			</model>
 			<model name='D'>
                 <roles>cavalry</roles>
-				<availability>CW:4</availability>
+				<availability>CLAN:3+</availability>
 			</model>
 			<model name='Prime'>
                 <roles>cavalry</roles>
@@ -4376,12 +4398,12 @@
 			</model>
 		</chassis>
 		<chassis name='Marauder IIC' unitType='Mek'>
-			<availability>CSA:7,CSR:6,CW:6,CLAN:6,CNC:6,CJF:6,CGB:7</availability>
+			<availability>CLAN!Keshik:4!Front Line:2!Second Line:1,CBS!Keshik:3!Front Line:1,CB!Keshik:4!Front Line:1,CCO:3+,CGB:3+,CGS!Keshik:5!Front Line:3!Second Line:1,CHH!Keshik:5!Front Line:3!Second Line:2,CIH!Keshik:5!Front Line:2!Second Line:1,CJF:3+,CNC:3+,CSJ!Keshik:4!Front Line:3!Second Line:1,CSR!Keshik:4!Front Line:3!Second Line:1,CSA:2+,CSV:3+,CW!Keshik:5!Front Line:3,BAN!Keshik:2!Front Line:1!Second Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8,CJF:8,CGB:8</availability>
+				<availability>CLAN:8,CJF:4,CW:4,BAN:8</availability>
 			</model>
 			<model name='9'>
-				<availability>CSA:4,CSV:4,CLAN:4,CJF:4</availability>
+				<availability>CJF:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Marauder' unitType='Mek'>
@@ -5008,27 +5030,46 @@
 				<availability>General:8</availability>
 			</model>
 		</chassis>
+        <chassis name='Naga II' unitType='Mek' omni='Clan'>
+            <availability>CHH!Front Line:1,CW!Front Line:2!Second Line:1</availability>
+            <model name='A'>
+                <roles>cavalry</roles>
+                <availability>CHH:6,CW:6</availability>
+            </model>
+            <model name='B'>
+                <roles>cavalry,fire_support</roles>
+                <availability>CHH:5,CW:5</availability>
+            </model>
+            <model name='C'>
+                <roles>cavalry,urban</roles>
+                <availability>CHH:6-,CW:6-</availability>
+            </model>
+            <model name='Prime'>
+                <roles>cavalry</roles>
+                <availability>CHH:8,CW:8</availability>
+            </model>
+        </chassis>
 		<chassis name='Naga' unitType='Mek' omni='Clan'>
-			<availability>CW:3,CHH:3</availability>
+			<availability>CHH!Front Line:1,CW!Second Line:1</availability>
 			<model name='A'>
 				<roles>mixed_artillery</roles>
-				<availability>CLAN:4</availability>
+                <availability>CHH:3+,CW:3+</availability>
 			</model>
 			<model name='B'>
 				<roles>mixed_artillery</roles>
-				<availability>CLAN:6</availability>
+                <availability>CHH:2+,CW:2+</availability>
 			</model>
 			<model name='C'>
 				<roles>missile_artillery</roles>
-				<availability>CLAN:4</availability>
+                <availability>CHH:3+,CW:3+</availability>
 			</model>
 			<model name='D'>
 				<roles>mixed_artillery</roles>
-				<availability>CLAN:4</availability>
+                <availability>CHH:2+,CW:2+</availability>
 			</model>
 			<model name='Prime'>
 				<roles>missile_artillery</roles>
-				<availability>CLAN:8</availability>
+                <availability>CHH:8,CW:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Naja' unitType='Mek'>
@@ -5079,10 +5120,10 @@
 			</model>
 		</chassis>
 		<chassis name='Nightstar' unitType='Mek'>
-			<availability>CSA:6,CS:4,CLAN:3,NIOPS:4</availability>
+			<availability>CS:4,CCO!Front Line:1,NIOPS:4+</availability>
 			<model name='NSR-9J'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CS:8,CCO:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Odin Scout Tank' unitType='Tank'>
@@ -5358,18 +5399,18 @@
             </model>
         </chassis>
 		<chassis name='Phoenix Hawk IIC' unitType='Mek'>
-			<availability>CCC:4,CIH:4,CSR:4,CDS:4,CSV:5,CLAN:3,CFM:4,CGS:2,CCO:4,CB:2</availability>
+			<availability>CFM!Keshik:3!Front Line:1,CJF!Keshik:3!Front Line:1,CSR:3+,CSV!Keshik:4!Front Line:3!Second Line:1</availability>
 			<model name=''>
                 <roles>cavalry</roles>
-				<availability>CLAN:8</availability>
+				<availability>CFM:8,CJF:8,CSR:8,CSV:8</availability>
 			</model>
 			<model name='2'>
 				<roles>cavalry,fire_support</roles>
-				<availability>CCC:6,CSR:6,CDS:6,CSV:6,CNC:6,CFM:6,CCO:6</availability>
+				<availability>CSR:5,CSV:5</availability>
 			</model>
 			<model name='9'>
-                <roles>cavalry</roles>
-				<availability>CLAN:2</availability>
+			    <roles>cavalry,fire_support</roles>
+				<availability>CSV:3</availability>
 			</model>
 		</chassis>
 		<chassis name='Phoenix Hawk LAM' unitType='Mek'>
@@ -5411,7 +5452,7 @@
 			</model>
 		</chassis>
 		<chassis name='Pillager' unitType='Mek'>
-			<availability>CLAN:3,CC:2+,CS:5,LA:2+,FWL:2+,NIOPS:5,FS:2+,BAN:0</availability>
+			<availability>FS:2+,LA:2+,FWL:2+,CC:2+,CS:5,CLAN:1+,CBS:2+,CGS:2+,CIH!Front Line:1,CSR!Front Line:1,CSA!Front Line:1,CSV!Front Line:1,NIOPS:5+,BAN:0</availability>
 			<model name='PLG-3Z'>
 				<availability>IS:8,CLAN:8,NIOPS:8</availability>
 			</model>
@@ -5517,12 +5558,6 @@
 				<availability>IS:4,Periphery:4</availability>
 			</model>
 		</chassis>
-		<chassis name='Pulverizer' unitType='Mek'>
-			<availability>CSR:3</availability>
-			<model name=''>
-				<availability>CSR:8</availability>
-			</model>
-		</chassis>
 		<chassis name='Puma Assault Tank' unitType='Tank'>
 			<availability>CC:1,CLAN:7,MERC:1,FS:1,CIR:2,Periphery:1,CS:8,LA:1,FWL:1,NIOPS:8,CJF:5,DC:1</availability>
 			<model name='PAT-005'>
@@ -5618,13 +5653,6 @@
 			<model name=''>
                 <roles>fire_support,anti_aircraft</roles>
 				<availability>CGB:8,CNC:8,CDS:8,CSR:8,CW:8</availability>
-			</model>
-		</chassis>
-		<chassis name='Rifleman II' unitType='Mek'>
-			<availability>CLAN:3</availability>
-			<model name='RFL-3N-2'>
-				<roles>anti_aircraft</roles>
-				<availability>CLAN:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Rifleman' unitType='Mek'>
@@ -5992,12 +6020,12 @@
 			</model>
 		</chassis>
 		<chassis name='Shogun' unitType='Mek'>
-			<availability>CSA:4,CIH:4,CBS:3,CLAN:3,FWL:1+,CCO:4,CB:3</availability>
+			<availability>FWL:1+,CBS:2,CB!Front Line:2!Second Line:1,CCC!Front Line:2!Second Line:1,CCO!Front Line:3!Second Line:2!Solahma:1,CSA!Front Line:3!Second Line:2!Solahma:1</availability>
 			<model name='C'>
-				<availability>CLAN:8</availability>
+				<availability>CBS:2+,CB:8,CCC:8,CCO:8,CSA:8</availability>
 			</model>
 			<model name='SHG-2H'>
-				<availability>General:8,CLAN:1-,BAN:4</availability>
+				<availability>FWL:8,CBS:4-</availability>
 			</model>
 		</chassis>
 		<chassis name='Sholagar' unitType='AeroSpaceFighter'>
@@ -6136,15 +6164,19 @@
 			</model>
 		</chassis>
 		<chassis name='Spartan' unitType='Mek'>
-			<availability>CS:5,CHH:4,CFM:5,CCO:3</availability>
+			<availability>CS:5,CCO!Front Line:1,CFM!Front Line:2!Second Line:1,CHH!Second Line:1,BAN:4+</availability>
 			<model name='C'>
                 <roles>cavalry</roles>
-				<availability>CLAN:8</availability>
+				<availability>CCO:8,CFM:8,CHH:8</availability>
 			</model>
 			<model name='SPT-N2'>
 				<roles>cavalry,spotter</roles>
-				<availability>IS:8</availability>
+				<availability>CS:8,BAN:3-</availability>
 			</model>
+            <model name='SPT-NF'>
+                <roles>cavalry</roles>
+                <availability>BAN:5</availability>
+            </model>
 		</chassis>
 		<chassis name='Spider' unitType='Mek'>
 			<availability>IS:2+,FS:3+,FWL:4+,DC:4+,MERC:1+,CS:1,Periphery:1+,Periphery.MW:2+,Periphery.ME:2+,NIOPS:4,HL:1+,Periphery.Deep:0,PIR:2+</availability>
@@ -6170,18 +6202,18 @@
             </model>
         </chassis>
 		<chassis name='Stalker' unitType='Mek'>
-			<availability>CC:7,HL:8,CLAN:5,IS:9,Periphery.Deep:9,FS:7,Periphery:10,CS:6,LA:9,FWL:10,NIOPS:6,DC:7</availability>
+			<availability>IS:9,FS:7,DC:7,FWL:10,CC:7,CS:6,CLAN:5-,CBS:6-,CCC:4-,CIH:4-,CJF:4-,CSR:4-,CW:4-,Periphery:10,NIOPS:6,Periphery.Deep:9,HL:8,BAN:3</availability>
 			<model name='STK-3F'>
-				<availability>HL:6,IS:8,Periphery.Deep:7,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:7,HL:6,BAN:5</availability>
 			</model>
 			<model name='STK-3Fb'>
-				<availability>CLAN:8,BAN:4</availability>
+				<availability>CLAN:8,BAN:3+</availability>
 			</model>
 			<model name='STK-3H'>
-				<availability>MOC:2,OA:2,IS:2,TC:2,Periphery:2</availability>
+				<availability>IS:2,Periphery:2,TC:2,MOC:2,OA:2</availability>
 			</model>
 			<model name='STK-4N'>
-				<availability>MOC:2,OA:2,IS:2,Periphery:1,TC:2</availability>
+				<availability>IS:2,Periphery:1,TC:2,MOC:2,OA:2</availability>
 			</model>
 		</chassis>
 		<chassis name='Star Lord JumpShip' unitType='Jumpship'>
@@ -6246,15 +6278,18 @@
 			</model>
 		</chassis>
 		<chassis name='Storm Giant' unitType='Mek'>
-			<availability>CSV:6</availability>
+			<availability>CSV!Keshik:1!Front Line:1</availability>
+            <model name=''>
+                <availability>CSV:8</availability>
+            </model>
 			<model name='2'>
-				<availability>General:8</availability>
+				<availability>CSV:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Striker' unitType='Mek'>
-			<availability>MOC:3,CC:8,CS:4,OA:3,LA:5,NIOPS:4,MERC:3,FS:3,TC:3,DC:3</availability>
+			<availability>FS:3,LA:5,DC:3,CC:8,MERC:3,CS:4,TC:3,MOC:3,OA:3,NIOPS:4</availability>
 			<model name='STC-2C'>
-				<availability>CC:8,General:8</availability>
+				<availability>IS:8,Periphery:8</availability>
 			</model>
 			<model name='STC-2S'>
 				<availability>LA:5</availability>
@@ -6276,9 +6311,9 @@
 			</model>
 		</chassis>
 		<chassis name='Supernova' unitType='Mek'>
-			<availability>CSA:3,CCC:5,CDS:3,CW:5,CNC:8,CLAN:2,CGB:4</availability>
+			<availability>CNC!Keshik:4!Front Line:2!Second Line:1,CDS:3+,CSJ!Front Line:2</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CNC:8,CDS:8,CSJ:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Svantovit Infantry Fighting Vehicle' unitType='Tank'>
@@ -6418,15 +6453,15 @@
 			</model>
 		</chassis>
 		<chassis name='Thug' unitType='Mek'>
-			<availability>CHH:6,CSV:8,CLAN:7,IS:2,CFM:9,FS:1,CS:7,CDS:6,CW:8,CBS:6,CNC:6,FWL:4,NIOPS:7,CJF:8,CGB:8</availability>
+			<availability>IS:2,FS:1,FWL:4,CS:7,CLAN!Keshik:3!Front Line:4!Second Line:5!Solahma:5!Provisional Garrison:5,CIH!Keshik:2!Front Line:3!Second Line:4!Solahma:4!Provisional Garrison:4,CSV!Keshik:2!Front Line:3!Second Line:4!Solahma:4!Provisional Garrison:4,NIOPS:7,BAN:4+</availability>
 			<model name='THG-10E'>
 				<availability>FWL:8,DC:8</availability>
 			</model>
 			<model name='THG-11E'>
-				<availability>CS:8,CLAN:6,FWL:1+,IS:1+,NIOPS:8,FS:1+,BAN:8,DC:1+</availability>
+				<availability>IS:1+,FS:1+,DC:1+,FWL:1+,CS:8,CLAN:4-,NIOPS:8,BAN:5</availability>
 			</model>
 			<model name='THG-11Eb'>
-				<availability>CLAN:7,BAN:4</availability>
+				<availability>CLAN:6,BAN:3+</availability>
 			</model>
 		</chassis>
 		<chassis name='Thumper Artillery Vehicle' unitType='Tank'>
@@ -6437,19 +6472,19 @@
 			</model>
 		</chassis>
 		<chassis name='Thunder Hawk' unitType='Mek'>
-			<availability>CS:2,CLAN:3,NIOPS:2</availability>
+			<availability>CS:2,NIOPS:2+</availability>
 			<model name='TDK-7X'>
                 <roles>command</roles>
-				<availability>General:8</availability>
+				<availability>CS:8,NIOPS:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Thunder Stallion' unitType='Mek'>
-			<availability>CHH:5</availability>
+			<availability>CHH:3+</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CHH:8</availability>
 			</model>
 			<model name='2 &apos;Fire Stallion&apos;'>
-				<availability>CHH:6,CGS:6</availability>
+				<availability>CHH:1</availability>
 			</model>
 		</chassis>
 		<chassis name='Thunderbird' unitType='AeroSpaceFighter'>
@@ -6806,15 +6841,18 @@
 			</model>
 		</chassis>
 		<chassis name='Victor' unitType='Mek'>
-			<availability>MOC:5,CC:6,HL:2,CLAN:1-,IS:4,Periphery.Deep:4,FS:9,CIR:5,Periphery.OS:5,TC:5,Periphery:4,CS:5-,OA:5,LA:5,Periphery.HR:5,FWL:5,NIOPS:5-,DC:5</availability>
-			<model name='VTR-9A'>
-				<availability>CC:1,CS:1,FS:1</availability>
+			<availability>IS:4,FS:9,LA:5,DC:5,FWL:5,CC:6,CS:5-,CBS!Second Line:1,CB!Second Line:1,CCO!Solahma:1,CGB!Second Line:1,CJF!Second Line:1,CNC!Second Line:1,CSJ!Second Line:1,CW!Second Line:1,Periphery:4,Periphery.OS:5,Periphery.HR:5,TC:5,MOC:5,OA:5,CIR:5,NIOPS:5-,Periphery.Deep:4+,HL:2</availability>
+            <model name='C'>
+                <availability>CBS:8,CB:8,CCO:8,CGB:8,CJF:8,CNC:8,CSJ:8,CW:8</availability>
+            </model>
+            <model name='VTR-9A'>
+				<availability>FS:1,CC:1,CS:1</availability>
 			</model>
 			<model name='VTR-9A1'>
-				<availability>CC:1,CS:1,FS:1</availability>
+				<availability>FS:1,CC:1,CS:1</availability>
 			</model>
 			<model name='VTR-9B'>
-				<availability>HL:6,General:8,CLAN:8,Periphery.Deep:7,Periphery:8</availability>
+				<availability>IS:8,Periphery:8,Periphery.Deep:7,HL:6</availability>
 			</model>
 		</chassis>
 		<chassis name='Vincent Corvette' unitType='Warship'>
@@ -6915,19 +6953,19 @@
 			</model>
 		</chassis>
 		<chassis name='Wakazashi' unitType='Mek'>
-			<availability>CJF:6</availability>
+			<availability>CJF!Keshik:2!Front Line:2!Second Line:1</availability>
 			<model name=''>
-				<availability>General:8</availability>
+				<availability>CJF:8</availability>
 			</model>
 		</chassis>
 		<chassis name='Warhammer IIC' unitType='Mek'>
-			<availability>CLAN:6</availability>
+			<availability>CLAN!Front Line:3,CBS:1+,CB:0,CCO!Keshik:3,CFM:1+,CGB!Keshik:5!Front Line:3!Second Line:1,CGS:0,CIH:1+,CJF:0,CNC!Front Line:2,CSJ!Keshik:3,CSA!Keshik:4!Front Line:3!Second Line:1,CSV!Front Line:2,BAN!Keshik:1!Front Line:1</availability>
 			<model name=''>
-				<availability>CLAN:8</availability>
+				<availability>CGB:8,CSA:8,BAN:8</availability>
 			</model>
 			<model name='2'>
 				<roles>fire_support</roles>
-				<availability>CLAN:4:2920</availability>
+				<availability>CLAN:8,CGB:0,CSA:5</availability>
 			</model>
 		</chassis>
 		<chassis name='Warhammer' unitType='Mek'>


### PR DESCRIPTION
Next in the ongoing series of general availability reviews, Clan faction Meks from the 2807-2900 years. The overall goals are:

- checking intro dates
- checking faction availability
- add any missing/overlooked chassis and models

As with the other updates this establishes a range of designs from best (A/Keshik) to worst (F/Provisional Garrison) equipped.  The early years, prior to introduction of actual Clan-tech and OmniMeks, are predominantly IS tech and almost entirely SLDF Royal designs which range from outstanding to 'just' very good.  The best-equipped have designs that are more anti-Mek and specialist focused, such as the Pillager and Atlas II; the worst equipped are populated with the more generic and common designs such as the BattleMaster, Atlas, and Stalker.  As time progresses the top-of-the-line designs are supplanted by Clan tech and OmniMek designs, while the worst-equipped stays more or less the same.

This batch has a few differences from the earlier ones.  It covers all weight classes (light, medium heavy, assault) for the range of years rather than a single class, and so is much larger.  This is due to the uneven introduction of Clan and OmniMek designs across those weight classes for various Clans - during any particular year a Clan may be introducing multiple Clan-tech light Meks while still fielding SLDF Royal Meks in the heavy and assault classes or vice versa.  The C/SL/O (Clan / Star League / Omni) ratings do not have weight class distinctions, and applying them automatically leads to distortions such as 'oops all Marauder IIC' when that is one of the first Clan-tech assault Meks.  Similarly a number of standard/non-advanced Meks such the Hunchback, Atlas, and Awesome would be filtered out by the 100% SL rating in the early years while adjusting that value would make other designs more common than they should be.

Getting around the C/SL/O issue means removing the indicated values as data in the top-most section of the availability XMLs (they are still retained in the files, as commented information).  The updated availability values are arrived at using the C/SL/O values as a guideline rather than enforced through calculations during RAT generation, allowing necessary variation based on MUL availability, introduction dates, and general progression.