### PR TITLE
Fix: Fixed Map Size Picker Missing 'Custom Board Size' Option

### DIFF
--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
@@ -1102,6 +1102,7 @@ public class ChatLounge extends AbstractPhaseDisplay
             comMapSizes.addItem(size);
         }
 
+        comMapSizes.addItem(Messages.getString("ChatLounge.CustomMapSize"));
         comMapSizes.setSelectedIndex(oldSelection != -1 ? oldSelection : 0);
         comMapSizes.addActionListener(lobbyListener);
     }


### PR DESCRIPTION
This accidentally got nixed at some point.