### PR TITLE
Issue MegaMek#7492: Send full entities list in more cases

### DIFF
--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -704,7 +704,7 @@ public class TWGameManager extends AbstractGameManager {
         if (doBlind()) {
             send(connId, createFilteredFullEntitiesPacket(game.getPlayer(connId), null));
         } else {
-            send(connId, createEntitiesPacket());
+            send(connId, createFullEntitiesPacket());
         }
     }
 
@@ -23840,7 +23840,7 @@ public class TWGameManager extends AbstractGameManager {
         }
 
         // Otherwise, send the full list.
-        send(createEntitiesPacket());
+        send(createFullEntitiesPacket());
     }
 
     /**


### PR DESCRIPTION
Fixes #7492 

We weren't sending the wrecks to the clients after toggling isometric off and back on.