### PR TITLE
 Fix crippling damage rules per TW Errata v11.01

### DIFF
--- a/megamek/src/megamek/common/units/LargeSupportTank.java
+++ b/megamek/src/megamek/common/units/LargeSupportTank.java
@@ -391,9 +391,6 @@ public class LargeSupportTank extends SupportTank {
         } else if ((getArmor(LOC_REAR) < 1) && (getOArmor(LOC_REAR) > 0)) {
             LOGGER.debug("{} CRIPPLED: Rear armor destroyed.", getDisplayName());
             return true;
-        } else if (isPermanentlyImmobilized(checkCrew)) {
-            LOGGER.debug("{} CRIPPLED: Immobilized.", getDisplayName());
-            return true;
         }
 
         // If this is not a military vehicle, we don't need to do a weapon check.

--- a/megamek/src/megamek/common/units/Mek.java
+++ b/megamek/src/megamek/common/units/Mek.java
@@ -5862,11 +5862,6 @@ public abstract class Mek extends Entity {
             return true;
         }
 
-        if (isPermanentlyImmobilized(checkCrew)) {
-            LOGGER.debug("{} CRIPPLED: Immobilized.", getDisplayName());
-            return true;
-        }
-
         // If this is not a military unit, we don't care about weapon status.
         if (!isMilitary()) {
             return false;

--- a/megamek/src/megamek/common/units/SuperHeavyTank.java
+++ b/megamek/src/megamek/common/units/SuperHeavyTank.java
@@ -439,9 +439,6 @@ public class SuperHeavyTank extends Tank {
         } else if ((getArmor(LOC_REAR) < 1) && (getOArmor(LOC_REAR) > 0)) {
             logger.debug("{} CRIPPLED: Rear armor destroyed.", getDisplayName());
             return true;
-        } else if (isPermanentlyImmobilized(checkCrew)) {
-            logger.debug("{} CRIPPLED: Immobilized.", getDisplayName());
-            return true;
         }
 
         // If this is not a military vehicle, we don't need to do a weapon check.

--- a/megamek/src/megamek/common/units/Tank.java
+++ b/megamek/src/megamek/common/units/Tank.java
@@ -2658,9 +2658,6 @@ public class Tank extends Entity {
         } else if ((getArmor(LOC_REAR) < 1) && (getOArmor(LOC_REAR) > 0)) {
             logger.debug("{} CRIPPLED: Rear armor destroyed.", getDisplayName());
             return true;
-        } else if (isPermanentlyImmobilized(checkCrew)) {
-            logger.debug("{} CRIPPLED: Immobilized.", getDisplayName());
-            return true;
         }
 
         // If this is not a military vehicle, we don't need to do a weapon

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -776,7 +776,8 @@ class PrincessTest {
         tank.setCrew(crew);
         crew.setDead(true);
         assertTrue(tank.isPermanentlyImmobilized(true));
-        assertTrue(tank.isCrippled());
+        // Per TW Errata v11.01 p.54, immobilized units are NOT automatically crippled
+        assertFalse(tank.isCrippled());
         assertFalse(tank.isShutDown());
         assertFalse(tank.isDoomed());
         assertTrue(mockPrincess.shouldAbandon(tank));
@@ -791,7 +792,8 @@ class PrincessTest {
         tank.setOriginalWalkMP(4);
         tank.setMotiveDamage(4);
         assertTrue(tank.isPermanentlyImmobilized(true));
-        assertTrue(tank.isCrippled());
+        // Per TW Errata v11.01 p.54, immobilized units are NOT automatically crippled
+        assertFalse(tank.isCrippled());
         assertFalse(tank.isShutDown());
         assertFalse(tank.isDoomed());
         assertTrue(mockPrincess.shouldAbandon(tank));
@@ -829,7 +831,8 @@ class PrincessTest {
         vtol.setCrew(crew);
 
         assertTrue(vtol.isPermanentlyImmobilized(true));
-        assertTrue(vtol.isCrippled());
+        // Per TW Errata v11.01 p.54, immobilized units are NOT automatically crippled
+        assertFalse(vtol.isCrippled());
         assertFalse(vtol.isShutDown());
         assertFalse(vtol.isDoomed());
         assertTrue(mockPrincess.shouldAbandon(vtol));


### PR DESCRIPTION
  Body:
  Fixes #7410

  Per Total Warfare Errata v11.01 p.54, the rule that immobilized vehicles
  and 'Mechs are automatically crippled was deleted.

  Root cause: The isCrippled() methods in Mek, Tank, SuperHeavyTank, and
  LargeSupportTank all checked isPermanentlyImmobilized() and returned
  true (crippled) if the unit was immobilized.

  Fix: Removed the isPermanentlyImmobilized() checks from all four unit
  classes. Immobilized units are no longer automatically considered
  crippled - they must meet other crippling criteria (destroyed locations,
  weapon loss, etc.) to be crippled.

  Updated PrincessTest assertions to reflect the corrected behavior.

  ---
  Files Changed:
  - megamek/src/megamek/common/units/Mek.java
  - megamek/src/megamek/common/units/Tank.java
  - megamek/src/megamek/common/units/SuperHeavyTank.java
  - megamek/src/megamek/common/units/LargeSupportTank.java
  - megamek/unittests/megamek/client/bot/princess/PrincessTest.java