### PR TITLE
MM side of fix for MML #2002: remove extraneous low-BAR weight values

### DIFF
--- a/megamek/src/megamek/common/equipment/ArmorType.java
+++ b/megamek/src/megamek/common/equipment/ArmorType.java
@@ -1798,7 +1798,6 @@ public class ArmorType extends MiscType {
         armor.bar = 4;
 
         armor.armorType = T_ARMOR_SV_BAR_4;
-        armor.weightPerPointSV.put(TechRating.A, 0.080);
         armor.weightPerPointSV.put(TechRating.B, 0.050);
         armor.weightPerPointSV.put(TechRating.C, 0.032);
         armor.weightPerPointSV.put(TechRating.D, 0.026);
@@ -1824,7 +1823,6 @@ public class ArmorType extends MiscType {
         armor.bar = 5;
 
         armor.armorType = T_ARMOR_SV_BAR_5;
-        armor.weightPerPointSV.put(TechRating.A, 0.100);
         armor.weightPerPointSV.put(TechRating.B, 0.063);
         armor.weightPerPointSV.put(TechRating.C, 0.040);
         armor.weightPerPointSV.put(TechRating.D, 0.032);
@@ -1850,8 +1848,6 @@ public class ArmorType extends MiscType {
         armor.bar = 6;
 
         armor.armorType = T_ARMOR_SV_BAR_6;
-        armor.weightPerPointSV.put(TechRating.A, 0.130);
-        armor.weightPerPointSV.put(TechRating.B, 0.075);
         armor.weightPerPointSV.put(TechRating.C, 0.048);
         armor.weightPerPointSV.put(TechRating.D, 0.038);
         armor.weightPerPointSV.put(TechRating.E, 0.034);
@@ -1879,8 +1875,6 @@ public class ArmorType extends MiscType {
         armor.bar = 7;
 
         armor.armorType = T_ARMOR_SV_BAR_7;
-        armor.weightPerPointSV.put(TechRating.A, 0.180);
-        armor.weightPerPointSV.put(TechRating.B, 0.088);
         armor.weightPerPointSV.put(TechRating.C, 0.056);
         armor.weightPerPointSV.put(TechRating.D, 0.045);
         armor.weightPerPointSV.put(TechRating.E, 0.040);
@@ -1908,9 +1902,6 @@ public class ArmorType extends MiscType {
         armor.bar = 8;
 
         armor.armorType = T_ARMOR_SV_BAR_8;
-        armor.weightPerPointSV.put(TechRating.A, 0.230);
-        armor.weightPerPointSV.put(TechRating.B, 0.120);
-        armor.weightPerPointSV.put(TechRating.C, 0.064);
         armor.weightPerPointSV.put(TechRating.D, 0.051);
         armor.weightPerPointSV.put(TechRating.E, 0.045);
         armor.weightPerPointSV.put(TechRating.F, 0.042);
@@ -1937,9 +1928,6 @@ public class ArmorType extends MiscType {
         armor.bar = 9;
 
         armor.armorType = T_ARMOR_SV_BAR_9;
-        armor.weightPerPointSV.put(TechRating.A, 0.0);
-        armor.weightPerPointSV.put(TechRating.B, 0.180);
-        armor.weightPerPointSV.put(TechRating.C, 0.100);
         armor.weightPerPointSV.put(TechRating.D, 0.057);
         armor.weightPerPointSV.put(TechRating.E, 0.051);
         armor.weightPerPointSV.put(TechRating.F, 0.047);
@@ -1964,9 +1952,6 @@ public class ArmorType extends MiscType {
         armor.bar = 10;
 
         armor.armorType = T_ARMOR_SV_BAR_10;
-        armor.weightPerPointSV.put(TechRating.A, 0.0);
-        armor.weightPerPointSV.put(TechRating.B, 0.250);
-        armor.weightPerPointSV.put(TechRating.C, 0.150);
         armor.weightPerPointSV.put(TechRating.D, 0.063);
         armor.weightPerPointSV.put(TechRating.E, 0.056);
         armor.weightPerPointSV.put(TechRating.F, 0.052);

--- a/megamek/unittests/megamek/common/verifier/TestSupportVehicleTest.java
+++ b/megamek/unittests/megamek/common/verifier/TestSupportVehicleTest.java
@@ -34,19 +34,35 @@ package megamek.common.verifier;
 
 import static megamek.common.equipment.EquipmentType.T_ARMOR_FERRO_FIBROUS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import megamek.common.enums.TechRating;
 import megamek.common.equipment.ArmorType;
+import megamek.common.equipment.Engine;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.equipment.MiscType;
+import megamek.common.exceptions.LocationFullException;
+import megamek.common.units.EntityMovementMode;
 import megamek.common.units.SupportTank;
 import megamek.common.verifier.TestSupportVehicle.ChassisModification;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
 
 class TestSupportVehicleTest {
+
+    private static ArrayList<EntityMovementMode> svMovementModes = new ArrayList<>(List.of(EntityMovementMode.TRACKED,
+          EntityMovementMode.HOVER, EntityMovementMode.WHEELED, EntityMovementMode.WIGE));
 
     @BeforeAll
     static void initialize() {
@@ -77,5 +93,228 @@ class TestSupportVehicleTest {
         assertEquals(
               1,
               ArmorType.of(T_ARMOR_FERRO_FIBROUS, true).getSupportVeeSlots(st));
+    }
+
+    private static SupportTank createValidSupportTank(EntityMovementMode mode, double weight, String armor,
+          TechRating techRating, double armorWeight, int engineRating, boolean armoredMod) throws
+          LocationFullException {
+        SupportTank st = new SupportTank();
+        st.setMovementMode(mode);
+        st.setWeight(weight);
+
+        ArmorType armorType = (ArmorType) EquipmentType.get(armor);
+        st.setArmorType(armorType.getArmorType());
+        st.setBARRating(armorType.getBAR());
+        st.setArmorTechRating(techRating);
+        st.setArmorTonnage(armorWeight);
+
+        int engineFlags = Engine.TANK_ENGINE | Engine.SUPPORT_VEE_ENGINE;
+        st.setEngine(new Engine(engineRating, Engine.NORMAL_ENGINE, engineFlags));
+
+        if (armoredMod) {
+            st.addEquipment((MiscType) EquipmentType.get("Armored Chassis"), SupportTank.LOC_BODY);
+            for (int location : List.of(1, 2, 3, 4, 5, 6)) {
+                st.initializeArmor(1, location);
+            }
+        }
+
+        return st;
+    }
+
+    private static List<SupportTank> createValidSupportTanks() throws LocationFullException {
+        ArrayList<SupportTank> tanks = new ArrayList<>();
+
+        for (EntityMovementMode mode : svMovementModes) {
+            // All tech ratings support BAR 2
+            for (TechRating rating : TechRating.values()) {
+                tanks.add(
+                      createValidSupportTank(
+                            mode, 50.0, "BAR 2 Armor", rating, 5.0, 250, false
+                      )
+                );
+            }
+            // A* - F support BAR 3 (*Armored Chassis only)
+            for (TechRating rating : TechRating.values()) {
+                tanks.add(
+                      createValidSupportTank(
+                            mode, 50.0, "BAR 3 Armor", rating, 5.0, 250, rating.equals(TechRating.A)
+                      )
+                );
+            }
+            // B - F support BAR 4
+            for (TechRating rating : List.of(TechRating.B, TechRating.C, TechRating.D, TechRating.E, TechRating.F)) {
+                tanks.add(
+                      createValidSupportTank(
+                            mode, 50.0, "BAR 4 Armor", rating, 5.0, 250, false
+                      )
+                );
+            }
+            // B* - F support BAR 5
+            for (TechRating rating : List.of(TechRating.B, TechRating.C, TechRating.D, TechRating.E, TechRating.F)) {
+                tanks.add(
+                      createValidSupportTank(
+                            mode, 50.0, "BAR 5 Armor", rating, 5.0, 250, rating.equals(TechRating.B)
+                      )
+                );
+            }
+            // C - F support BAR 6
+            for (TechRating rating : List.of(TechRating.C, TechRating.D, TechRating.E, TechRating.F)) {
+                tanks.add(
+                      createValidSupportTank(
+                            mode, 50.0, "BAR 6 Armor", rating, 5.0, 250, false
+                      )
+                );
+            }
+            // C* - F support BAR 7
+            for (TechRating rating : List.of(TechRating.C, TechRating.D, TechRating.E, TechRating.F)) {
+                tanks.add(
+                      createValidSupportTank(
+                            mode, 50.0, "BAR 7 Armor", rating, 5.0, 250, rating.equals(TechRating.C)
+                      )
+                );
+            }
+            // D* - F support BAR 8
+            for (TechRating rating : List.of(TechRating.D, TechRating.E, TechRating.F)) {
+                tanks.add(
+                      createValidSupportTank(
+                            mode, 50.0, "BAR 8 Armor", rating, 5.0, 250, rating.equals(TechRating.D)
+                      )
+                );
+            }
+            // D*, E*, F support BAR 9
+            for (TechRating rating : List.of(TechRating.D, TechRating.E, TechRating.F)) {
+                tanks.add(
+                      createValidSupportTank(
+                            mode, 50.0, "BAR 9 Armor", rating, 5.0, 250, rating.equals(TechRating.D) || rating.equals(TechRating.E)
+                      )
+                );
+            }
+            // D*, E*, F* support BAR 10
+            for (TechRating rating : List.of(TechRating.D, TechRating.E, TechRating.F)) {
+                tanks.add(
+                      createValidSupportTank(
+                            mode, 50.0, "BAR 10 Armor", rating, 5.0, 250, true
+                      )
+                );
+            }
+        }
+
+        return tanks;
+    }
+
+    private static List<SupportTank> createInvalidSupportTanks() throws LocationFullException {
+        ArrayList<SupportTank> tanks = new ArrayList<>();
+
+        for (EntityMovementMode mode : svMovementModes) {
+            for (boolean bool : List.of(true, false)) {
+                // TL A Bar 4 is invalid with or without Armoured Chassis
+                tanks.add(
+                      createValidSupportTank(
+                            mode, 50.0, "BAR 4 Armor", TechRating.A, 5.0, 250, bool
+                      )
+                );
+                // TL B Bar 6 is invalid with or without Armoured Chassis
+                tanks.add(
+                      createValidSupportTank(
+                            mode, 50.0, "BAR 6 Armor", TechRating.B, 5.0, 250, bool
+                      )
+                );
+                // TL C Bar 8-10 is invalid with or without Armoured Chassis
+                tanks.add(
+                      createValidSupportTank(
+                            mode, 50.0, "BAR 8 Armor", TechRating.C, 5.0, 250, bool
+                      )
+                );
+                tanks.add(
+                      createValidSupportTank(
+                            mode, 50.0, "BAR 9 Armor", TechRating.C, 5.0, 250, bool
+                      )
+                );
+                tanks.add(
+                      createValidSupportTank(
+                            mode, 50.0, "BAR 10 Armor", TechRating.C, 5.0, 250, bool
+                      )
+                );
+            }
+            // TL D BAR 8 without A.C. is invalid
+            tanks.add(
+                  createValidSupportTank(
+                        mode, 50.0, "BAR 8 Armor", TechRating.D, 5.0, 250, false
+                  )
+            );
+            // TL D, E BAR 9 without A.C. is invalid
+            tanks.add(
+                  createValidSupportTank(
+                        mode, 50.0, "BAR 9 Armor", TechRating.D, 5.0, 250, false
+                  )
+            );
+            tanks.add(
+                  createValidSupportTank(
+                        mode, 50.0, "BAR 9 Armor", TechRating.E, 5.0, 250, false
+                  )
+            );
+            // TL D, E, F BAR 10 without A.C. is invalid
+            tanks.add(
+                  createValidSupportTank(
+                        mode, 50.0, "BAR 10 Armor", TechRating.D, 5.0, 250, false
+                  )
+            );
+            tanks.add(
+                  createValidSupportTank(
+                        mode, 50.0, "BAR 10 Armor", TechRating.E, 5.0, 250, false
+                  )
+            );
+            tanks.add(
+                  createValidSupportTank(
+                        mode, 50.0, "BAR 10 Armor", TechRating.F, 5.0, 250, false
+                  )
+            );
+        }
+
+        return tanks;
+    }
+
+    private static Stream<Arguments> createValidSupportTanksStream() throws LocationFullException {
+        List<SupportTank> list = createValidSupportTanks();
+        return list.stream().map(t -> Arguments.of(Named.of(
+              String.format("%.1f ton %s vee with TL %s BAR %s (%sA.C.)", t.getWeight(),
+                    t.getMovementModeAsString(), t.getArmorTechRating().toString(),
+                    t.getBARRating(0), (t.hasArmoredChassis() ? "*": "no ")), t))
+        );
+    }
+
+    private static Stream<Arguments> createInvalidSupportTanksStream() throws LocationFullException {
+        List<SupportTank> list = createInvalidSupportTanks();
+        return list.stream().map(t -> Arguments.of(Named.of(
+              String.format("%.1f ton %s vee with TL %s BAR %s (%sA.C.)", t.getWeight(),
+                    t.getMovementModeAsString(), t.getArmorTechRating().toString(),
+                    t.getBARRating(0), (t.hasArmoredChassis() ? "*": "no ")), t))
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "createValidSupportTanksStream")
+    void test_valid_support_tank_armor(SupportTank supportTank) {
+        StringBuffer sb = new StringBuffer();
+        EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
+              "testresources/data/mekfiles/UnitVerifierOptions.xml"));
+        TestEntity testEntity = new TestSupportVehicle(supportTank, entityVerifier.tankOption, null);
+
+        boolean result = testEntity.correctEntity(sb, supportTank.getTechLevel());
+        assertTrue(sb.toString().isEmpty());
+        assertTrue(result);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "createInvalidSupportTanksStream")
+    void test_invalid_support_tank_armor(SupportTank supportTank) {
+        StringBuffer sb = new StringBuffer();
+        EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
+              "testresources/data/mekfiles/UnitVerifierOptions.xml"));
+        TestEntity testEntity = new TestSupportVehicle(supportTank, entityVerifier.tankOption, null);
+
+        boolean result = testEntity.correctEntity(sb, supportTank.getTechLevel());
+        assertFalse(sb.toString().isEmpty());
+        assertFalse(result);
     }
 }


### PR DESCRIPTION
It looks like a bunch of extraneous values got extrapolated and added during the big data refactoring pass.
Currently we rely on  BAR armor _not_ having a weight for a given tech rating to determine if it is not applicable, or at least having a 0.0 value defined.
We somehow ended up with numerous incorrect weight values for the lower BAR armor types; removing them corrects the MML issue where e.g. Tech Rating A can equip BAR 4 armour.

Testing:
- Added a flipping buttload of new unit tests to validate every combination against the documentation listed in the OP.
- Ran all 3 projects' unit tests.
- Ran a couple games and loaded several SVs to verify that no canon designs have been rendered invalid.

Closes: MegaMek/megameklab#2002

Note: this patch is independent from the MML patch and can be merged in any order.