### PR TITLE
TAG cannot into rotor

### DIFF
--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -946,8 +946,7 @@ public class TestTank extends TestEntity {
                 buffer.append(eq.getName()).append(" cannot be mounted in the body.\n");
                 return false;
             }
-            if ((tank instanceof VTOL) && (location == VTOL.LOC_ROTOR)
-                  && !eq.hasFlag(WeaponType.F_TAG)) {
+            if ((tank instanceof VTOL) && (location == VTOL.LOC_ROTOR)) {
                 buffer.append(eq.getName()).append(" cannot be mounted in the rotor.\n");
                 return false;
             }


### PR DESCRIPTION
Fixes MegaMek/megameklab#2006

TAG isn't allowed in rotors/mast mounts, so it's unclear why this exception existed in the code.