### PR TITLE
Fix 7409: starting location only updating once via apply button

### DIFF
--- a/megamek/src/megamek/client/AbstractClient.java
+++ b/megamek/src/megamek/client/AbstractClient.java
@@ -227,7 +227,16 @@ public abstract class AbstractClient implements IClient {
      * Sends the info associated with the local player.
      */
     public void sendPlayerInfo() {
-        send(new Packet(PacketCommand.PLAYER_UPDATE, getGame().getPlayer(localPlayerNumber)));
+        sendPlayerInfo(getGame().getPlayer(localPlayerNumber));
+    }
+
+    /**
+     * Sends the info associated with a player, usually the local game's local player but sometimes the modified version
+     * of that player.
+     * @param player
+     */
+    public void sendPlayerInfo(Player player) {
+        send(new Packet(PacketCommand.PLAYER_UPDATE, player));
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/PlayerSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/PlayerSettingsDialog.java
@@ -637,7 +637,7 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
                 // Use sendUpdate because we want the Game to allow us to change on Bot's
                 // behalf.
                 clientgui.chatlounge.sendProxyUpdates(updateEntities, client.getLocalPlayer());
-                // clientGUI.chatlounge.sendUpdate(updateEntities);
+                clientgui.chatlounge.sendUpdate(updateEntities);
             }
         }
 
@@ -649,7 +649,7 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
         player.setStartingAnyNWy(getStartingAnyNWy());
         player.setStartingAnySEx(getStartingAnySEx());
         player.setStartingAnySEy(getStartingAnySEy());
-        client.sendPlayerInfo();
+        client.sendPlayerInfo(player);
     }
 
     private JPanel initiativeSection() {


### PR DESCRIPTION
Avoids an issue with the dialog's Player info and the local client's version of the same info desynching while within the 
player settings dialog.
The initial change to the player's deployment area would be sent out, but further changes would not be applied... because the local client's game would not update until the dialog closed.
Fix is to send out the dialog's version of the Player instance, and let the AbstractClient and / or Server worry about keeping the local client's game in sync.

Testing:
- Ran all 3 projects' unit tests
- Confirmed fix now applies player starting zone updates every time Apply is pressed.

Close #7409 