### PR TITLE
Task: De-escalated Error Level of Incorrect Flag Check

### DIFF
--- a/megamek/src/megamek/common/equipment/WeaponType.java
+++ b/megamek/src/megamek/common/equipment/WeaponType.java
@@ -821,7 +821,7 @@ public class WeaponType extends EquipmentType {
         if (flag instanceof WeaponTypeFlag) {
             return super.hasFlag(flag);
         } else {
-            LOGGER.warn("Incorrect flag check: tested {} instead of WeaponTypeFlag",
+            LOGGER.debug("Incorrect flag check: tested {} instead of WeaponTypeFlag",
                   flag.getClass().getSimpleName(),
                   new Throwable("Incorrect flag tested " + flag.getClass().getSimpleName() + " instead of " +
                         "WeaponTypeFlag"));


### PR DESCRIPTION
We've been seeing a decent amount of user contact regarding incorrect flag checks. As these are benign errors I got permission from Hammer to de-escalate them from WARN to debug. This means the logs are still there in case anyone shows an interest in this, but they're not spamming up user logs and leading to contact.