### PR TITLE
Fix 7434: wrong data type for entity transfer packet

### DIFF
--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -471,7 +471,7 @@ public class Client extends AbstractClient {
      * Sends a packet containing multiple entity updates. Should only be used in the lobby phase.
      */
     public void sendChangeOwner(Collection<Entity> entities, int newOwnerId) throws InvalidPacketDataException {
-        send(new Packet(PacketCommand.ENTITY_ASSIGN, entities, newOwnerId));
+        send(new Packet(PacketCommand.ENTITY_ASSIGN, List.of(entities), newOwnerId));
     }
 
     /**

--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -471,7 +471,7 @@ public class Client extends AbstractClient {
      * Sends a packet containing multiple entity updates. Should only be used in the lobby phase.
      */
     public void sendChangeOwner(Collection<Entity> entities, int newOwnerId) throws InvalidPacketDataException {
-        send(new Packet(PacketCommand.ENTITY_ASSIGN, List.of(entities), newOwnerId));
+        send(new Packet(PacketCommand.ENTITY_ASSIGN, entities, newOwnerId));
     }
 
     /**

--- a/megamek/src/megamek/common/net/packets/Packet.java
+++ b/megamek/src/megamek/common/net/packets/Packet.java
@@ -512,8 +512,10 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
         if (object == null) {
             return result;
         }
-        if (object instanceof List<?> list) {
-            for (Object entity : list) {
+
+        // Must accept Collections, at least until other changes are made
+        if (object instanceof Collection<?> collection) {
+            for (Object entity : collection) {
                 if (entity instanceof Entity verifiedEntity) {
                     result.add(verifiedEntity);
                 }
@@ -521,7 +523,7 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
             return result;
         }
 
-        throw new InvalidPacketDataException("List<?>", object, index);
+        throw new InvalidPacketDataException("Collection<?>", object, index);
     }
 
     /**


### PR DESCRIPTION
It turns out we need to use Collection here after all, as different sources produce different types of Collections.

Testing:
- Ran all unit tests
- Ran repro from issue

Close #7434 