### PR TITLE
Fix 7398: Cannot change ownership of units in the lobby

### DIFF
--- a/megamek/src/megamek/common/net/packets/Packet.java
+++ b/megamek/src/megamek/common/net/packets/Packet.java
@@ -493,8 +493,8 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
 
         ArrayList<Entity> result = new ArrayList<>();
 
-        if (object instanceof List<?> list) {
-            for (Object entity : list) {
+        if (object instanceof Collection<?> collection) {
+            for (Object entity : collection) {
                 if (entity instanceof Entity verifiedEntity) {
                     result.add(verifiedEntity);
                 }


### PR DESCRIPTION
A bunch of the packet handling code has been updated; in this case the entities contained in the packet were being treated as a List but were actually passed as a HashSet.

Fix is to treat the packet object as a Collection to allow Sets as well; most of the other packet handlers took this route so I'm not sure why this one was only allowing Lists.

Testing:
- Created and transferred many sets of units between player and bot armies.
- Ran all 3 projects' unit tests.

## NOTE
This packet handler was silently dropping all the entities because it did not expect an object of the type it actually got.
This made debugging more difficult than it needed to be.
If a packet with a given command does not find the expected value type, it should throw or at least log this info.
We should review the updated packet handling code to make sure that typing is being applied.