### PR TITLE
Issue #7382 - Fixes Submarines can move when at the seafloor

### DIFF
--- a/megamek/src/megamek/common/moves/MoveStep.java
+++ b/megamek/src/megamek/common/moves/MoveStep.java
@@ -2038,6 +2038,8 @@ public class MoveStep implements Serializable {
                 if ((getEntity().getMovementMode() == EntityMovementMode.VTOL ||
                       getEntity().getMovementMode() == EntityMovementMode.WIGE) && getClearance() > 0) {
                     movementType = EntityMovementType.MOVE_VTOL_WALK;
+                } else if ((getEntity().getMovementMode() == EntityMovementMode.SUBMARINE) && getElevation() < 0) {
+                    movementType = EntityMovementType.MOVE_SUBMARINE_WALK;
                 } else {
                     movementType = EntityMovementType.MOVE_WALK;
                     // Vehicles moving along pavement get "road bonus" of 1 MP.
@@ -2080,6 +2082,8 @@ public class MoveStep implements Serializable {
                 if ((entity.getMovementMode() == EntityMovementMode.VTOL ||
                       entity.getMovementMode() == EntityMovementMode.WIGE) && getClearance() > 0) {
                     movementType = EntityMovementType.MOVE_VTOL_RUN;
+                } else if ((entity.getMovementMode() == EntityMovementMode.SUBMARINE) && getElevation() < 0) {
+                    movementType = EntityMovementType.MOVE_SUBMARINE_RUN;
                 } else {
                     movementType = EntityMovementType.MOVE_RUN;
                 }
@@ -2102,6 +2106,16 @@ public class MoveStep implements Serializable {
                 } else {
                     movementType = EntityMovementType.MOVE_SPRINT;
                 }
+            }
+        }
+
+        // Submarines at seafloor cannot move horizontally or change facing (TW p.56)
+        // They can only ascend vertically
+        if (entity.getMovementMode() == EntityMovementMode.SUBMARINE) {
+            final Hex prevHex = game.getBoard(boardId).getHex(prev.getPosition());
+            if ((prev.getElevation() == -prevHex.depth()) && (type != MoveStepType.UP)) {
+                movementType = EntityMovementType.MOVE_ILLEGAL;
+                return;
             }
         }
 


### PR DESCRIPTION
  Summary for fixes #7382

  Part 1: Submarine Movement Type Assignment
  - ✅ Added submarine movement type checks to WALK and RUN sections
  - ✅ Submarines now display depth indicators ({-1}, {-2}) in UI
  - ✅ Foundation established for depth-based restrictions
  - ✅ Tested and validated (Tests 1-3)

  Part 2: Seafloor Movement Restriction
  - ✅ Added seafloor immobilization check (TW p.56)
  - ✅ Blocks horizontal movement at seafloor
  - ✅ Blocks facing changes at seafloor
  - ✅ Allows vertical ascent from seafloor
  - ✅ Works across all water depths (depth-1, depth-2, depth-3+)
  - ✅ Tested and validated (Tests 4-8)

  Bug Fixed During Testing:
  - Initial implementation checked destination instead of origin
  - Fixed to use prev.getPosition() and prev.getElevation()
  - Now correctly prevents movement from seafloor

  Files Changed

  1. MoveStep.java (lines 2041-2042, 2085-2086, 2112-2119)
    - Part 1: Submarine movement type assignment
    - Part 2: Seafloor movement restriction check
  2. 7382-submarine-seafloor-movement.md
    - Complete issue documentation with implementation details, test results, and notes