### PR TITLE
Allow two modular armor in the same location if they have different facing

### DIFF
--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -1797,7 +1797,7 @@ public abstract class TestEntity implements TestEntityOption {
         for (var loc : modArmorByLocation.keySet()) {
             if (modArmorByLocation.get(loc) > 1) {
                 buff.append("Only one modular armor slot may be mounted in a single location (")
-                      .append(getEntity().getLocationName(loc.getLeft())).append(loc.getRight() ?  " (R))" : ")").append('\n');
+                      .append(getEntity().getLocationName(loc.getLeft())).append(loc.getRight() ? " (R))" : ")").append('\n');
                 illegal = true;
             }
         }


### PR DESCRIPTION
Normally you can't have two modular armors in one location, but on mek torso locations, you can have one mod armor for the front and one for the rear.

Ruling: https://battletech.com/forums/index.php?topic=89727.0

Fixes MegaMek/megameklab#2058