### PR TITLE
Improvement #7521: Added Client Option to Hide Unit Fluff Images from Certain Views in MegaMek & MekHQ

### DIFF
--- a/megamek/resources/megamek/client/messages.properties
+++ b/megamek/resources/megamek/client/messages.properties
@@ -1369,6 +1369,9 @@ CommonSettingsDialog.showIPAddressesInChat.tooltip=<html>If enabled, all server 
 CommonSettingsDialog.showIPAddressesInChat=Show IP Addresses in Chat (WARNING: Security Sensitive)
 CommonSettingsDialog.startSearchlightsOn.tooltip=<html>If enabled, units always start with their Searchlights illuminated.</html>
 CommonSettingsDialog.startSearchlightsOn=Start with Searchlights on
+CommonSettingsDialog.spritesOnly.tooltip=Some units display photos of their BattleTech models in certain views, such \
+  as TRO View. Enabling this option will cause the unit sprite to display, instead.
+CommonSettingsDialog.spritesOnly=Sprites Only
 CommonSettingsDialog.showMapsheets=Show map-sheet borders.
 CommonSettingsDialog.showPilotPortraitTT=Show pilot portrait in tooltip.
 CommonSettingsDialog.showReportPlayerList=Show Player Search List and Buttons
@@ -5022,7 +5025,6 @@ ForceDisplay.Button.ECM=ECM
 ForceDisplay.Button.Quirks=Quirks
 ForceDisplay.Button.C3=C3
 ForceDisplay.Button.Misc=Misc.
-
 # Source Chooser Dialog
 SourceChooser.title=Choose Source
 SourceChooser.list=Choose From List:

--- a/megamek/src/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialog.java
@@ -272,6 +272,8 @@ public class CommonSettingsDialog extends AbstractButtonDialog
           "CommonSettingsDialog.showIPAddressesInChat"));
     private final JCheckBox startSearchlightsOn = new JCheckBox(Messages.getString(
           "CommonSettingsDialog.startSearchlightsOn"));
+    private final JCheckBox spritesOnly = new JCheckBox(Messages.getString(
+          "CommonSettingsDialog.spritesOnly"));
     private final JCheckBox showDamageLevel = new JCheckBox(Messages.getString("CommonSettingsDialog.showDamageLevel"));
     private final JCheckBox showDamageDecal = new JCheckBox(Messages.getString("CommonSettingsDialog.showDamageDecal"));
     private final JCheckBox showMapSheets = new JCheckBox(Messages.getString("CommonSettingsDialog.showMapsheets"));
@@ -2188,6 +2190,8 @@ public class CommonSettingsDialog extends AbstractButtonDialog
               Messages.getString("CommonSettingsDialog.showIPAddressesInChat.tooltip")));
         comps.add(checkboxEntry(startSearchlightsOn,
               Messages.getString("CommonSettingsDialog.startSearchlightsOn.tooltip")));
+        comps.add(checkboxEntry(spritesOnly,
+              Messages.getString("CommonSettingsDialog.spritesOnly.tooltip")));
         return createSettingsPanel(comps);
     }
 
@@ -2296,6 +2300,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog
             reportFilterKeywordsTextPane.setText(CLIENT_PREFERENCES.getReportFilterKeywords());
             showIPAddressesInChat.setSelected(CLIENT_PREFERENCES.getShowIPAddressesInChat());
             startSearchlightsOn.setSelected(CLIENT_PREFERENCES.getStartSearchlightsOn());
+            spritesOnly.setSelected(CLIENT_PREFERENCES.getSpritesOnly());
 
             defaultAutoEjectDisabled.setSelected(CLIENT_PREFERENCES.defaultAutoEjectDisabled());
             useAverageSkills.setSelected(CLIENT_PREFERENCES.useAverageSkills());
@@ -2790,6 +2795,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog
         CLIENT_PREFERENCES.setReportFilterKeywords(reportFilterKeywordsTextPane.getText());
         CLIENT_PREFERENCES.setShowIPAddressesInChat(showIPAddressesInChat.isSelected());
         CLIENT_PREFERENCES.setStartSearchlightsOn(startSearchlightsOn.isSelected());
