### PR TITLE
Mark armored interface cockpit as invalid

### DIFF
--- a/megamek/src/megamek/common/verifier/TestMek.java
+++ b/megamek/src/megamek/common/verifier/TestMek.java
@@ -1086,6 +1086,13 @@ public class TestMek extends TestEntity {
             illegal = true;
         }
 
+        if (mek.getCockpitType() == Mek.COCKPIT_INTERFACE) {
+            if (mek.getCockpit().stream().anyMatch(CriticalSlot::isArmored)) {
+                buff.append("Interface cockpits may not use component armoring.\n");
+                illegal = true;
+            }
+        }
+
         if (mek.isIndustrial()) {
             if ((mek.getCockpitType() == Mek.COCKPIT_INDUSTRIAL
                   || mek.getCockpitType() == Mek.COCKPIT_PRIMITIVE_INDUSTRIAL) && hasC3) {


### PR DESCRIPTION
Interface cockpit is a special exception and cannot use component armoring.
Fixes MegaMek/megameklab#2041.