### PR TITLE
Fix: Fixed Hammer Traveling Back in Time to Release MegaMek Before MegaMek Was Invented, Thus Creating an Time Paradox That Breaches the Temporal Prime Directive

### DIFF
--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -325,6 +325,7 @@ tasks.register("packagePrepWork") {
     dependsOn createStartScripts
     dependsOn copyFiles
     dependsOn createImageAtlases
+    dependsOn createAllExecutables
 }
 
 distZip {


### PR DESCRIPTION
This PR updates our gradle build so that file and folder metadata is preserved when the files are packaged inside an archive.

I have no idea why this broke, but this fixes it.