### PR TITLE
Issue #7371 Trailers and movement

### DIFF
--- a/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
@@ -1255,7 +1255,7 @@ public class MegaMekGUI implements IPreferenceChangeListener {
                 host();
                 break;
             case ClientGUI.FILE_GAME_SCENARIO:
-                if ((ev.getModifiers() & InputEvent.CTRL_DOWN_MASK) != 0) {
+                if ((ev.getModifiers() & Event.CTRL_MASK) != 0) {
                     // As a dev convenience, start the last scenario again when clicked with CTRL
                     scenario(PreferenceManager.getClientPreferences().getLastScenario());
                 } else {

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -558,14 +558,6 @@ public class Compute {
                         continue;
                     }
 
-                    // ignore the first trailer behind a non-superheavy tractor which can be in the same hex
-//                    if (isTrain && !entering.isSuperHeavy()) {
-//                        Entity firstTrailer = game.getEntity(entering.getAllTowedUnits().get(0));
-//                        if (inHex.equals(firstTrailer)) {
-//                            continue;
-//                        }
-//                    }
-
                     // One small/medium tractor and trailer or two such trailers are counted as a single unit. I'm
                     // making the assumption that it is not required that one is towing the other to allow forming
                     // and dissolving trains in a graceful way. TW, p.57

--- a/megamek/src/megamek/common/units/Entity.java
+++ b/megamek/src/megamek/common/units/Entity.java
@@ -1638,8 +1638,9 @@ public abstract class Entity extends TurnOrdered
         return EntityWeightClass.getClassName(getWeightClass(), this);
     }
 
-    // Since this varies by unit type, it will be defined as overrides in each
-    // relevant class
+    /**
+     * @return True if this unit counts as superheavy (Combat Vehicles and Meks) or as a Large Support Vehicle.
+     */
     public boolean isSuperHeavy() {
         return false;
     }

--- a/megamek/testresources/data/scenarios/test_setups/Trailers.mms
+++ b/megamek/testresources/data/scenarios/test_setups/Trailers.mms
@@ -17,7 +17,7 @@
 MMSVersion: 2
 name: Test Setup for Trailers
 planet: None
-description: A J-27 with trailer to hitch up and a Galleon to shoot at it
+description: Some small and large tractors and trailers to pick up and a Galleon to shoot at them
 map: buildingsnobasement/dropport2.board
 
 options:
@@ -29,11 +29,34 @@ factions:
 
   units:
   - fullname: J-27 Ordnance Transport
-    at: [ 9, 10 ]
+    at: [ 9, 11 ]
+
 
   - fullname: J-27 Ordnance Transport (Trailer)
-    at: [ 10, 10 ]
+    at: [ 9, 8 ]
 
-  - fullname: Galleon Light Tank GAL-100
-    at: [ 11, 10 ]
+  - fullname: J-27 Ordnance Transport (Trailer)
+    at: [ 9, 8 ]
 
+  - fullname: J-27 Ordnance Transport (Trailer)
+    at: [ 9, 8 ]
+
+
+  - fullname: J-27 Ordnance Transport (Trailer)
+    at: [ 9, 9 ]
+
+  - fullname: J-27 Ordnance Transport (Trailer)
+    at: [ 9, 9 ]
+
+  - fullname: J-27 Ordnance Transport (Trailer)
+    at: [ 9, 10 ]
+
+  - fullname: Assassin ASN-21
+    at: [ 13, 6 ]
+    facing: 4
+
+#  - fullname: Galaport Ground Tug
+#    at: [ 11, 11 ]
+#
+#  - fullname: Galaport Ground Trailer
+#    at: [ 11, 12 ]

--- a/megamek/testresources/data/scenarios/test_setups/Trailers.mms
+++ b/megamek/testresources/data/scenarios/test_setups/Trailers.mms
@@ -55,8 +55,8 @@ factions:
     at: [ 13, 6 ]
     facing: 4
 
-#  - fullname: Galaport Ground Tug
-#    at: [ 11, 11 ]
-#
-#  - fullname: Galaport Ground Trailer
-#    at: [ 11, 12 ]
+  - fullname: Galaport Ground Tug
+    at: [ 11, 11 ]
+
+  - fullname: Galaport Ground Trailer
+    at: [ 11, 12 ]


### PR DESCRIPTION
Fixes #7371 
This fixes movement with trailers to some extent. Movement through trains is now mostly unhindered except for Large SV which block almost everything and are themselved blocked by almost everything. My understanding of TW p57 and 205 (two trailers count as one unit) is that for small/med units, trains of up to 4 units in a single hex can be formed.
I think there are still issues with actually forming such trains but at least movement should be better now.
Also fixes key event error. Event.CTRL_MASK is deprecated but replacing it with InputEvent.CTRL_DOWN_MASK doesn't work and I'm not aware of how to make it work.
Also, the test scenario now has a bunch of trailers to play around with.