### PR TITLE
Add shortname for Chameleon LPS

### DIFF
--- a/megamek/src/megamek/common/equipment/MiscType.java
+++ b/megamek/src/megamek/common/equipment/MiscType.java
@@ -8051,6 +8051,7 @@ public class MiscType extends EquipmentType {
         MiscType misc = new MiscType();
 
         misc.name = "Chameleon Light Polarization Shield";
+        misc.shortName = "Chameleon LPS";
         misc.setInternalName("Chameleon Light Polarization Shield");
         misc.addLookupName("Chameleon Light Polarization Field");
         misc.addLookupName("ChameleonLightPolarizationShield");


### PR DESCRIPTION
The full long name doesn't fit on sheets: 
<img width="2448" height="3168" alt="image" src="https://github.com/user-attachments/assets/58607f86-51b9-4986-a090-2f490492cae4" />

Shorten it to Chameleon LPS and now it fits:
<img width="2448" height="3168" alt="image" src="https://github.com/user-attachments/assets/cc22654d-c2eb-4d71-9c33-79fb6ebbac22" />
