### PR TITLE
Improvement: Updated CodeQL to (Hopefully) Analyze Using the Right Version of Java

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,12 @@ jobs:
       - name: "Check out MegaMek"
         uses: actions/checkout@v5
 
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:


### PR DESCRIPTION
I finally got fed up with CodeQL spitting out rubbish feedback enough to actually do something about it.

If my Google-Fu hasn't failed me this addition will give CodeQL the context necessary to review our code with the understanding that we're using J17. Apparently, it was defaulting to J8.

If this explodes CodeQL ~~nothing of value will be lost~~ we can easily reverse this change.