### PR TITLE
Fix #7691: Fixed Incorrect Rounding of Direct Blow Additional Damage

### DIFF
--- a/megamek/src/megamek/common/weapons/handlers/AmmoBayWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/AmmoBayWeaponHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 
 import megamek.common.RangeType;
@@ -129,7 +131,7 @@ public class AmmoBayWeaponHandler extends BayWeaponHandler {
             }
         }
         if (bDirect) {
-            av = Math.min(av + (toHit.getMoS() / 3.0), av * 2);
+            av = Math.min(av + (int) floor(toHit.getMoS() / 3.0), av * 2);
         }
         av = applyGlancingBlowModifier(av, false);
         av = (int) Math.floor(getBracketingMultiplier() * av);

--- a/megamek/src/megamek/common/weapons/handlers/BayWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/BayWeaponHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 import java.util.Vector;
 
@@ -102,7 +104,7 @@ public class BayWeaponHandler extends WeaponHandler {
             }
         }
         if (bDirect) {
-            av = Math.min(av + (toHit.getMoS() / 3.0), av * 2);
+            av = Math.min(av + (int) floor(toHit.getMoS() / 3.0), av * 2);
         }
         av = applyGlancingBlowModifier(av, false);
         av = (int) Math.floor(getBracketingMultiplier() * av);

--- a/megamek/src/megamek/common/weapons/handlers/ChemicalLaserHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/ChemicalLaserHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 
 import megamek.common.HitData;
@@ -102,7 +104,7 @@ public class ChemicalLaserHandler extends AmmoWeaponHandler {
                   ((Infantry) target).isMechanized(),
                   toHit.getThruBldg() != null, attackingEntity.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0), toReturn * 2);
+            toReturn = Math.min(toReturn + (int) floor(toHit.getMoS() / 3.0), toReturn * 2);
         }
 
         toReturn = applyGlancingBlowModifier(toReturn, target.isConventionalInfantry());

--- a/megamek/src/megamek/common/weapons/handlers/EnergyWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/EnergyWeaponHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 
 import megamek.common.HitData;
@@ -122,7 +124,7 @@ public class EnergyWeaponHandler extends WeaponHandler {
                   ((Infantry) target).isMechanized(),
                   toHit.getThruBldg() != null, attackingEntity.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0), toReturn * 2);
+            toReturn = Math.min(toReturn + (int) floor(toHit.getMoS() / 3.0), toReturn * 2);
         }
 
         toReturn = applyGlancingBlowModifier(toReturn, target.isConventionalInfantry());

--- a/megamek/src/megamek/common/weapons/handlers/GRHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/GRHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 
 import megamek.common.RangeType;
@@ -85,7 +87,7 @@ public class GRHandler extends AmmoWeaponHandler {
                   ((Infantry) target).isMechanized(),
                   toHit.getThruBldg() != null, attackingEntity.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0), toReturn * 2);
+            toReturn = Math.min(toReturn + (int) floor(toHit.getMoS() / 3.0), toReturn * 2);
         }
 
         toReturn = applyGlancingBlowModifier(toReturn, false);

--- a/megamek/src/megamek/common/weapons/handlers/HyperLaserHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/HyperLaserHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 import java.util.Vector;
 
@@ -129,7 +131,7 @@ public class HyperLaserHandler extends EnergyWeaponHandler {
                 toReturn++;
             }
         } else if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0), toReturn * 2);
+            toReturn = Math.min(toReturn + (int) floor(toHit.getMoS() / 3.0), toReturn * 2);
         }
 
         if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_RANGE)

--- a/megamek/src/megamek/common/weapons/handlers/MGHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/MGHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 import java.util.Vector;
 
@@ -82,7 +84,7 @@ public class MGHandler extends AmmoWeaponHandler {
             toReturn = applyGlancingBlowModifier(toReturn, false);
 
             if (bDirect) {
-                toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0),
+                toReturn = Math.min(toReturn + (int) floor(toHit.getMoS() / 3.0),
                       toReturn * 2);
             }
         } else {
@@ -97,7 +99,7 @@ public class MGHandler extends AmmoWeaponHandler {
             } else {
                 toReturn = weaponType.getDamage();
                 if (bDirect) {
-                    toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0),
+                    toReturn = Math.min(toReturn + (int) floor(toHit.getMoS() / 3.0),
                           toReturn * 2);
                 }
 

--- a/megamek/src/megamek/common/weapons/handlers/MissileBayWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/MissileBayWeaponHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 import java.util.Vector;
 
@@ -158,7 +160,7 @@ public class MissileBayWeaponHandler extends AmmoBayWeaponHandler {
 
         // Apply direct/glancing blow modifiers to the survivors
         if (bDirect) {
-            av = Math.min(av + (toHit.getMoS() / 3.0), av * 2);
+            av = Math.min(av + (int) floor(toHit.getMoS() / 3.0), av * 2);
         }
 
         av = applyGlancingBlowModifier(av, false);

--- a/megamek/src/megamek/common/weapons/handlers/PPCHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/PPCHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 import java.util.Vector;
 
@@ -137,7 +139,7 @@ public class PPCHandler extends EnergyWeaponHandler {
                   ((Infantry) target).isMechanized(),
                   toHit.getThruBldg() != null, attackingEntity.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0), toReturn * 2);
+            toReturn = Math.min(toReturn + (int) floor(toHit.getMoS() / 3.0), toReturn * 2);
         }
 
         toReturn = applyGlancingBlowModifier(toReturn, target.isConventionalInfantry());

