### PR TITLE
Convert Forces list to HashSet when TWGameManager resends entity updates

### DIFF
--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -25094,9 +25094,9 @@ public class TWGameManager extends AbstractGameManager {
         final List<Entity> entities = entityIds.stream()
               .map(id -> getGame().getEntity(id))
               .toList();
-        final List<Force> forceList = forceIds.stream()
+        final HashSet<Force> forceList = new HashSet<Force>(forceIds.stream()
               .map(id -> getGame().getForces().getForce(id))
-              .toList();
+              .toList());
         return new Packet(PacketCommand.ENTITY_ADD, entities, forceList);
     }
 


### PR DESCRIPTION
Now that we are enforcing packet data types with a new exception, we need TWGameManager to play ball and compile its forceList as a HashSet like all the other good little functions.

The reason that saving a game from MHQ and then reloading it in stand-alone MegaMek works is because all of the information was stored correctly in the _server_ state (which is where we save from) but when sent as a packet the clients choked on it due to the unexpected data type.

Testing:
- Confirmed fixed issue in 7558 with units not appearing in the lobby.
- Ran all 3 projects' unit tests

Close MegaMek/MekHQ#7558