### PR TITLE
Fix #7495: Illegal Capacity Errors when Advancing to New Round 

### DIFF
--- a/megamek/src/megamek/common/turns/TurnOrdered.java
+++ b/megamek/src/megamek/common/turns/TurnOrdered.java
@@ -135,7 +135,8 @@ public abstract class TurnOrdered implements ITurnOrdered {
         }
 
         if (game.getOptions().booleanOption(OptionsConstants.INIT_INF_MOVE_MULTI)) {
-            double lanceSize = Math.max(game.getOptions().intOption(OptionsConstants.INIT_INF_PROTO_MOVE_MULTI), 1);
+            //TODO: Prevent INIT_INF_PROTO_MOVE_MULTI from being less than 1 in settings
+            double lanceSize = Math.max(game.getOptions().intOption(OptionsConstants.INIT_INF_PROTO_MOVE_MULTI), 1.0);
             Integer numInfMultiples = turns_multi.get(EntityClassTurn.CLASS_INFANTRY);
             if (numInfMultiples != null) {
                 turns += (int) Math.ceil(numInfMultiples / lanceSize);


### PR DESCRIPTION
Fixes #7495

Don't divide by 0, it's bad for your health. 

As a long term fix, we might want to look into locking down these fields in the settings to prevent nonsense values. Negative CF for bridges sounds pretty silly.