--- a/megamek/src/megamek/common/weapons/handlers/PulseLaserWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/PulseLaserWeaponHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 import java.util.Vector;
 
@@ -116,7 +118,7 @@ public class PulseLaserWeaponHandler extends EnergyWeaponHandler {
                   ((Infantry) target).isMechanized(),
                   toHit.getThruBldg() != null, attackingEntity.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0), toReturn * 2);
+            toReturn = Math.min(toReturn + (int) floor(toHit.getMoS() / 3.0), toReturn * 2);
         }
 
         toReturn = applyGlancingBlowModifier(toReturn, target.isConventionalInfantry());

--- a/megamek/src/megamek/common/weapons/handlers/RifleWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/RifleWeaponHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 import java.util.Vector;
 
@@ -88,7 +90,7 @@ public class RifleWeaponHandler extends AmmoWeaponHandler {
                   ((Infantry) target).isMechanized(),
                   toHit.getThruBldg() != null, attackingEntity.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0), toReturn * 2);
+            toReturn = Math.min(toReturn + (int) floor(toHit.getMoS() / 3.0), toReturn * 2);
         }
         Entity te;
         if (target instanceof Entity) {

--- a/megamek/src/megamek/common/weapons/handlers/ThunderBoltWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/ThunderBoltWeaponHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 import java.util.Vector;
 
@@ -94,7 +96,7 @@ public class ThunderBoltWeaponHandler extends MissileWeaponHandler {
                   ((Infantry) target).isMechanized(),
                   toHit.getThruBldg() != null, attackingEntity.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0), toReturn * 2);
+            toReturn = Math.min(toReturn + (int) floor(toHit.getMoS() / 3.0), toReturn * 2);
         }
         return (int) Math.ceil(toReturn);
     }

--- a/megamek/src/megamek/common/weapons/handlers/UltraWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/UltraWeaponHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 import java.util.Vector;
 
@@ -202,7 +204,7 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
             // Cluster bonuses or penalties can't apply to "two rolls" UACs, so
             // if we have one, modify the damage per hit directly.
         } else if (bDirect && (howManyShots == 1 || twoRollsUltra)) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0), toReturn * 2);
+            toReturn = Math.min(toReturn + (int) floor(toHit.getMoS() / 3.0), toReturn * 2);
         }
 
         if (howManyShots == 1 || twoRollsUltra) {

--- a/megamek/src/megamek/common/weapons/handlers/VariableSpeedPulseLaserWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/VariableSpeedPulseLaserWeaponHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 
 import megamek.common.RangeType;
@@ -93,7 +95,7 @@ public class VariableSpeedPulseLaserWeaponHandler extends EnergyWeaponHandler {
                 toReturn++;
             }
         } else if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0), toReturn * 2);
+            toReturn = Math.min(toReturn + (int) floor(toHit.getMoS() / 3.0), toReturn * 2);
         }
 
         if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_RANGE)

--- a/megamek/src/megamek/common/weapons/handlers/VehicleFlamerHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/VehicleFlamerHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 import java.util.Vector;
 
@@ -153,7 +155,7 @@ public class VehicleFlamerHandler extends AmmoWeaponHandler {
                 toReturn = Compute.d6(4);
             }
             if (bDirect) {
-                toReturn += toHit.getMoS() / 3.0;
+                toReturn += (int) floor(toHit.getMoS() / 3.0);
             }
             // pain shunted infantry get half damage
             if (((Entity) target).hasAbility(OptionsConstants.MD_PAIN_SHUNT)) {

--- a/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers;
 
+import static java.lang.Math.floor;
+
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -1280,7 +1282,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
                   ((Infantry) target).isMechanized(),
                   toHit.getThruBldg() != null, attackingEntity.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0), toReturn * 2);
+            toReturn = Math.min(toReturn + (int) floor(toHit.getMoS() / 3.0), toReturn * 2);
         }
 
         toReturn = applyGlancingBlowModifier(toReturn, target.isConventionalInfantry());

--- a/megamek/src/megamek/common/weapons/handlers/ac/ACFlechetteHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/ac/ACFlechetteHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers.ac;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 import java.util.Vector;
 
