### PR TITLE
Improvement: Added Two New Utility Methods to Reduce Potential Mistakes When Comparing Planetary Tech Levels

### DIFF
--- a/megamek/src/megamek/common/enums/TechRating.java
+++ b/megamek/src/megamek/common/enums/TechRating.java
@@ -72,6 +72,9 @@ public enum TechRating {
      * <p>The comparison is based on the internal {@code index} value; a larger index indicates a more advanced
      * rating.</p>
      *
+     * <p><b>Warning:</b> Do not use when comparing planetary tech levels. Use
+     * {@link #isPlanetaryTechLevelBetterThan(TechRating)} instead.</p>
+     *
      * @param other the {@link TechRating} to compare against
      *
      * @return {@code true} if this rating is strictly higher than {@code other}
@@ -87,6 +90,9 @@ public enum TechRating {
      * <p>The comparison is based on the internal {@code index} value; a larger or equal index indicates an
      * equivalent or more advanced rating.</p>
      *
+     * <p><b>Warning:</b> Do not use when comparing planetary tech levels. Use
+     * {@link #isPlanetaryTechLevelBetterOrEqualThan(TechRating)} instead.</p>
+     *
      * @param other the {@link TechRating} to compare against
      * @return {@code true} if this rating is greater than or equal to {@code other}
      */
@@ -100,6 +106,9 @@ public enum TechRating {
      *
      * <p><b>Note:</b> Planetary tech levels use an inverted scale compared to normal tech ratings — a <b>lower</b>
      * internal {@code index} indicates a more advanced planetary tech level.</p>
+     *
+     * <p><b>Warning:</b> Do not use when comparing equipment tech levels. Use {@link #isBetterThan(TechRating)}
+     * instead.</p>
      *
      * @param other the {@link TechRating} to compare against
      *
@@ -119,6 +128,9 @@ public enum TechRating {
      *
      * <p><b>Note:</b> Planetary tech levels use an inverted scale compared to normal tech ratings — a <b>lower</b>
      * internal {@code index} indicates a more advanced planetary tech level.</p>
+     *
+     * <p><b>Warning:</b> Do not use when comparing equipment tech levels. Use
+     * {@link #isBetterOrEqualThan(TechRating)} instead.</p>
      *
      * @param other the {@link TechRating} to compare against
      *


### PR DESCRIPTION
## Required by [Fix: Fixed Availability of Prosthetics Based on Planetary Tech Level](https://github.com/MegaMek/mekhq/pull/8362)

The planetary tech level scale is inverted (F->A) instead of the scale used by normal parts and units (A->F). That means the existing comparisons were not suitable when comparing planetary tech levels. This recently caused a bug to enter MekHQ due to the non-obvious nature of this inversion.

This PR adds two new utility methods explicitly for use when comparing planetary tech levels. It also added extensive JavaDocs to further reduce room for error.