### PR TITLE
Prevent log message from empty lines in rat data

### DIFF
--- a/megamek/src/megamek/client/generator/RandomUnitGenerator.java
+++ b/megamek/src/megamek/client/generator/RandomUnitGenerator.java
@@ -181,7 +181,7 @@ public class RandomUnitGenerator implements Serializable {
                     return;
                 }
 
-                if (line.startsWith("#")) {
+                if (line.startsWith("#") || line.isBlank()) {
                     continue;
                 }
 


### PR DESCRIPTION
Lots of log entries from empty lines after the license note in rat data now.