### PR TITLE
Fix #7666: Restored Missing Whitespace Causing Glancing Blow Reports to Break

### DIFF
--- a/megamek/resources/megamek/common/report-messages.properties
+++ b/megamek/resources/megamek/common/report-messages.properties
@@ -377,11 +377,13 @@
 3181=Succeeds.
 3182=fails, subjecting the unit to particle feedback!
 3185=<newline>    (continuing hit report):
-3186=\ - Glancing Blow -\
+# This trailing white space is important and shouldn't be removed
+3186=\ - Glancing Blow -\u0020
 9985=\ - Glancing Blow due to Narrow/Low Profile -
 3187=does nothing (didn't target a unit).
 3188=<span class='success'><B>hits</B></span>, target tagged.
-3189=\ - Direct Blow -\
+# This trailing white space is important and shouldn't be removed
+3189=\ - Direct Blow -\u0020
 3190=<span class='success'><B>hits</B></span> the intended hex <data>.
 3191=<span class='success'><B>hits</B></span> the target in hex <data> with FLAK rounds.
 3192=<span class='miss'><B>misses</B></span> and the FLAK rounds scatter to hex <data>.


### PR DESCRIPTION
Fix #7666

Sometimes a trailing white space is deliberate. It turns out this was one of those cases 