### PR TITLE
Task: Added Portrait Compatibility Handler for Removal of Combat Technician/Engineer

### DIFF
--- a/megamek/src/megamek/common/icons/AbstractIcon.java
+++ b/megamek/src/megamek/common/icons/AbstractIcon.java
@@ -254,7 +254,8 @@ public abstract class AbstractIcon implements Serializable {
                 category = category.replace("Vehicle Driver", "Vehicle Crew Ground");
                 category = category.replace("Naval Driver", "Vehicle Crew Naval");
                 category = category.replace("VTOL Pilot", "Vehicle Crew VTOL");
-                category = category.replace("Vehicle Crewmember", "Combat Technician");
+                category = category.replace("Vehicle Crewmember", "Vehicle Crew/Generic");
+                category = category.replace("Combat Technician", "Vehicle Crew/Generic");
                 category = category.replace("Conventional Aircraft Pilot", "Conventional Aircraft Crew");
 
                 setCategory(category);


### PR DESCRIPTION
Required by [Improvement: Removed the Combat Technician/Engineer Profession](https://github.com/MegaMek/mekhq/pull/8225)