### PR TITLE
Small Entity Readout Fixes

### DIFF
--- a/megamek/resources/megamek/client/messages.properties
+++ b/megamek/resources/megamek/client/messages.properties
@@ -4769,8 +4769,8 @@ CMVPanel.MUL=Open MUL
 CMVPanel.font=Font:
 # Section Choice - used programmatically
 CMVPanel.FULL=Full Readout
-CMVPanel.INGAME=Combat Info
-CMVPanel.NOFLUFF=No Fluff Text
+CMVPanel.IN_GAME=Combat Info
+CMVPanel.NO_FLUFF=No Fluff Text
 CMVPanel.NONCOMBAT=Non-Combat Info
 # Scenario Chooser
 ScenarioChooser.title=Choose Scenario

--- a/megamek/src/megamek/client/ui/entityreadout/MekReadout.java
+++ b/megamek/src/megamek/client/ui/entityreadout/MekReadout.java
@@ -115,4 +115,9 @@ class MekReadout extends GeneralEntityReadout {
         }
         return result;
     }
+
+    @Override
+    protected List<ViewElement> createSpecialMiscElements() {
+        return ReadoutUtils.createChassisModList(mek);
+    }
 }


### PR DESCRIPTION
Fixes for the entity readout:
- Chassis mods were not shown for Meks
- i18n texts were incorrectly named for the sections chooser