### PR TITLE
Allow setting an entity's game to null

### DIFF
--- a/megamek/src/megamek/common/units/Entity.java
+++ b/megamek/src/megamek/common/units/Entity.java
@@ -1128,7 +1128,7 @@ public abstract class Entity extends TurnOrdered
         this.game = game;
         restore();
         // Make sure the owner is set.
-        if (null == owner) {
+        if (game != null && owner == null) {
             if (Entity.NONE == ownerId) {
                 throw new IllegalStateException("Entity doesn't know its owner's ID.");
             }


### PR DESCRIPTION
Currently the `setGame` method NPEs if the game is null, but it's possible to intentionally want to unset an entity's game. Fixes MegaMek/megameklab#2069.