### PR TITLE
Fix 7592: Call correct super method to avoid infinite recursion in QuadMek hit location resolution

### DIFF
--- a/megamek/src/megamek/common/units/QuadMek.java
+++ b/megamek/src/megamek/common/units/QuadMek.java
@@ -828,7 +828,7 @@ public class QuadMek extends Mek {
                     return new HitData(Mek.LOC_LEFT_TORSO, true, effects);
             }
         }
-        return super.rollHitLocation(table, side, aimedLocation, aimingMode, cover);
+        return super.innerRollHitLocation(table, side, aimedLocation, aimingMode, cover);
     }
 
     @Override


### PR DESCRIPTION
QuadMeks only handle QM-specific hit locations in their version of `innerRollHitLocation()`, and then delegate part of the work to the superclass's version.  We needed to be calling `super.innerRollHitLocation()` to avoid the infinite regress.

Testing:
- Ran several games with QuadMeks to confirm proper operation.
- Ran some turns on OP's attached save game.
- Ran all 3 projects' unit tests.
 Fix #7592 