### PR TITLE
Implement packet type check exceptions

### DIFF
--- a/megamek/src/megamek/client/AbstractClient.java
+++ b/megamek/src/megamek/client/AbstractClient.java
@@ -362,10 +362,10 @@ public abstract class AbstractClient implements IClient {
     }
 
     protected void receiveUnitReplace(Packet packet) throws InvalidPacketDataException {
-        @SuppressWarnings(value = "unchecked") List<Force> forces = (List<Force>) packet.getObject(1);
+        List<Force> forces = packet.getForceList(1);
         forces.forEach(force -> getGame().getForces().replace(force.getId(), force));
 
-        @SuppressWarnings(value = "unchecked") List<InGameObject> units = (List<InGameObject>) packet.getObject(0);
+        List<InGameObject> units = packet.getInGameObjectList(0);
         getGame().replaceUnits(units);
     }
 

--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -104,6 +104,7 @@ import megamek.common.interfaces.IEntityRemovalConditions;
 import megamek.common.loaders.MapSettings;
 import megamek.common.moves.MovePath;
 import megamek.common.net.enums.PacketCommand;
+import megamek.common.net.packets.InvalidPacketDataException;
 import megamek.common.net.packets.Packet;
 import megamek.common.options.GameOptions;
 import megamek.common.options.IBasicOption;
