### PR TITLE
ACAR complex force structure handling

### DIFF
--- a/megamek/src/megamek/common/autoResolve/converter/SingletonForces.java
+++ b/megamek/src/megamek/common/autoResolve/converter/SingletonForces.java
@@ -71,9 +71,8 @@ public class SingletonForces extends ForceConsolidation {
 
     private static int transformIntoTopLevelForce(IGame game, Force force, Force subForce,
           ArrayList<Container> newTopLevelForces, int forceId, int team) {
-        var hasNoSubForce = subForce.subForceCount() == 0;
         var hasEntities = subForce.entityCount() > 0;
-        if (hasNoSubForce && hasEntities) {
+        if (hasEntities) {
             for (var entityId : subForce.getEntities()) {
                 var optionalEntity = game.getInGameObject(entityId);
                 if (optionalEntity.isPresent() && optionalEntity.get() instanceof Entity entity) {


### PR DESCRIPTION
Fixes https://github.com/MegaMek/mekhq/issues/8121

Previously, units that were in forces that had subforces were being ignored in ACAR simulations. This fix should rectify that.