### PR TITLE
Enforce min 5mp requirement for WiGEs

### DIFF
--- a/megamek/src/megamek/common/verifier/TestTank.java
+++ b/megamek/src/megamek/common/verifier/TestTank.java
@@ -400,7 +400,7 @@ public class TestTank extends TestEntity {
         }
 
         if (tank.getMovementMode() == EntityMovementMode.WIGE) {
-            if (tank.getOriginalWalkMP() < 5) {
+            if (tank.getWalkMP() < 5) {
                 buff.append("WiGE must have at least 5 Cruise MP.\n");
                 correct = false;
             }


### PR DESCRIPTION
It is illegal to construct a WiGE with fewer than 5 cruise mp.