### PR TITLE
Remove incorrect final from class variables

### DIFF
--- a/megamek/src/megamek/common/universe/Faction2.java
+++ b/megamek/src/megamek/common/universe/Faction2.java
@@ -101,9 +101,10 @@ public class Faction2 {
     private final Set<String> fallBackFactions = new HashSet<>();
     private final HonorRating preInvasionHonorRating = HonorRating.NONE;
     private final HonorRating postInvasionHonorRating = HonorRating.NONE;
-    private final int formationBaseSize = UNKNOWN;
-    private final int formationGrouping = UNKNOWN;
-    private final String rankSystem = null;
+    // Do not final the variables
+    private int formationBaseSize = UNKNOWN;
+    private int formationGrouping = UNKNOWN;
+    private String rankSystem = null;
     private List<FactionLeaderData> factionLeaders = new ArrayList<>();
 
     public List<String> getRatingLevels() {


### PR DESCRIPTION
Class variables that get set during Faction creation were marked as final, preventing updates.
This caused some MHQ:CombatTeamTest.java tests to fail because their FormationBasicSize could not be updated.

## NOTE

This will only fix a small number of the MHQ tests.