### PR TITLE
Fix #6413: Fixed Inability to Charge From Prone

### DIFF
--- a/megamek/src/megamek/common/actions/ChargeAttackAction.java
+++ b/megamek/src/megamek/common/actions/ChargeAttackAction.java
@@ -429,6 +429,11 @@ public class ChargeAttackAction extends DisplacementAttackAction {
             return new ToHitData(TargetRoll.IMPOSSIBLE, "No backwards movement allowed while charging");
         }
 
+        // no prone
+        if (md.getFinalProne()) {
+            return new ToHitData(TargetRoll.IMPOSSIBLE, "You cannot charge if you end the movement phase prone");
+        }
+
         // no evading
         if (md.contains(MoveStepType.EVADE)) {
             return new ToHitData(TargetRoll.IMPOSSIBLE, "No evading while charging");

--- a/megamek/src/megamek/common/units/Entity.java
+++ b/megamek/src/megamek/common/units/Entity.java
@@ -10008,7 +10008,7 @@ public abstract class Entity extends TurnOrdered
      * @return Whether this type of unit can perform charges
      */
     public boolean canCharge() {
-        return !isImmobile() && (getWalkMP() > 0) && !isStuck() && !isProne();
+        return !isImmobile() && (getWalkMP() > 0) && !isStuck();
     }
 
     /**


### PR DESCRIPTION
A unit can perform a charge so long as it ends its movement phase standing, even if it started prone. This PR removes the 'isProne' check from 'canCharge' and moves the check to the charge attack action, instead.

I tested by squaring up a few units and making sure they could charge, but that the charge failed once it came time to roll the attack.