### PR TITLE
Fix ammo combo box becoming unresponsive in weapon panel

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitDisplay/WeaponPanel.java
@@ -1392,8 +1392,9 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
      */
     private void displaySelected() {
         removeListeners();
-        // short circuit if not selected
-        if (weaponList.getSelectedIndex() == -1) {
+        try {
+            // short circuit if not selected
+            if (weaponList.getSelectedIndex() == -1) {
             ((DefaultComboBoxModel<String>) m_chAmmo.getModel())
                   .removeAllElements();
             m_chAmmo.setEnabled(false);
@@ -1989,7 +1990,9 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         unitDisplayPanel.getClientGUI().showSensorRanges(entity);
         unitDisplayPanel.processMekDisplayEvent(new MekDisplayEvent(this, entity, mounted));
         onResize();
-        addListeners();
+        } finally {
+            addListeners();
+        }
     }
 
     private String formatAmmo(Mounted<?> m) {


### PR DESCRIPTION
  Fixes #7680

  Root cause: In displaySelected(), removeListeners() was called at the
  start but the early return path (when no weapon is selected) did not
  call addListeners(). This caused the listenerCounter to become negative,
  permanently disabling the ammo combo box ActionListener.

  This bug was introduced in commit 6acd3f3c1c5 (Aug 2015) when listener
  management was added to fix bug #4591, but the early return was not
  updated. The same pattern was fixed in mouseDragged() in commit
  a570613ee1 (Nov 2025) but displaySelected() was missed.

  Fix: Wrap method body in try/finally to ensure addListeners() is always
  called, matching the pattern used in mouseDragged().

  Testing:
  - gradlew compileJava: PASSED
  - gradlew test: PASSED (9 tasks, BUILD SUCCESSFUL)
  - Manual testing: Ammo switching works after weapon reordering
  
  Details on Manual Testing. 
    1. Build and run MegaMek with the fix
  2. Start a new game or load a save with a unit that has multiple ballistic weapons with switchable ammo (e.g., a
  Mech with both Gauss Rifle and LB 10-X AC)

  Test Case 1: Basic Ammo Switching  (PASSED)

  1. Enter the Firing Phase
  2. Select the second weapon in the list (e.g., LB 10-X)
  3. Click on the ammo dropdown and select different ammo (e.g., switch from Cluster to Slug)
  4. Expected: Ammo actually changes (verify by looking at the weapon info or firing)

  Test Case 2: Reproduce Original Bug Scenario (PASSED)

  1. In Firing Phase, select first weapon (Gauss)
  2. Reorder weapons by dragging Gauss below LB 10-X
  3. Select the LB 10-X (now first)
  4. Try to change its ammo
  5. Expected: Ammo combo responds to clicks and changes ammo

  Test Case 3: Unit Switching (PASSED)

  1. Have multiple units in the game
  2. Select Unit A, select a weapon, note ammo
  3. Switch to Unit B
  4. Switch back to Unit A
  5. Try to change ammo on the weapon
  6. Expected: Ammo combo still works

  Test Case 4: Edge Case - No Weapon Selected (PASSED)

  1. If possible, get into a state where no weapon is selected
  2. Select a weapon
  3. Try to change ammo
  4. Expected: Ammo combo works normally


  🤖 Generated with [Claude Code](https://claude.com/claude-code)

  Co-Authored-By: Claude <noreply@anthropic.com>