### PR TITLE
Fix ARAD equipment detector flag type checking

### DIFF
--- a/megamek/src/megamek/common/units/Tank.java
+++ b/megamek/src/megamek/common/units/Tank.java
@@ -243,7 +243,10 @@ public class Tank extends Entity {
     @Override
     public CrewType defaultCrewType() {
         // A tank that is a trailer, has no weapon list, and has no engine does not need any crew.
-        if (isTrailer() && getWeaponList().isEmpty() && (getEngineType() == Engine.NONE)) {
+        if (isTrailer()
+              && getWeaponList().isEmpty()
+              && (getEngineType() == Engine.NONE)
+              && Compute.getAdditionalNonGunner(this) == 0) {
             return CrewType.NONE;
         }
         return CrewType.CREW;

--- a/megamek/src/megamek/common/weapons/handlers/capitalMissile/CapitalMissileBearingsOnlyHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/capitalMissile/CapitalMissileBearingsOnlyHandler.java
@@ -213,6 +213,7 @@ public class CapitalMissileBearingsOnlyHandler extends AmmoBayWeaponHandler {
 
         // This has to be up here so that we don't screw up glancing/direct blow reports
         attackValue = calcAttackValue();
+        nDamPerHit = attackValue;
 
         // CalcAttackValue triggers counterfire, so now we can safely get this
         CapMissileAMSMod = getCapMissileAMSMod();


### PR DESCRIPTION
  Root cause: ARADEquipmentDetector was calling hasFlag() with MiscTypeFlag
  constants on generic EquipmentType objects. When the equipment was AmmoType,
  it triggered type checking warnings and returned false instead of properly
  checking flags.

  The warning was logged every time ARAD missiles checked equipment on units
  carrying ammunition, causing log spam:
  "Incorrect flag check: tested MiscTypeFlag instead of AmmoTypeFlag"

  Fix: Add instanceof MiscType checks before all hasFlag() calls using Java 16
  pattern matching. This prevents type mismatch warnings and follows the
  standard pattern used throughout the codebase (TWGameManager, SystemPanel).

  Affected methods (6 total):
  - hasActiveProbe() - Line 133
  - hasArtemis() - Lines 150-152
  - hasBlueShield() - Line 171
  - hasC3() - Lines 208-212
  - hasHeavyComms() - Line 238
  - hasECM() - Line 272

  Pattern used (Java 16):
    if (equipment.getType() instanceof MiscType miscType && miscType.hasFlag(MiscType.F_ECM) && ...)

  This modernizes the code while fixing the functional bug. The fix eliminates
  warning spam and sets a good precedent for using Java 16 pattern matching
  in future code (per docs/java-17-best-practices.md).

  Functional impact: None - ammunition never has MiscType equipment, so the
  incorrect false returns were coincidentally correct. This fix eliminates
  warnings and improves code quality.