### PR TITLE
Prevent multiple clan CASE per location

### DIFF
--- a/megamek/src/megamek/common/units/Aero.java
+++ b/megamek/src/megamek/common/units/Aero.java
@@ -1870,6 +1870,11 @@ public abstract class Aero extends Entity implements IAero, IBomber {
             if (i == LOC_WINGS) {
                 continue;
             }
+            // Skip location if it already contains CASE
+            if (locationHasCase(i) || hasCASEII(i)) {
+                continue;
+            }
+
             explosiveFound = false;
             for (Mounted<?> m : getEquipment()) {
                 if (m.getType().isExplosive(m, true) && (m.getLocation() == i)) {

--- a/megamek/src/megamek/common/units/Mek.java
+++ b/megamek/src/megamek/common/units/Mek.java
@@ -2657,6 +2657,11 @@ public abstract class Mek extends Entity {
         boolean explosiveFound;
         EquipmentType clCase = EquipmentType.get(EquipmentTypeLookup.CLAN_CASE);
         for (int i = 0; i < locations(); i++) {
+            // Skip location if it already contains CASE
+            if (locationHasCase(i) || hasCASEII(i)) {
+                continue;
+            }
+
             explosiveFound = false;
             for (Mounted<?> m : getEquipment()) {
                 if (m.getType().isExplosive(m, true)


### PR DESCRIPTION
Currently a new Clan CASE gets added every time MML makes a change to a unit's equipment, so if you add 5 ammo bins to a location you get 5 Clan CASEs.

If a location already has CASE, it doesn't need more CASE.