### PR TITLE
Adding override to Streak LRMs to prevent indirect mode

### DIFF
--- a/megamek/src/megamek/common/weapons/lrms/StreakLRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/StreakLRMWeapon.java
@@ -52,7 +52,6 @@ import megamek.common.equipment.Mounted;
 import megamek.common.game.Game;
 import megamek.common.loaders.EntityLoadingException;
 import megamek.common.options.IGameOptions;
-import megamek.common.options.OptionsConstants;
 import megamek.common.units.Entity;
 import megamek.common.weapons.handlers.AttackHandler;
 import megamek.common.weapons.handlers.lrm.StreakLRMHandler;
@@ -91,7 +90,7 @@ public abstract class StreakLRMWeapon extends LRMWeapon {
 
     @Override
     // Streak LRMs could end up with an Indirect mode as a result of this game option selection. Overriding to 
-    // prevent this.
+    // prevent this. Bug report #7618
     public void adaptToGameOptions(IGameOptions gameOptions) {
         super.adaptToGameOptions(gameOptions);
 


### PR DESCRIPTION
Streak LRMs could select indirect mode (but the ammo would prevent usage). This adds an override of the LRM class that added the indirect mode, and runs a removal of it to be sure, as clearing the modes in the constructor did not prevent it getting added later.