### PR TITLE
Fix: Fixed Portrait Compatibility Handler Not Covering All Changed Professions

### DIFF
--- a/megamek/src/megamek/common/icons/AbstractIcon.java
+++ b/megamek/src/megamek/common/icons/AbstractIcon.java
@@ -255,6 +255,7 @@ public abstract class AbstractIcon implements Serializable {
                 category = category.replace("Naval Driver", "Vehicle Crew Naval");
                 category = category.replace("VTOL Pilot", "Vehicle Crew VTOL");
                 category = category.replace("Vehicle Crewmember", "Combat Technician");
+                category = category.replace("Conventional Aircraft Pilot", "Conventional Aircraft Crew");
 
                 setCategory(category);
                 break;


### PR DESCRIPTION
This is a followup to #7533. Apparently I fixed most of the newly changed professions. This causes portraits to be broken for anyone upgrading a campaign to 50.10