### PR TITLE
Fix typo in names of settings

### DIFF
--- a/megamek/resources/megamek/common/options/messages.properties
+++ b/megamek/resources/megamek/common/options/messages.properties
@@ -41,12 +41,15 @@ GameOptionsInfo.option.turn_timer_physical.displayableName=Turn timer in seconds
 GameOptionsInfo.option.turn_timer_physical.description=If value is greater 0, the game will end a players current action turn after the time is up. deactivated by 0 value by default.
 GameOptionsInfo.option.turn_timer_allow_extension.displayableName=Allow Turn Timer Extensions
 GameOptionsInfo.option.turn_timer_allow_extension.description=When Turn Timer gets to 2 seconds left, reset timer.
-GameOptionsInfo.option.skip_ineligable_movement.displayableName=Skip ineligible during movement
-GameOptionsInfo.option.skip_ineligable_movement.description=If checked, the game will skip a unit during the movement phase if it is immobile or otherwise inactive. \nUnchecked by default.
-GameOptionsInfo.option.skip_ineligable_firing.displayableName=Skip ineligible during firing
-GameOptionsInfo.option.skip_ineligable_firing.description=If checked, the game will skip a unit during the firing phase if it is inactive. \nUnchecked by default.
-GameOptionsInfo.option.skip_ineligable_physical.displayableName=Skip ineligible during physical
-GameOptionsInfo.option.skip_ineligable_physical.description=If checked, the game will skip a unit during the physical phase if no attacks are possible or there are no valid targets.\nChecked by default.
+GameOptionsInfo.option.skip_ineligible_movement.displayableName=Skip ineligible during movement
+GameOptionsInfo.option.skip_ineligible_movement.description=If checked, the game will skip a unit during the movement\
+  \ phase if it is immobile or otherwise inactive. \nUnchecked by default.
+GameOptionsInfo.option.skip_ineligible_firing.displayableName=Skip ineligible during firing
+GameOptionsInfo.option.skip_ineligible_firing.description=If checked, the game will skip a unit during the firing \
+  phase if it is inactive. \nUnchecked by default.
+GameOptionsInfo.option.skip_ineligible_physical.displayableName=Skip ineligible during physical
+GameOptionsInfo.option.skip_ineligible_physical.description=If checked, the game will skip a unit during the physical\
+  \ phase if no attacks are possible or there are no valid targets.\nChecked by default.
 GameOptionsInfo.option.push_off_board.displayableName=Allow pushing off the map
 GameOptionsInfo.option.push_off_board.description=This options allows a Mek to be pushed off the map and out of the game by push, charge or DFA attacks.\nChecked by default.
 GameOptionsInfo.option.team_initiative.displayableName=Teams roll initiative


### PR DESCRIPTION
Makes the setting name and description not show up right in the settings ui