### PR TITLE
Fix 7548: avoid hang and serialization exceptions by making Game ref in ExternalCargo transient 

### DIFF
--- a/megamek/src/megamek/common/equipment/ExternalCargo.java
+++ b/megamek/src/megamek/common/equipment/ExternalCargo.java
@@ -42,7 +42,7 @@ import java.util.Vector;
 
 public class ExternalCargo implements Transporter {
 
-    protected Game game;
+    protected transient Game game;
 
     /** The total amount of space available for objects. */
     protected double totalSpace;

--- a/megamek/src/megamek/common/net/connections/AbstractConnection.java
+++ b/megamek/src/megamek/common/net/connections/AbstractConnection.java
@@ -227,9 +227,13 @@ public abstract class AbstractConnection {
 
     /** Adds a packet to the send queue to be sent on a separate thread. */
     public synchronized void send(Packet packet) {
-        sendQueue.addPacket(new SendPacket(packet, this));
-        // Send right now
-        flush();
+        try {
+            sendQueue.addPacket(new SendPacket(packet, this));
+            // Send right now
+            flush();
+        } catch (Exception e) {
+            LOGGER.error("Failed to send packet {}", packet, e);
+        }
     }
 
     /** Send the packet now, on a separate thread; This is the blocking call. */

--- a/megamek/src/megamek/common/net/connections/DataStreamConnection.java
+++ b/megamek/src/megamek/common/net/connections/DataStreamConnection.java
@@ -120,7 +120,7 @@ public class DataStreamConnection extends AbstractConnection {
         synchronized (out) {
             out.writeBoolean(isZipped);
             out.writeInt(marshallingType);
-            out.writeInt(data.length);
+            out.writeInt((data != null) ? data.length : 0);
             out.write(data);
         }
     }

--- a/megamek/src/megamek/common/net/connections/SendPacket.java
+++ b/megamek/src/megamek/common/net/connections/SendPacket.java
@@ -49,7 +49,7 @@ public class SendPacket implements INetworkPacket {
     private final PacketCommand command;
     private final AbstractConnection connection;
 
-    public SendPacket(Packet packet, AbstractConnection connection) {
+    public SendPacket(Packet packet, AbstractConnection connection) throws java.io.NotSerializableException {
         command = packet.command();
         this.connection = connection;
         ByteArrayOutputStream bos = new ByteArrayOutputStream();


### PR DESCRIPTION
Make ExternalCargo's reference to Game `transient` so it won't get serialized and blow up everything.

This was a pernicious one to track down because 
A) none of the exceptions referenced any fields that are stored in Mek or Entity;
B) it didn't _always_ happen on unit destruction, just Mek destruction that involved ejection;
C) None of the recent changes seemed to involve any of the code or classes that Java was complaining about.

In the end I had to add a breakpoint inside `ObjectOutputStream::writeObject0`, wait for the exception to be thrown, and then climb back up the stack of serialized objects to find the field inside the Mek that we actually needed to change.

tl;dr: use `transient Game`

I also added some safer handling around SendPacket; it should now be much clearer when we would have tried to send a malformed, incomplete Packet, and why.

Testing:
- Ran savegames from #7548 through a couple of Mek destructions 
- Ran all 3 projects' unit tests

Close: #7548 