### PR TITLE
Fix 4879: zipline dropping using starting position rather than target step position

### DIFF
--- a/megamek/src/megamek/client/ui/SharedUtility.java
+++ b/megamek/src/megamek/client/ui/SharedUtility.java
@@ -562,10 +562,10 @@ public class SharedUtility {
                       && (((Entity) targ).getJumpMP() < 1)
                       && !((Infantry) targ).isMechanized()) {
                     rollTarget = TWGameManager.getEjectModifiers(game, (Entity) targ, 0,
-                          false, entity.getPosition(), "zip lining");
+                          false, md.getFinalCoords(), "zip lining");
                     // Factor in Elevation
-                    if (entity.getElevation() > 0) {
-                        rollTarget.addModifier(entity.getElevation(), "elevation");
+                    if (md.getFinalElevation() > 0) {
+                        rollTarget.addModifier(md.getFinalElevation(), "elevation");
                     }
                     checkNag(rollTarget, nagReport, psrList);
                 }


### PR DESCRIPTION
Use the target hex coordinates and target move step elevation for generating ziplining PSR mods.
Previously we were using the VTOL unit's starting hex and elevation, which would cause incorrect mods to be applied to the zipline PSR.

Testing:
- Tested dropping non-jump MP infantry and BA units from a VTOL at various heights and over various terrains.
- Ran all 3 projects' unit tests.

Close #4879 