### PR TITLE
Improvement: Updated Crew Needs Calculations to Account for Extra Seating

### DIFF
--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -6924,11 +6924,26 @@ public class Compute {
     }
 
     /**
-     * Calculates additional crew required by vehicles and advanced aerospace vessels for certain misc equipment.
+     * Calculates the number of additional non-gunner crew members required by vehicles and advanced aerospace vessels
+     * due to specific miscellaneous equipment mounts or special unit features.
      *
-     * @param entity The unit
+     * <p>Crew additions are based on the tonnage or equipment size of certain mounted systems, such as:</p>
      *
-     * @return The number of additional crew required
+     * <ul>
+     *   <li>Communications equipment ({@code F_COMMUNICATIONS}): +1 crew per ton of equipment</li>
+     *   <li>Field Kitchens ({@code F_FIELD_KITCHEN}): +3 crew per mount</li>
+     *   <li>Mobile Field Bases ({@code F_MOBILE_FIELD_BASE}): +5 crew per mount</li>
+     *   <li>MASH units ({@code F_MASH}): +5 crew per size unit</li>
+     * </ul>
+     *
+     * <p>For tanks, any additional crew seats (via {@code getExtraCrewSeats()}) are added.</p>
+     *
+     * <p>If the unit has a drone operating system it requires 0 additional crew. For super-heavy meks, this always
+     * returns {@code 1} (to represent the Tactical Officer).</p>
+     *
+     * @param entity The unit for which to calculate the additional crew requirements
+     *
+     * @return The number of additional non-gunner crew required for the given unit
      */
     public static int getAdditionalNonGunner(Entity entity) {
         if (entity.hasDroneOs()) {


### PR DESCRIPTION
This PR just updates the methods used to fetch total crew needs to account for extra seating. I wasn't able to find a canon design with this seating, so tested using home-brewed designs.

This is necessary for MekHQ PR: https://github.com/MegaMek/mekhq/pull/7738