### PR TITLE
Prevent Trailer Hitch Damage Transfer

### DIFF
--- a/megamek/src/megamek/common/equipment/TankTrailerHitch.java
+++ b/megamek/src/megamek/common/equipment/TankTrailerHitch.java
@@ -248,16 +248,12 @@ public class TankTrailerHitch implements Transporter {
      */
     @Override
     public final Entity getExteriorUnitAt(int loc, boolean isRear) {
-        return game.getEntity(towed);
+        return null;
     }
 
     @Override
     public final List<Entity> getExternalUnits() {
-        ArrayList<Entity> rv = new ArrayList<>(1);
-        if (towed != Entity.NONE) {
-            rv.add(game.getEntity(towed));
-        }
-        return Collections.unmodifiableList(rv);
+        return Collections.emptyList();
     }
 
     @Override

--- a/megamek/testresources/data/scenarios/test_setups/Trailers.mms
+++ b/megamek/testresources/data/scenarios/test_setups/Trailers.mms
@@ -1,0 +1,39 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+MMSVersion: 2
+name: Test Setup for Trailers
+planet: None
+description: A J-27 with trailer to hitch up and a Galleon to shoot at it
+map: buildingsnobasement/dropport2.board
+
+options:
+  off:
+    - check_victory
+
+factions:
+- name: Test Player
+
+  units:
+  - fullname: J-27 Ordnance Transport
+    at: [ 9, 10 ]
+
+  - fullname: J-27 Ordnance Transport (Trailer)
+    at: [ 10, 10 ]
+
+  - fullname: Galleon Light Tank GAL-100
+    at: [ 11, 10 ]
+


### PR DESCRIPTION
Fixes #7372

"External units" in Transporters must only care about BA.

If time permits, I'll supply a refactor PR later that clears up Transporters a bit and improves javadoc.