### PR TITLE
Fix Issue MegaMek/mekhq#7948: Trailers with equipment that requires crew should be considered crewed

### DIFF
--- a/megamek/src/megamek/common/units/Tank.java
+++ b/megamek/src/megamek/common/units/Tank.java
@@ -243,7 +243,10 @@ public class Tank extends Entity {
     @Override
     public CrewType defaultCrewType() {
         // A tank that is a trailer, has no weapon list, and has no engine does not need any crew.
-        if (isTrailer() && getWeaponList().isEmpty() && (getEngineType() == Engine.NONE)) {
+        if (isTrailer()
+              && getWeaponList().isEmpty()
+              && (getEngineType() == Engine.NONE)
+              && Compute.getAdditionalNonGunner(this) == 0) {
             return CrewType.NONE;
         }
         return CrewType.CREW;


### PR DESCRIPTION
Fixes MegaMek/mekhq#7948

Certain equipment, like a MASH Theater, Comms Equipment, Mobile Field Bases, or Field Kitchens require additional crews. An unmanned trailer cannot be considered unmanned if it needs this crew (or has extra crew seats manually added).

Notably, if it's no longer considered uncrewed, per the rules the unit needs a driver, so stuff like the Hector Road Train (Passenger) now have a driver requirement (and an extra crew member for being an SV with more than 6 crew).