### PR TITLE
Fix 7612: Non-DS ASFs landing too softly when terrain isn't causing them to crash

### DIFF
--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -5252,8 +5252,8 @@ public class TWGameManager extends AbstractGameManager {
                     // destruction (of DropShips and larger) is assured.
                     // Reasons: crew incapacitated, ship shut down, engines destroyed prior to this turn.
                     destroyDropShip = true;
-                    canCrashLand = false;
                 }
+                canCrashLand = false;
             }
 
             // 2. Check if there is space available to land; if not, they will crash
@@ -5267,9 +5267,6 @@ public class TWGameManager extends AbstractGameManager {
             // Also update 'c' to represent final position.
             entity.setPosition(finalPosition, true);
             c = finalPosition;
-
-            // Technically bring to a halt; actual landing is handled above.
-            ((IAero) entity).land();
 
             // Check if still on board
             if (board.contains(c) && board.contains(finalPosition)) {
@@ -5351,10 +5348,14 @@ public class TWGameManager extends AbstractGameManager {
                 }
             }
         }
+
         // Units with velocity zero are treated like that had velocity two
         if (vel < 1) {
             vel = 2;
         }
+
+        // Technically bring to a halt; actual landing is handled above.
+        ((IAero) entity).land();
 
         // deal crash damage only once; if entity already crash-landed, don't damage it again.
         boolean damageDealt = crashLanded;


### PR DESCRIPTION
This patch:
- Moves `land()` call later so that it doesn't mess with the OOC check; 
- disables crash "landing" for non-DS ASFs that are missing conscious crew, power source, or sufficient thrust.

At some point the call to `land()` the affected ASF got moved above the check for OOC; since `land()` sets OOC to `false`, this was letting ASFs avoid a lot of crashes on terrain that allowed for soft landing.

Testing:
- Ran existing unit tests
- Shot down so many ASFs and DropShips

Fix MegaMek#7612