### PR TITLE
Fix #7441: Restrict player "list" to Vector

### DIFF
--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -1271,7 +1271,7 @@ public class Client extends AbstractClient {
     /**
      * Sends a packet containing multiple entity updates. Should only be used in the lobby phase.
      */
-    public void sendChangeTeam(Collection<Player> players, int newTeamId) {
+    public void sendChangeTeam(Vector<Player> players, int newTeamId) {
         send(new Packet(PacketCommand.PLAYER_TEAM_CHANGE, players, newTeamId));
     }
 

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/LobbyActions.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/LobbyActions.java
@@ -928,7 +928,7 @@ public class LobbyActions {
      * Change the team of a controlled player (the local player or one of his bots).
      */
     void changeTeam(Collection<Player> players, int team) {
-        var toSend = new HashSet<Player>();
+        var toSend = new Vector<Player>();
         players.stream()
               .filter(this::isSelfOrLocalBot)
               .filter(p -> p.getTeam() != team)


### PR DESCRIPTION
More fallout from implementing strict typing in Packet handling: some team change packets were being created with HashSets (for whatever reason) but we had been expecting Vectors based on other packet creation code.

Testing:
- Ran all 3 projects' unit tests.
- Ran reporter's repro campaign and confirmed functionality is working correctly.

Close #7441 