@@ -278,7 +279,7 @@ public class Client extends AbstractClient {
     /**
      * Loads the turn list from the data in the packet
      */
-    protected void receiveTurns(Packet packet) {
+    protected void receiveTurns(Packet packet) throws InvalidPacketDataException {
         game.setTurnVector(packet.getGameTurnList(0));
     }
 
@@ -469,7 +470,7 @@ public class Client extends AbstractClient {
     /**
      * Sends a packet containing multiple entity updates. Should only be used in the lobby phase.
      */
-    public void sendChangeOwner(Collection<Entity> entities, int newOwnerId) {
+    public void sendChangeOwner(Collection<Entity> entities, int newOwnerId) throws InvalidPacketDataException {
         send(new Packet(PacketCommand.ENTITY_ASSIGN, entities, newOwnerId));
     }
 
@@ -516,7 +517,7 @@ public class Client extends AbstractClient {
     /**
      * Loads the entities from the data in the net command.
      */
-    protected void receiveEntities(Packet packet) {
+    protected void receiveEntities(Packet packet) throws InvalidPacketDataException {
         List<Entity> newEntities = packet.getEntityList(0);
         List<Entity> newOutOfGame = packet.getEntityList(1);
         Forces forces = packet.getForces(2);
@@ -548,7 +549,7 @@ public class Client extends AbstractClient {
     /**
      * Receives a force-related update containing affected forces and affected entities
      */
-    protected void receiveForceUpdate(Packet packet) {
+    protected void receiveForceUpdate(Packet packet) throws InvalidPacketDataException {
         Collection<Force> forces = packet.getForceList(0);
         Collection<Entity> entities = packet.getEntityList(1);
 
@@ -564,7 +565,7 @@ public class Client extends AbstractClient {
     /**
      * Receives a server packet commanding deletion of forces. Only valid in the lobby phase.
      */
-    protected void receiveForcesDelete(Packet packet) {
+    protected void receiveForcesDelete(Packet packet) throws InvalidPacketDataException {
         Collection<Integer> forceIds = packet.getIntList(0);
         Forces forces = game.getForces();
 
@@ -589,7 +590,7 @@ public class Client extends AbstractClient {
     /**
      * Loads entity update data from the data in the net command.
      */
-    protected void receiveEntityUpdate(Packet packet) {
+    protected void receiveEntityUpdate(Packet packet) throws InvalidPacketDataException {
         int entityIndex = packet.getIntValue(0);
         Entity entity = packet.getEntity(1);
 
@@ -603,14 +604,14 @@ public class Client extends AbstractClient {
     /**
      * Update multiple entities from the server. Used only in the lobby phase.
      */
-    protected void receiveEntitiesUpdate(Packet packet) {
+    protected void receiveEntitiesUpdate(Packet packet) throws InvalidPacketDataException {
         Collection<Entity> entities = packet.getEntityList(0);
         for (Entity entity : entities) {
             getGame().setEntity(entity.getId(), entity);
         }
     }
 
-    protected void receiveEntityRemove(Packet packet) {
+    protected void receiveEntityRemove(Packet packet) throws InvalidPacketDataException {
         List<Integer> entityIds = packet.getIntList(0);
         int condition = packet.getIntValue(1);
         List<Force> forces = packet.getForceList(2);
@@ -628,7 +629,7 @@ public class Client extends AbstractClient {
         game.removeEntities(entityIds, condition);
     }
 
-    protected void receiveEntityVisibilityIndicator(Packet packet) {
+    protected void receiveEntityVisibilityIndicator(Packet packet) throws InvalidPacketDataException {
         Entity entity = game.getEntity(packet.getIntValue(0));
 
         if (entity != null) { // we may not have this entity due to double-blind
@@ -643,24 +644,24 @@ public class Client extends AbstractClient {
         }
     }
 
-    protected void receiveUpdateGroundObjects(Packet packet) {
+    protected void receiveUpdateGroundObjects(Packet packet) throws InvalidPacketDataException {
         game.setGroundObjects(packet.getCoordsWithICarryableListMap(0));
         game.processGameEvent(new GameBoardChangeEvent(this));
     }
 
-    protected void receiveDeployMinefields(Packet packet) {
+    protected void receiveDeployMinefields(Packet packet) throws InvalidPacketDataException {
         game.addMinefields(packet.getMinefieldVector(0));
     }
 
-    protected void receiveSendingMinefields(Packet packet) {
+    protected void receiveSendingMinefields(Packet packet) throws InvalidPacketDataException {
         game.setMinefields(packet.getMinefieldVector(0));
     }
 
-    protected void receiveIlluminatedHexes(Packet packet) {
+    protected void receiveIlluminatedHexes(Packet packet) throws InvalidPacketDataException {
         game.setIlluminatedPositions(packet.getCoordsHashSet(0));
     }
 
-    protected void receiveRevealMinefield(Packet packet) {
+    protected void receiveRevealMinefield(Packet packet) throws InvalidPacketDataException {
         Minefield minefield = packet.getMinefield(0);
 
         if (minefield != null) {
@@ -668,7 +669,7 @@ public class Client extends AbstractClient {
         }
     }
 
-    protected void receiveRemoveMinefield(Packet packet) {
+    protected void receiveRemoveMinefield(Packet packet) throws InvalidPacketDataException {
         Minefield minefield = packet.getMinefield(0);
 
         if (minefield != null) {
@@ -676,7 +677,7 @@ public class Client extends AbstractClient {
         }
     }
 
-    protected void receiveUpdateMinefields(Packet packet) {
+    protected void receiveUpdateMinefields(Packet packet) throws InvalidPacketDataException {
         // only update information if you know about the minefield
         Vector<Minefield> newMines = new Vector<>();
         for (Minefield mf : packet.getMinefieldVector(0)) {
@@ -690,13 +691,13 @@ public class Client extends AbstractClient {
         }
     }
 
-    protected void receiveBuildingUpdate(Packet packet) {
+    protected void receiveBuildingUpdate(Packet packet) throws InvalidPacketDataException {
         for (Building building : packet.getBuildingList(0)) {
             game.getBoard(building.getBoardId()).updateBuilding(building);
         }
     }
 
-    protected void receiveBuildingCollapse(Packet packet) {
+    protected void receiveBuildingCollapse(Packet packet) throws InvalidPacketDataException {
         int boardId = packet.getIntValue(1);
         game.getBoard(boardId).collapseBuilding(packet.getCoordsVector(0));
     }
@@ -704,7 +705,7 @@ public class Client extends AbstractClient {
     /**
      * Loads entity firing data from the data in the net command
      */
-    protected void receiveAttack(Packet packet) {
+    protected void receiveAttack(Packet packet) throws InvalidPacketDataException {
         List<EntityAction> vector = packet.getEntityActionList(0);
         boolean isCharge = packet.getBooleanValue(1);
         boolean addAction = true;
@@ -914,276 +915,282 @@ public class Client extends AbstractClient {
 
     @Override
     protected boolean handleGameSpecificPacket(Packet packet) {
-        switch (packet.command()) {
-            case SERVER_GREETING:
-                if (this instanceof Princess) {
-                    ((Princess) this).sendPrincessSettings();
-                }
-                break;
-            case PRINCESS_SETTINGS:
-                game.setBotSettings(packet.getStringWIthBehaviorSettingsMap(0));
-                break;
-            case ENTITY_UPDATE:
-                receiveEntityUpdate(packet);
-                break;
-            case ENTITY_MULTI_UPDATE:
-                receiveEntitiesUpdate(packet);
-                break;
-            case ENTITY_REMOVE:
-                receiveEntityRemove(packet);
-                break;
-            case ENTITY_VISIBILITY_INDICATOR:
-                receiveEntityVisibilityIndicator(packet);
-                break;
-            case FORCE_UPDATE:
-                receiveForceUpdate(packet);
-                break;
-            case FORCE_DELETE:
-                receiveForcesDelete(packet);
-                break;
-            case SENDING_MINEFIELDS:
-                receiveSendingMinefields(packet);
-                break;
-            case SENDING_ILLUMINATED_HEXES:
-                receiveIlluminatedHexes(packet);
-                break;
-            case CLEAR_ILLUMINATED_HEXES:
-                game.clearIlluminatedPositions();
-                break;
-            case UPDATE_MINEFIELDS:
-                receiveUpdateMinefields(packet);
-                break;
-            case DEPLOY_MINEFIELDS:
-                receiveDeployMinefields(packet);
-                break;
-            case REVEAL_MINEFIELD:
-                receiveRevealMinefield(packet);
-                break;
-            case REMOVE_MINEFIELD:
-                receiveRemoveMinefield(packet);
-                break;
-            case UPDATE_GROUND_OBJECTS:
-                receiveUpdateGroundObjects(packet);
-                break;
-            case ADD_SMOKE_CLOUD:
-                SmokeCloud cloud = packet.getSmokeCloud(0);
+        try {
+            switch (packet.command()) {
+                case SERVER_GREETING:
+                    if (this instanceof Princess) {
+                        ((Princess) this).sendPrincessSettings();
+                    }
+                    break;
+                case PRINCESS_SETTINGS:
+                    game.setBotSettings(packet.getStringWIthBehaviorSettingsMap(0));
+                    break;
+                case ENTITY_UPDATE:
+                    receiveEntityUpdate(packet);
+                    break;
+                case ENTITY_MULTI_UPDATE:
+                    receiveEntitiesUpdate(packet);
+                    break;
+                case ENTITY_REMOVE:
+                    receiveEntityRemove(packet);
+                    break;
+                case ENTITY_VISIBILITY_INDICATOR:
+                    receiveEntityVisibilityIndicator(packet);
+                    break;
+                case FORCE_UPDATE:
+                    receiveForceUpdate(packet);
+                    break;
+                case FORCE_DELETE:
+                    receiveForcesDelete(packet);
+                    break;
+                case SENDING_MINEFIELDS:
+                    receiveSendingMinefields(packet);
+                    break;
+                case SENDING_ILLUMINATED_HEXES:
+                    receiveIlluminatedHexes(packet);
+                    break;
+                case CLEAR_ILLUMINATED_HEXES:
+                    game.clearIlluminatedPositions();
+                    break;
+                case UPDATE_MINEFIELDS:
+                    receiveUpdateMinefields(packet);
+                    break;
+                case DEPLOY_MINEFIELDS:
+                    receiveDeployMinefields(packet);
+                    break;
+                case REVEAL_MINEFIELD:
+                    receiveRevealMinefield(packet);
+                    break;
+                case REMOVE_MINEFIELD:
+                    receiveRemoveMinefield(packet);
+                    break;
+                case UPDATE_GROUND_OBJECTS:
+                    receiveUpdateGroundObjects(packet);
+                    break;
+                case ADD_SMOKE_CLOUD:
+                    SmokeCloud cloud = packet.getSmokeCloud(0);
 
-                if (cloud != null) {
-                    game.addSmokeCloud(cloud);
-                }
+                    if (cloud != null) {
+                        game.addSmokeCloud(cloud);
+                    }
 
-                break;
-            case CHANGE_HEX:
-                Coords hexCoords = packet.getCoords(0);
-                int boardID = packet.getIntValue(1);
-                Hex targetHex = packet.getHex(2);
+                    break;
+                case CHANGE_HEX:
+                    Coords hexCoords = packet.getCoords(0);
+                    int boardID = packet.getIntValue(1);
+                    Hex targetHex = packet.getHex(2);
 
-                if (hexCoords != null) {
-                    game.getBoard(boardID).setHex(hexCoords, targetHex);
-                }
+                    if (hexCoords != null) {
+                        game.getBoard(boardID).setHex(hexCoords, targetHex);
+                    }
 
-                break;
-            case CHANGE_HEXES:
-                var changedHexes = packet.getBoardLocationHexMap(0);
-                game.getBoards().values().forEach(board -> board.setHexes(changedHexes));
-                break;
-            case BLDG_UPDATE:
-                receiveBuildingUpdate(packet);
-                break;
-            case BLDG_COLLAPSE:
-                receiveBuildingCollapse(packet);
-                break;
-            case SENDING_TURNS:
-                receiveTurns(packet);
-                break;
-            case SENDING_ENTITIES:
-                receiveEntities(packet);
-                break;
-            case SENDING_REPORTS:
-            case SENDING_REPORTS_TACTICAL_GENIUS:
-                phaseReport = receiveReport(packet.getReportList(0));
-                if (keepGameLog()) {
-                    if ((log == null) && (game.getRoundCount() == 1)) {
+                    break;
+                case CHANGE_HEXES:
+                    var changedHexes = packet.getBoardLocationHexMap(0);
+                    game.getBoards().values().forEach(board -> board.setHexes(changedHexes));
+                    break;
+                case BLDG_UPDATE:
+                    receiveBuildingUpdate(packet);
+                    break;
+                case BLDG_COLLAPSE:
+                    receiveBuildingCollapse(packet);
+                    break;
+                case SENDING_TURNS:
+                    receiveTurns(packet);
+                    break;
+                case SENDING_ENTITIES:
+                    receiveEntities(packet);
+                    break;
+                case SENDING_REPORTS:
+                case SENDING_REPORTS_TACTICAL_GENIUS:
+                    phaseReport = receiveReport(packet.getReportList(0));
+                    if (keepGameLog()) {
+                        if ((log == null) && (game.getRoundCount() == 1)) {
+                            initGameLog();
+                        }
+                        if (log != null) {
+                            log.append(phaseReport);
+                        }
+                    }
+                    game.addReports(packet.getReportList(0));
+                    roundReport = receiveReport(game.getReports(game.getRoundCount()));
+                    if (packet.command().isSendingReportsTacticalGenius()) {
+                        game.processGameEvent(new GameReportEvent(this, roundReport));
+                    }
+                    break;
+                case SENDING_REPORTS_SPECIAL:
+                    game.processGameEvent(new GameReportEvent(this, receiveReport(packet.getReportList(0))));
+                    break;
+                case SENDING_REPORTS_ALL:
+                    var allReports = packet.getReportListOfList(0);
+                    game.setAllReports(allReports);
+                    if (keepGameLog()) {
+                        // Re-write gamelog.txt from scratch
                         initGameLog();
-                    }
-                    if (log != null) {
-                        log.append(phaseReport);
-                    }
-                }
-                game.addReports(packet.getReportList(0));
-                roundReport = receiveReport(game.getReports(game.getRoundCount()));
-                if (packet.command().isSendingReportsTacticalGenius()) {
-                    game.processGameEvent(new GameReportEvent(this, roundReport));
-                }
-                break;
-            case SENDING_REPORTS_SPECIAL:
-                game.processGameEvent(new GameReportEvent(this, receiveReport(packet.getReportList(0))));
-                break;
-            case SENDING_REPORTS_ALL:
-                var allReports = packet.getReportListOfList(0);
-                game.setAllReports(allReports);
-                if (keepGameLog()) {
-                    // Re-write gamelog.txt from scratch
-                    initGameLog();
-                    if (log != null) {
-                        for (List<Report> allReport : allReports) {
-                            log.append(receiveReport(allReport));
+                        if (log != null) {
+                            for (List<Report> allReport : allReports) {
+                                log.append(receiveReport(allReport));
+                            }
                         }
                     }
-                }
-                roundReport = receiveReport(game.getReports(game.getRoundCount()));
-                // We don't really have a copy of the phase report at
-                // this point, so I guess we'll just use the round report
-                // until the next phase actually completes.
-                phaseReport = roundReport;
-                break;
-            case ENTITY_ATTACK:
-                receiveAttack(packet);
-                break;
-            case TURN:
-                changeTurnIndex(packet.getIntValue(0), packet.getIntValue(1));
-                break;
-            case SENDING_GAME_SETTINGS:
-                GameOptions options = packet.getGameOptions(0);
+                    roundReport = receiveReport(game.getReports(game.getRoundCount()));
+                    // We don't really have a copy of the phase report at
+                    // this point, so I guess we'll just use the round report
+                    // until the next phase actually completes.
+                    phaseReport = roundReport;
+                    break;
+                case ENTITY_ATTACK:
+                    receiveAttack(packet);
+                    break;
+                case TURN:
+                    changeTurnIndex(packet.getIntValue(0), packet.getIntValue(1));
+                    break;
+                case SENDING_GAME_SETTINGS:
+                    GameOptions options = packet.getGameOptions(0);
 
-                if (options != null) {
-                    game.setOptions(options);
-                }
+                    if (options != null) {
+                        game.setOptions(options);
+                    }
 
-                break;
-            case SENDING_MAP_SETTINGS:
-                MapSettings mapSettings = packet.getMapSettings(0);
+                    break;
+                case SENDING_MAP_SETTINGS:
+                    MapSettings mapSettings = packet.getMapSettings(0);
 
-                if (mapSettings != null) {
-                    game.setMapSettings(mapSettings);
-                    GameSettingsChangeEvent gameSettingsChangeEvent = new GameSettingsChangeEvent(this);
-                    gameSettingsChangeEvent.setMapSettingsOnlyChange(true);
-                    game.processGameEvent(gameSettingsChangeEvent);
-                }
-                break;
-            case SENDING_PLANETARY_CONDITIONS:
-                PlanetaryConditions planetaryConditions = packet.getPlanetaryConditions(0);
+                    if (mapSettings != null) {
+                        game.setMapSettings(mapSettings);
+                        GameSettingsChangeEvent gameSettingsChangeEvent = new GameSettingsChangeEvent(this);
+                        gameSettingsChangeEvent.setMapSettingsOnlyChange(true);
+                        game.processGameEvent(gameSettingsChangeEvent);
+                    }
+                    break;
+                case SENDING_PLANETARY_CONDITIONS:
+                    PlanetaryConditions planetaryConditions = packet.getPlanetaryConditions(0);
 
-                if (planetaryConditions != null) {
-                    game.setPlanetaryConditions(planetaryConditions);
-                    game.processGameEvent(new GameSettingsChangeEvent(this));
-                }
-                break;
-            case SENDING_TAG_INFO:
-                Vector<TagInfo> tagInfoVector = packet.getTagInfoVector(0);
-                for (TagInfo tagInfo : tagInfoVector) {
-                    game.addTagInfo(tagInfo);
-                }
-                break;
-            case RESET_TAG_INFO:
-                game.resetTagInfo();
-                break;
-            case END_OF_GAME:
-                String sEntityStatus = packet.getStringValue(0);
-                game.end(packet.getIntValue(1), packet.getIntValue(2));
-                // save victory report
-                saveEntityStatus(sEntityStatus);
-                break;
-            case SENDING_ARTILLERY_ATTACKS:
-                Vector<ArtilleryAttackAction> artilleryAttackActions = packet.getArtilleryAttackAction(0);
-                game.setArtilleryVector(artilleryAttackActions);
-                break;
-            case SENDING_FLARES:
-                Vector<Flare> flareVector = packet.getFlareVector(0);
-                game.setFlares(flareVector);
-                break;
-            case SEND_SAVEGAME:
-                String sFinalFile = packet.getStringValue(0);
-                String sLocalPath = packet.getStringValue(2);
-                String localFile = sLocalPath + File.separator + sFinalFile;
-                File sDir = new File(sLocalPath);
-                if (!sDir.exists()) {
-                    try {
-                        if (!sDir.mkdir()) {
-                            LOGGER.error("Failed to create savegames directory.");
-                            return true;
+                    if (planetaryConditions != null) {
+                        game.setPlanetaryConditions(planetaryConditions);
+                        game.processGameEvent(new GameSettingsChangeEvent(this));
+                    }
+                    break;
+                case SENDING_TAG_INFO:
+                    Vector<TagInfo> tagInfoVector = packet.getTagInfoVector(0);
+                    for (TagInfo tagInfo : tagInfoVector) {
+                        game.addTagInfo(tagInfo);
+                    }
+                    break;
+                case RESET_TAG_INFO:
+                    game.resetTagInfo();
+                    break;
+                case END_OF_GAME:
+                    String sEntityStatus = packet.getStringValue(0);
+                    game.end(packet.getIntValue(1), packet.getIntValue(2));
+                    // save victory report
+                    saveEntityStatus(sEntityStatus);
+                    break;
+                case SENDING_ARTILLERY_ATTACKS:
+                    Vector<ArtilleryAttackAction> artilleryAttackActions = packet.getArtilleryAttackAction(0);
+                    game.setArtilleryVector(artilleryAttackActions);
+                    break;
+                case SENDING_FLARES:
+                    Vector<Flare> flareVector = packet.getFlareVector(0);
+                    game.setFlares(flareVector);
+                    break;
+                case SEND_SAVEGAME:
+                    String sFinalFile = packet.getStringValue(0);
+                    String sLocalPath = packet.getStringValue(2);
+                    String localFile = sLocalPath + File.separator + sFinalFile;
+                    File sDir = new File(sLocalPath);
+                    if (!sDir.exists()) {
+                        try {
+                            if (!sDir.mkdir()) {
+                                LOGGER.error("Failed to create savegames directory.");
+                                return true;
+                            }
+                        } catch (Exception ex) {
+                            LOGGER.error(ex, "Unable to create savegames directory.");
                         }
+                    }
+
+                    try (OutputStream os = new FileOutputStream(localFile);
+                          BufferedOutputStream bos = new BufferedOutputStream(os)) {
+                        List<Integer> data = packet.getIntList(1);
+                        for (Integer integer : data) {
+                            bos.write(integer);
+                        }
+                        bos.flush();
                     } catch (Exception ex) {
-                        LOGGER.error(ex, "Unable to create savegames directory.");
+                        LOGGER.error(ex, "Unable to save file {}", sFinalFile);
                     }
-                }
+                    break;
+                case LOAD_SAVEGAME:
+                    String loadFile = packet.getStringValue(0);
+                    try {
+                        sendLoadGame(new File(MMConstants.SAVEGAME_DIR, loadFile));
+                    } catch (Exception ex) {
+                        LOGGER.error(ex, "Unable to load savegame file: {}", loadFile);
+                    }
+                    break;
+                case SENDING_SPECIAL_HEX_DISPLAY:
+                    var shdTable = packet.getCoordsWithSpecialHexDisplayCollectionMap(0);
+                    var boardId = packet.getIntValue(1);
+                    game.getBoard(boardId).setSpecialHexDisplayTable(shdTable);
+                    game.processGameEvent(new GameBoardChangeEvent(this));
+                    break;
+                case SENDING_AVAILABLE_MAP_SIZES:
+                    availableSizes = packet.getBoardDimensionsSet(0);
+                    game.processGameEvent(new GameSettingsChangeEvent(this));
+                    break;
+                case ENTITY_NOVA_NETWORK_CHANGE:
+                    receiveEntityNovaNetworkModeChange(packet);
+                    break;
+                case CLIENT_FEEDBACK_REQUEST:
+                    final PacketCommand cfrType = packet.getPacketCommand(0);
+                    if (cfrType != null) {
+                        GameCFREvent cfrEvt = new GameCFREvent(this, cfrType);
+                        switch (cfrType) {
+                            case CFR_DOMINO_EFFECT:
+                                cfrEvt.setEntityId(packet.getIntValue(1));
+                                break;
+                            case CFR_AMS_ASSIGN:
+                                cfrEvt.setEntityId(packet.getIntValue(1));
+                                cfrEvt.setAmsEquipNum(packet.getIntValue(2));
+                                cfrEvt.setWAAs(packet.getWeaponAttackActionList(3));
+                                break;
+                            case CFR_APDS_ASSIGN:
+                                cfrEvt.setEntityId(packet.getIntValue(1));
+                                cfrEvt.setApdsDistances(packet.getIntList(2));
+                                cfrEvt.setWAAs(packet.getWeaponAttackActionList(3));
+                                break;
+                            case CFR_HIDDEN_PBS:
+                                cfrEvt.setEntityId(packet.getIntValue(1));
+                                cfrEvt.setTargetId(packet.getIntValue(2));
+                                break;
+                            case CFR_TELEGUIDED_TARGET:
+                                cfrEvt.setTeleguidedMissileTargets(packet.getIntList(1));
+                                cfrEvt.setTmToHitValues(packet.getIntList(2));
+                                break;
+                            case CFR_TAG_TARGET:
+                                cfrEvt.setTAGTargets(packet.getIntList(1));
+                                cfrEvt.setTAGTargetTypes(packet.getIntList(2));
+                                break;
+                            default:
+                                break;
+                        }
+                        game.processGameEvent(cfrEvt);
+                    }
+                    break;
+                case GAME_VICTORY_EVENT:
+                    GameVictoryEvent gve = new GameVictoryEvent(this, game);
+                    game.processGameEvent(gve);
+                    break;
+                default:
+                    return false;
+            }
+            return true;
 
-                try (OutputStream os = new FileOutputStream(localFile);
-                      BufferedOutputStream bos = new BufferedOutputStream(os)) {
-                    List<Integer> data = packet.getIntList(1);
-                    for (Integer integer : data) {
-                        bos.write(integer);
-                    }
-                    bos.flush();
-                } catch (Exception ex) {
-                    LOGGER.error(ex, "Unable to save file {}", sFinalFile);
-                }
-                break;
-            case LOAD_SAVEGAME:
-                String loadFile = packet.getStringValue(0);
-                try {
-                    sendLoadGame(new File(MMConstants.SAVEGAME_DIR, loadFile));
-                } catch (Exception ex) {
-                    LOGGER.error(ex, "Unable to load savegame file: {}", loadFile);
-                }
-                break;
-            case SENDING_SPECIAL_HEX_DISPLAY:
-                var shdTable = packet.getCoordsWithSpecialHexDisplayCollectionMap(0);
-                var boardId = packet.getIntValue(1);
-                game.getBoard(boardId).setSpecialHexDisplayTable(shdTable);
-                game.processGameEvent(new GameBoardChangeEvent(this));
-                break;
-            case SENDING_AVAILABLE_MAP_SIZES:
-                availableSizes = packet.getBoardDimensionsSet(0);
-                game.processGameEvent(new GameSettingsChangeEvent(this));
-                break;
-            case ENTITY_NOVA_NETWORK_CHANGE:
-                receiveEntityNovaNetworkModeChange(packet);
-                break;
-            case CLIENT_FEEDBACK_REQUEST:
-                final PacketCommand cfrType = packet.getPacketCommand(0);
-                if (cfrType != null) {
-                    GameCFREvent cfrEvt = new GameCFREvent(this, cfrType);
-                    switch (cfrType) {
-                        case CFR_DOMINO_EFFECT:
-                            cfrEvt.setEntityId(packet.getIntValue(1));
-                            break;
-                        case CFR_AMS_ASSIGN:
-                            cfrEvt.setEntityId(packet.getIntValue(1));
-                            cfrEvt.setAmsEquipNum(packet.getIntValue(2));
-                            cfrEvt.setWAAs(packet.getWeaponAttackActionList(3));
-                            break;
-                        case CFR_APDS_ASSIGN:
-                            cfrEvt.setEntityId(packet.getIntValue(1));
-                            cfrEvt.setApdsDistances(packet.getIntList(2));
-                            cfrEvt.setWAAs(packet.getWeaponAttackActionList(3));
-                            break;
-                        case CFR_HIDDEN_PBS:
-                            cfrEvt.setEntityId(packet.getIntValue(1));
-                            cfrEvt.setTargetId(packet.getIntValue(2));
-                            break;
-                        case CFR_TELEGUIDED_TARGET:
-                            cfrEvt.setTeleguidedMissileTargets(packet.getIntList(1));
-                            cfrEvt.setTmToHitValues(packet.getIntList(2));
-                            break;
-                        case CFR_TAG_TARGET:
-                            cfrEvt.setTAGTargets(packet.getIntList(1));
-                            cfrEvt.setTAGTargetTypes(packet.getIntList(2));
-                            break;
-                        default:
-                            break;
-                    }
-                    game.processGameEvent(cfrEvt);
-                }
-                break;
-            case GAME_VICTORY_EVENT:
-                GameVictoryEvent gve = new GameVictoryEvent(this, game);
-                game.processGameEvent(gve);
-                break;
-            default:
-                return false;
+        } catch (InvalidPacketDataException e) {
+            LOGGER.error("Invalid packet data:", e);
+            return false;
         }
-        return true;
     }
 
     /**

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -94,6 +94,7 @@ import megamek.common.game.IGame;
 import megamek.common.moves.MovePath;
 import megamek.common.moves.MoveStep;
 import megamek.common.net.enums.PacketCommand;
+import megamek.common.net.packets.InvalidPacketDataException;
 import megamek.common.net.packets.Packet;
 import megamek.common.options.OptionsConstants;
 import megamek.common.pathfinder.BoardClusterTracker;
@@ -3795,7 +3796,7 @@ public class Princess extends BotClient {
      * Override for the 'receive entity update' handler Updates internal state in addition to base client functionality
      */
     @Override
-    public void receiveEntityUpdate(final Packet packet) {
+    public void receiveEntityUpdate(final Packet packet) throws InvalidPacketDataException {
         super.receiveEntityUpdate(packet);
         updateEntityState((Entity) packet.getObject(1));
     }

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/LobbyActions.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/LobbyActions.java
@@ -72,6 +72,7 @@ import megamek.common.force.Forces;
 import megamek.common.game.Game;
 import megamek.common.icons.Camouflage;
 import megamek.common.interfaces.ForceAssignable;
+import megamek.common.net.packets.InvalidPacketDataException;
 import megamek.common.options.OptionsConstants;
 import megamek.common.strategicBattleSystems.SBFFormationConverter;
 import megamek.common.units.Crew;
@@ -908,7 +909,9 @@ public class LobbyActions {
      * Change the given entities' controller to the player with ID newOwnerId. If the given forceList is not empty, an
      * error message will be shown.
      */
-    void changeOwner(Collection<Entity> entities, Collection<Force> forceList, int newOwnerId) {
+    void changeOwner(
+          Collection<Entity> entities, Collection<Force> forceList, int newOwnerId
+    ) throws InvalidPacketDataException {
         if (entities.isEmpty() || game().getPlayer(newOwnerId) == null) {
             return;
         } else if (!forceList.isEmpty()) {

--- a/megamek/src/megamek/common/net/packets/InvalidPacketDataException.java
+++ b/megamek/src/megamek/common/net/packets/InvalidPacketDataException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/src/megamek/common/net/packets/InvalidPacketDataException.java
+++ b/megamek/src/megamek/common/net/packets/InvalidPacketDataException.java
@@ -67,4 +67,40 @@ public class InvalidPacketDataException extends Exception {
     public InvalidPacketDataException(final String message, final Throwable cause) {
         super(message, cause);
     }
+
+    /**
+     * Construct a new exception with desired object type, the object in question, and its specified index
+     * @param desiredType String naming the type that was expected but not found.
+     * @param objectionable Object we didn't like.
+     * @param index int containing the object's position within the packet's data.
+     */
+    public InvalidPacketDataException(String desiredType, Object objectionable, int index) {
+        this(buildMessage(desiredType, objectionable, index));
+    }
+
+    /**
+     * Construct a new exception with desired object type, the object in question, and its specified index
+     * @param desiredType String naming the type that was expected but not found.
+     * @param objectionable Object we didn't like.
+     * @param index int containing the object's position within the packet's data.
+     * @param cause Throwable that initiated the exception
+     */
+    public InvalidPacketDataException(String desiredType, Object objectionable, int index, final Throwable cause) {
+        this(buildMessage(desiredType, objectionable, index), cause);
+    }
+
+    /**
+     * Construct a new message with desired object type, the object in question, and its specified index
+     * @param desiredType String naming the type that was expected but not found.
+     * @param objectionable Object we didn't like.
+     * @param index int containing the object's position within the packet's data.
+     */
+    private static String buildMessage(String desiredType, Object objectionable, int index) {
+        return String.format(
+              "Value not %s: %s (%s)",
+              desiredType,
+              (objectionable == null) ? "Null object at index " + index : objectionable,
+              (objectionable == null) ? "Unknown" : objectionable.getClass()
+        );
+    }
 }

--- a/megamek/src/megamek/common/net/packets/InvalidPacketDataException.java
+++ b/megamek/src/megamek/common/net/packets/InvalidPacketDataException.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.net.packets;
+
+import java.io.Serial;
+
+/**
+ * This exception is thrown whenever a packet data object does not match the expected type(s) and cannot be read
+ */
+public class InvalidPacketDataException extends Exception {
+    @Serial
+    private static final long serialVersionUID = -4472736483205970853L;
+
+    /**
+     * Creates new <code>InvalidPacketDataException</code> without detail message.
+     */
+    public InvalidPacketDataException() {
+
+    }
+
+    /**
+     * Constructs an <code>InvalidPacketDataException</code> with the specified detail message.
+     *
+     * @param msg the detail message.
+     */
+    public InvalidPacketDataException(String msg) {
+        super(msg);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message the detail message
+     * @param cause   the cause
+     */
+    public InvalidPacketDataException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/megamek/src/megamek/common/net/packets/Packet.java
+++ b/megamek/src/megamek/common/net/packets/Packet.java
@@ -1131,7 +1131,8 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
         }
 
         throw new InvalidPacketDataException(
-              String.format("Value not Vector: %s (%s)", object, object.getClass()));
+              String.format("Value not Vector: %s (%s)", (object == null) ? "Null object at index " + index : object,
+                    (object == null) ? "Unknown" : object.getClass()));
 
     }
 

--- a/megamek/src/megamek/common/net/packets/Packet.java
+++ b/megamek/src/megamek/common/net/packets/Packet.java
@@ -127,14 +127,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the <code>int</code> value of the object at the specified index
      */
-    public int getIntValue(int index) {
+    public int getIntValue(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof Integer integer) {
             return integer;
         }
 
-        return 0;
+        throw new InvalidPacketDataException(
+              String.format("Value not integer: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -142,7 +143,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a List of {@link Integer}'s value of the object at the specified index
      */
-    public List<Integer> getIntList(int index) {
+    public List<Integer> getIntList(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         ArrayList<Integer> result = new ArrayList<>();
@@ -153,9 +154,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(verifiedInt);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not List: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -163,7 +166,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a Map of {@link Integer} to {@link Integer}'s value of the object at the specified index
      */
-    public Map<Integer, Integer> getIntMapToInt(int index) {
+    public Map<Integer, Integer> getIntMapToInt(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         Map<Integer, Integer> result = new HashMap<>();
@@ -176,9 +179,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     }
                 }
             });
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Map<Integer, Integer>: %s (%s)", object, object.getClass()));
     }
 
 
@@ -188,7 +193,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      * @return a Map of {@link Coords} key's with a Collection of {@link SpecialHexDisplay} value's of the object at the
      *       specified index
      */
-    public Map<Integer, List<SBFReportEntry>> getIntegerWithSBFReportEntryList(int index) {
+    public Map<Integer, List<SBFReportEntry>> getIntegerWithSBFReportEntryList(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         Map<Integer, List<SBFReportEntry>> result = new HashMap<>();
@@ -208,9 +213,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     }
                 }
             });
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Map<Integer, List>: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -218,14 +225,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the <code>boolean</code> value of the object at the specified index
      */
-    public boolean getBooleanValue(int index) {
+    public boolean getBooleanValue(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof Boolean bool) {
             return bool;
         }
 
-        return false;
+        throw new InvalidPacketDataException(
+              String.format("Value not Boolean: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -233,14 +241,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the <code>String</code> value of the object at the specified index
      */
-    public String getStringValue(int index) {
+    public @Nullable String getStringValue(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof String value) {
             return value;
         }
 
-        return "";
+        throw new InvalidPacketDataException(
+              String.format("Value not String: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -248,7 +257,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a Map of {@link String} key's with {@link BehaviorSettings} value's of the object at the specified index
      */
-    public Map<String, BehaviorSettings> getStringWIthBehaviorSettingsMap(int index) {
+    public Map<String, BehaviorSettings> getStringWIthBehaviorSettingsMap(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         Map<String, BehaviorSettings> result = new HashMap<>();
@@ -261,9 +270,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     }
                 }
             });
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Map<String, BehaviorSettings>: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -271,7 +282,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a Vector of {@link ArtilleryAttackAction}'s value of the object at the specified index
      */
-    public Vector<ArtilleryAttackAction> getArtilleryAttackAction(int index) {
+    public Vector<ArtilleryAttackAction> getArtilleryAttackAction(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         Vector<ArtilleryAttackAction> result = new Vector<>();
@@ -282,9 +293,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(value);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Vector: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -292,7 +305,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a Set of {@link BoardDimensions}'s value of the object at the specified index
      */
-    public Set<BoardDimensions> getBoardDimensionsSet(int index) {
+    public Set<BoardDimensions> getBoardDimensionsSet(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         Set<BoardDimensions> result = new HashSet<>();
@@ -303,9 +316,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(value);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Set: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -313,7 +328,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a Map of {@link BoardLocation} key's with {@link Hex} value's of the object at the specified index
      */
-    public Map<BoardLocation, Hex> getBoardLocationHexMap(int index) {
+    public Map<BoardLocation, Hex> getBoardLocationHexMap(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         Map<BoardLocation, Hex> result = new HashMap<>();
@@ -326,9 +341,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     }
                 }
             });
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Map<Location, Hex>: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -336,7 +353,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a List of {@link Building}'s value of the object at the specified index
      */
-    public List<Building> getBuildingList(int index) {
+    public List<Building> getBuildingList(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         ArrayList<Building> result = new ArrayList<>();
@@ -347,9 +364,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(verifiedBuilding);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not List: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -357,14 +376,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the {@link Coords} value of the object at the specified index
      */
-    public @Nullable Coords getCoords(int index) {
+    public @Nullable Coords getCoords(int index)  throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof Coords coords) {
             return coords;
         }
 
-        return null;
+        throw new InvalidPacketDataException(
+              String.format("Value not Coords: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -372,7 +392,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a HashSet of {@link Coords}'s value of the object at the specified index
      */
-    public HashSet<Coords> getCoordsHashSet(int index) {
+    public HashSet<Coords> getCoordsHashSet(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         HashSet<Coords> result = new HashSet<>();
@@ -383,9 +403,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(verifiedCoord);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not HashSet: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -393,7 +415,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a Vector of {@link Coords}'s value of the object at the specified index
      */
-    public Vector<Coords> getCoordsVector(int index) {
+    public Vector<Coords> getCoordsVector(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         Vector<Coords> result = new Vector<>();
@@ -404,9 +426,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(verifiedCoord);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Collection: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -415,7 +439,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      * @return a Map of {@link Coords} key's with a List of {@link ICarryable} value's of the object at the specified
      *       index
      */
-    public Map<Coords, List<ICarryable>> getCoordsWithICarryableListMap(int index) {
+    public Map<Coords, List<ICarryable>> getCoordsWithICarryableListMap(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         Map<Coords, List<ICarryable>> result = new HashMap<>();
@@ -435,9 +459,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     }
                 }
             });
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Map<Coords, List>: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -446,7 +472,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      * @return a Map of {@link Coords} key's with a Collection of {@link SpecialHexDisplay} value's of the object at the
      *       specified index
      */
-    public Map<Coords, Collection<SpecialHexDisplay>> getCoordsWithSpecialHexDisplayCollectionMap(int index) {
+    public Map<Coords, Collection<SpecialHexDisplay>> getCoordsWithSpecialHexDisplayCollectionMap(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         Map<Coords, Collection<SpecialHexDisplay>> result = new HashMap<>();
@@ -466,9 +492,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     }
                 }
             });
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Map<Coords, Collection>: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -476,14 +504,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the {@link Entity} value of the object at the specified index
      */
-    public @Nullable Entity getEntity(int index) {
+    public @Nullable Entity getEntity(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof Entity entity) {
             return entity;
         }
 
-        return null;
+        throw new InvalidPacketDataException(
+              String.format("Value not Entity: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -491,7 +520,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a List of {@link Entity}'s value of the object at the specified index
      */
-    public List<Entity> getEntityList(int index) {
+    public List<Entity> getEntityList(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         ArrayList<Entity> result = new ArrayList<>();
@@ -502,9 +531,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(verifiedEntity);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Collection<?>: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -512,7 +543,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a List of {@link megamek.common.actions.EntityAction}'s value of the object at the specified index
      */
-    public List<EntityAction> getEntityActionList(int index) {
+    public List<EntityAction> getEntityActionList(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         ArrayList<EntityAction> result = new ArrayList<>();
@@ -523,9 +554,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(verifiedEntityAction);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Collection<?>: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -533,14 +566,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the {@link FighterSquadron} value of the object at the specified index
      */
-    public @Nullable FighterSquadron getFighterSquadron(int index) {
+    public @Nullable FighterSquadron getFighterSquadron(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof FighterSquadron value) {
             return value;
         }
 
-        return null;
+        throw new InvalidPacketDataException(
+              String.format("Value not FighterSquadron: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -548,7 +582,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a Vector of {@link Flare}'s value of the object at the specified index
      */
-    public Vector<Flare> getFlareVector(int index) {
+    public Vector<Flare> getFlareVector(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         Vector<Flare> result = new Vector<>();
@@ -559,9 +593,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(value);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Vector<?>: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -569,14 +605,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the {@link Force} value of the object at the specified index or NULL
      */
-    public @Nullable Force getForce(int index) {
+    public @Nullable Force getForce(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof Force value) {
             return value;
         }
 
-        return null;
+        throw new InvalidPacketDataException(
+              String.format("Value not Force: %s (%s)", object, object.getClass()));
     }
 
 
@@ -585,14 +622,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the {@link Forces} value of the object at the specified index
      */
-    public @Nullable Forces getForces(int index) {
+    public @Nullable Forces getForces(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof Forces force) {
             return force;
         }
 
-        return null;
+        throw new InvalidPacketDataException(
+              String.format("Value not Forces: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -600,7 +638,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a List of {@link Force}'s value of the object at the specified index
      */
-    public List<Force> getForceList(int index) {
+    public List<Force> getForceList(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         ArrayList<Force> result = new ArrayList<>();
@@ -611,9 +649,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(verifiedForce);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Collection: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -621,14 +661,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the {@link GameOptions} value of the object at the specified index
      */
-    public @Nullable GameOptions getGameOptions(int index) {
+    public @Nullable GameOptions getGameOptions(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof GameOptions gameOptions) {
             return gameOptions;
         }
 
-        return null;
+        throw new InvalidPacketDataException(
+              String.format("Value not GameOptions: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -636,7 +677,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a List of {@link GameTurn}'s value of the object at the specified index
      */
-    public List<GameTurn> getGameTurnList(int index) {
+    public List<GameTurn> getGameTurnList(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         ArrayList<GameTurn> result = new ArrayList<>();
@@ -647,9 +688,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(verifiedGameTurn);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Collection<?>: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -657,14 +700,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the {@link Hex} value of the object at the specified index
      */
-    public @Nullable Hex getHex(int index) {
+    public @Nullable Hex getHex(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof Hex hex) {
             return hex;
         }
 
-        return null;
+        throw new InvalidPacketDataException(
+              String.format("Value not Hex: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -672,7 +716,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a Vector of {@link Player}'s value of the object at the specified index
      */
-    public Vector<IBasicOption> getIBasicOptionVector(int index) {
+    public Vector<IBasicOption> getIBasicOptionVector(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         Vector<IBasicOption> result = new Vector<>();
@@ -683,9 +727,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(verifiedValue);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Vector: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -693,14 +739,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the {@link InGameObject} value of the object at the specified index
      */
-    public @Nullable InGameObject getInGameObject(int index) {
+    public @Nullable InGameObject getInGameObject(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof InGameObject value) {
             return value;
         }
 
-        return null;
+        throw new InvalidPacketDataException(
+              String.format("Value not InGameObject: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -708,7 +755,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a List of {@link InGameObject}'s value of the object at the specified index
      */
-    public List<InGameObject> getInGameObjectList(int index) {
+    public List<InGameObject> getInGameObjectList(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         ArrayList<InGameObject> result = new ArrayList<>();
@@ -719,9 +766,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(value);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Collection<?>: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -729,14 +778,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the {@link MapSettings} value of the object at the specified index
      */
-    public @Nullable MapSettings getMapSettings(int index) {
+    public @Nullable MapSettings getMapSettings(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof MapSettings mapSettings) {
             return mapSettings;
         }
 
-        return null;
+        throw new InvalidPacketDataException(
+              String.format("Value not MapSettings: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -744,14 +794,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the {@link Minefield} value of the object at the specified index
      */
-    public @Nullable Minefield getMinefield(int index) {
+    public @Nullable Minefield getMinefield(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof Minefield minefield) {
             return minefield;
         }
 
-        return null;
+        throw new InvalidPacketDataException(
+              String.format("Value not Minefield: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -759,7 +810,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a Vector of {@link Minefield}'s value of the object at the specified index
      */
-    public Vector<Minefield> getMinefieldVector(int index) {
+    public Vector<Minefield> getMinefieldVector(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         Vector<Minefield> result = new Vector<>();
@@ -770,9 +821,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(verifiedMinefield);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Vector: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -780,14 +833,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the {@link MovePath} value of the object at the specified index
      */
-    public @Nullable MovePath getMovePath(int index) {
+    public @Nullable MovePath getMovePath(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof MovePath movePath) {
             return movePath;
         }
 
-        return null;
+        throw new InvalidPacketDataException(
+              String.format("Value not MovePath: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -810,14 +864,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the {@link PlanetaryConditions} value of the object at the specified index
      */
-    public @Nullable PlanetaryConditions getPlanetaryConditions(int index) {
+    public @Nullable PlanetaryConditions getPlanetaryConditions(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof PlanetaryConditions planetaryConditions) {
             return planetaryConditions;
         }
 
-        return null;
+        throw new InvalidPacketDataException(
+              String.format("Value not PlanetaryConditions: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -825,14 +880,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the {@link Player} value of the object at the specified index
      */
-    public @Nullable Player getPlayer(int index) {
+    public @Nullable Player getPlayer(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof Player value) {
             return value;
         }
 
-        return null;
+        throw new InvalidPacketDataException(
+              String.format("Value not Player: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -840,7 +896,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a Vector of {@link Player}'s value of the object at the specified index
      */
-    public PlayerIDAndList<BoardLocation> getPlayerIDAndListWithBoardLocation(int index) {
+    public PlayerIDAndList<BoardLocation> getPlayerIDAndListWithBoardLocation(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         PlayerIDAndList<BoardLocation> result = new PlayerIDAndList<>();
@@ -853,9 +909,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(value);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not PlayerIDAndList: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -863,7 +921,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a Vector of {@link Player}'s value of the object at the specified index
      */
-    public Vector<Player> getPlayerVector(int index) {
+    public Vector<Player> getPlayerVector(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         Vector<Player> result = new Vector<>();
@@ -874,9 +932,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(verifiedPlayer);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Vector: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -884,7 +944,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a List of {@link Report}'s value of the object at the specified index
      */
-    public List<Report> getReportList(int index) {
+    public List<Report> getReportList(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         ArrayList<Report> result = new ArrayList<>();
@@ -895,9 +955,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(verifiedReport);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Collection<?>: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -905,7 +967,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a List of Lists of {@link Report}'s value of the object at the specified index
      */
-    public List<List<Report>> getReportListOfList(int index) {
+    public List<List<Report>> getReportListOfList(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         ArrayList<List<Report>> result = new ArrayList<>();
@@ -924,9 +986,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(verifiedReports);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Collection<?>: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -934,14 +998,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the {@link megamek.common.strategicBattleSystems.SBFMovePath} value of the object at the specified index
      */
-    public @Nullable SBFMovePath getSBFMovePath(int index) {
+    public @Nullable SBFMovePath getSBFMovePath(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof SBFMovePath sbfMovePath) {
             return sbfMovePath;
         }
 
-        return null;
+        throw new InvalidPacketDataException(
+              String.format("Value not SBFMovePath: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -949,7 +1014,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a List of {@link SBFReportEntry}'s value of the object at the specified index
      */
-    public List<SBFReportEntry> getSBFReportEntryList(int index) {
+    public List<SBFReportEntry> getSBFReportEntryList(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         ArrayList<SBFReportEntry> result = new ArrayList<>();
@@ -960,9 +1025,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(value);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Collection<?>: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -970,7 +1037,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a List of {@link SBFTurn}'s value of the object at the specified index
      */
-    public List<SBFTurn> getSBFTurnList(int index) {
+    public List<SBFTurn> getSBFTurnList(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         ArrayList<SBFTurn> result = new ArrayList<>();
@@ -981,9 +1048,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(value);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Collection<?>: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -991,14 +1060,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the {@link SmokeCloud} value of the object at the specified index
      */
-    public @Nullable SmokeCloud getSmokeCloud(int index) {
+    public @Nullable SmokeCloud getSmokeCloud(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof SmokeCloud smokeCloud) {
             return smokeCloud;
         }
 
-        return null;
+        throw new InvalidPacketDataException(
+              String.format("Value not SmokeCloud: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -1006,14 +1076,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the {@link SpecialHexDisplay} value of the object at the specified index
      */
-    public @Nullable SpecialHexDisplay getSpecialHexDisplay(int index) {
+    public @Nullable SpecialHexDisplay getSpecialHexDisplay(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof SpecialHexDisplay value) {
             return value;
         }
 
-        return null;
+        throw new InvalidPacketDataException(
+              String.format("Value not SpecialHexDisplay: %s (%s)", object, object.getClass()));
     }
 
 
@@ -1022,7 +1093,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a Vector of {@link TagInfo}'s value of the object at the specified index
      */
-    public Vector<TagInfo> getTagInfoVector(int index) {
+    public Vector<TagInfo> getTagInfoVector(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         Vector<TagInfo> result = new Vector<>();
@@ -1033,9 +1104,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(verifiedTagInfo);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not List: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -1043,7 +1116,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a Vector of {@link UnitLocation}'s value of the object at the specified index
      */
-    public Vector<UnitLocation> getUnitLocationVector(int index) {
+    public Vector<UnitLocation> getUnitLocationVector(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         Vector<UnitLocation> result = new Vector<>();
@@ -1054,9 +1127,12 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(verifiedLocation);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Vector: %s (%s)", object, object.getClass()));
+
     }
 
     /**
@@ -1064,7 +1140,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return a List of {@link WeaponAttackAction}'s value of the object at the specified index
      */
-    public List<WeaponAttackAction> getWeaponAttackActionList(int index) {
+    public List<WeaponAttackAction> getWeaponAttackActionList(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         ArrayList<WeaponAttackAction> result = new ArrayList<>();
@@ -1075,9 +1151,11 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
                     result.add(verifiedValue);
                 }
             }
+            return result;
         }
 
-        return result;
+        throw new InvalidPacketDataException(
+              String.format("Value not Collection<?>: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -1085,14 +1163,15 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
      *
      * @return the {@link megamek.common.enums.WeaponSortOrder} value of the object at the specified index
      */
-    public @Nullable WeaponSortOrder getWeaponSortOrder(int index) {
+    public @Nullable WeaponSortOrder getWeaponSortOrder(int index) throws InvalidPacketDataException {
         Object object = getObject(index);
 
         if (object instanceof WeaponSortOrder value) {
             return value;
         }
 
-        return null;
+        throw new InvalidPacketDataException(
+              String.format("Value not WeaponSortOrder: %s (%s)", object, object.getClass()));
     }
 
     @Override

--- a/megamek/src/megamek/common/net/packets/Packet.java
+++ b/megamek/src/megamek/common/net/packets/Packet.java
@@ -358,8 +358,8 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
 
         ArrayList<Building> result = new ArrayList<>();
 
-        if (object instanceof Collection<?> collection) {
-            for (Object building : collection) {
+        if (object instanceof Vector<?> vector) {
+            for (Object building : vector) {
                 if (building instanceof Building verifiedBuilding) {
                     result.add(verifiedBuilding);
                 }
@@ -368,7 +368,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
         }
 
         throw new InvalidPacketDataException(
-              String.format("Value not List: %s (%s)", object, object.getClass()));
+              String.format("Value not Vector: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -420,8 +420,8 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
 
         Vector<Coords> result = new Vector<>();
 
-        if (object instanceof Collection<?> collection) {
-            for (Object coord : collection) {
+        if (object instanceof Vector<?> vector) {
+            for (Object coord : vector) {
                 if (coord instanceof Coords verifiedCoord) {
                     result.add(verifiedCoord);
                 }
@@ -430,7 +430,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
         }
 
         throw new InvalidPacketDataException(
-              String.format("Value not Collection: %s (%s)", object, object.getClass()));
+              String.format("Value not Vector: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -525,8 +525,8 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
 
         ArrayList<Entity> result = new ArrayList<>();
 
-        if (object instanceof Collection<?> collection) {
-            for (Object entity : collection) {
+        if (object instanceof List<?> list) {
+            for (Object entity : list) {
                 if (entity instanceof Entity verifiedEntity) {
                     result.add(verifiedEntity);
                 }
@@ -535,7 +535,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
         }
 
         throw new InvalidPacketDataException(
-              String.format("Value not Collection<?>: %s (%s)", object, object.getClass()));
+              String.format("Value not List<?>: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -548,8 +548,9 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
 
         ArrayList<EntityAction> result = new ArrayList<>();
 
-        if (object instanceof Collection<?> collection) {
-            for (Object entityAction : collection) {
+        // Found users are List<> and Vector<> so this works.
+        if (object instanceof List<?> list) {
+            for (Object entityAction : list) {
                 if (entityAction instanceof EntityAction verifiedEntityAction) {
                     result.add(verifiedEntityAction);
                 }
@@ -558,7 +559,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
         }
 
         throw new InvalidPacketDataException(
-              String.format("Value not Collection<?>: %s (%s)", object, object.getClass()));
+              String.format("Value not List<?>: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -643,8 +644,9 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
 
         ArrayList<Force> result = new ArrayList<>();
 
-        if (object instanceof Collection<?> collection) {
-            for (Object forces : collection) {
+        // Users should now only use HashSet.
+        if (object instanceof HashSet<?> set) {
+            for (Object forces : set) {
                 if (forces instanceof Force verifiedForce) {
                     result.add(verifiedForce);
                 }
@@ -653,7 +655,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
         }
 
         throw new InvalidPacketDataException(
-              String.format("Value not Collection: %s (%s)", object, object.getClass()));
+              String.format("Value not HashSet: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -682,8 +684,8 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
 
         ArrayList<GameTurn> result = new ArrayList<>();
 
-        if (object instanceof Collection<?> collection) {
-            for (Object gameTurns : collection) {
+        if (object instanceof List<?> list) {
+            for (Object gameTurns : list) {
                 if (gameTurns instanceof GameTurn verifiedGameTurn) {
                     result.add(verifiedGameTurn);
                 }
@@ -692,7 +694,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
         }
 
         throw new InvalidPacketDataException(
-              String.format("Value not Collection<?>: %s (%s)", object, object.getClass()));
+              String.format("Value not List: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -760,8 +762,8 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
 
         ArrayList<InGameObject> result = new ArrayList<>();
 
-        if (object instanceof Collection<?> collection) {
-            for (Object report : collection) {
+        if (object instanceof List<?> list) {
+            for (Object report : list) {
                 if (report instanceof InGameObject value) {
                     result.add(value);
                 }
@@ -770,7 +772,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
         }
 
         throw new InvalidPacketDataException(
-              String.format("Value not Collection<?>: %s (%s)", object, object.getClass()));
+              String.format("Value not List: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -926,8 +928,8 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
 
         Vector<Player> result = new Vector<>();
 
-        if (object instanceof Collection<?> collection) {
-            for (Object player : collection) {
+        if (object instanceof HashSet<?> set) {
+            for (Object player : set) {
                 if (player instanceof Player verifiedPlayer) {
                     result.add(verifiedPlayer);
                 }
@@ -936,7 +938,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
         }
 
         throw new InvalidPacketDataException(
-              String.format("Value not Vector: %s (%s)", object, object.getClass()));
+              String.format("Value not HashSet: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -949,8 +951,8 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
 
         ArrayList<Report> result = new ArrayList<>();
 
-        if (object instanceof Collection<?> collection) {
-            for (Object report : collection) {
+        if (object instanceof Vector<?> vector) {
+            for (Object report : vector) {
                 if (report instanceof Report verifiedReport) {
                     result.add(verifiedReport);
                 }
@@ -959,7 +961,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
         }
 
         throw new InvalidPacketDataException(
-              String.format("Value not Collection<?>: %s (%s)", object, object.getClass()));
+              String.format("Value not Vector: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -972,6 +974,9 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
 
         ArrayList<List<Report>> result = new ArrayList<>();
 
+        // TODO: refactor SBFFullGameReport.java:createFilteredReport to _not_ return a HashMap
+        // but instead a list of lists, or refactor all other creators of data objects for this
+        // method to also create HashMaps (this may reduce bandwidth usage slightly).
         if (object instanceof Collection<?> collection) {
             for (Object reportList : collection) {
                 if (reportList instanceof List<?> verifiedReportList) {
@@ -1042,8 +1047,8 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
 
         ArrayList<SBFTurn> result = new ArrayList<>();
 
-        if (object instanceof Collection<?> collection) {
-            for (Object report : collection) {
+        if (object instanceof List<?> list) {
+            for (Object report : list) {
                 if (report instanceof SBFTurn value) {
                     result.add(value);
                 }
@@ -1052,7 +1057,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
         }
 
         throw new InvalidPacketDataException(
-              String.format("Value not Collection<?>: %s (%s)", object, object.getClass()));
+              String.format("Value not List: %s (%s)", object, object.getClass()));
     }
 
     /**
@@ -1146,8 +1151,8 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
 
         ArrayList<WeaponAttackAction> result = new ArrayList<>();
 
-        if (object instanceof Collection<?> collection) {
-            for (Object value : collection) {
+        if (object instanceof List<?> list) {
+            for (Object value : list) {
                 if (value instanceof WeaponAttackAction verifiedValue) {
                     result.add(verifiedValue);
                 }
@@ -1156,7 +1161,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
         }
 
         throw new InvalidPacketDataException(
-              String.format("Value not Collection<?>: %s (%s)", object, object.getClass()));
+              String.format("Value not List: %s (%s)", object, object.getClass()));
     }
 
     /**

--- a/megamek/src/megamek/common/net/packets/Packet.java
+++ b/megamek/src/megamek/common/net/packets/Packet.java
@@ -134,8 +134,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return integer;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not integer: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("int", object, index);
     }
 
     /**
@@ -157,8 +156,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not List: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("List", object, index);
     }
 
     /**
@@ -182,8 +180,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Map<Integer, Integer>: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Map<Integer, Integer>", object, index);
     }
 
 
@@ -216,8 +213,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Map<Integer, List>: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Map<Integer, List>", object, index);
     }
 
     /**
@@ -232,8 +228,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return bool;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Boolean: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Boolean", object, index);
     }
 
     /**
@@ -248,8 +243,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return value;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not String: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("String", object, index);
     }
 
     /**
@@ -273,8 +267,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Map<String, BehaviorSettings>: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Map<String, BehaviorSettings>", object, index);
     }
 
     /**
@@ -296,8 +289,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Vector: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Vector", object, index);
     }
 
     /**
@@ -319,8 +311,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Set: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Set", object, index);
     }
 
     /**
@@ -344,8 +335,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Map<Location, Hex>: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Map<Location, Hex>", object, index);
     }
 
     /**
@@ -367,8 +357,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Vector: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Vector", object, index);
     }
 
     /**
@@ -383,8 +372,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return coords;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Coords: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Coords", object, index);
     }
 
     /**
@@ -406,8 +394,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not HashSet: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("HashSet", object, index);
     }
 
     /**
@@ -429,8 +416,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Vector: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Vector", object, index);
     }
 
     /**
@@ -462,8 +448,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Map<Coords, List>: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Map<Coords, List>", object, index);
     }
 
     /**
@@ -495,8 +480,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Map<Coords, Collection>: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Map<Coords, Collection>", object, index);
     }
 
     /**
@@ -511,8 +495,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return entity;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Entity: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Entity", object, index);
     }
 
     /**
@@ -534,8 +517,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not List<?>: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("List<?>", object, index);
     }
 
     /**
@@ -558,8 +540,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not List<?>: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("List<?>", object, index);
     }
 
     /**
@@ -574,8 +555,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return value;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not FighterSquadron: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("FighterSquadron", object, index);
     }
 
     /**
@@ -597,8 +577,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Vector<?>: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Vector", object, index);
     }
 
     /**
@@ -613,8 +592,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return value;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Force: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Force", object, index);
     }
 
 
@@ -630,8 +608,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return force;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Forces: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Forces", object, index);
     }
 
     /**
@@ -654,8 +631,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not HashSet: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("HashSet", object, index);
     }
 
     /**
@@ -670,8 +646,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return gameOptions;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not GameOptions: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("GameOptions", object, index);
     }
 
     /**
@@ -693,8 +668,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not List: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("List", object, index);
     }
 
     /**
@@ -709,8 +683,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return hex;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Hex: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Hex", object, index);
     }
 
     /**
@@ -732,8 +705,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Vector: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Vector", object, index);
     }
 
     /**
@@ -748,8 +720,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return value;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not InGameObject: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("InGameObject", object, index);
     }
 
     /**
@@ -771,8 +742,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not List: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("List", object, index);
     }
 
     /**
@@ -787,8 +757,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return mapSettings;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not MapSettings: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("MapSettings", object, index);
     }
 
     /**
@@ -803,8 +772,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return minefield;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Minefield: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Minefield", object, index);
     }
 
     /**
@@ -826,8 +794,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Vector: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Vector", object, index);
     }
 
     /**
@@ -842,8 +809,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return movePath;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not MovePath: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("MovePath", object, index);
     }
 
     /**
@@ -873,8 +839,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return planetaryConditions;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not PlanetaryConditions: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("PlanetaryConditions", object, index);
     }
 
     /**
@@ -889,8 +854,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return value;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Player: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Player", object, index);
     }
 
     /**
@@ -914,8 +878,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not PlayerIDAndList: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("PlayerIDAndList", object, index);
     }
 
     /**
@@ -937,8 +900,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not HashSet: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("HashSet", object, index);
     }
 
     /**
@@ -960,8 +922,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Vector: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Vector", object, index);
     }
 
     /**
@@ -994,8 +955,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Collection<?>: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Collection<?>", object, index);
     }
 
     /**
@@ -1010,8 +970,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return sbfMovePath;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not SBFMovePath: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("SBFMovePath", object, index);
     }
 
     /**
@@ -1033,8 +992,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Collection<?>: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("Collection<?>", object, index);
     }
 
     /**
@@ -1056,8 +1014,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not List: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("List", object, index);
     }
 
     /**
@@ -1072,8 +1029,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return smokeCloud;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not SmokeCloud: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("SmokeCloud", object, index);
     }
 
     /**
@@ -1088,8 +1044,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return value;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not SpecialHexDisplay: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("SpecialHexDisplay", object, index);
     }
 
 
@@ -1112,10 +1067,8 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not List: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("List", object, index);
     }
-
     /**
      * @param index the index of the desired object
      *
@@ -1135,9 +1088,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not Vector: %s (%s)", (object == null) ? "Null object at index " + index : object,
-                    (object == null) ? "Unknown" : object.getClass()));
+        throw new InvalidPacketDataException("Vector", object, index);
 
     }
 
@@ -1160,8 +1111,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not List: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("List", object, index);
     }
 
     /**
@@ -1176,8 +1126,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return value;
         }
 
-        throw new InvalidPacketDataException(
-              String.format("Value not WeaponSortOrder: %s (%s)", object, object.getClass()));
+        throw new InvalidPacketDataException("WeaponSortOrder", object, index);
     }
 
     @Override

--- a/megamek/src/megamek/common/weapons/handlers/capitalMissile/CapitalMissileBearingsOnlyHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/capitalMissile/CapitalMissileBearingsOnlyHandler.java
@@ -56,6 +56,7 @@ import megamek.common.equipment.WeaponMounted;
 import megamek.common.equipment.WeaponType;
 import megamek.common.game.Game;
 import megamek.common.loaders.EntityLoadingException;
+import megamek.common.net.packets.InvalidPacketDataException;
 import megamek.common.options.OptionsConstants;
 import megamek.common.rolls.TargetRoll;
 import megamek.common.units.Aero;
@@ -539,7 +540,12 @@ public class CapitalMissileBearingsOnlyHandler extends AmmoBayWeaponHandler {
                 targetIds.add(target.getId());
                 toHitValues.add(toHit.getValue());
             }
-            int choice = gameManager.processTeleguidedMissileCFR(attackingEntity.getOwnerId(), targetIds, toHitValues);
+            int choice = 0;
+            try {
+                choice = gameManager.processTeleguidedMissileCFR(attackingEntity.getOwnerId(), targetIds, toHitValues);
+            } catch (InvalidPacketDataException e) {
+                LOGGER.error("Invalid packet data:", e);
+            }
             newTarget = targets.get(choice);
             target = newTarget;
             aaa.setTargetId(target.getId());

--- a/megamek/src/megamek/server/AbstractGameManager.java
+++ b/megamek/src/megamek/server/AbstractGameManager.java
@@ -37,6 +37,7 @@ import megamek.common.game.IGame;
 import megamek.common.Player;
 import megamek.common.enums.GamePhase;
 import megamek.common.net.enums.PacketCommand;
+import megamek.common.net.packets.InvalidPacketDataException;
 import megamek.common.net.packets.Packet;
 import megamek.common.options.OptionsConstants;
 import megamek.common.preference.PreferenceManager;
@@ -73,9 +74,13 @@ public abstract class AbstractGameManager implements IGameManager {
     @Override
     public void handlePacket(int connId, Packet packet) {
         if (packet.command() == PacketCommand.PLAYER_READY) {
-            receivePlayerDone(packet, connId);
-            send(packetHelper.createPlayerDonePacket(connId));
-            checkReady();
+            try {
+                receivePlayerDone(packet, connId);
+                send(packetHelper.createPlayerDonePacket(connId));
+                checkReady();
+            } catch (InvalidPacketDataException e) {
+                logger.error("Invalid packet data:", e);
+            }
         }
     }
 
@@ -175,7 +180,7 @@ public abstract class AbstractGameManager implements IGameManager {
     /**
      * Sets a player's ready status as received from the Client. This method does not perform any follow-up actions.
      */
-    private void receivePlayerDone(Packet packet, int connIndex) {
+    private void receivePlayerDone(Packet packet, int connIndex) throws InvalidPacketDataException {
         boolean ready = packet.getBooleanValue(0);
         Player player = getGame().getPlayer(connIndex);
         if (null != player) {

--- a/megamek/src/megamek/server/ServerLobbyHelper.java
+++ b/megamek/src/megamek/server/ServerLobbyHelper.java
@@ -476,7 +476,7 @@ public class ServerLobbyHelper {
      * entities.
      */
     static Packet createForceUpdatePacket(Collection<Force> changedForces) {
-        return createForceUpdatePacket(changedForces, new ArrayList<>());
+        return createForceUpdatePacket(changedForces, new HashSet<>());
     }
 
     /**

--- a/megamek/src/megamek/server/ServerLobbyHelper.java
+++ b/megamek/src/megamek/server/ServerLobbyHelper.java
@@ -47,6 +47,7 @@ import megamek.common.force.Forces;
 import megamek.common.game.Game;
 import megamek.common.interfaces.ForceAssignable;
 import megamek.common.net.enums.PacketCommand;
+import megamek.common.net.packets.InvalidPacketDataException;
 import megamek.common.net.packets.Packet;
 import megamek.common.options.OptionsConstants;
 import megamek.common.units.Entity;
@@ -220,7 +221,9 @@ public class ServerLobbyHelper {
      * Handles a force parent packet, attaching the sent forces to a new parent or making the sent forces top-level.
      * This method is intended for use in the lobby!
      */
-    public static void receiveForceParent(Packet packet, int connId, Game game, TWGameManager gameManager) {
+    public static void receiveForceParent(
+          Packet packet, int connId, Game game, TWGameManager gameManager
+    ) throws InvalidPacketDataException {
         var forceList = packet.getForceList(0);
         int newParentId = packet.getIntValue(1);
 
@@ -247,7 +250,9 @@ public class ServerLobbyHelper {
      * Handles a force assign full packet, changing the owner of forces and everything in them. This method is intended
      * for use in the lobby!
      */
-    public static void receiveEntitiesAssign(Packet packet, int connId, Game game, TWGameManager gameManager) {
+    public static void receiveEntitiesAssign(
+          Packet packet, int connId, Game game, TWGameManager gameManager
+    ) throws InvalidPacketDataException  {
         var entityList = packet.getEntityList(0);
         int newOwnerId = packet.getIntValue(1);
         Player newOwner = game.getPlayer(newOwnerId);
@@ -272,7 +277,9 @@ public class ServerLobbyHelper {
      * Handles a force assign full packet, changing the owner of forces and everything in them. This method is intended
      * for use in the lobby!
      */
-    public static void receiveForceAssignFull(Packet packet, int connId, Game game, TWGameManager gameManager) {
+    public static void receiveForceAssignFull(
+          Packet packet, int connId, Game game, TWGameManager gameManager
+    ) throws InvalidPacketDataException {
         var forceList = packet.getForceList(0);
         int newOwnerId = packet.getIntValue(1);
         Player newOwner = game.getPlayer(newOwnerId);
@@ -308,7 +315,9 @@ public class ServerLobbyHelper {
      * move subforce/entity up/down (this does not change the entity, only the force) - owner change of only the force
      * (not the entities, only within a team) This method is intended for use in the lobby!
      */
-    public static void receiveForceUpdate(Packet packet, int connId, Game game, TWGameManager gameManager) {
+    public static void receiveForceUpdate(
+          Packet packet, int connId, Game game, TWGameManager gameManager
+    ) throws InvalidPacketDataException {
         var forceList = packet.getForceList(0);
 
         // Check if the updated Forces are valid
@@ -328,7 +337,9 @@ public class ServerLobbyHelper {
     /**
      * Handles a team change, updating units and forces as necessary. This method is intended for use in the lobby!
      */
-    public static void receiveLobbyTeamChange(Packet packet, int connId, Game game, TWGameManager gameManager) {
+    public static void receiveLobbyTeamChange(
+          Packet packet, int connId, Game game, TWGameManager gameManager
+    ) throws InvalidPacketDataException {
         var players = packet.getPlayerVector(0);
         var newTeam = packet.getIntValue(1);
 
@@ -401,7 +412,9 @@ public class ServerLobbyHelper {
      * Handles an add entity to force / remove from force packet, attaching the sent entities to a force or removing
      * them from any force. This method is intended for use in the lobby!
      */
-    public static void receiveAddEntitiesToForce(Packet packet, int connId, Game game, TWGameManager gameManager) {
+    public static void receiveAddEntitiesToForce(
+          Packet packet, int connId, Game game, TWGameManager gameManager
+    ) throws InvalidPacketDataException {
         var entityList = packet.getEntityList(0);
         var forceId = packet.getIntValue(1);
         // Get the local (server) entities
@@ -435,7 +448,9 @@ public class ServerLobbyHelper {
     /**
      * Adds a force with the info from the client. Only valid during the lobby phase.
      */
-    public static void receiveForceAdd(Packet packet, int connId, Game game, TWGameManager gameManager) {
+    public static void receiveForceAdd(
+          Packet packet, int connId, Game game, TWGameManager gameManager
+    ) throws InvalidPacketDataException {
         var force = packet.getForce(0);
         var entities = packet.getEntityList(1);
 

--- a/megamek/src/megamek/server/totalWarfare/DeploymentProcessor.java
+++ b/megamek/src/megamek/server/totalWarfare/DeploymentProcessor.java
@@ -40,6 +40,7 @@ import megamek.common.board.Coords;
 import megamek.common.compute.Compute;
 import megamek.common.enums.BuildingType;
 import megamek.common.game.GameTurn;
+import megamek.common.net.packets.InvalidPacketDataException;
 import megamek.common.net.packets.Packet;
 import megamek.common.options.OptionsConstants;
 import megamek.common.planetaryConditions.Atmosphere;
@@ -66,7 +67,7 @@ public class DeploymentProcessor extends AbstractTWRuleHandler {
     /**
      * Receives a deployment packet from a Client connection. If valid, executes it and ends the current turn.
      */
-    void receiveDeployment(Packet packet, int connId) {
+    void receiveDeployment(Packet packet, int connId) throws InvalidPacketDataException {
         Entity entity = getGame().getEntity(packet.getIntValue(0));
 
         if (entity == null) {
@@ -144,7 +145,7 @@ public class DeploymentProcessor extends AbstractTWRuleHandler {
      * @param packet the packet to be processed
      * @param connId the id for connection that received the packet.
      */
-    void receiveDeploymentUnload(Packet packet, int connId) {
+    void receiveDeploymentUnload(Packet packet, int connId) throws InvalidPacketDataException {
         Entity loader = getGame().getEntity(packet.getIntValue(0));
         Entity loaded = getGame().getEntity(packet.getIntValue(1));
 

--- a/megamek/src/megamek/server/totalWarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalWarfare/MovePathHandler.java
@@ -74,6 +74,7 @@ import megamek.common.game.Game;
 import megamek.common.game.GameTurn;
 import megamek.common.moves.MovePath;
 import megamek.common.moves.MoveStep;
+import megamek.common.net.packets.InvalidPacketDataException;
 import megamek.common.options.OptionsConstants;
 import megamek.common.planetaryConditions.PlanetaryConditions;
 import megamek.common.rolls.PilotingRollData;
@@ -1126,6 +1127,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
                         if (targetDest != null) {
                             addReport(gameManager.doEntityDisplacement(violation,
                                   entity.getPosition(), targetDest, prd));
+
                             // Update the violating entity's position on the
                             // client.
                             gameManager.entityUpdate(violation.getId());
@@ -1395,7 +1397,13 @@ class MovePathHandler extends AbstractTWRuleHandler {
                         // Update entity position on client
                         gameManager.send(entity.getOwnerId(),
                               gameManager.createEntityPacket(this.entity.getId(), null));
-                        boolean tookPBS = gameManager.processPointblankShotCFR(entity, this.entity);
+                        // Allow for packet data read failure
+                        boolean tookPBS = false;
+                        try {
+                            tookPBS = gameManager.processPointblankShotCFR(entity, this.entity);
+                        } catch (InvalidPacketDataException e) {
+                            logger.error("Invalid packet data:", e);
+                        }
                         // Movement should be interrupted
                         if (tookPBS) {
                             // Attacking reveals hidden unit


### PR DESCRIPTION
Per our conversation on Discord, this implements throwing InvalidPacketDataException when packet data types do not match their respective expected type[s].
This should give us explicit feedback when unexpected data formats are passed through packets; previously this would cause packet ingest to fail silently, leading to many parts of the UI or network behaviour to fail silently and inexplicably.

Part of this work is to add `try...catch` clauses around most of the packet handling `switch/case` constructs, the majority of which had no exception handling whatsoever.
We have the opportunity in 0.50.07 to greatly increase our error handling and logging in these areas by expanding on this work, but I'm unsure of the possible performance impacts.

Testing:
- Ran all MM unit tests (MHQ was still broken)
- Ran multi-hour bot vs. bot fight and confirmed no new errors or exceptions