### PR TITLE
Issue MegaMek#7507: Get firerer from all entities so dead entities can have their missiles targeted by AMS.

### DIFF
--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -9821,7 +9821,7 @@ public class TWGameManager extends AbstractGameManager {
             WeaponHandler wh = (WeaponHandler) ah;
             WeaponAttackAction waa = wh.weaponAttackAction;
 
-            Entity artilleryFirer = game.getEntity(waa.getEntityId());
+            Entity artilleryFirer = game.getEntityFromAllSources(waa.getEntityId());
 
             // for artillery attacks, the attacking entity might no longer be in the game.
             // TODO : Yeah, I know there's an exploit here, but better able to shoot some ArrowIVs than none, right?


### PR DESCRIPTION
Relates to #7507. In Discord there was a discussion around a log message `Can't Assign AMS: Artillery firer is null!`. While the game-locking-up bug wasn't replicated, I was able to see that message. This change will allow arty fired by a now-destroyed entity to be targeted by AMS. 