### PR TITLE
Sanity Input Filter Fix

### DIFF
--- a/megamek/src/megamek/common/net/marshalling/SanityInputFilter.java
+++ b/megamek/src/megamek/common/net/marshalling/SanityInputFilter.java
@@ -90,7 +90,7 @@ public class SanityInputFilter implements ObjectInputFilter {
           Pattern.compile("java\\.util\\.HashMap"),
           Pattern.compile("java\\.util\\.HashSet"),
           Pattern.compile("java\\.util\\.Hashtable"),
-          Pattern.compile("java\\.util\\.ImmutableCollections\\$List"),
+          Pattern.compile("java\\.util\\.ImmutableCollections\\$List.*"),
           Pattern.compile("java\\.util\\.LinkedHashMap"),
           Pattern.compile("java\\.util\\.LinkedHashSet"),
           Pattern.compile("java\\.util\\.LinkedList"),


### PR DESCRIPTION
Encountering this on `main`. Why `List12`? Any ideas?
```

19:11:32,575 INFO  [megamek.common.net.marshalling.SanityInputFilter] {Connection 0}
megamek.common.net.marshalling.SanityInputFilter.checkInput(SanityInputFilter.java:137) - Class is Rejected: java.util.ImmutableCollections$List12

19:11:32,579 ERROR [megamek.common.net.connections.AbstractConnection] {Connection 0}
megamek.common.net.connections.AbstractConnection.update(AbstractConnection.java:321) - Server
java.io.InvalidClassException: filter status: REJECTED
	at java.base/java.io.ObjectInputStream.filterCheck(ObjectInputStream.java:1409)
	at java.base/java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2276)
	at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1733)
	at java.base/java.io.ObjectInputStream$FieldValues.<init>(ObjectInputStream.java:2606)
	at java.base/java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2457)
	at java.base/java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2257)
	at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1733)
	at java.base/java.io.ObjectInputStream.readArray(ObjectInputStream.java:2157)
	at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1721)
	at java.base/java.io.ObjectInputStream$FieldValues.<init>(ObjectInputStream.java:2606)
	at java.base/java.io.ObjectInputStream.readFields(ObjectInputStream.java:691)
	at java.base/java.util.Vector.readObject(Vector.java:1158)
	at java.base/jdk.internal.reflect.GeneratedMethodAccessor38.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.io.ObjectStreamClass.invokeReadObject(ObjectStreamClass.java:1100)
	at java.base/java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2423)
	at java.base/java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2257)
	at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1733)
	at java.base/java.io.ObjectInputStream$FieldValues.<init>(ObjectInputStream.java:2606)
	at java.base/java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2457)
	at java.base/java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2257)
	at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1733)
	at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:509)
	at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:467)
	at java.base/java.util.ArrayList.readObject(ArrayList.java:899)
	at java.base/jdk.internal.reflect.GeneratedMethodAccessor85.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at java.base/java.io.ObjectStreamClass.invokeReadObject(ObjectStreamClass.java:1100)
	at java.base/java.io.ObjectInputStream.readSerialData(ObjectInputStream.java:2423)
	at java.base/java.io.ObjectInputStream.readOrdinaryObject(ObjectInputStream.java:2257)
	at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1733)
	at java.base/java.io.ObjectInputStream.readArray(ObjectInputStream.java:2157)
	at java.base/java.io.ObjectInputStream.readObject0(ObjectInputStream.java:1721)
	at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:509)
	at java.base/java.io.ObjectInputStream.readObject(ObjectInputStream.java:467)
	at megamek.common.net.marshalling.NativeSerializationMarshaller.unmarshall(NativeSerializationMarshaller.java:68)
	at megamek.common.net.connections.AbstractConnection.processPacket(AbstractConnection.java:359)
	at megamek.common.net.connections.AbstractConnection.update(AbstractConnection.java:315)
	at megamek.server.ConnectionHandler.run(ConnectionHandler.java:67)
	at java.base/java.lang.Thread.run(Thread.java:840)
	```