### PR TITLE
Fix 7515: Double-safety the weapon panel list and drag event handling

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/unitDisplay/WeaponListModel.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitDisplay/WeaponListModel.java
@@ -132,6 +132,9 @@ class WeaponListModel extends AbstractListModel<String> {
     }
 
     public WeaponMounted getWeaponAt(int index) {
+        if (index < 0 || index >= weapons.size()) {
+            return null;
+        }
         return weapons.get(index);
     }
 

--- a/megamek/src/megamek/client/ui/dialogs/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitDisplay/WeaponPanel.java
@@ -135,34 +135,47 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         public void mouseDragged(MouseEvent e) {
             removeListeners();
 
-            Object src = e.getSource();
-            // Check to see if we are in a state we care about
-            if (!mouseDragging || !(src instanceof JList<?> srcList)) {
-                return;
-            }
-            WeaponListModel srcModel = (WeaponListModel) srcList.getModel();
-            int currentIndex = srcList.locationToIndex(e.getPoint());
-            if (currentIndex != dragSourceIndex) {
-                int dragTargetIndex = srcList.getSelectedIndex();
-                WeaponMounted weaponAt = srcModel.getWeaponAt(dragSourceIndex);
-                srcModel.swapIdx(dragSourceIndex, dragTargetIndex);
-                dragSourceIndex = currentIndex;
-                Entity ent = weaponAt.getEntity();
-
-                // If this is a Custom Sort Order, update the weapon sort order drop down
-                if (!Objects.requireNonNull(comboWeaponSortOrder.getSelectedItem()).isCustom()) {
-                    // Set the order to custom
-                    ent.setWeaponSortOrder(WeaponSortOrder.CUSTOM);
-                    comboWeaponSortOrder.setSelectedItem(WeaponSortOrder.CUSTOM);
+            try {
+                Object src = e.getSource();
+                // Check to see if we are in a state we care about
+                if (!mouseDragging || !(src instanceof JList<?> srcList)) {
+                    return;
                 }
+                WeaponListModel srcModel = (WeaponListModel) srcList.getModel();
+                int currentIndex = srcList.locationToIndex(e.getPoint());
+                if (currentIndex != dragSourceIndex) {
+                    int dragTargetIndex = srcList.getSelectedIndex();
+                    WeaponMounted weaponAt = srcModel.getWeaponAt(dragSourceIndex);
 
-                // Update custom order
-                for (int i = 0; i < srcModel.getSize(); i++) {
-                    WeaponMounted m = srcModel.getWeaponAt(i);
-                    ent.setCustomWeaponOrder(m, i);
+                    if (weaponAt == null) {
+                        // Somehow we found no weapon there.
+                        return;
+                    }
+
+                    srcModel.swapIdx(dragSourceIndex, dragTargetIndex);
+                    dragSourceIndex = currentIndex;
+                    Entity ent = weaponAt.getEntity();
+
+                    // If this is a Custom Sort Order, update the weapon sort order drop down
+                    if (!Objects.requireNonNull(comboWeaponSortOrder.getSelectedItem()).isCustom()) {
+                        // Set the order to custom
+                        ent.setWeaponSortOrder(WeaponSortOrder.CUSTOM);
+                        comboWeaponSortOrder.setSelectedItem(WeaponSortOrder.CUSTOM);
+                    }
+
+                    // Update custom order
+                    for (int i = 0; i < srcModel.getSize(); i++) {
+                        WeaponMounted m = srcModel.getWeaponAt(i);
+                        ent.setCustomWeaponOrder(m, i);
+                    }
                 }
+            } catch (Exception ex) {
+                logger.error("Unable to handle unexpected drag event: {}", e.toString());
+
+            } finally {
+                // Return listeners before returning!
+                addListeners();
             }
-            addListeners();
         }
     }
 


### PR DESCRIPTION
Although we've been unable to replicate the original issue, probably due to lack of sufficient numbers of client machines to generate appropriate mid-GUI-interaction interrupts, the logs show that this issue was caused by an unhandled null value when getting the currently selected item in the weapons panel.

So we will watch out for that.

We will also stop _turning off the listeners for the weapons panel completely and forgetting to turn them back on_, as that causes a suboptimal user experience.
It's also bad.

So we'll watch out for that, too.

Testing:
- Many attempts to repro the original issue
- Ran all 3 projects' unit tests

Fix #7515 