### PR TITLE
Fix burst-fire MG menu incorrectly appearing for battle armor

### DIFF
--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/LobbyMekPopup.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/LobbyMekPopup.java
@@ -64,6 +64,7 @@ import megamek.client.ui.util.MenuScroller;
 import megamek.client.ui.util.ScalingPopup;
 import megamek.client.ui.util.UIUtil;
 import megamek.common.Player;
+import megamek.common.battleArmor.BattleArmor;
 import megamek.common.battleArmor.ProtoMekClampMount;
 import megamek.common.bays.Bay;
 import megamek.common.equipment.AmmoType;
@@ -993,6 +994,10 @@ class LobbyMekPopup {
      * @return true when the entity has an MG set to rapid fire.
      */
     private static boolean hasRapidFireMG(Entity entity) {
+        // Battle armor cannot use burst-fire MGs per errata
+        if (entity instanceof BattleArmor) {
+            return false;
+        }
         for (Mounted<?> m : entity.getWeaponList()) {
             EquipmentType etype = m.getType();
             if (etype.hasFlag(WeaponType.F_MG) && m.isRapidFire()) {
@@ -1004,6 +1009,10 @@ class LobbyMekPopup {
 
     /** Returns true when the entity has an MG set to normal (non-rapid) fire. */
     private static boolean hasNormalFireMG(Entity entity) {
+        // Battle armor cannot use burst-fire MGs per errata
+        if (entity instanceof BattleArmor) {
+            return false;
+        }
         for (Mounted<?> m : entity.getWeaponList()) {
             EquipmentType etype = m.getType();
             if (etype.hasFlag(WeaponType.F_MG) && !m.isRapidFire()) {


### PR DESCRIPTION
 Fixes #5202

 Battle armor units were incorrectly displaying a burst-fire machine gun option in the lobby context menu, despite errata prohibiting this feature for BA weapons.

Root cause: The hasRapidFireMG() and hasNormalFireMG() methods checked  all entities without excluding battle armor, causing the Equipment menu to appear when it shouldn't.

Fix: Add battle armor checks at the start of both methods to return false immediately, preventing BA units from triggering the burst-fire menu options.

Changes:
  - LobbyMekPopup.java: Add BattleArmor import
  - hasRapidFireMG(): Return false for battle armor entities
  - hasNormalFireMG(): Return false for battle armor entities

The burst-fire option now correctly appears only for non-BA units with MGs  when the TacOps Burst Fire MGs option is enabled.

Hammer Notes - Test in lobby and in game and no issues spotted.