### PR TITLE
Improvement: Bolstered Clan Forces

### DIFF
--- a/megamek/src/megamek/common/universe/HonorRating.java
+++ b/megamek/src/megamek/common/universe/HonorRating.java
@@ -36,10 +36,10 @@ package megamek.common.universe;
  * Represents the honor of a Clan
  */
 public enum HonorRating {
-    NONE(0.0, Integer.MAX_VALUE),
-    LIBERAL(1.25, Integer.MAX_VALUE),
-    OPPORTUNISTIC(1.0, 5),
-    STRICT(0.75, 0);
+    NONE(1.0, Integer.MAX_VALUE),
+    LIBERAL(1.5, Integer.MAX_VALUE),
+    OPPORTUNISTIC(1.25, 5),
+    STRICT(1.0, 0);
 
     private final double bvMultiplier;
     private final int bondsmanTargetNumber;


### PR DESCRIPTION
<07 we had a nasty little bug that caused Clan OpFors to cheat. They would claim to agree to the terms of a Batchall, only to then pretend to bid away units when they were actually adding them all back to their forces afterwards.

We fixed that bug, hurray!

However, now Clan forces are no longer cheating the feedback we've received is that they've actually become easier than IS forces. While the chief reason is resolved by https://github.com/MegaMek/mekhq/pull/7649, Clan forces still lacked teeth.

This PR just bolsters their BV allowance for mhq OpFor generation a little. It also adds a x1 multiplier to 'no honor' to ensure the above cited bug can never again cause us mischief.