### PR TITLE
Clear/Delete Icon

### DIFF
--- a/megamek/src/megamek/client/ui/baseComponents/DeleteIcon.java
+++ b/megamek/src/megamek/client/ui/baseComponents/DeleteIcon.java
@@ -40,21 +40,21 @@ import com.formdev.flatlaf.icons.FlatAbstractIcon;
 import megamek.client.ui.clientGUI.GUIPreferences;
 
 /**
- * An icon showing an x in the GUIPreferences warning color for a "delete" button
+ * An icon showing an x in the GUIPreferences warning color for a "delete" or "clear" button
  */
 public class DeleteIcon extends FlatAbstractIcon {
     private final int size;
 
     /**
-     * Creates a delete icon at the standard size (16) suitable to place it in line with, e.g. a JTextfield and with a
-     * GUIPreferences warning color.
+     * Creates a delete/clear icon at the standard size (16) suitable to place it in line with, e.g. a JTextfield and
+     * with a GUIPreferences warning color.
      */
     public DeleteIcon() {
         this(16);
     }
 
     /**
-     * Creates a books icon of the given size and with the GUIPreferences warning color.
+     * Creates a delete/clear icon of the given size and with the GUIPreferences warning color.
      */
     public DeleteIcon(int size) {
         super(size, size, GUIPreferences.getInstance().getWarningColor());


### PR DESCRIPTION
Adds a clear or delete icon (an X in the GUIP warning color) for JButtons. Used in an MML PR but makes sense to have it in MM.