### PR TITLE
Fixes #7134 - Default skin selection correction in client settings.

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialog.java
@@ -2373,9 +2373,9 @@ public class CommonSettingsDialog extends AbstractButtonDialog
             xmlFiles.addAll(filteredFiles(internalUserDataDir, ".xml"));
             xmlFiles.removeIf(file -> !SkinXMLHandler.validSkinSpecFile(file));
             Collections.sort(xmlFiles);
-            var model = new DefaultComboBoxModel<>(xmlFiles.toArray(new String[0]));
+            ComboBoxModel<String> model = new DefaultComboBoxModel<>(xmlFiles.toArray(new String[0]));
+            model.setSelectedItem(GUIP.getSkinFile());
             skinFiles.setModel(model);
-            skinFiles.setSelectedItem(GUIP.getSkinFile());
 
             uiThemes.removeAllItems();
             for (LookAndFeelInfo lafInfo : UIManager.getInstalledLookAndFeels()) {


### PR DESCRIPTION
The default skin was not being set on the skin selector combo box in the client settings.  

This was fixed by setting the default selected skin on the combo box model instead of the combo box itself.

Fixes #7134 