### PR TITLE
Issue 7524 Custom Deploy Zone Fixes

### DIFF
--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -51,6 +51,7 @@ import megamek.common.game.InGameObject;
 import megamek.common.hexArea.BorderHexArea;
 import megamek.common.hexArea.HexArea;
 import megamek.common.icons.Camouflage;
+import megamek.common.interfaces.IStartingPositions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.turns.TurnOrdered;
 import megamek.common.units.Entity;
@@ -485,7 +486,7 @@ public final class Player extends TurnOrdered {
      * Set deployment zone to edge of board for reinforcements
      */
     public void adjustStartingPosForReinforcements() {
-        if (startingPos > 10) {
+        if ((startingPos > 10) && (startingPos < IStartingPositions.START_LOCATION_NAMES.length)) {
             startingPos -= 10; // deep deploy change to standard
         }
 

--- a/megamek/src/megamek/common/interfaces/IStartingPositions.java
+++ b/megamek/src/megamek/common/interfaces/IStartingPositions.java
@@ -39,4 +39,21 @@ public interface IStartingPositions {
                                       "NE", "E", "SE", "S", "SW", "W", "EDG", "CTR", "NW (deep)",
                                       "N (deep)", "NE (deep)", "E (deep)", "SE (deep)", "S (deep)",
                                       "SW (deep)", "W (deep)", "EDG (deep)" };
+
+
+    /**
+     * Returns a display name for the given starting position index. "Custom" is returned for any value of index outside
+     * the standard starting positions (the method is safe to call for all values of index).
+     *
+     * @param index the starting position index
+     *
+     * @return A name, e.g. "Any" for index 0
+     */
+    static String getDisplayName(int index) {
+        if ((index >= 0) && (index < START_LOCATION_NAMES.length)) {
+            return START_LOCATION_NAMES[index];
+        } else {
+            return "Custom";
+        }
+    }
 }

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -2969,7 +2969,7 @@ public class TWGameManager extends AbstractGameManager {
                     report = new Report(1066);
                     report.subject = entity.getId();
                     report.addDesc(entity);
-                    String s = IStartingPositions.START_LOCATION_NAMES[entity.getStartingPos()];
+                    String s = IStartingPositions.getDisplayName(entity.getStartingPos());
                     report.add(s);
                     addReport(report);
                 }

--- a/megamek/testresources/data/scenarios/test_setups/customdeploy.mms
+++ b/megamek/testresources/data/scenarios/test_setups/customdeploy.mms
@@ -1,0 +1,50 @@
+# MegaMek Data (C) 2025 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+MMSVersion: 2
+name: Custom deploy zones
+planet: None
+description: A few units on a small map with Princess deploying to custom zones at start of game and in round 2
+map: buildingsnobasement/dropport2.board
+
+options:
+  off:
+    - check_victory
+
+factions:
+- name: Test Player
+  deploy:
+    area:
+      circle:
+        center: [ 14, 10 ]
+        radius: 4
+  units:
+  - fullname: Locust LCT-1M
+  - fullname: Hunchback HBK-4G
+    deploymentround: 2
+
+- name: PrincessTest
+  deploy:
+    area:
+      circle:
+        center: [ 4, 10 ]
+        radius: 4
+  units:
+  - fullname: Charger CGR-1A1
+  - fullname: Atlas AS7-D
+    deploymentround: 2
+
+


### PR DESCRIPTION
Fixes #7524
Adds a method to IStartingPositions to safely get a display text for any starting position index and uses it to avoid the exception mentioned in the issue. Also prevents the custom deployment zone index from being modified for reinforcements which made it nonfunctional after initial deployment. Also adds the test setup scenario I used to test this.