### PR TITLE
Fix: allow proper characterization of C3 master systems

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/ModelRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/ModelRecord.java
@@ -549,7 +549,9 @@ public class ModelRecord extends AbstractUnitRecord {
                 if (unitType <= UnitType.AEROSPACE_FIGHTER && eq.hasFlag(WeaponType.F_TAG)) {
                     roles.add(MissionRole.SPOTTER);
                     losTech = true;
-                    continue;
+                    if (!eq.hasFlag(WeaponType.F_C3M) && !eq.hasFlag(WeaponType.F_C3MBS)) {
+                        continue;
+                    }
                 }
 
                 totalWeaponBV += eq.getBV(null) * unitData.getEquipmentQuantities().get(i);


### PR DESCRIPTION
Minor update to how units are characterized for force generation role selection.  The built-in TAG of C3 systems was causing a premature loop, which meant the C3 master check never happened.  This adds a simple logic gate on the continue statement.

Fixes #7234 