### PR TITLE
FIX: Issue 7400 - fixes missing faction availability for clan mechs with is names

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/AvailabilityPanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/AvailabilityPanel.java
@@ -553,7 +553,6 @@ public class AvailabilityPanel {
     }
 
     public void setUnit(String model, String chassis) {
-        //record = RAT_GENERATOR.getModelRecord(chassis + " " + model);
         record = RAT_GENERATOR.getModelRecord((chassis + " " + model).trim());
         initializePanel();
     }

--- a/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/EntityViewPane.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/EntityViewPane.java
@@ -112,7 +112,6 @@ public class EntityViewPane extends EnhancedTabbedPane {
             factionPanel.reset();
         } else {
             troPanel.showEntity(entity, TROView.createView(entity, ViewFormatting.HTML));
-            //factionPanel.setUnit(entity.getModel(), entity.getChassis());
             factionPanel.setUnit(entity.getModel(), entity.getFullChassis());
         }
 

--- a/megamek/src/megamek/client/ui/entityreadout/LiveEntityViewPane.java
+++ b/megamek/src/megamek/client/ui/entityreadout/LiveEntityViewPane.java
@@ -104,7 +104,6 @@ class LiveEntityViewPane extends EnhancedTabbedPane {
             alphaStrikeCardPanel.setASElement(null);
         } else {
             troPanel.showEntity(entity, TROView.createView(entity, ViewFormatting.HTML));
-            //factionPanel.setUnit(entity.getModel(), entity.getChassis());
             factionPanel.setUnit(entity.getModel(), entity.getFullChassis());
             if (ASConverter.canConvert(entity)) {
                 alphaStrikeCardPanel.setASElement(ASConverter.convert(entity, new FlexibleCalculationReport()));


### PR DESCRIPTION
fixes #7400

changed the 3 setUnit method calls to use entity.getFullChassis() instead of entity.getChassis()
also added a trim() at the AvailabilityPanel call to getModel from RatGenerator to make sure any blank models dont cause issues

the PreviewTab in megameklab also had a call to setUnit
MegaMek/megameklab#2056