@@ -77,7 +79,7 @@ public class ACFlechetteHandler extends AmmoWeaponHandler {
         double toReturn = weaponType.getDamage();
 
         if (bDirect) {
-            toReturn += toHit.getMoS() / 3.0;
+            toReturn += (int) floor(toHit.getMoS() / 3.0);
         }
 
         toReturn = applyGlancingBlowModifier(toReturn, false);

--- a/megamek/src/megamek/common/weapons/handlers/ac/ACWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/ac/ACWeaponHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers.ac;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 
 import megamek.common.RangeType;
@@ -78,7 +80,7 @@ public class ACWeaponHandler extends AmmoWeaponHandler {
                   toHit.getThruBldg() != null,
                   attackingEntity.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0), toReturn * 2);
+            toReturn = Math.min(toReturn + (int) floor(toHit.getMoS() / 3.0), toReturn * 2);
         }
         toReturn = applyGlancingBlowModifier(toReturn, target.isConventionalInfantry());
         if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_RANGE)

--- a/megamek/src/megamek/common/weapons/handlers/capitalMissile/CapitalMissileBayHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/capitalMissile/CapitalMissileBayHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers.capitalMissile;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 import java.util.Vector;
 
@@ -382,7 +384,7 @@ public class CapitalMissileBayHandler extends AmmoBayWeaponHandler {
         CapMissileAMSMod = calcCapMissileAMSMod();
 
         if (bDirect) {
-            av = Math.min(av + (toHit.getMoS() / 3.0), av * 2);
+            av = Math.min(av + (int) floor(toHit.getMoS() / 3.0), av * 2);
         }
         av = applyGlancingBlowModifier(av, false);
         av = (int) Math.floor(getBracketingMultiplier() * av);

--- a/megamek/src/megamek/common/weapons/handlers/capitalMissile/CapitalMissileBearingsOnlyHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/capitalMissile/CapitalMissileBearingsOnlyHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers.capitalMissile;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -797,7 +799,7 @@ public class CapitalMissileBearingsOnlyHandler extends AmmoBayWeaponHandler {
         CapMissileAMSMod = calcCapMissileAMSMod();
 
         if (bDirect) {
-            attackValue = Math.min(attackValue + (toHit.getMoS() / 3.0f), attackValue * 2);
+            attackValue = Math.min(attackValue + (int) floor(toHit.getMoS() / 3.0), attackValue * 2);
         }
 
         attackValue = applyGlancingBlowModifier(attackValue, false);
@@ -841,7 +843,7 @@ public class CapitalMissileBearingsOnlyHandler extends AmmoBayWeaponHandler {
 
         // we default to direct fire weapons for anti-infantry damage
         if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0f), toReturn * 2);
+            toReturn = Math.min(toReturn + (int) floor(toHit.getMoS() / 3.0), toReturn * 2);
         }
 
         toReturn = applyGlancingBlowModifier(toReturn, false);

--- a/megamek/src/megamek/common/weapons/handlers/capitalMissile/CapitalMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/capitalMissile/CapitalMissileHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers.capitalMissile;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 import java.util.Vector;
 
@@ -448,7 +450,7 @@ public class CapitalMissileHandler extends AmmoWeaponHandler {
 
         // we default to direct fire weapons for anti-infantry damage
         if (bDirect) {
-            toReturn = Math.min(toReturn + (toHit.getMoS() / 3.0), toReturn * 2);
+            toReturn = Math.min(toReturn + (int) floor(toHit.getMoS() / 3.0), toReturn * 2);
         }
 
         toReturn = applyGlancingBlowModifier(toReturn, false);

--- a/megamek/src/megamek/common/weapons/handlers/lrm/LRMFragHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/lrm/LRMFragHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers.lrm;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 import java.util.Vector;
 
@@ -82,7 +84,7 @@ public class LRMFragHandler extends LRMHandler {
         if (target.isConventionalInfantry()) {
             toReturn = weaponType.getRackSize();
             if (bDirect) {
-                toReturn += toHit.getMoS() / 3.0;
+                toReturn += (int) floor(toHit.getMoS() / 3.0);
             }
         }
 

--- a/megamek/src/megamek/common/weapons/handlers/srm/SRMFragHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/srm/SRMFragHandler.java
@@ -34,6 +34,8 @@
 
 package megamek.common.weapons.handlers.srm;
 
+import static java.lang.Math.floor;
+
 import java.io.Serial;
 import java.util.Vector;
 
@@ -82,7 +84,7 @@ public class SRMFragHandler extends SRMHandler {
         if (target.isConventionalInfantry()) {
             toReturn *= weaponType.getRackSize();
             if (bDirect) {
-                toReturn += toHit.getMoS() / 3.0;
+                toReturn += (int) floor(toHit.getMoS() / 3.0);
             }
 
             toReturn = applyGlancingBlowModifier(toReturn, true);


### PR DESCRIPTION
Fix #7691

During _The Great Refactor of 50.07_ we changed from integer division to division by double. This removed an IDE complaint but introduced a bug, as later we then hit the result with `ceil`. This resulted in Direct Blow additional damage being rounded up instead of down. This PR applies `floor` call to the division ensuring it behaves identically to prior to the refactor.