+        CLIENT_PREFERENCES.setSpritesOnly(spritesOnly.isSelected());
         CLIENT_PREFERENCES.setEnableExperimentalBotFeatures(enableExperimentalBotFeatures.isSelected());
         CLIENT_PREFERENCES.setDefaultAutoEjectDisabled(defaultAutoEjectDisabled.isSelected());
         CLIENT_PREFERENCES.setUseAverageSkills(useAverageSkills.isSelected());

--- a/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/EntityReadoutPanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/EntityReadoutPanel.java
@@ -63,9 +63,10 @@ import megamek.client.ui.util.FluffImageHelper;
 import megamek.client.ui.util.UIUtil;
 import megamek.client.ui.util.UIUtil.FixedXPanel;
 import megamek.client.ui.util.ViewFormatting;
-import megamek.common.units.Entity;
 import megamek.common.Report;
+import megamek.common.preference.PreferenceManager;
 import megamek.common.templates.TROView;
+import megamek.common.units.Entity;
 
 /**
  * @author Jay Lawson
@@ -209,7 +210,8 @@ public class EntityReadoutPanel extends JPanel {
     }
 
     private void setFluffImage(Entity entity) {
-        Image image = FluffImageHelper.getFluffImage(entity);
+        boolean isSpritesOnly = PreferenceManager.getClientPreferences().getSpritesOnly();
+        Image image = isSpritesOnly ? null : FluffImageHelper.getFluffImage(entity);
         // Scale down to the default width if the image is wider than that
         if (null != image) {
             if (image.getWidth(this) > DEFAULT_WIDTH) {

--- a/megamek/src/megamek/common/preference/ClientPreferences.java
+++ b/megamek/src/megamek/common/preference/ClientPreferences.java
@@ -96,6 +96,7 @@ public class ClientPreferences extends PreferenceStoreProxy {
     private static final String REPORT_FILTER_KEYWORDS_DEFAULTS = "Fire Hit Damage\nHit Damage";
     public static final String IP_ADDRESSES_IN_CHAT = "IPAddressesInChat";
     public static final String START_SEARCHLIGHTS_ON = "StartSearchlightsOn";
+    public static final String SPRITES_ONLY = "SpritesOnly";
     public static final String ENABLE_EXPERIMENTAL_BOT_FEATURES = "EnableExperimentalBotFeatures";
     public static final String NAG_ASK_FOR_VICTORY_LIST = "AskForVictoryList";
     public static final String SHOW_AUTO_RESOLVE_PANEL = "ShowAutoResolvePanel";
@@ -145,6 +146,7 @@ public class ClientPreferences extends PreferenceStoreProxy {
         store.setDefault(REPORT_FILTER_KEYWORDS, REPORT_FILTER_KEYWORDS_DEFAULTS);
         store.setDefault(IP_ADDRESSES_IN_CHAT, false);
         store.setDefault(START_SEARCHLIGHTS_ON, true);
+        store.setDefault(SPRITES_ONLY, false);
         store.setDefault(ENABLE_EXPERIMENTAL_BOT_FEATURES, false);
         store.setDefault(USER_DIR, "");
         store.setDefault(MML_PATH, "");
@@ -405,6 +407,14 @@ public class ClientPreferences extends PreferenceStoreProxy {
 
     public void setStartSearchlightsOn(boolean value) {
         store.setValue(START_SEARCHLIGHTS_ON, value);
+    }
+
+    public boolean getSpritesOnly() {
+        return store.getBoolean(SPRITES_ONLY);
+    }
+
+    public void setSpritesOnly(boolean value) {
+        store.setValue(SPRITES_ONLY, value);
     }
 
     public void setEnableExperimentalBotFeatures(boolean value) {


### PR DESCRIPTION
Close #7521

In certain instances we show photos of a unit's real life model. This PR adds an option that will cause either no image, or the unit sprite, to display instead. This option affects both MegaMek and MekHQ.