### PR TITLE
Fix 7421: Replace incorrect artillery code with correct bomb code in BA Micro Bomb Rack handler

### DIFF
--- a/megamek/src/megamek/common/weapons/handlers/MicroBombHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/MicroBombHandler.java
@@ -34,20 +34,22 @@
 
 package megamek.common.weapons.handlers;
 
-import static megamek.common.weapons.handlers.AreaEffectHelper.calculateDamageFallOff;
-
 import java.io.Serial;
 import java.util.Vector;
 
+import megamek.common.HexTarget;
+import megamek.common.Messages;
+import megamek.common.Player;
 import megamek.common.Report;
+import megamek.common.SpecialHexDisplay;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.board.Coords;
 import megamek.common.compute.Compute;
+import megamek.common.equipment.enums.BombType;
 import megamek.common.game.Game;
 import megamek.common.loaders.EntityLoadingException;
 import megamek.common.units.Entity;
-import megamek.common.units.Infantry;
 import megamek.server.totalWarfare.TWGameManager;
 
 /**
@@ -76,11 +78,22 @@ public class MicroBombHandler extends AmmoWeaponHandler {
     @Override
     protected boolean specialResolution(Vector<Report> vPhaseReport, Entity entityTarget) {
         Coords coords = target.getPosition();
+        Player player = attackingEntity.getOwner();
+        String bombMsg;
+
         if (!bMissed) {
             Report r = new Report(3190);
             r.subject = subjectId;
             r.add(coords.getBoardNum());
             vPhaseReport.add(r);
+
+            bombMsg = "Bomb hit here on round " + game.getRoundCount()
+                  + ", dropped by " + ((player != null) ? player.getName() : "somebody");
+
+            game.getBoard(target).addSpecialHexDisplay(coords,
+                  new SpecialHexDisplay(SpecialHexDisplay.Type.BOMB_HIT, game.getRoundCount(),
+                        player, bombMsg));
+
         } else {
             // magic number - BA-launched micro bombs only scatter 1 hex per TW-2018 p 228
             coords = Compute.scatter(coords, 1);
@@ -89,18 +102,50 @@ public class MicroBombHandler extends AmmoWeaponHandler {
                 report.subject = subjectId;
                 report.add(coords.getBoardNum());
                 vPhaseReport.add(report);
+
+                bombMsg = "Bomb missed!  Round " + game.getRoundCount()
+                      + ", by " + ((player != null) ? player.getName() : "somebody") + ", drifted to "
+                      + coords.getBoardNum();
+                game.getBoard(target).addSpecialHexDisplay(coords,
+                      new SpecialHexDisplay(SpecialHexDisplay.Type.BOMB_MISS, game.getRoundCount(),
+                            player, bombMsg));
+
             } else {
                 Report report = new Report(3200);
                 report.subject = subjectId;
                 vPhaseReport.add(report);
+
+                bombMsg = "Bomb missed!  Round " + game.getRoundCount()
+                      + ", by " + ((player != null) ? player.getName() : "somebody")
+                      + ", drifted off the board";
+                game.getBoard(target).addSpecialHexDisplay(coords,
+                      new SpecialHexDisplay(SpecialHexDisplay.Type.BOMB_MISS, game.getRoundCount(),
+                            player, bombMsg));
+
                 return !bMissed;
             }
         }
-        // Not mine clearing if we are shooting an entity
-        Infantry ba = (Infantry) attackingEntity;
-        DamageFalloff falloff = calculateDamageFallOff(ammo.getType(), ba.getShootingStrength(), false);
-        gameManager.artilleryDamageArea(coords, ammo.getType(), subjectId,
-              attackingEntity, falloff, false, 0, vPhaseReport, false);
+
+        // Deal bomb damage to the hit coordinates, with all that entails
+        HexTarget dropHex = new HexTarget(coords, target.getBoardId(), target.getTargetType());
+        Vector<Integer> hitIds = gameManager.deliverBombDamage(dropHex,
+              BombType.BombTypeEnum.HE, subjectId, attackingEntity,
+              vPhaseReport);
+
+        // Display drifts that hit nothing separately from drifts that dealt damage
+        if (bMissed) {
+            if (hitIds == null || hitIds.isEmpty()) {
+                game.getBoard(target).addSpecialHexDisplay(coords,
+                      new SpecialHexDisplay(SpecialHexDisplay.Type.BOMB_DRIFT, game.getRoundCount(),
+                            player, Messages.getString("BombMessage.drifted")
+                            + " " + coords.getBoardNum()));
+            } else {
+                game.getBoard(target).addSpecialHexDisplay(coords,
+                      new SpecialHexDisplay(SpecialHexDisplay.Type.BOMB_HIT, game.getRoundCount(),
+                            player, Messages.getString("BombMessage.drifted")
+                            + " " + coords.getBoardNum()));
+            }
+        }
         return true;
     }
 }


### PR DESCRIPTION
BA Micro Bomb Racks were dealing damage to the carrying units no matter what terrain they were over, which is not how bomb blast shaping should work.
I didn't notice this when expanding on the artillery handling, but the BA micro bomb handler ended up with artillery, not bomb, damage delivery code at some point.

This PR:
1. switches wrong code that caused artillery-type blast shape with correct bomb blast call.
2. adds missing bomb markings so that UI elements showing bomb hits and misses will be drawn.

Testing:
- Tested with Sylph BAs over a variety of targets and terrain
- Ran all 3 projects' unit tests.

Fix #7421 