### PR TITLE
Fix for 7465: Allow null movePath objects in entity updates

### DIFF
--- a/megamek/src/megamek/common/net/packets/Packet.java
+++ b/megamek/src/megamek/common/net/packets/Packet.java
@@ -1089,6 +1089,10 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
 
         Vector<UnitLocation> result = new Vector<>();
 
+        // In some instances we may get a null entry; this is valid and handled in Game
+        if (object == null) {
+            return null;
+        }
         if (object instanceof Vector<?> vector) {
             for (Object unitLocation : vector) {
                 if (unitLocation instanceof UnitLocation verifiedLocation) {


### PR DESCRIPTION
Patch to prevent null movePath values from raising exceptions during entity updates.
It's unclear why we would send a null movePath instead of an empty path (although I suspect Double Blind is at fault).
I was also not able to repro the original error seen by the OP, though their save game does show the effects.
At any rate, until this issue is better understood we need to allow null values to be returned in this case.

Testing:
- Ran all 3 projects' unit tests.
- Attempted repros but was unable to capture the exact issue.

Close #7465 