### PR TITLE
Fix: Corrected DropShips Being Incorrectly Able to Salvage on Ground

### DIFF
--- a/megamek/src/megamek/common/units/Dropship.java
+++ b/megamek/src/megamek/common/units/Dropship.java
@@ -821,11 +821,6 @@ public class Dropship extends SmallCraft {
     }
 
     @Override
-    public boolean canPerformGroundSalvageOperations() {
-        return true;
-    }
-
-    @Override
     public boolean canPerformSpaceSalvageOperations() {
         return true;
     }


### PR DESCRIPTION
DropShips are not meant to be a ground salvage enabled unit, this fixes that by removing the override. The default returns `false`.