### PR TITLE
Fix 7449: Replace entity ID with actual entity to avoid NPEs

### DIFF
--- a/megamek/src/megamek/client/commands/MoveCommand.java
+++ b/megamek/src/megamek/client/commands/MoveCommand.java
@@ -58,7 +58,7 @@ public class MoveCommand extends ClientCommand {
 
     // considering movement data
     private MovePath cmd;
-    // considered ce()
+    // considered currentEntity()
     private int cen = Entity.NONE;
     int gear;
 
@@ -94,19 +94,19 @@ public class MoveCommand extends ClientCommand {
                 try {
                     clearAllMoves();
                     cen = Integer.parseInt(args[2]);
-                    if (ce() == null) {
+                    if (currentEntity() == null) {
                         cen = Entity.NONE;
                         return "Not an entity ID or valid number.";
                     }
-                    cmd = new MovePath(getClient().getGame(), ce());
+                    cmd = new MovePath(getClient().getGame(), currentEntity());
 
-                    getClientGUI().setCurrentHex(ce().getPosition());
-                    return "Entity " + ce().toString()
+                    getClientGUI().setCurrentHex(currentEntity().getPosition());
+                    return "Entity " + currentEntity().toString()
                           + " selected for movement.";
                 } catch (Exception e) {
                     return "Not an entity ID or valid number." + e;
                 }
-            } else if (ce() != null) {
+            } else if (currentEntity() != null) {
                 if (args[1].equalsIgnoreCase("JUMP")) {
 
                     clearAllMoves();
@@ -115,7 +115,7 @@ public class MoveCommand extends ClientCommand {
                     }
                     gear = GEAR_JUMP;
 
-                    return "Entity " + ce().toString() + " is going to jump.";
+                    return "Entity " + currentEntity().toString() + " is going to jump.";
                 } else if (args[1].equalsIgnoreCase("COMMIT")) {
                     moveTo(cmd);
                     return "Move sent.";
@@ -134,7 +134,7 @@ public class MoveCommand extends ClientCommand {
                 } else if (args[1].equalsIgnoreCase("CLIP")) {
                     cmd.clipToPossible();
                     return "Path clipped to whats actually possible. "
-                          + ce().toString() + " is now in gear "
+                          + currentEntity().toString() + " is now in gear "
                           + gearName(gear) + " heading towards "
                           + cmd.getFinalCoords().toFriendlyString()
                           + " with a final facing of "
@@ -166,7 +166,7 @@ public class MoveCommand extends ClientCommand {
 
                 currentMove(target);
 
-                return "Commands accepted " + ce().toString()
+                return "Commands accepted " + currentEntity().toString()
                       + " is now in gear " + gearName(gear)
                       + " heading towards "
                       + cmd.getFinalCoords().toFriendlyString()
@@ -224,14 +224,14 @@ public class MoveCommand extends ClientCommand {
      */
     private void clearAllMoves() {
         // switch back from swimming to normal mode.
-        if (ce() != null) {
-            if (ce().getMovementMode().isBipedSwim()) {
-                ce().setMovementMode(EntityMovementMode.BIPED);
-            } else if (ce().getMovementMode().isQuadSwim()) {
-                ce().setMovementMode(EntityMovementMode.QUAD);
+        if (currentEntity() != null) {
+            if (currentEntity().getMovementMode().isBipedSwim()) {
+                currentEntity().setMovementMode(EntityMovementMode.BIPED);
+            } else if (currentEntity().getMovementMode().isQuadSwim()) {
+                currentEntity().setMovementMode(EntityMovementMode.QUAD);
             }
 
-            cmd = new MovePath(getClient().getGame(), ce());
+            cmd = new MovePath(getClient().getGame(), currentEntity());
         } else {
             cmd = null;
         }
@@ -245,8 +245,8 @@ public class MoveCommand extends ClientCommand {
     private synchronized void moveTo(MovePath md) {
         md.clipToPossible();
 
-        if (ce().hasUMU()) {
-            getClient().sendUpdateEntity(ce());
+        if (currentEntity().hasUMU()) {
+            getClient().sendUpdateEntity(currentEntity());
         }
         getClient().moveEntity(cen, md);
     }
@@ -254,7 +254,7 @@ public class MoveCommand extends ClientCommand {
     /**
      * Returns the current Entity.
      */
-    public Entity ce() {
+    public Entity currentEntity() {
         return getClient().getGame().getEntity(cen);
     }
 }

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/overlay/OffBoardTargetOverlay.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/overlay/OffBoardTargetOverlay.java
@@ -159,8 +159,8 @@ public class OffBoardTargetOverlay implements IDisplayable {
         for (Entity entity : game().getAllOffboardEnemyEntities(getCurrentPlayer())) {
             if (entity.isOffBoardObserved(getCurrentPlayer().getTeam()) &&
                   (entity.getOffBoardDirection() == direction) &&
-                  (targetingPhaseDisplay.ce() != null &&
-                        targetingPhaseDisplay.ce().isOffBoard() ||
+                  (targetingPhaseDisplay.currentEntity() != null &&
+                        targetingPhaseDisplay.currentEntity().isOffBoard() ||
                         weaponFacingInDirection(selectedArtilleryWeapon, direction))) {
                 return true;
             }
@@ -396,10 +396,10 @@ public class OffBoardTargetOverlay implements IDisplayable {
         if (choice != null) {
             // display dropdown containing all observed offboard enemy entities in given direction upon selection,
             // generate an ArtilleryAttackAction vs selected entity as per TargetingPhaseDisplay, like so:
-            WeaponAttackAction weaponAttackAction = new ArtilleryAttackAction(targetingPhaseDisplay.ce().getId(),
+            WeaponAttackAction weaponAttackAction = new ArtilleryAttackAction(targetingPhaseDisplay.currentEntity().getId(),
                   choice.getTargetType(),
                   choice.getId(),
-                  targetingPhaseDisplay.ce().getEquipmentNum(clientGUI.getBoardView().getSelectedArtilleryWeapon()),
+                  targetingPhaseDisplay.currentEntity().getEquipmentNum(clientGUI.getBoardView().getSelectedArtilleryWeapon()),
                   clientGUI.getClient().getGame());
 
             // Only add if chance of success.

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/ActionPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/ActionPhaseDisplay.java
@@ -308,7 +308,7 @@ public abstract class ActionPhaseDisplay extends StatusBarPhaseDisplay {
      *
      * @see ClientGUI#getDisplayedUnit()
      */
-    public final Entity ce() {
+    public final Entity currentEntity() {
         return game.getEntity(currentEntity);
     }
 

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/AimedShotHandler.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/AimedShotHandler.java
@@ -100,7 +100,7 @@ public class AimedShotHandler implements ActionListener, ItemListener {
                     aimingAt = Mek.LOC_CENTER_TORSO;
                 }
             } else if (this.firingDisplay.getTarget() instanceof Tank) {
-                int side = ComputeSideTable.sideTable(this.firingDisplay.ce(), this.firingDisplay.getTarget());
+                int side = ComputeSideTable.sideTable(this.firingDisplay.currentEntity(), this.firingDisplay.getTarget());
                 if (this.firingDisplay.getTarget() instanceof LargeSupportTank) {
                     if (side == ToHitData.SIDE_FRONT_LEFT) {
                         aimingAt = LargeSupportTank.LOC_FRONT_LEFT;
@@ -153,7 +153,7 @@ public class AimedShotHandler implements ActionListener, ItemListener {
 
         Arrays.fill(mask, true);
 
-        int side = ComputeSideTable.sideTable(firingDisplay.ce(), firingDisplay.getTarget());
+        int side = ComputeSideTable.sideTable(firingDisplay.currentEntity(), firingDisplay.getTarget());
 
         // on a tank, remove turret if its missing
         // also, remove body
@@ -368,8 +368,8 @@ public class AimedShotHandler implements ActionListener, ItemListener {
         boolean allowAim;
 
         // TC against a mek
-        allowAim = ((this.firingDisplay.getTarget() != null) && (this.firingDisplay.ce() != null)
-              && this.firingDisplay.ce().hasAimModeTargComp() && ((this.firingDisplay.getTarget() instanceof Mek)
+        allowAim = ((this.firingDisplay.getTarget() != null) && (this.firingDisplay.currentEntity() != null)
+              && this.firingDisplay.currentEntity().hasAimModeTargComp() && ((this.firingDisplay.getTarget() instanceof Mek)
               || (this.firingDisplay.getTarget() instanceof Tank)
               || (this.firingDisplay.getTarget() instanceof BattleArmor)
               || (this.firingDisplay.getTarget() instanceof ProtoMek)));

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/MovementDisplay.java
@@ -311,7 +311,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void computeEnvelope() {
-        Entity currentEntity = ce();
+        Entity currentEntity = currentEntity();
         if (currentEntity != null) {
             computeMovementEnvelope(currentEntity);
         }
@@ -319,7 +319,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
     private void cancel() {
         clear();
-        Entity currentEntity = ce();
+        Entity currentEntity = currentEntity();
 
         if (currentEntity != null) {
             computeMovementEnvelope(currentEntity);
@@ -364,7 +364,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void performToggleConversionMode() {
-        final Entity currentlySelectedEntity = ce();
+        final Entity currentlySelectedEntity = currentEntity();
 
         if (currentlySelectedEntity == null) {
             LOGGER.error("Cannot execute a conversion mode command for a null entity.");
@@ -425,7 +425,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      */
     @Override
     protected ArrayList<MegaMekButton> getButtonList() {
-        final Entity currentlySelectedEntity = ce();
+        final Entity currentlySelectedEntity = currentEntity();
         int flag = CMD_MEK;
         // Chain of Instance Of Tests that should be refactored using either polymorphism or something else.
         if (currentlySelectedEntity != null) {
@@ -612,7 +612,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      *       of Mechanical Jump Boosters.
      */
     private boolean hasJumpMP() {
-        return (ce() != null) && (ce().getAnyTypeMaxJumpMP() > 0);
+        return (currentEntity() != null) && (currentEntity().getAnyTypeMaxJumpMP() > 0);
     }
 
     /**
@@ -620,7 +620,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      */
     private void updateButtons() {
         final GameOptions gameOptions = game.getOptions();
-        final Entity selectedUnit = ce();
+        final Entity selectedUnit = currentEntity();
         if (selectedUnit == null) {
             LOGGER.error("Cannot update buttons based on a null entity");
             return;
@@ -759,7 +759,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
               (selectedUnit instanceof Tank)) {
             // Vehicles don't have ejection systems, so crews abandon, and must enter a valid hex. If they cannot,
             // they can't abandon as per TO pg 197.
-            Coords position = ce().getPosition();
+            Coords position = currentEntity().getPosition();
             Infantry infantry = new Infantry();
             infantry.setGame(game);
             boolean hasLegalHex = !infantry.isLocationProhibited(position);
@@ -870,7 +870,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateMove(boolean redrawMovement) {
-        Entity ce = ce();
+        Entity ce = currentEntity();
         if (redrawMovement && (ce != null)) {
             clientgui.getBoardView(ce).drawMovementData(ce, cmd);
         }
@@ -880,7 +880,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateFleeButton() {
-        Entity movingEntity = ce();
+        Entity movingEntity = currentEntity();
         if (movingEntity == null) {
             return;
         }
@@ -896,7 +896,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateAeroButtons() {
-        Entity movingEntity = ce();
+        Entity movingEntity = currentEntity();
         if (movingEntity instanceof IAero aero) {
             getBtn(MoveCommand.MOVE_THRUST).setEnabled(true);
             getBtn(MoveCommand.MOVE_YAW).setEnabled(true);
@@ -935,7 +935,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
         MovePath possible = cmd.clone();
         possible.clipToPossible();
-        Entity ce = ce();
+        Entity ce = currentEntity();
         if ((possible.length() == 0) || (ce == null)) {
             updateDonePanelButtons(Messages.getString("MovementDisplay.Move"),
                   Messages.getString("MovementDisplay.Skip"),
@@ -1080,7 +1080,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * Clears out old movement data and disables relevant buttons.
      */
     private synchronized void endMyTurn() {
-        final Entity currentlySelectedEntity = ce();
+        final Entity currentlySelectedEntity = currentEntity();
 
         stopTimer();
 
@@ -1195,7 +1195,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      */
     @Override
     public void clear() {
-        final Entity currentlySelectedEntity = ce();
+        final Entity currentlySelectedEntity = currentEntity();
 
         // clear board cursors
         clientgui.boardViews().forEach(IBoardView::clearMarkedHexes);
@@ -1300,7 +1300,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
         cmd.removeLastStep();
 
-        final Entity currentlySelectedEntity = ce();
+        final Entity currentlySelectedEntity = currentEntity();
         if (currentlySelectedEntity == null) {
             LOGGER.warn("Cannot process removeLastStep for a null currentlySelectedEntity.");
             return;
@@ -1313,9 +1313,9 @@ public class MovementDisplay extends ActionPhaseDisplay {
             }
         } else {
             // clear board cursors
-            clientgui.getBoardView(ce()).select(cmd.getFinalCoords());
-            clientgui.getBoardView(ce()).cursor(cmd.getFinalCoords());
-            clientgui.getBoardView(ce()).drawMovementData(currentlySelectedEntity, cmd);
+            clientgui.getBoardView(currentEntity()).select(cmd.getFinalCoords());
+            clientgui.getBoardView(currentEntity()).cursor(cmd.getFinalCoords());
+            clientgui.getBoardView(currentEntity()).drawMovementData(currentlySelectedEntity, cmd);
             clientgui.updateFiringArc(currentlySelectedEntity);
             clientgui.showSensorRanges(currentlySelectedEntity, cmd.getFinalCoords());
 
@@ -1363,7 +1363,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         String check = SharedUtility.doPSRCheck(cmd);
         String thrustCheck = SharedUtility.doThrustCheck(cmd, clientgui.getClient());
 
-        Entity currentlySelectedEntity = ce();
+        Entity currentlySelectedEntity = currentEntity();
 
         if (needNagForNoAction()) {
             if ((currentlySelectedEntity != null) && (cmd.length() == 0) && !currentlySelectedEntity.isAirborne()) {
@@ -1571,15 +1571,15 @@ public class MovementDisplay extends ActionPhaseDisplay {
         }
 
         if (needNagForOther()) {
-            if (ce() != null
-                  && (ce() instanceof Infantry)
-                  && ((Infantry) ce()).hasMicrolite()) {
-                boolean finalElevation = (ce().getElevation() != cmd.getFinalElevation());
-                boolean airborneVTOLOrWIGEOrFinalElevation = ce().isAirborneVTOLorWIGE()
+            if (currentEntity() != null
+                  && (currentEntity() instanceof Infantry)
+                  && ((Infantry) currentEntity()).hasMicrolite()) {
+                boolean finalElevation = (currentEntity().getElevation() != cmd.getFinalElevation());
+                boolean airborneVTOLOrWIGEOrFinalElevation = currentEntity().isAirborneVTOLorWIGE()
                       || finalElevation;
-                int terrainLevelBuilding = game.getBoard(ce()).getHex(cmd.getFinalCoords())
+                int terrainLevelBuilding = game.getBoard(currentEntity()).getHex(cmd.getFinalCoords())
                       .terrainLevel(Terrains.BLDG_ELEV);
-                int terrainLevelBridge = game.getBoard(ce()).getHex(cmd.getFinalCoords())
+                int terrainLevelBridge = game.getBoard(currentEntity()).getHex(cmd.getFinalCoords())
                       .terrainLevel(Terrains.BRIDGE_ELEV);
                 if (airborneVTOLOrWIGEOrFinalElevation
                       && !cmd.contains(MoveStepType.FORWARDS)
@@ -1603,7 +1603,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                       cmd.getFinalCoords(),
                       cmd.getFinalFacing());
                 if (landingPath.stream()
-                      .map(c -> game.getBoard(ce()).getHex(c))
+                      .map(c -> game.getBoard(currentEntity()).getHex(c))
                       .filter(Objects::nonNull)
                       .anyMatch(h -> h.containsTerrain(Terrains.ROUGH) || h.containsTerrain(Terrains.RUBBLE))) {
                     String title = Messages.getString("MovementDisplay.areYouSure");
@@ -1631,12 +1631,12 @@ public class MovementDisplay extends ActionPhaseDisplay {
             }
         }
 
-        return ce() == null;
+        return currentEntity() == null;
     }
 
     @Override
     public synchronized void ready() {
-        Entity ce = ce();
+        Entity ce = currentEntity();
         if (ce == null) {
             return;
         }
@@ -1696,20 +1696,20 @@ public class MovementDisplay extends ActionPhaseDisplay {
             if (cmd.getLastStep() != null) {
                 src = cmd.getLastStep().getPosition();
             } else {
-                src = ce().getPosition();
+                src = currentEntity().getPosition();
             }
 
             int direction = src.direction(dest);
-            int facing = ce().getFacing();
+            int facing = currentEntity().getFacing();
             // Adjust direction based upon facing
             // Java does Remainder, not Modulo, so need the Absolute value as it can go negative.
             direction = Math.abs((direction - facing) % 6);
             switch (direction) {
                 case 0:
-                    cmd.findSimplePathTo(dest, MoveStepType.FORWARDS, src.direction(dest), ce().getFacing());
+                    cmd.findSimplePathTo(dest, MoveStepType.FORWARDS, src.direction(dest), currentEntity().getFacing());
                     break;
                 case 1:
-                    cmd.findSimplePathTo(dest, MoveStepType.LATERAL_RIGHT, src.direction(dest), ce().getFacing());
+                    cmd.findSimplePathTo(dest, MoveStepType.LATERAL_RIGHT, src.direction(dest), currentEntity().getFacing());
                     break;
                 case 2:
                     // TODO: backwards lateral shifts are switched:
@@ -1717,10 +1717,10 @@ public class MovementDisplay extends ActionPhaseDisplay {
                     cmd.findSimplePathTo(dest,
                           MoveStepType.LATERAL_LEFT_BACKWARDS,
                           src.direction(dest),
-                          ce().getFacing());
+                          currentEntity().getFacing());
                     break;
                 case 3:
-                    cmd.findSimplePathTo(dest, MoveStepType.BACKWARDS, src.direction(dest), ce().getFacing());
+                    cmd.findSimplePathTo(dest, MoveStepType.BACKWARDS, src.direction(dest), currentEntity().getFacing());
                     break;
                 case 4:
                     // TODO: backwards lateral shifts are switched:
@@ -1728,10 +1728,10 @@ public class MovementDisplay extends ActionPhaseDisplay {
                     cmd.findSimplePathTo(dest,
                           MoveStepType.LATERAL_RIGHT_BACKWARDS,
                           src.direction(dest),
-                          ce().getFacing());
+                          currentEntity().getFacing());
                     break;
                 case 5:
-                    cmd.findSimplePathTo(dest, MoveStepType.LATERAL_LEFT, src.direction(dest), ce().getFacing());
+                    cmd.findSimplePathTo(dest, MoveStepType.LATERAL_LEFT, src.direction(dest), currentEntity().getFacing());
                     break;
             }
         } else if (gear == GEAR_STRAFE) {
@@ -1750,11 +1750,11 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 cmd.setStrafingStep(cmd.getStep(i).getPosition());
             }
 
-            cmd.compile(game, ce(), false);
+            cmd.compile(game, currentEntity(), false);
             gear = GEAR_LAND;
         } else if ((gear == GEAR_LAND) || (gear == GEAR_JUMP)) {
             extendPathTo(dest, boardId, MoveStepType.FORWARDS);
-            if (shouldDesignateFlightPath(ce())) {
+            if (shouldDesignateFlightPath(currentEntity())) {
                 // Interpreting TW p.242 to mean that designating a flight path is optional, as making A2G attacks is
                 // certainly optional
                 gear = GEAR_FLIGHTPATH;
@@ -1805,20 +1805,20 @@ public class MovementDisplay extends ActionPhaseDisplay {
             int maxMp;
             MoveStepType stepType;
             if (gear == GEAR_LONGEST_WALK) {
-                maxMp = ce().getWalkMP();
+                maxMp = currentEntity().getWalkMP();
                 stepType = MoveStepType.BACKWARDS;
                 gear = GEAR_BACKUP;
             } else {
-                maxMp = ce().getRunMPWithoutMASC();
+                maxMp = currentEntity().getRunMPWithoutMASC();
                 stepType = MoveStepType.FORWARDS;
                 gear = GEAR_LAND;
             }
 
             LongestPathFinder lpf;
-            if (ce().isAero()) {
-                lpf = LongestPathFinder.newInstanceOfAeroPath(maxMp, ce().getGame());
+            if (currentEntity().isAero()) {
+                lpf = LongestPathFinder.newInstanceOfAeroPath(maxMp, currentEntity().getGame());
             } else {
-                lpf = LongestPathFinder.newInstanceOfLongestPath(maxMp, stepType, ce().getGame());
+                lpf = LongestPathFinder.newInstanceOfLongestPath(maxMp, stepType, currentEntity().getGame());
             }
             final int timeLimit = PreferenceManager.getClientPreferences().getMaxPathfinderTime();
             lpf.addStopCondition(new StopConditionTimeout<>(timeLimit * 4));
@@ -1830,8 +1830,8 @@ public class MovementDisplay extends ActionPhaseDisplay {
             }
         }
 
-        clientgui.showSensorRanges(ce(), cmd.getFinalCoords());
-        clientgui.updateFiringArc(ce());
+        clientgui.showSensorRanges(currentEntity(), cmd.getFinalCoords());
+        clientgui.updateFiringArc(currentEntity());
     }
 
     /**
@@ -1857,7 +1857,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             return;
         }
 
-        final Entity currentlySelectedEntity = ce();
+        final Entity currentlySelectedEntity = currentEntity();
 
         // Are we ignoring events?
         if (isIgnoringEvents()) {
@@ -2190,7 +2190,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
     private void updateTakeCoverButton() {
         final GameOptions gOpts = game.getOptions();
-        boolean isInfantry = (ce() instanceof Infantry);
+        boolean isInfantry = (currentEntity() instanceof Infantry);
 
         // Infantry - Taking Cover
         if (isInfantry && gOpts.booleanOption(OptionsConstants.ADVANCED_TAC_OPS_TAKE_COVER)) {
@@ -2198,8 +2198,8 @@ public class MovementDisplay extends ActionPhaseDisplay {
             Coords pos;
             int elevation;
             if (cmd == null) {
-                pos = ce().getPosition();
-                elevation = ce().getElevation();
+                pos = currentEntity().getPosition();
+                elevation = currentEntity().getElevation();
             } else {
                 pos = cmd.getFinalCoords();
                 elevation = cmd.getFinalElevation();
@@ -2211,7 +2211,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private synchronized void updateChaffButton() {
-        Entity ce = ce();
+        Entity ce = currentEntity();
         if (ce == null) {
             return;
         }
@@ -2220,7 +2220,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private synchronized void updateProneButtons() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if (ce == null) {
             setGetUpEnabled(false);
             setGoProneEnabled(false);
@@ -2272,7 +2272,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateRACButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if (ce == null) {
             return;
         }
@@ -2292,7 +2292,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateSearchlightButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if (ce == null) {
             return;
         }
@@ -2305,7 +2305,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private synchronized void updateElevationButtons() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if (ce == null) {
             return;
         }
@@ -2336,7 +2336,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             return;
         }
 
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if ((ce instanceof IAero aero) && ce.isAero() && !ce.isAirborne() && !ce.isShutDown()
               && (usingAeroOnGroundMovement() || hasAtmosphericMapForLiftOff(game, ce))) {
             setTakeOffEnabled(aero.canTakeOffHorizontally());
@@ -2369,7 +2369,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             return;
         }
 
-        Entity selectedEntity = ce();
+        Entity selectedEntity = currentEntity();
         if ((selectedEntity == null) || !selectedEntity.isAero() || !(selectedEntity instanceof IAero aero)) {
             return;
         }
@@ -2404,7 +2404,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateRollButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if ((ce == null) || !ce.isAero()) {
             return;
         }
@@ -2421,7 +2421,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateHoverButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if (null == ce) {
             return;
         }
@@ -2443,7 +2443,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateThrustButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if (null == ce) {
             return;
         }
@@ -2463,7 +2463,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private synchronized void updateSpeedButtons() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if (null == ce) {
             return;
         }
@@ -2559,7 +2559,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateFlyOffButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
 
         // Aerospace should be able to fly off if they reach a border hex with velocity remaining and facing the
         // right direction
@@ -2611,7 +2611,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateLaunchButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
 
         if (null == ce) {
             return;
@@ -2681,7 +2681,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateDropButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if (ce == null) {
             return;
         }
@@ -2708,7 +2708,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateEvadeButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
 
         if (null == ce) {
             return;
@@ -2727,7 +2727,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateBootleggerButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
 
         if (null == ce) {
             return;
@@ -2753,7 +2753,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateShutdownButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
 
         if (null == ce) {
             return;
@@ -2767,7 +2767,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateStartupButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
 
         if (null == ce) {
             return;
@@ -2781,7 +2781,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateSelfDestructButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
 
         if (null == ce) {
             return;
@@ -2804,7 +2804,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateTraitorButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
 
         if (null == ce) {
             return;
@@ -2823,7 +2823,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             }
         }
 
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
 
         if (null == ce) {
             setModeConvertEnabled(false);
@@ -2866,7 +2866,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateRecklessButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
 
         if (null == ce) {
             return;
@@ -2884,13 +2884,13 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateBraceButton() {
-        if (null == ce()) {
+        if (null == currentEntity()) {
             return;
         }
 
         MovePath movePath = cmd;
         if (null == movePath) {
-            movePath = new MovePath(game, ce());
+            movePath = new MovePath(game, currentEntity());
         }
 
         setBraceEnabled(!movePath.contains(MoveStepType.BRACE) &&
@@ -2899,7 +2899,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateManeuverButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
 
         if (null == ce) {
             return;
@@ -2935,12 +2935,12 @@ public class MovementDisplay extends ActionPhaseDisplay {
             return;
         }
 
-        setStrafeEnabled(ce() instanceof VTOL);
+        setStrafeEnabled(currentEntity() instanceof VTOL);
     }
 
     private void updateBombButton() {
         MoveStep lastStep = cmd.getLastStep();
-        if ((lastStep == null) && !ce().isAirborneVTOLorWIGE()) {
+        if ((lastStep == null) && !currentEntity().isAirborneVTOLorWIGE()) {
             setBombEnabled(false);
             return;
         }
@@ -2950,11 +2950,11 @@ public class MovementDisplay extends ActionPhaseDisplay {
             return;
         }
 
-        if (ce().isBomber()
-              && ((ce() instanceof LandAirMek)
+        if (currentEntity().isBomber()
+              && ((currentEntity() instanceof LandAirMek)
               || game.getOptions()
               .booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_VTOL_ATTACKS))
-              && ((IBomber) ce()).getBombPoints() > 0) {
+              && ((IBomber) currentEntity()).getBombPoints() > 0) {
             setBombEnabled(true);
         }
     }
@@ -2973,7 +2973,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
     /** Updates the status of the "pickup cargo" button */
     private void updatePickupCargoButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         // there has to be an entity, objects are on the ground,
         // the entity can pick them up
         if ((ce == null) ||
@@ -2988,7 +2988,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
     /** Updates the status of the "drop cargo" button */
     private void updateDropCargoButton() {
-        final Entity currentlySelectedEntity = ce();
+        final Entity currentlySelectedEntity = currentEntity();
         // there has to be an entity, objects are on the ground, the entity can pick them up
         if ((currentlySelectedEntity == null) || currentlySelectedEntity.getCarriedObjects().isEmpty()) {
             setDropCargoEnabled(false);
@@ -3000,7 +3000,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
     /** Updates the status of the Load button. */
     private void updateLoadButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if ((ce == null) || (ce instanceof SmallCraft) || (ce.getWalkMP() <= 0)) {
             setLoadEnabled(false);
             return;
@@ -3016,7 +3016,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
     /** Updates the status of the Unload button. */
     private void updateUnloadButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if (ce == null) {
             setUnloadEnabled(false);
             return;
@@ -3050,7 +3050,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateMountButton() {
-        final Entity movingEntity = ce();
+        final Entity movingEntity = currentEntity();
         if ((movingEntity == null) || (movingEntity instanceof SmallCraft)) {
             setMountEnabled(false);
             return;
@@ -3074,7 +3074,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
     /** Updates the status of the Tow and Disconnect buttons. */
     private void updateTowingButtons() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if ((ce == null) || (ce instanceof SmallCraft)) {
             setTowEnabled(false);
             setDisconnectEnabled(false);
@@ -3101,26 +3101,26 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * @return The end position of the current movement path if there is one, the current position otherwise.
      */
     private Coords finalPosition() {
-        return cmd == null ? ce().getPosition() : cmd.getFinalCoords();
+        return cmd == null ? currentEntity().getPosition() : cmd.getFinalCoords();
     }
 
     /**
      * @return True when the endpoint of the current movement path is on the board.
      */
     private boolean isFinalPositionOnBoard() {
-        return game.getBoard(ce().getBoardId()).contains(cmd == null ? ce().getPosition() : cmd.getFinalCoords());
+        return game.getBoard(currentEntity().getBoardId()).contains(cmd == null ? currentEntity().getPosition() : cmd.getFinalCoords());
     }
 
     private int finalBoardId() {
-        return cmd == null ? ce().getBoardId() : cmd.getFinalBoardId();
+        return cmd == null ? currentEntity().getBoardId() : cmd.getFinalBoardId();
     }
 
     private int finalFacing() {
-        return cmd == null ? ce().getFacing() : cmd.getFinalFacing();
+        return cmd == null ? currentEntity().getFacing() : cmd.getFinalFacing();
     }
 
     private void updateLayMineButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if (null == ce) {
             return;
         }
@@ -3137,7 +3137,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private Entity getMountedUnit() {
-        Entity ce = ce();
+        Entity ce = currentEntity();
         Entity choice = null;
         Coords pos = ce.getPosition();
         int elev = ce.getElevation();
@@ -3210,7 +3210,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
         Vector<Entity> choices = new Vector<>();
         for (Entity other : game.getEntitiesVector(cmd.getFinalCoords())) {
-            if (other.isLoadableThisTurn() && (ce() != null) && ce().canLoad(other, false)) {
+            if (other.isLoadableThisTurn() && (currentEntity() != null) && currentEntity().canLoad(other, false)) {
                 choices.addElement(other);
             }
         }
@@ -3227,8 +3227,8 @@ public class MovementDisplay extends ActionPhaseDisplay {
                   .showInputDialog(clientgui.getFrame(),
                         Messages.getString(
                               "DeploymentDisplay.loadUnitDialog.message",
-                              ce().getShortName(),
-                              ce().getUnusedString()),
+                              currentEntity().getShortName(),
+                              currentEntity().getUnusedString()),
                         Messages.getString("DeploymentDisplay.loadUnitDialog.title"),
                         JOptionPane.QUESTION_MESSAGE,
                         null,
@@ -3242,7 +3242,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
         if (!(choice instanceof Infantry)) {
             List<Integer> bayChoices = new ArrayList<>();
-            for (Transporter t : ce().getTransports()) {
+            for (Transporter t : currentEntity().getTransports()) {
                 if (t.canLoad(choice) && (t instanceof Bay)) {
                     bayChoices.add(((Bay) t).getBayNumber());
                 }
@@ -3251,10 +3251,10 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 String[] retVal = new String[bayChoices.size()];
                 int i = 0;
                 for (Integer bn : bayChoices) {
-                    retVal[i++] = bn.toString() + " (Free Slots: " + (int) ce().getBayById(bn).getUnused() + ")";
+                    retVal[i++] = bn.toString() + " (Free Slots: " + (int) currentEntity().getBayById(bn).getUnused() + ")";
                 }
                 String bayString = (String) JOptionPane.showInputDialog(clientgui.getFrame(),
-                      Messages.getString("MovementDisplay.loadUnitBayNumberDialog.message", ce().getShortName()),
+                      Messages.getString("MovementDisplay.loadUnitBayNumberDialog.message", currentEntity().getShortName()),
                       Messages.getString("MovementDisplay.loadUnitBayNumberDialog.title"),
                       JOptionPane.QUESTION_MESSAGE,
                       null,
@@ -3266,7 +3266,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 clientgui.getClient().sendUpdateEntity(choice);
             } else if (choice.hasETypeFlag(Entity.ETYPE_PROTOMEK)) {
                 bayChoices = new ArrayList<>();
-                for (Transporter t : ce().getTransports()) {
+                for (Transporter t : currentEntity().getTransports()) {
                     if ((t instanceof ProtoMekClampMount) && t.canLoad(choice)) {
                         bayChoices.add(((ProtoMekClampMount) t).isRear() ? 1 : 0);
                     }
@@ -3280,7 +3280,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                               Messages.getString("MovementDisplay.loadProtoClampMountDialog.front");
                     }
                     String bayString = (String) JOptionPane.showInputDialog(clientgui.getFrame(),
-                          Messages.getString("MovementDisplay.loadProtoClampMountDialog.message", ce().getShortName()),
+                          Messages.getString("MovementDisplay.loadProtoClampMountDialog.message", currentEntity().getShortName()),
                           Messages.getString("MovementDisplay.loadProtoClampMountDialog.title"),
                           JOptionPane.QUESTION_MESSAGE,
                           null,
@@ -3317,9 +3317,9 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
         // We have to account for the positions of the whole train when looking to add
         // new trailers
-        for (Coords pos : ce().getHitchLocations()) {
+        for (Coords pos : currentEntity().getHitchLocations()) {
             for (Entity other : game.getEntitiesVector(pos)) {
-                if (ce() != null && ce().canTow(other.getId())) {
+                if (currentEntity() != null && currentEntity().canTow(other.getId())) {
                     choices.add(other);
                 }
             }
@@ -3334,7 +3334,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         // If we have multiple choices, display a selection dialog.
         if (choices.size() > 1) {
             String input = (String) JOptionPane.showInputDialog(clientgui.getFrame(),
-                  Messages.getString("DeploymentDisplay.towUnitDialog.message", ce().getShortName()),
+                  Messages.getString("DeploymentDisplay.towUnitDialog.message", currentEntity().getShortName()),
                   Messages.getString("DeploymentDisplay.towUnitDialog.title"),
                   JOptionPane.QUESTION_MESSAGE,
                   null,
@@ -3393,8 +3393,8 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
         // next, set up a list of all the entities in this train
         ArrayList<Entity> thisTrain = new ArrayList<>();
-        thisTrain.add(ce());
-        for (int id : ce().getAllTowedUnits()) {
+        thisTrain.add(currentEntity());
+        for (int id : currentEntity().getAllTowedUnits()) {
             Entity tr = game.getEntity(id);
             thisTrain.add(tr);
         }
@@ -3421,7 +3421,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 retVal[i++] = hc.toString();
             }
             String selection = (String) JOptionPane.showInputDialog(clientgui.getFrame(),
-                  Messages.getString("MovementDisplay.loadUnitHitchDialog.message", ce().getShortName()),
+                  Messages.getString("MovementDisplay.loadUnitHitchDialog.message", currentEntity().getShortName()),
                   Messages.getString("MovementDisplay.loadUnitHitchDialog.title"),
                   JOptionPane.QUESTION_MESSAGE,
                   null,
@@ -3451,8 +3451,8 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
         // We need to update the entities here so that the server knows
         // about our changes
-        ce().setTowing(choice.getId());
-        clientgui.getClient().sendUpdateEntity(ce());
+        currentEntity().setTowing(choice.getId());
+        clientgui.getClient().sendUpdateEntity(currentEntity());
         clientgui.getClient().sendUpdateEntity(choice);
 
         // Return the chosen unit.
@@ -3466,7 +3466,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * @return The <code>Entity</code> that the player wants to unload. This value will not be <code>null</code>.
      */
     private Entity getDisconnectedUnit() {
-        Entity ce = ce();
+        Entity ce = currentEntity();
         Entity choice;
 
         // Handle error condition.
@@ -3504,7 +3504,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * @return The Entity to unload.
      */
     private @Nullable Entity getUnloadedUnit() {
-        Entity ce = ce();
+        Entity ce = currentEntity();
         Entity choice = null;
         if (unloadableUnits.isEmpty()) {
             LOGGER.error("No loaded units");
@@ -3538,7 +3538,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * @return The position to unload to
      */
     private @Nullable Coords getUnloadPosition(Entity unloaded) {
-        Entity ce = ce();
+        Entity ce = currentEntity();
         // we need to allow the user to select a hex for offloading
         Coords pos = ce.getPosition();
         if (null != cmd) {
@@ -3664,7 +3664,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * Need a new function
      */
     private synchronized void updateRecoveryButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if (null == ce) {
             return;
         }
@@ -3730,7 +3730,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             return;
         }
 
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if (null == ce) {
             return;
         }
@@ -3787,7 +3787,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * @return The <code>Entity</code> that the player wants to unload. This value will not be <code>null</code>.
      */
     private TreeMap<Integer, Vector<Integer>> getLaunchedUnits() {
-        Entity ce = ce();
+        Entity ce = currentEntity();
         TreeMap<Integer, Vector<Integer>> choices = new TreeMap<>();
 
         Vector<Entity> launchableFighters = ce.getLaunchableFighters();
@@ -3896,7 +3896,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * @return The <code>Entity</code> that the player wants to unload. This value will not be <code>null</code>.
      */
     private TreeMap<Integer, Vector<Integer>> getUndockedUnits() {
-        Entity currentlySelectedEntity = ce();
+        Entity currentlySelectedEntity = currentEntity();
         TreeMap<Integer, Vector<Integer>> choices = new TreeMap<>();
 
         Vector<Entity> launchableFighters = currentlySelectedEntity.getLaunchableFighters();
@@ -3981,7 +3981,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * @param craft The launching entity, which has already been tested to see if it's a small craft
      */
     private void loadPassengerAtLaunch(SmallCraft craft) {
-        final Entity currentEntity = ce();
+        final Entity currentEntity = currentEntity();
         if (currentEntity == null) {
             LOGGER.error("Cannot load passenger at launch for a null current entity.");
             return;
@@ -4032,7 +4032,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * @return The <code>Entity</code> that the player wants to unload. This value will not be <code>null</code>.
      */
     private TreeMap<Integer, Vector<Integer>> getDroppedUnits() {
-        Entity ce = ce();
+        Entity ce = currentEntity();
         if (ce == null) {
             LOGGER.error("Cannot get dropped units for a null current entity");
             return new TreeMap<>();
@@ -4131,7 +4131,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * get the unit id that the player wants to be recovered by
      */
     private int getRecoveryUnit() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         List<Entity> choices = new ArrayList<>();
 
         // collect all possible choices
@@ -4205,7 +4205,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * @return the unit id that the player wants to join
      */
     private int getUnitJoined() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         List<Entity> choices = new ArrayList<>();
 
         // collect all possible choices
@@ -4262,7 +4262,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * check for out-of-control and adjust buttons
      */
     private void checkOOC() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if (null == ce) {
             return;
         }
@@ -4291,7 +4291,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
 
     /** Checks Aerospace for remaining fuel and adjusts buttons when necessary. */
     private void checkFuel() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if ((ce == null) || !ce.isAero()) {
             return;
         }
@@ -4317,7 +4317,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * check for atmosphere and adjust buttons
      */
     private void checkAtmosphere() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if ((ce instanceof IAero aero) && !aero.isSpaceborne()) {
             PlanetaryConditions conditions = game.getPlanetaryConditions();
             if (aero.isSpheroid() || conditions.getAtmosphere().isLighterThan(Atmosphere.THIN)) {
@@ -4335,7 +4335,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * @param pos - the <code>Coords</code> containing targets.
      */
     private Targetable chooseTarget(Coords pos) {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
 
         // Assume that we have *no* choice.
         Targetable choice = null;
@@ -4369,7 +4369,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                   Messages.getString("MovementDisplay.ChooseTargetDialog.message", pos.getBoardNum()),
                   targets,
                   clientgui,
-                  ce());
+                  currentEntity());
 
         }
 
@@ -4377,13 +4377,13 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private int chooseMineToLay() {
-        MineLayingDialog mld = new MineLayingDialog(clientgui.getFrame(), ce());
+        MineLayingDialog mld = new MineLayingDialog(clientgui.getFrame(), currentEntity());
         mld.setVisible(true);
         return mld.getAnswer() ? mld.getMine() : -1;
     }
 
     private void dumpBombs() {
-        if (!ce().isAero()) {
+        if (!currentEntity().isAero()) {
             return;
         }
 
@@ -4393,10 +4393,10 @@ public class MovementDisplay extends ActionPhaseDisplay {
         }
         // bring up a dialog to dump bombs, then make a control roll and report success or failure should update mp
         // available
-        int numFighters = ce().getActiveSubEntities().size();
+        int numFighters = currentEntity().getActiveSubEntities().size();
         BombPayloadDialog dumpBombsDialog = new BombPayloadDialog(clientgui.getFrame(),
               Messages.getString("MovementDisplay.BombDumpDialog.title"),
-              ce().getBombLoadout(),
+              currentEntity().getBombLoadout(),
               false,
               true,
               -1,
@@ -4405,11 +4405,11 @@ public class MovementDisplay extends ActionPhaseDisplay {
         if (dumpBombsDialog.getAnswer()) {
             dumpBombsDialog.getChoices();
             // first make a control roll
-            PilotingRollData psr = ce().getBasePilotingRoll(overallMoveType);
+            PilotingRollData psr = currentEntity().getBasePilotingRoll(overallMoveType);
             Roll diceRoll = Compute.rollD6(2);
             Report report = new Report(9500);
-            report.subject = ce().getId();
-            report.add(ce().getDisplayName());
+            report.subject = currentEntity().getId();
+            report.add(currentEntity().getDisplayName());
             report.add(psr);
             report.add(diceRoll);
             report.newlines = 0;
@@ -4420,7 +4420,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 String body = Messages.getString("MovementDisplay.DumpFailure.message");
                 clientgui.doAlertDialog(title, body);
                 // failed the roll, so dump all bombs
-                ce().getBombLoadout();
+                currentEntity().getBombLoadout();
             } else {
                 // avoided damage
                 report.choose(true);
@@ -4454,10 +4454,10 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 gear = MovementDisplay.GEAR_SPLIT_S;
                 return false;
             case ManeuverType.MAN_VIFF:
-                if (!ce().isAero()) {
+                if (!currentEntity().isAero()) {
                     return false;
                 }
-                IAero a = (IAero) ce();
+                IAero a = (IAero) currentEntity();
                 MoveStep last = cmd.getLastStep();
                 int vel = a.getCurrentVelocity();
                 if (null != last) {
@@ -4472,7 +4472,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             case ManeuverType.MAN_SIDE_SLIP_LEFT:
                 // If we are on a ground map, slide slip works slightly differently
                 // See Total Warfare pg 85
-                if (game.getBoard(ce()).isGround()) {
+                if (game.getBoard(currentEntity()).isGround()) {
                     for (int i = 0; i < 8; i++) {
                         addStepToMovePath(MoveStepType.LATERAL_LEFT, true, true, type);
                     }
@@ -4486,7 +4486,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             case ManeuverType.MAN_SIDE_SLIP_RIGHT:
                 // If we are on a ground map, slide slip works slightly differently
                 // See Total Warfare pg 85
-                if (game.getBoard(ce()).isGround()) {
+                if (game.getBoard(currentEntity()).isGround()) {
                     for (int i = 0; i < 8; i++) {
                         addStepToMovePath(MoveStepType.LATERAL_RIGHT, true, true, type);
                     }
@@ -4599,9 +4599,9 @@ public class MovementDisplay extends ActionPhaseDisplay {
             }
         } else if (mvMode == GEAR_BACKUP) {
             maxMP = en.getWalkMP();
-        } else if ((ce() instanceof Mek) &&
-              !(ce() instanceof QuadVee) &&
-              (ce().getMovementMode() == EntityMovementMode.TRACKED)) {
+        } else if ((currentEntity() instanceof Mek) &&
+              !(currentEntity() instanceof QuadVee) &&
+              (currentEntity().getMovementMode() == EntityMovementMode.TRACKED)) {
             // A non-QuadVee `Mek that is using tracked movement is limited to walking
             maxMP = en.getWalkMP();
         } else {
@@ -4648,7 +4648,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             return;
         }
 
-        Entity entity = ce();
+        Entity entity = currentEntity();
         int movementGear = gear;
 
         if ((entity == null) && (suggestion == null)) {
@@ -4745,7 +4745,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     public void computeModifierEnvelope() {
-        Entity currentEntity = ce();
+        Entity currentEntity = currentEntity();
         if (currentEntity == null) {
             return;
         }
@@ -4795,7 +4795,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     //
     @Override
     public synchronized void actionPerformed(ActionEvent ev) {
-        final Entity entity = ce();
+        final Entity entity = currentEntity();
         final String actionCmd = ev.getActionCommand();
         if (actionCmd.equals(MoveCommand.MOVE_NEXT.getCmd())) {
             selectEntity(clientgui.getClient().getNextEntityNum(currentEntity));
@@ -4968,14 +4968,14 @@ public class MovementDisplay extends ActionPhaseDisplay {
             int clear = Minefield.CLEAR_NUMBER_INFANTRY;
             int boom = Minefield.CLEAR_NUMBER_INFANTRY_ACCIDENT;
             // Check for Minesweeping Engineers
-            if ((ce() instanceof Infantry inf)) {
+            if ((currentEntity() instanceof Infantry inf)) {
                 if (inf.hasSpecialization(Infantry.MINE_ENGINEERS)) {
                     clear = Minefield.CLEAR_NUMBER_INF_ENG;
                     boom = Minefield.CLEAR_NUMBER_INF_ENG_ACCIDENT;
                 }
             }
             // Check for Mine clearance manipulators on BA
-            if ((ce() instanceof BattleArmor ba)) {
+            if ((currentEntity() instanceof BattleArmor ba)) {
                 String mcmName = BattleArmor.MANIPULATOR_TYPE_STRINGS[BattleArmor.MANIPULATOR_BASIC_MINE_CLEARANCE];
                 if (ba.getLeftManipulatorName().equals(mcmName)) {
                     clear = Minefield.CLEAR_NUMBER_BA_SWEEPER;
@@ -5077,14 +5077,14 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 addStepToMovePath(MoveStepType.HULL_DOWN);
             }
         } else if (actionCmd.equals(MoveCommand.MOVE_BRACE.getCmd())) {
-            var options = ce().getValidBraceLocations();
+            var options = currentEntity().getValidBraceLocations();
             if (options.size() == 1) {
                 addStepToMovePath(MoveStepType.BRACE, options.get(0));
             } else if (options.size() > 1) {
                 String[] locationNames = new String[options.size()];
 
                 for (int x = 0; x < options.size(); x++) {
-                    locationNames[x] = ce().getLocationName(options.get(x));
+                    locationNames[x] = currentEntity().getLocationName(options.get(x));
                 }
 
                 // Dialog for choosing which location to brace
@@ -5181,12 +5181,12 @@ public class MovementDisplay extends ActionPhaseDisplay {
             Entity other = getUnloadedUnit();
             if (other != null) {
                 if (!other.isInfantry() ||
-                      ce() instanceof SmallCraft ||
-                      (ce().isSupportVehicle() && (ce().getWeightClass() == EntityWeightClass.WEIGHT_LARGE_SUPPORT))
+                      currentEntity() instanceof SmallCraft ||
+                      (currentEntity().isSupportVehicle() && (currentEntity().getWeightClass() == EntityWeightClass.WEIGHT_LARGE_SUPPORT))
                       // FIXME: unclear why towed/towing is checked here:
                       ||
-                      !ce().getAllTowedUnits().isEmpty() ||
-                      ce().getTowedBy() != Entity.NONE) {
+                      !currentEntity().getAllTowedUnits().isEmpty() ||
+                      currentEntity().getTowedBy() != Entity.NONE) {
                     // unload into adjacent hexes
                     Coords pos = getUnloadPosition(other);
                     if (null != pos) {
@@ -5203,7 +5203,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
         } else if (actionCmd.equals(MoveCommand.MOVE_PICKUP_CARGO.getCmd())) {
             processPickupCargoCommand();
         } else if (actionCmd.equals(MoveCommand.MOVE_DROP_CARGO.getCmd())) {
-            var options = ce().getDistinctCarriedObjects();
+            var options = currentEntity().getDistinctCarriedObjects();
 
             if (options.size() == 1) {
                 addStepToMovePath(MoveStepType.DROP_CARGO);
@@ -5214,8 +5214,8 @@ public class MovementDisplay extends ActionPhaseDisplay {
                 // but need to send the ID in the move path.
                 Map<String, Integer> locationMap = new HashMap<>();
 
-                for (int location : ce().getCarriedObjects().keySet()) {
-                    locationMap.put(ce().getLocationName(location), location);
+                for (int location : currentEntity().getCarriedObjects().keySet()) {
+                    locationMap.put(currentEntity().getLocationName(location), location);
                 }
 
                 // Dialog for choosing which object to pick up
@@ -5295,7 +5295,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             }
         } else if (actionCmd.equals(MoveCommand.MOVE_CALL_SUPPORT.getCmd())) {
             ((Infantry) entity).createLocalSupport();
-            clientgui.getClient().sendUpdateEntity(ce());
+            clientgui.getClient().sendUpdateEntity(currentEntity());
         } else if (actionCmd.equals(MoveCommand.MOVE_DIG_IN.getCmd())) {
             addStepToMovePath(MoveStepType.DIG_IN);
         } else if (actionCmd.equals(MoveCommand.MOVE_FORTIFY.getCmd())) {
@@ -5433,10 +5433,10 @@ public class MovementDisplay extends ActionPhaseDisplay {
         } else if (actionCmd.equals(MoveCommand.MOVE_DUMP.getCmd())) {
             dumpBombs();
         } else if (actionCmd.equals(MoveCommand.MOVE_TAKE_OFF.getCmd())) {
-            if (ce().isAero() && (null != ((IAero) ce()).hasRoomForHorizontalTakeOff())) {
+            if (currentEntity().isAero() && (null != ((IAero) currentEntity()).hasRoomForHorizontalTakeOff())) {
                 String title = Messages.getString("MovementDisplay.NoTakeOffDialog.title");
                 String body = Messages.getString("MovementDisplay.NoTakeOffDialog.message",
-                      ((IAero) ce()).hasRoomForHorizontalTakeOff());
+                      ((IAero) currentEntity()).hasRoomForHorizontalTakeOff());
                 clientgui.doAlertDialog(title, body);
             } else {
                 if (clientgui.doYesNoDialog(Messages.getString("MovementDisplay.TakeOffDialog.title"),
@@ -5467,7 +5467,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
             Integer[] playerIds = new Integer[players.size() - 1];
             String[] playerNames = new String[players.size() - 1];
             String[] options = new String[players.size() - 1];
-            Entity e = ce();
+            Entity e = currentEntity();
             if (e == null) {
                 return;
             }
@@ -5577,7 +5577,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      */
     private void processPickupCargoCommand() {
         var options = game.getGroundObjects(finalPosition());
-        var displayedOptions = game.getGroundObjects(finalPosition(), ce());
+        var displayedOptions = game.getGroundObjects(finalPosition(), currentEntity());
 
         // if there's only one thing to pick up, pick it up. regardless of how many objects we are picking up, we may
         // have to choose the location with which to pick it up
@@ -5625,7 +5625,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
      * Worker function to choose a limb (or whatever) with which to pick up cargo
      */
     private Integer getPickupLocation(ICarryable cargo) {
-        var validPickupLocations = ce().getValidHalfWeightPickupLocations(cargo);
+        var validPickupLocations = currentEntity().getValidHalfWeightPickupLocations(cargo);
         int pickupLocation = Entity.LOC_NONE;
 
         // if we need to choose a pickup location, then do so
@@ -5634,8 +5634,8 @@ public class MovementDisplay extends ActionPhaseDisplay {
             // send the ID in the move path.
             Map<String, Integer> locationMap = new HashMap<>();
 
-            for (int location : ce().getValidHalfWeightPickupLocations(cargo)) {
-                locationMap.put(ce().getLocationName(location), location);
+            for (int location : currentEntity().getValidHalfWeightPickupLocations(cargo)) {
+                locationMap.put(currentEntity().getLocationName(location), location);
             }
 
             // Dialog for choosing which object to pick up
@@ -5670,7 +5670,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     private void adjustConvertSteps(EntityMovementMode endMode) {
         // Since conversion is not allowed in water, we shouldn't have to deal with the possibility of `swim` modes.
         // Account for grounded LAMs in fighter mode with movement type wheeled
-        if (ce().getMovementMode() == endMode || (ce().isAero() && endMode == EntityMovementMode.AERODYNE)) {
+        if (currentEntity().getMovementMode() == endMode || (currentEntity().isAero() && endMode == EntityMovementMode.AERODYNE)) {
             cmd.clear();
             return;
         }
@@ -5678,13 +5678,13 @@ public class MovementDisplay extends ActionPhaseDisplay {
             return;
         }
         clear();
-        ce().setConvertingNow(true);
+        currentEntity().setConvertingNow(true);
         addStepToMovePath(MoveStepType.CONVERT_MODE);
         if (cmd.getFinalConversionMode() != endMode) {
             addStepToMovePath(MoveStepType.CONVERT_MODE);
         }
-        if (ce() instanceof Mek && ((Mek) ce()).hasTracks()) {
-            ce().setMovementMode(endMode);
+        if (currentEntity() instanceof Mek && ((Mek) currentEntity()).hasTracks()) {
+            currentEntity().setMovementMode(endMode);
         }
         updateMove();
     }
@@ -5753,7 +5753,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     // board view listener
     @Override
     public void finishedMovingUnits(BoardViewEvent b) {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
 
         // Are we ignoring events?
         if (isIgnoringEvents()) {
@@ -6119,7 +6119,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void updateTurnButton() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
         if (null == ce) {
             return;
         }
@@ -6136,7 +6136,7 @@ public class MovementDisplay extends ActionPhaseDisplay {
     }
 
     private void performAeroLand(LandingDirection landingDirection) {
-        Entity entity = ce();
+        Entity entity = currentEntity();
         if (!(entity instanceof IAero aero) || !entity.isAero()) {
             LOGGER.warn("Selected aero landing for a non-aero unit!");
             return;

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/PhysicalDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/PhysicalDisplay.java
@@ -816,7 +816,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
 
         // and add it into the game, temporarily
         game.addAction(saa);
-        clientgui.getBoardView(currentEntity).addAttack(saa);
+        clientgui.getBoardView(ce()).addAttack(saa);
 
         // and prevent duplicates
         setSearchlightEnabled(false);

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/PhysicalDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/PhysicalDisplay.java
@@ -257,7 +257,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
     private void cacheVisibleTargets() {
         clearVisibleTargets();
 
-        List<Entity> vec = clientgui.getClient().getGame().getValidTargets(ce());
+        List<Entity> vec = clientgui.getClient().getGame().getValidTargets(currentEntity());
         TreeSet<Entity> tree = getEntityTreeSet();
         visibleTargets = new Entity[vec.size()];
 
@@ -279,8 +279,8 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
                 return 0;
             }
 
-            int rangeToX = ce().getPosition().distance(entX.getPosition());
-            int rangeToY = ce().getPosition().distance(entY.getPosition());
+            int rangeToX = currentEntity().getPosition().distance(entX.getPosition());
+            int rangeToY = currentEntity().getPosition().distance(entY.getPosition());
 
             if (rangeToX == rangeToY) {
                 return ((entX.getId() < entY.getId()) ? -1 : 1);
@@ -357,7 +357,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
             // Check done
             // TODO Implement "only valid" physical attack target selection
             if (ignoreAllies) {
-                done = result.isEnemyOf(ce());
+                done = result.isEnemyOf(currentEntity());
             }
         }
         return result;
@@ -437,14 +437,14 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
             return;
         }
 
-        if ((ce() != null) && ce().isWeaponOrderChanged()) {
-            clientgui.getClient().sendEntityWeaponOrderUpdate(ce());
+        if ((currentEntity() != null) && currentEntity().isWeaponOrderChanged()) {
+            clientgui.getClient().sendEntityWeaponOrderUpdate(currentEntity());
         }
 
         currentEntity = en;
         clientgui.setSelectedEntityNum(en);
 
-        Entity entity = ce();
+        Entity entity = currentEntity();
 
         target(null);
         if (entity instanceof Mek) {
@@ -457,7 +457,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
             }
         }
         clientgui.onAllBoardViews(IBoardView::clearMarkedHexes);
-        clientgui.getBoardView(ce()).highlight(ce().getPosition());
+        clientgui.getBoardView(currentEntity()).highlight(currentEntity().getPosition());
 
         clientgui.getUnitDisplay().displayEntity(entity);
         if (GUIP.getMoveDisplayTabDuringMovePhases()) {
@@ -533,8 +533,8 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
         Entity next = game.getNextEntity(game.getTurnIndex());
         if (game.getPhase().isPhysical() &&
               (null != next) &&
-              (null != ce()) &&
-              (next.getOwnerId() != ce().getOwnerId())) {
+              (null != currentEntity()) &&
+              (next.getOwnerId() != currentEntity().getOwnerId())) {
             clientgui.maybeShowUnitDisplay();
         }
         currentEntity = Entity.NONE;
@@ -578,7 +578,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
             }
         }
 
-        return ce() == null;
+        return currentEntity() == null;
     }
 
     @Override
@@ -593,8 +593,8 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
         removeAllAttacks();
         // close aimed shot display, if any
         ash.closeDialog();
-        if (ce().isWeaponOrderChanged()) {
-            clientgui.getClient().sendEntityWeaponOrderUpdate(ce());
+        if (currentEntity().isWeaponOrderChanged()) {
+            clientgui.getClient().sendEntityWeaponOrderUpdate(currentEntity());
         }
         endMyTurn();
     }
@@ -608,8 +608,8 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
             removeAllAttacks();
         }
 
-        if (ce() != null) {
-            clientgui.getUnitDisplay().wPan.displayMek(ce());
+        if (currentEntity() != null) {
+            clientgui.getUnitDisplay().wPan.displayMek(currentEntity());
         }
         updateTarget();
 
@@ -621,10 +621,10 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
      * Punch the target!
      */
     public void punch() {
-        if (ce() == null) {
+        if (currentEntity() == null) {
             return;
         }
-        final Entity en = ce();
+        final Entity en = currentEntity();
         final boolean isAptPiloting = (en.getCrew() != null)
               && en.hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING);
         final boolean canZweihander = (en instanceof BipedMek)
@@ -674,11 +674,11 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
                   && game.getOptions()
                   .booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_RETRACTABLE_BLADES)
                   && (leftArm.getValue() != TargetRoll.IMPOSSIBLE)
-                  && ((Mek) ce()).hasRetractedBlade(Mek.LOC_LEFT_ARM)) {
+                  && ((Mek) currentEntity()).hasRetractedBlade(Mek.LOC_LEFT_ARM)) {
                 leftBladeExtend = clientgui.doYesNoDialog(
                       Messages.getString("PhysicalDisplay.ExtendBladeDialog.title"),
                       Messages.getString("PhysicalDisplay.ExtendBladeDialog.message",
-                            ce().getLocationName(Mek.LOC_LEFT_ARM)));
+                            currentEntity().getLocationName(Mek.LOC_LEFT_ARM)));
             }
             if ((en instanceof Mek)
                   && (target instanceof Entity)
@@ -800,7 +800,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
 
     private void doSearchlight() {
         // validate
-        if ((ce() == null) || (target == null)) {
+        if ((currentEntity() == null) || (target == null)) {
             throw new IllegalArgumentException("current searchlight parameters are invalid");
         }
 
@@ -816,7 +816,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
 
         // and add it into the game, temporarily
         game.addAction(saa);
-        clientgui.getBoardView(ce()).addAttack(saa);
+        clientgui.getBoardView(currentEntity()).addAttack(saa);
 
         // and prevent duplicates
         setSearchlightEnabled(false);
@@ -829,10 +829,10 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
      * Kick the target!
      */
     public void kick() {
-        if (ce() == null) {
+        if (currentEntity() == null) {
             return;
         }
-        final Entity en = ce();
+        final Entity en = currentEntity();
         final boolean isAptPiloting = (en.getCrew() != null) && en.hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING);
         final boolean isMeleeMaster = (en.getCrew() != null) && en.hasAbility(OptionsConstants.PILOT_MELEE_MASTER);
 
@@ -912,7 +912,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
         String title = Messages.getString("PhysicalDisplay.PushDialog.title", target.getDisplayName());
         String message = Messages.getString("PhysicalDisplay.PushDialog.message",
               toHit.getValueAsString(),
-              Compute.oddsAbove(toHit.getValue(), ce().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
+              Compute.oddsAbove(toHit.getValue(), currentEntity().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
               toHit.getDesc());
         if (clientgui.doYesNoDialog(title, message)) {
             disableButtons();
@@ -937,7 +937,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
         String title = Messages.getString("PhysicalDisplay.TripDialog.title", target.getDisplayName());
         String message = Messages.getString("PhysicalDisplay.TripDialog.message",
               toHit.getValueAsString(),
-              Compute.oddsAbove(toHit.getValue(), ce().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
+              Compute.oddsAbove(toHit.getValue(), currentEntity().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
               toHit.getDesc());
         if (clientgui.doYesNoDialog(title, message)) {
             disableButtons();
@@ -955,7 +955,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
      * Grapple that target!
      */
     public void doGrapple() {
-        if (ce().getGrappled() == Entity.NONE) {
+        if (currentEntity().getGrappled() == Entity.NONE) {
             grapple(false);
         } else {
             breakGrapple();
@@ -967,13 +967,13 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
         String title = Messages.getString("PhysicalDisplay.GrappleDialog.title", target.getDisplayName());
         String message = Messages.getString("PhysicalDisplay.GrappleDialog.message",
               toHit.getValueAsString(),
-              Compute.oddsAbove(toHit.getValue(), ce().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
+              Compute.oddsAbove(toHit.getValue(), currentEntity().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
               toHit.getDesc());
         if (counter) {
             message = Messages.getString("PhysicalDisplay.CounterGrappleDialog.message",
                   target.getDisplayName(),
                   toHit.getValueAsString(),
-                  Compute.oddsAbove(toHit.getValue(), ce().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
+                  Compute.oddsAbove(toHit.getValue(), currentEntity().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
                   toHit.getDesc());
         }
 
@@ -994,7 +994,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
         String title = Messages.getString("PhysicalDisplay.BreakGrappleDialog.title", target.getDisplayName());
         String message = Messages.getString("PhysicalDisplay.BreakGrappleDialog.message",
               toHit.getValueAsString(),
-              Compute.oddsAbove(toHit.getValue(), ce().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
+              Compute.oddsAbove(toHit.getValue(), currentEntity().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
               toHit.getDesc());
         if (clientgui.doYesNoDialog(title, message)) {
             disableButtons();
@@ -1020,9 +1020,9 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
         String title = Messages.getString("PhysicalDisplay.BAVibroClawDialog.title", target.getDisplayName());
         String message = Messages.getString("PhysicalDisplay.BAVibroClawDialog.message",
               toHit.getValueAsString(),
-              Compute.oddsAbove(toHit.getValue(), ce().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
+              Compute.oddsAbove(toHit.getValue(), currentEntity().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
               toHit.getDesc(),
-              ce().getVibroClaws() + toHit.getTableDesc());
+              currentEntity().getVibroClaws() + toHit.getTableDesc());
 
         // Give the user to cancel the attack.
         if (clientgui.doYesNoDialog(title, message)) {
@@ -1036,13 +1036,13 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
         ToHitData toHit;
         int leg;
         int damage;
-        if (ce().isProne()) {
+        if (currentEntity().isProne()) {
             toHit = JumpJetAttackAction.toHit(game,
                   currentEntity,
                   target,
                   JumpJetAttackAction.BOTH);
             leg = JumpJetAttackAction.BOTH;
-            damage = JumpJetAttackAction.getDamageFor(ce(), JumpJetAttackAction.BOTH);
+            damage = JumpJetAttackAction.getDamageFor(currentEntity(), JumpJetAttackAction.BOTH);
         } else {
             ToHitData left = JumpJetAttackAction.toHit(clientgui.getClient().getGame(),
                   currentEntity,
@@ -1052,13 +1052,13 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
                   currentEntity,
                   target,
                   JumpJetAttackAction.RIGHT);
-            int d_left = JumpJetAttackAction.getDamageFor(ce(), JumpJetAttackAction.LEFT);
-            int d_right = JumpJetAttackAction.getDamageFor(ce(), JumpJetAttackAction.RIGHT);
+            int d_left = JumpJetAttackAction.getDamageFor(currentEntity(), JumpJetAttackAction.LEFT);
+            int d_right = JumpJetAttackAction.getDamageFor(currentEntity(), JumpJetAttackAction.RIGHT);
             if ((d_left *
-                  Compute.oddsAbove(left.getValue(), ce().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING))) >
+                  Compute.oddsAbove(left.getValue(), currentEntity().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING))) >
                   (d_right *
                         Compute.oddsAbove(right.getValue(),
-                              ce().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)))) {
+                              currentEntity().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)))) {
                 toHit = left;
                 leg = JumpJetAttackAction.LEFT;
                 damage = d_left;
@@ -1072,7 +1072,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
         String title = Messages.getString("PhysicalDisplay.JumpJetDialog.title", target.getDisplayName());
         String message = Messages.getString("PhysicalDisplay.JumpJetDialog.message",
               toHit.getValueAsString(),
-              Compute.oddsAbove(toHit.getValue(), ce().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
+              Compute.oddsAbove(toHit.getValue(), currentEntity().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
               toHit.getDesc(),
               damage);
         if (clientgui.doYesNoDialog(title, message)) {
@@ -1088,7 +1088,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
     }
 
     private MiscMounted chooseClub() {
-        java.util.List<MiscMounted> clubs = ce().getClubs();
+        java.util.List<MiscMounted> clubs = currentEntity().getClubs();
         if (clubs.size() == 1) {
             return clubs.get(0);
         } else if (clubs.size() > 1) {
@@ -1097,7 +1097,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
                 MiscMounted club = clubs.get(loop);
                 final ToHitData toHit = ClubAttackAction.toHit(game, currentEntity,
                       target, club, ash.getAimTable(), false);
-                final int dmg = ClubAttackAction.getDamageFor(ce(), club,
+                final int dmg = ClubAttackAction.getDamageFor(currentEntity(), club,
                       target.isConventionalInfantry(), false);
                 // Need to do this outside getDamageFor, as it only returns int
                 String dmgString = String.valueOf(dmg);
@@ -1145,10 +1145,10 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
         if (null == club) {
             return;
         }
-        if (ce() == null) {
+        if (currentEntity() == null) {
             return;
         }
-        final Entity en = ce();
+        final Entity en = currentEntity();
 
         final boolean isAptPiloting = (en.getCrew() != null)
               && en.hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING);
@@ -1234,9 +1234,9 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
               target.getDisplayName());
         String message = Messages.getString("PhysicalDisplay.ProtoMekAttackDialog.message",
               proto.getValueAsString(),
-              Compute.oddsAbove(proto.getValue(), ce().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
+              Compute.oddsAbove(proto.getValue(), currentEntity().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
               proto.getDesc(),
-              ProtoMekPhysicalAttackAction.getDamageFor(ce(), target) + proto.getTableDesc());
+              ProtoMekPhysicalAttackAction.getDamageFor(currentEntity(), target) + proto.getTableDesc());
         if (clientgui.doYesNoDialog(title, message)) {
             disableButtons();
             // declare searchlight, if possible
@@ -1316,20 +1316,20 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
         // If we can hit with the left arm, get
         // the damage and construct the string.
         if (canHitLeft) {
-            damageLeft = BrushOffAttackAction.getDamageFor(ce(), BrushOffAttackAction.LEFT);
+            damageLeft = BrushOffAttackAction.getDamageFor(currentEntity(), BrushOffAttackAction.LEFT);
             left = Messages.getString("PhysicalDisplay.LAHit",
                   toHitLeft.getValueAsString(),
-                  Compute.oddsAbove(toHitLeft.getValue(), ce().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
+                  Compute.oddsAbove(toHitLeft.getValue(), currentEntity().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
                   damageLeft);
         }
 
         // If we can hit with the right arm, get
         // the damage and construct the string.
         if (canHitRight) {
-            damageRight = BrushOffAttackAction.getDamageFor(ce(), BrushOffAttackAction.RIGHT);
+            damageRight = BrushOffAttackAction.getDamageFor(currentEntity(), BrushOffAttackAction.RIGHT);
             right = Messages.getString("PhysicalDisplay.RAHit",
                   toHitRight.getValueAsString(),
-                  Compute.oddsAbove(toHitRight.getValue(), ce().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
+                  Compute.oddsAbove(toHitRight.getValue(), currentEntity().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
                   damageRight);
         }
 
@@ -1435,9 +1435,9 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
         String title = Messages.getString("PhysicalDisplay.TrashDialog.title", target.getDisplayName());
         String message = Messages.getString("PhysicalDisplay.TrashDialog.message",
               toHit.getValueAsString(),
-              Compute.oddsAbove(toHit.getValue(), ce().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
+              Compute.oddsAbove(toHit.getValue(), currentEntity().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING)),
               toHit.getDesc(),
-              ThrashAttackAction.getDamageFor(ce()) + toHit.getTableDesc());
+              ThrashAttackAction.getDamageFor(currentEntity()) + toHit.getTableDesc());
 
         // Give the user to cancel the attack.
         if (clientgui.doYesNoDialog(title, message)) {
@@ -1499,7 +1499,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
     void updateTarget() {
         // dis/enable physical attach buttons
         if ((currentEntity != Entity.NONE) &&
-              ce().equals(clientgui.getUnitDisplay().getCurrentEntity()) &&
+              currentEntity().equals(clientgui.getUnitDisplay().getCurrentEntity()) &&
               (target != null)) {
             if (target.getTargetType() != Targetable.TYPE_I_NARC_POD) {
                 // punch?
@@ -1577,7 +1577,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
                 // clubbing?
                 boolean canClub = false;
                 boolean canAim = false;
-                for (Mounted<?> club : ce().getClubs()) {
+                for (Mounted<?> club : currentEntity().getClubs()) {
                     if (club != null) {
                         ToHitData clubToHit = ClubAttackAction.toHit(game,
                               currentEntity, target, club, ash.getAimTable(), false);
@@ -1648,7 +1648,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
             setProtoEnabled(false);
             setVibroEnabled(false);
         }
-        setSearchlightEnabled((ce() != null) && (target != null) && ce().isUsingSearchlight());
+        setSearchlightEnabled((currentEntity() != null) && (target != null) && currentEntity().isUsingSearchlight());
     }
 
     //
@@ -1685,7 +1685,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
             return;
         }
 
-        if (isMyTurn() && (event.getCoords() != null) && (ce() != null)) {
+        if (isMyTurn() && (event.getCoords() != null) && (currentEntity() != null)) {
             Targetable target = chooseTarget(event);
             target(target);
         }
@@ -1697,7 +1697,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
      * @param event The hex selection event
      */
     private Targetable chooseTarget(BoardViewEvent event) {
-        Entity attacker = ce();
+        Entity attacker = currentEntity();
         if (attacker == null) {
             return null;
         }
@@ -2007,7 +2007,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
 
         public void showDialog() {
 
-            if ((ce() == null) || (target == null)) {
+            if ((currentEntity() == null) || (target == null)) {
                 return;
             }
 
@@ -2018,10 +2018,10 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
             }
 
             if (canAim) {
-                final int attackerElevation = ce().getElevation() + game.getHexOf(ce()).getLevel();
+                final int attackerElevation = currentEntity().getElevation() + game.getHexOf(currentEntity()).getLevel();
                 final int targetElevation = target.getElevation() + game.getHexOf(target).getLevel();
 
-                if ((target instanceof Mek) && (ce() instanceof Mek) && (attackerElevation == targetElevation)) {
+                if ((target instanceof Mek) && (currentEntity() instanceof Mek) && (attackerElevation == targetElevation)) {
                     String[] options = { "punch", "kick" };
                     boolean[] enabled = { true, true };
 

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/PrephaseDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/PrephaseDisplay.java
@@ -221,7 +221,7 @@ public class PrephaseDisplay extends StatusBarPhaseDisplay implements ListSelect
 
             // If the selected entity is not on the board, use the next one.
             // ASSUMPTION: there will always be *at least one* entity on map.
-            if (null == ce().getPosition()) {
+            if (null == currentEntity().getPosition()) {
 
                 // Walk through the list of entities for this player.
                 for (int nextId = client.getNextEntityNum(en); nextId != en; nextId = client.getNextEntityNum(nextId)) {
@@ -236,19 +236,19 @@ public class PrephaseDisplay extends StatusBarPhaseDisplay implements ListSelect
                 } // Check the player's next entity.
 
                 // We were *supposed* to have found an on-board entity.
-                if (null == ce().getPosition()) {
+                if (null == currentEntity().getPosition()) {
                     logger.error("Could not find an on-board entity: {}", en);
                     return;
                 }
             }
 
             clientgui.boardViews().forEach(IBoardView::clearMarkedHexes);
-            clientgui.getBoardView(ce()).highlight(ce().getPosition());
+            clientgui.getBoardView(currentEntity()).highlight(currentEntity().getPosition());
 
             refreshAll();
 
-            if (!clientgui.isCurrentBoardViewShowingAnimation() && !ce().isOffBoard()) {
-                clientgui.centerOnUnit(ce());
+            if (!clientgui.isCurrentBoardViewShowingAnimation() && !currentEntity().isOffBoard()) {
+                clientgui.centerOnUnit(currentEntity());
             }
         } else {
             logger.error("Tried to select non-existent entity: {}", en);
@@ -256,7 +256,7 @@ public class PrephaseDisplay extends StatusBarPhaseDisplay implements ListSelect
     }
 
     private void refreshButtons() {
-        final Entity ce = ce();
+        final Entity ce = currentEntity();
 
         if (ce == null || ce.isDone()) {
             // how get here?
@@ -345,11 +345,11 @@ public class PrephaseDisplay extends StatusBarPhaseDisplay implements ListSelect
     private void refreshAll() {
         refreshButtons();
 
-        if (ce() == null) {
+        if (currentEntity() == null) {
             return;
         }
-        clientgui.boardViews().forEach(bv -> ((BoardView) bv).redrawEntity(ce()));
-        clientgui.getUnitDisplay().displayEntity(ce());
+        clientgui.boardViews().forEach(bv -> ((BoardView) bv).redrawEntity(currentEntity()));
+        clientgui.getUnitDisplay().displayEntity(currentEntity());
         if (GUIP.getFireDisplayTabDuringFiringPhases()) {
             clientgui.getUnitDisplay().showPanel(MekPanelTabStrip.WEAPONS);
         }
@@ -359,7 +359,7 @@ public class PrephaseDisplay extends StatusBarPhaseDisplay implements ListSelect
     /**
      * Returns the current entity.
      */
-    Entity ce() {
+    Entity currentEntity() {
         return game().getEntity(cen);
     }
 
@@ -452,13 +452,13 @@ public class PrephaseDisplay extends StatusBarPhaseDisplay implements ListSelect
     // GameListener
     @Override
     public void gameEntityChange(GameEntityChangeEvent event) {
-        if (!event.getEntity().equals(ce())) {
+        if (!event.getEntity().equals(currentEntity())) {
             return;
         }
 
         // Reviewers: Is this the right place to catch the change applied by a server packet
         // that changes an entity from done to not-done?
-        if (ce().isDone()) {
+        if (currentEntity().isDone()) {
             selectEntity(clientgui.getClient().getNextEntityNum(cen));
         }
 
@@ -510,9 +510,9 @@ public class PrephaseDisplay extends StatusBarPhaseDisplay implements ListSelect
             return;
         }
 
-        if (clientgui.getClient().isMyTurn() && (ce() != null)) {
+        if (clientgui.getClient().isMyTurn() && (currentEntity() != null)) {
             clientgui.maybeShowUnitDisplay();
-            clientgui.centerOnUnit(ce());
+            clientgui.centerOnUnit(currentEntity());
         }
     }
 


### PR DESCRIPTION
It looks like we were mistakenly passing the activated entity ID rather than the entity itself, but the function to return a BoardView using an `int` is expecting a Board ID, not an entity ID.
This would only fire for:
1. _Not_ unit ID 0,
2. _Not_ already using the searchlight,
3. _With_ `AutoDeclareSearchlight` enabled,
4. With light level set such that a searchlight would be beneficial,
so it was sort of a pain to repro - tip of the hat to the reporter for getting a good repro save.

Close #7449 

Testing:
- Confirmed fix with OP's savegame.
- Ran all 3 projects' unit tests.