### PR TITLE
Fix BV calculation and broken unit tests

### DIFF
--- a/megamek/src/megamek/common/equipment/WeaponType.java
+++ b/megamek/src/megamek/common/equipment/WeaponType.java
@@ -754,8 +754,6 @@ public class WeaponType extends EquipmentType {
     protected int waterLongRange;
     protected int waterExtremeRange;
 
-    protected double bv;
-
     // the class of weapon for infantry damage
     public int infDamageClass = WEAPON_DIRECT_FIRE;
 

--- a/megamek/unittests/megamek/common/ConfigurationTests.java
+++ b/megamek/unittests/megamek/common/ConfigurationTests.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 
+import org.apache.commons.io.FilenameUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -75,7 +76,8 @@ class ConfigurationTests {
      */
     @Test
     final void testDataDir() {
-        assertEquals("testresources/data", Configuration.dataDir().toString());
+        assertEquals(FilenameUtils.normalize("testresources/data"),
+              FilenameUtils.normalize(Configuration.dataDir().toString()));
     }
 
     /**

--- a/megamek/unittests/megamek/common/loaders/BulkUnitFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/BulkUnitFileTest.java
@@ -63,6 +63,7 @@ import megamek.common.units.SmallCraft;
 import megamek.common.units.Tank;
 import megamek.common.verifier.*;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -80,6 +81,7 @@ public class BulkUnitFileTest {
         BombType.initializeTypes();
     }
 
+    @Disabled("This was broken before this test was added, we hope to fix save/load eventually we're not there yet.")
     @ParameterizedTest(name = "{0}")
     @MethodSource("allBlkFiles")
     void loadVerifySaveVerifyBLKFiles(File file) throws EntitySavingException, IOException {

--- a/megamek/unittests/megamek/common/loaders/BulkUnitFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/BulkUnitFileTest.java
@@ -81,7 +81,7 @@ public class BulkUnitFileTest {
         BombType.initializeTypes();
     }
 
-    @Disabled("This was broken before this test was added, we hope to fix save/load eventually we're not there yet.")
+    @Disabled("This was broken before this test was added. We hope to fix save/load eventually, but we're not there yet.")
     @ParameterizedTest(name = "{0}")
     @MethodSource("allBlkFiles")
     void loadVerifySaveVerifyBLKFiles(File file) throws EntitySavingException, IOException {


### PR DESCRIPTION
- Fixes weapon BVs all being 0
- Skips a unit test that already used to be disabled
- Normalizes configuration path tests across operating systems