### PR TITLE
 Fix bearings-only capital missiles dealing zero damage on hit (#7597)

### DIFF
--- a/megamek/src/megamek/common/weapons/handlers/capitalMissile/CapitalMissileBearingsOnlyHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/capitalMissile/CapitalMissileBearingsOnlyHandler.java
@@ -213,6 +213,7 @@ public class CapitalMissileBearingsOnlyHandler extends AmmoBayWeaponHandler {
 
         // This has to be up here so that we don't screw up glancing/direct blow reports
         attackValue = calcAttackValue();
+        nDamPerHit = attackValue;
 
         // CalcAttackValue triggers counterfire, so now we can safely get this
         CapMissileAMSMod = getCapMissileAMSMod();


### PR DESCRIPTION
 
  Bearings-only fired capital missiles were registering hits (including
  glancing and direct blows) but dealing zero damage. The root cause was
  that attackValue was calculated via calcAttackValue() but never assigned
  to nDamPerHit, leaving it at the default value of 0.

  This caused the zero damage check at line 424 to trigger incorrectly,
  even when the attack successfully hit the target.

  Fix: Assign attackValue to nDamPerHit after calculation (line 216) to
  match the pattern used in parent class BayWeaponHandler.

  Related to issue #6957 (BA Artillery) which had a similar pattern.