### PR TITLE
Fix #7427: Fixed Board Size Display in Lobby

### DIFF
--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
@@ -1076,16 +1076,32 @@ public class ChatLounge extends AbstractPhaseDisplay
         }
     }
 
-    /** Updates the list of available map sizes. */
+    /**
+     * Refreshes the map size selection combo box with all available map sizes, sorted by width and then by height.
+     *
+     * <p>This method obtains the set of available map sizes from the client, sorts them first by width (ascending)
+     * and then by height (ascending), and populates the combo box with these sorted sizes. An additional "Custom Map
+     * Size" entry is added at the end of the list. The previously selected index is preserved if possible.</p>
+     *
+     * <p>The combo box's action listener is temporarily removed during the update to prevent unwanted event
+     * firing.</p>
+     */
     private void refreshMapSizes() {
         int oldSelection = comMapSizes.getSelectedIndex();
         Set<BoardDimensions> mapSizes = clientgui.getClient().getAvailableMapSizes();
+
+        // Sort the map sizes by width (w()) and then by height (h())
+        List<BoardDimensions> sortedSizes = new ArrayList<>(mapSizes);
+        sortedSizes.sort(Comparator.comparingInt(BoardDimensions::w)
+              .thenComparingInt(BoardDimensions::h));
+
         comMapSizes.removeActionListener(lobbyListener);
         comMapSizes.removeAllItems();
-        for (BoardDimensions size : mapSizes) {
+
+        for (BoardDimensions size : sortedSizes) {
             comMapSizes.addItem(size);
         }
-        comMapSizes.addItem(Messages.getString("ChatLounge.CustomMapSize"));
+
         comMapSizes.setSelectedIndex(oldSelection != -1 ? oldSelection : 0);
         comMapSizes.addActionListener(lobbyListener);
     }


### PR DESCRIPTION
Fix #7427

This PR adds sorting to the returned list of board sizes so that they are sorted (ascending) first by width and then height.

<img width="552" height="742" alt="image" src="https://github.com/user-attachments/assets/b74f5f4d-4a1b-43b6-804a-c278d71805b2" />

Previously no sorting was applied, causing the map sizes to be arranged in whatever order they were encountered.