### PR TITLE
Fix 7397: cannot change teams in the lobby

### DIFF
--- a/megamek/src/megamek/common/net/packets/Packet.java
+++ b/megamek/src/megamek/common/net/packets/Packet.java
@@ -87,11 +87,14 @@ import megamek.server.SmokeCloud;
  * Application layer data packet used to exchange information between client and server.
  */
 public record Packet(PacketCommand command, Object... data) implements Serializable {
+
     /**
      * Creates a <code>Packet</code> with a command and an array of objects
      *
      */
-    public Packet {
+    public Packet(PacketCommand command, Object... data) {
+        this.command = command;
+        this.data = data;
     }
 
     /**
@@ -865,8 +868,8 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
 
         Vector<Player> result = new Vector<>();
 
-        if (object instanceof Vector<?> vector) {
-            for (Object player : vector) {
+        if (object instanceof Collection<?> collection) {
+            for (Object player : collection) {
                 if (player instanceof Player verifiedPlayer) {
                     result.add(verifiedPlayer);
                 }


### PR DESCRIPTION
Replicates the fix for unit reassignment by making the packet handler more permissive.

Edit: also adds a canonical constructor to the Packet Record type to get Idea to shut up about "unable to apply" errors.

Testing:
- Created and moved players/bots between several teams
- Ran all 3 projects' unit tests

Close #7397 