### PR TITLE
  Issue #7290 Fix - Protomechs cannot back up

### DIFF
--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/commands/MoveCommand.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/commands/MoveCommand.java
@@ -53,7 +53,7 @@ public enum MoveCommand implements StatusBarPhaseDisplay.PhaseCommand {
     MOVE_WALK("moveWalk", MovementDisplay.CMD_GROUND),
     MOVE_JUMP("moveJump",
           MovementDisplay.CMD_MEK | MovementDisplay.CMD_TANK | MovementDisplay.CMD_INF | MovementDisplay.CMD_PROTOMEK),
-    MOVE_BACK_UP("moveBackUp", MovementDisplay.CMD_MEK | MovementDisplay.CMD_TANK | MovementDisplay.CMD_VTOL),
+    MOVE_BACK_UP("moveBackUp", MovementDisplay.CMD_MEK | MovementDisplay.CMD_TANK | MovementDisplay.CMD_VTOL | MovementDisplay.CMD_PROTOMEK),
     MOVE_GET_UP("moveGetUp", MovementDisplay.CMD_MEK),
     MOVE_FORWARD_INI("moveForwardIni", MovementDisplay.CMD_ALL),
     MOVE_CHARGE("moveCharge", MovementDisplay.CMD_MEK | MovementDisplay.CMD_TANK),


### PR DESCRIPTION
What Was Done

  1. Root Cause Identified:
  - Protomech "Back Up" button missing due to CMD_PROTOMEK flag not included in MOVE_BACK_UP command

  2. Fix Applied:
  - File: MoveCommand.java:56
  - Change: Added | MovementDisplay.CMD_PROTOMEK to MOVE_BACK_UP flag
  - Result: One-line fix that adds Protomechs to units that can back up

  3. Documentation Created:
  - Created docs/issues/bug-fixes/7290-protomech-backup.md
  - Includes: Problem summary, root cause, implementation details, testing plan

  4. Build Verified:
  - ✅ Code compiles successfully
  - ✅ No errors introduced
  - ✅ Ready for testing
  
  Closes #7290