### PR TITLE
Fix: Fixed Failing Tests Following Data Overhaul (MegaMek Edition)

### DIFF
--- a/megamek/src/megamek/client/generator/RandomCallsignGenerator.java
+++ b/megamek/src/megamek/client/generator/RandomCallsignGenerator.java
@@ -49,23 +49,53 @@ import megamek.logging.MMLogger;
  * that is used during generation
  */
 public class RandomCallsignGenerator {
-    private final static RandomCallsignGenerator INSTANCE = new RandomCallsignGenerator();
     private final static MMLogger logger = MMLogger.create(RandomCallsignGenerator.class);
+
+    private final static String TEST_DIR = "testresources/data/names/callsigns_test.csv";
+
+    private final static RandomCallsignGenerator INSTANCE = new RandomCallsignGenerator(false);
+    private final static RandomCallsignGenerator TEST_INSTANCE = new RandomCallsignGenerator(true);
+
 
     private final WeightedIntMap<String> weightedCallsigns = new WeightedIntMap<>();
 
-    RandomCallsignGenerator() {
+    RandomCallsignGenerator(boolean useTestDirectory) {
         final Map<String, Integer> callsigns = new HashMap<>();
-        loadCallsignsFromFile(new File(MMConstants.CALLSIGN_FILE_PATH), callsigns);
-        loadCallsignsFromFile(new File(MMConstants.USER_CALLSIGN_FILE_PATH), callsigns);
+
+        if (useTestDirectory) {
+            loadCallsignsFromFile(new File(TEST_DIR), callsigns);
+        } else {
+            loadCallsignsFromFile(new File(MMConstants.CALLSIGN_FILE_PATH), callsigns);
+            loadCallsignsFromFile(new File(MMConstants.USER_CALLSIGN_FILE_PATH), callsigns);
+        }
 
         for (final Map.Entry<String, Integer> entry : callsigns.entrySet()) {
             getWeightedCallsigns().add(entry.getValue(), entry.getKey());
         }
     }
 
+    /**
+     * Retrieves a singleton instance of the {@link RandomCallsignGenerator}.
+     *
+     * @return the singleton instance of {@link RandomCallsignGenerator}
+     */
     public static RandomCallsignGenerator getInstance() {
-        return INSTANCE;
+        return getInstance(false);
+    }
+
+    /**
+     * Returns an instance of the {@link RandomCallsignGenerator} class. The instance retrieved depends on whether the
+     * test directory is being used or not.
+     *
+     * @param useTestDirectory a boolean indicating whether to use the test directory. If {@code true}, the instance
+     *                         specific to the test directory will be returned. If {@code false}, the default instance
+     *                         will be returned.
+     *
+     * @return an instance of {@link RandomCallsignGenerator}, either for the test directory or the default instance,
+     *       based on the parameter value.
+     */
+    public static RandomCallsignGenerator getInstance(boolean useTestDirectory) {
+        return useTestDirectory ? TEST_INSTANCE : INSTANCE;
     }
 
     // region Getters/Setters

--- a/megamek/src/megamek/client/generator/RandomNameGenerator.java
+++ b/megamek/src/megamek/client/generator/RandomNameGenerator.java
@@ -253,24 +253,26 @@ public class RandomNameGenerator implements Serializable {
     public String[] generateGivenNameSurnameSplit(Gender gender, boolean clanPilot, String faction) {
         String[] name = { UNNAMED, UNNAMED_SURNAME };
         if (initialized) {
-            // This checks to see if we've got a name map for the faction. If we do not,
-            // then we
-            // go to check if the person is a clanPilot. If they are, then they default to
-            // the default
-            // clan key provided that exists.
-            // If the key isn't set by either case above, then the name is generated based
-            // on the
-            // default faction key
-            faction = factionEthnicCodes.containsKey(faction) ? faction
-                  : ((clanPilot && (factionEthnicCodes.containsKey(KEY_DEFAULT_CLAN)))
-                  ? KEY_DEFAULT_CLAN
-                  : KEY_DEFAULT_FACTION);
-            final int ethnicCode = factionEthnicCodes.get(faction).randomItem();
-            final int givenNameEthnicCode = factionGivenNames.get(faction).get(ethnicCode).randomItem();
+            int ethnicCode = 0;
+            try {
+                // This checks to see if we've got a name map for the faction. If we do not, then we go to check if the
+                // person is a clanPilot. If they are, then they default to the default clan key provided that exists. If
+                // the key isn't set by either case above, then the name is generated based on the default faction key
+                faction = factionEthnicCodes.containsKey(faction) ? faction
+                      : ((clanPilot && (factionEthnicCodes.containsKey(KEY_DEFAULT_CLAN)))
+                      ? KEY_DEFAULT_CLAN
+                      : KEY_DEFAULT_FACTION);
+                ethnicCode = factionEthnicCodes.get(faction).randomItem();
+                final int givenNameEthnicCode = factionGivenNames.get(faction).get(ethnicCode).randomItem();
 
-            name[0] = (gender.isFemale() ? femaleGivenNames : maleGivenNames).get(givenNameEthnicCode).randomItem();
-
-            name[1] = clanPilot ? "" : surnames.get(ethnicCode).randomItem();
+                name[0] = (gender.isFemale() ? femaleGivenNames : maleGivenNames).get(givenNameEthnicCode).randomItem();
+                name[1] = clanPilot ? "" : surnames.get(ethnicCode).randomItem();
+            } catch (Exception e) {
+                // This should only fail when we have no name data passed in. For example, if we're running in a
+                // dataless environment such as the GitHub test environment.
+                LOGGER.error(e, "Error generating name for faction: {} and ethnic code: {}", faction, ethnicCode);
+                return name;
+            }
         }
         return name;
     }

--- a/megamek/src/megamek/common/units/Crew.java
+++ b/megamek/src/megamek/common/units/Crew.java
@@ -324,7 +324,8 @@ public class Crew implements Serializable {
     }
 
     public String getNickname(final int pos) {
-        return getNicknames()[pos];
+        String nickname = getNicknames()[pos];
+        return nickname == null ? "" : nickname;
     }
 
     public void setNickname(final String nickname, final int pos) {

--- a/megamek/src/megamek/common/universe/Factions2.java
+++ b/megamek/src/megamek/common/universe/Factions2.java
@@ -105,6 +105,8 @@ public final class Factions2 {
     private static final MMLogger LOGGER = MMLogger.create(Factions2.class);
     private static Factions2 instance;
 
+    private static final String TEST_DIR = "testresources/data/universe/factions";
+
     private final Map<String, Faction2> factions = new HashMap<>();
 
     private Factions2() {
@@ -112,8 +114,12 @@ public final class Factions2 {
     }
 
     public static synchronized Factions2 getInstance() {
+        return getInstance(false);
+    }
+
+    public static synchronized Factions2 getInstance(boolean useTestDirectory) {
         if (instance == null) {
-            instance = new Factions2();
+            instance = useTestDirectory ? new Factions2(TEST_DIR) : new Factions2();
         }
 
         return instance;


### PR DESCRIPTION
Following the data overhaul we found ourselves with a number of failing tests. These were tests that relied on data being present when the GitHub Test Environment ran.

With the segregation of Data out of the individual program directories we now run in a dataless state.

This PR updates a handful of classes so that they can accept both test and non-test directories. This allows us to include test data for testing purposes.

This PR is required for https://github.com/MegaMek/mekhq/pull/7588