### PR TITLE
Optimize MRM to-hit modifier into MRMWeapon

### DIFF
--- a/megamek/src/megamek/common/actions/compute/ComputeToHit.java
+++ b/megamek/src/megamek/common/actions/compute/ComputeToHit.java
@@ -1463,10 +1463,6 @@ public class ComputeToHit {
                     modifier += RangeType.RANGE_LONG;
                 }
             }
-            // PLAYTEST3 No more modifier for MRMs
-            if (game.getOptions().booleanOption(OptionsConstants.PLAYTEST_3) && weaponType instanceof MRMWeapon) {
-                modifier--;
-            }
             toHit.addModifier(modifier, Messages.getString("WeaponAttackAction.WeaponMod"));
 
         }

--- a/megamek/src/megamek/common/weapons/missiles/MRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/missiles/MRMWeapon.java
@@ -47,6 +47,7 @@ import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
 import megamek.common.game.Game;
 import megamek.common.loaders.EntityLoadingException;
+import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.handlers.AttackHandler;
 import megamek.common.weapons.handlers.MRMHandler;
 import megamek.server.totalWarfare.TWGameManager;
@@ -66,6 +67,16 @@ public abstract class MRMWeapon extends MissileWeapon {
         atClass = CLASS_MRM;
     }
 
+    @Override
+    // PLAYTEST3 MRMS no longer have a +1 to hit.
+    public int getToHitModifier(@Nullable Mounted<?> mounted) {
+        if (mounted != null && mounted.getEntity() != null && mounted.getEntity().getGame() != null && mounted.getEntity().getGame().getOptions().booleanOption(OptionsConstants.PLAYTEST_3)) {
+            return 0;
+        } else {
+            return toHitModifier;
+        }
+    }
+    
     @Override
     @Nullable
     public AttackHandler getCorrectHandler(ToHitData toHit, WeaponAttackAction waa, Game game, TWGameManager manager) {


### PR DESCRIPTION
This is moving the MRM to-hit modifier for playtest out of ComputeToHit, and into MRMWeapon