### PR TITLE
Issue 7535 Image Logging Fixes 

### DIFF
--- a/megamek/src/megamek/client/ui/clientGUI/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/BoardView.java
@@ -580,7 +580,7 @@ public final class BoardView extends AbstractBoardView
                       || gamePhaseChangeEvent.getOldPhase().isPhysical())) {
                     File dir = new File(Configuration.gameSummaryImagesBVDir(), game.getUUIDString());
 
-                    if (!dir.exists() || dir.mkdirs()) {
+                    if (dir.exists() || dir.mkdirs()) {
                         String fileName = String.format("round_%03d_%03d_%s.png",
                               game.getRoundCount(),
                               gamePhaseChangeEvent.getOldPhase().ordinal(),

--- a/megamek/src/megamek/client/ui/dialogs/minimap/MinimapPanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/minimap/MinimapPanel.java
@@ -332,8 +332,9 @@ public final class MinimapPanel extends JPanel implements IPreferenceChangeListe
                     if (!dir.exists()) {
                         dir.mkdirs();
                     }
-                    File imgFile = new File(dir, "round_" + game.getRoundCount() + "_" + e.getOldPhase().ordinal() + "_"
-                          + e.getOldPhase() + ".png");
+                    String filenameTemplate = "round_%d_%d_%s.png";
+                    File imgFile = new File(dir,
+                          filenameTemplate.formatted(game.getRoundCount(), e.getOldPhase().ordinal(), e.getOldPhase()));
 
                     try {
                         BufferedImage image = getMinimapImage(game, bv, GAME_SUMMARY_ZOOM, clientGui, null,

--- a/megamek/src/megamek/utilities/GifWriter.java
+++ b/megamek/src/megamek/utilities/GifWriter.java
@@ -87,7 +87,7 @@ public class GifWriter {
      */
     public GifWriter(String gameSummary) {
         folder = new File(gameSummaryImagesMMDir(), gameSummary);
-        outputFile = new File(gameSummaryImagesMMDir(), gameSummary + ".gif");
+        outputFile = new File(folder, gameSummary + ".gif");
     }
 
     private OutputStream outputStream = null;


### PR DESCRIPTION
Fixes #7535
BoardView:A small logic error prevented the board image logging directory from being created when necessary
GifWriter: Moves the minimap gif into the game's UUID subfolder (where that game's minimap pngs are also placed)
MinimapPanel: only a readability change