### PR TITLE
Fix 7408: Force Generator tab only creates one unit

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/ForceNode.java
+++ b/megamek/src/megamek/client/ratgenerator/ForceNode.java
@@ -408,7 +408,7 @@ public class ForceNode extends RulesetNode {
                         }
                     }
                     break;
-                case "subForces":
+                case "subforces":
                     subForces.add(SubForcesNode.createFromXml(wn));
                     break;
                 case "attachedForces":


### PR DESCRIPTION
Un-camelCases an XML tag that was preventing ForceNodes from reading their required subforce layouts, leading to only a single top-level unit getting created.

Testing:
- Ran through several Force Generator configurations for various factions.
- Ran all 3 projects' unit tests.

## NOTE ##
We likely will need to write a script or tool that can validate all XML ingest tag strings against data in the `mm-data` repo, and flag any strings that are near-matches or non-matches to existing tag names.

close: #7408 