### PR TITLE
Fix for MHQ 8240: move GAME_LOCK.lock/.unlock deeper into stack to tighten coverage

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -233,8 +233,6 @@ public class Server implements Runnable {
          */
         @Override
         public void disconnected(DisconnectedEvent e) {
-            // Only do this if nobody is trying to save a game currently
-            GAME_LOCK.lock();
             AbstractConnection conn = e.getConnection();
 
             // write something in the log
@@ -256,7 +254,6 @@ public class Server implements Runnable {
             if (null != player) {
                 Server.this.disconnected(player);
             }
-            GAME_LOCK.unlock();
         }
 
         @Override
@@ -879,7 +876,10 @@ public class Server implements Runnable {
      * appropriate housekeeping.
      */
     void disconnected(Player player) {
+        // Only do this if nobody is trying to save a game currently
+        GAME_LOCK.lock();
         gameManager.disconnect(player);
+        GAME_LOCK.unlock();
     }
 
     public void resetGame() {

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -878,8 +878,11 @@ public class Server implements Runnable {
     void disconnected(Player player) {
         // Only do this if nobody is trying to save a game currently
         GAME_LOCK.lock();
-        gameManager.disconnect(player);
-        GAME_LOCK.unlock();
+        try {
+            gameManager.disconnect(player);
+        } finally {
+            GAME_LOCK.unlock();
+        }
     }
 
     public void resetGame() {


### PR DESCRIPTION
MegaMek/MekHQ#8240 reports a deadlock during PACAR scenario completion, where one Connection enters Server to execute the disconnection of one bot client _simultaneously_ with another Connection attempting to rebroadcast that bot client's sign-off Chat message but discovering that the connection has been closed remotely.

This PR moves the GAME_LOCK lock handling much deeper into the `disconnected(e)` call stack, where hopefully the simultaneous disconnection handling will not collide.

NOTE:
This was always possible, but much harder to repro, because both of these paths cross through several `synchronized` functions, in different orders, meaning deadlocks were always at least conceivably possible.
The new GAME_LOCK lock just made it much easier to hit.
Unfortunately, completely removing the chance of deadlocks probably requires moving a lot of the `.close()` calls in Connection out to ConnectionHandler and making them scheduled rather than immediately calling `.close()` when a disconnected Connection is discovered.

Testing:
- Reran OP's repro multiple times without seeing the deadlock behavior.
- Ran all 3 projects' unit tests.

Fix MegaMek/MekHQ#8240