### PR TITLE
Fix for 7550: allow JumboEnumSet to be deserialized

### DIFF
--- a/megamek/src/megamek/common/net/marshalling/SanityInputFilter.java
+++ b/megamek/src/megamek/common/net/marshalling/SanityInputFilter.java
@@ -86,6 +86,7 @@ public class SanityInputFilter implements ObjectInputFilter {
           Pattern.compile("java\\.util\\.concurrent\\.locks\\.ReentrantLock\\$Sync"),
           Pattern.compile("java\\.util\\.EnumMap"),
           Pattern.compile("java\\.util\\.EnumSet"),
+          Pattern.compile("java\\.util\\.JumboEnumSet"),
           Pattern.compile("java\\.util\\.HashMap"),
           Pattern.compile("java\\.util\\.HashSet"),
           Pattern.compile("java\\.util\\.Hashtable"),


### PR DESCRIPTION
It appears that we are using `EnumSet.of()` with a collection that has 65 or more entities now, and this has caused Java to give us back a JumboEnumSet that we currently don't allow.

Adding JumboEnumSet to the SanityInputFilter.java code should be sufficient to avoid this issue going forward.

I _believe_ this is causing both #7550 and #7548, as the fix for the former also seems to have resolved the latter.

Testing:
- Played several turns with savegames from both issues.
- Ran all 3 projects' unit tests.

Close #7550 
Close #7548 