### PR TITLE
fix: direct equality checks for null are preferred over .equals()

### DIFF
--- a/megamek/src/megamek/server/totalWarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalWarfare/MovePathHandler.java
@@ -2989,7 +2989,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
                     loaded = entities.next();
 
                     // This should never ever happen, but just in case...
-                    if (loaded.equals(null)) {
+                    if (loaded == null) {
                         continue;
                     }
 


### PR DESCRIPTION
https://docs.pmd-code.org/snapshot/pmd_rules_java_errorprone.html#equalsnull