### PR TITLE
Task: Expanded Portrait Compatibility Handler to Account for MekHQ Vehicle Crew Changes

### DIFF
--- a/megamek/src/megamek/common/icons/AbstractIcon.java
+++ b/megamek/src/megamek/common/icons/AbstractIcon.java
@@ -249,6 +249,8 @@ public abstract class AbstractIcon implements Serializable {
 
                 // <50.07 compatibility handlers
                 category = category.replaceAll("Mek Tech", "MekTech");
+                // <50.10 compatibility handlers
+                category = category.replace("Vehicle Gunner", "Vehicle Crew Ground");
 
                 setCategory(category);
                 break;


### PR DESCRIPTION
# Required By [Improvement: Replaced Several Vehicle Professions. Updated Vehicle Commander Picking](https://github.com/MegaMek/mekhq/pull/7866)
## See Also [Task: Renamed Portraits to Account for MekHQ Vehicle Crew Changes; Consolidated Vehicle Gunner Portraits into Vehicle Crew Ground Folder](https://github.com/MegaMek/mm-data/pull/130)

This adds a compatibility handler that handles backwards compatibility of portraits for players loading <50.10 campaigns in >=50.10