### PR TITLE
Task: Removed No Longer Used Methods

### DIFF
--- a/megamek/src/megamek/common/enums/TechRating.java
+++ b/megamek/src/megamek/common/enums/TechRating.java
@@ -72,9 +72,6 @@ public enum TechRating {
      * <p>The comparison is based on the internal {@code index} value; a larger index indicates a more advanced
      * rating.</p>
      *
-     * <p><b>Warning:</b> Do not use when comparing planetary tech levels. Use
-     * {@link #isPlanetaryTechLevelBetterThan(TechRating)} instead.</p>
-     *
      * @param other the {@link TechRating} to compare against
      *
      * @return {@code true} if this rating is strictly higher than {@code other}
@@ -84,64 +81,18 @@ public enum TechRating {
     }
 
     /**
-     * Determines whether this {@link TechRating} represents a technological level that is greater than or equal to
-     * the specified rating.
+     * Determines whether this {@link TechRating} represents a technological level that is greater than or equal to the
+     * specified rating.
      *
      * <p>The comparison is based on the internal {@code index} value; a larger or equal index indicates an
      * equivalent or more advanced rating.</p>
      *
-     * <p><b>Warning:</b> Do not use when comparing planetary tech levels. Use
-     * {@link #isPlanetaryTechLevelBetterOrEqualThan(TechRating)} instead.</p>
-     *
      * @param other the {@link TechRating} to compare against
+     *
      * @return {@code true} if this rating is greater than or equal to {@code other}
      */
     public boolean isBetterOrEqualThan(TechRating other) {
         return this.index >= other.index;
-    }
-
-    /**
-     * Determines whether this {@link TechRating} represents a higher <b>planetary</b> tech level than the specified
-     * rating.
-     *
-     * <p><b>Note:</b> Planetary tech levels use an inverted scale compared to normal tech ratings — a <b>lower</b>
-     * internal {@code index} indicates a more advanced planetary tech level.</p>
-     *
-     * <p><b>Warning:</b> Do not use when comparing equipment tech levels. Use {@link #isBetterThan(TechRating)}
-     * instead.</p>
-     *
-     * @param other the {@link TechRating} to compare against
-     *
-     * @return {@code true} if this rating’s planetary tech level is strictly higher (i.e., has a lower index) than
-     *       {@code other}
-     *
-     * @author Illiani
-     * @since 0.50.10
-     */
-    public boolean isPlanetaryTechLevelBetterThan(TechRating other) {
-        return this.index < other.index;
-    }
-
-    /**
-     * Determines whether this {@link TechRating} represents a <b>planetary</b> tech level that is greater than or equal
-     * to the specified rating.
-     *
-     * <p><b>Note:</b> Planetary tech levels use an inverted scale compared to normal tech ratings — a <b>lower</b>
-     * internal {@code index} indicates a more advanced planetary tech level.</p>
-     *
-     * <p><b>Warning:</b> Do not use when comparing equipment tech levels. Use
-     * {@link #isBetterOrEqualThan(TechRating)} instead.</p>
-     *
-     * @param other the {@link TechRating} to compare against
-     *
-     * @return {@code true} if this rating’s planetary tech level is greater than or equal to {@code other} (i.e., its
-     *       index is less than or equal)
-     *
-     * @author Illiani
-     * @since 0.50.10
-     */
-    public boolean isPlanetaryTechLevelBetterOrEqualThan(TechRating other) {
-        return this.index <= other.index;
     }
 
     public static TechRating fromIndex(int idx) {


### PR DESCRIPTION
Removed two no longer in use methods. This were incorrectly implemented, regardless, because it turns out that planetary tech rating _isn't_ normal tech rating backwards. It's a whole separate thing and we already translate planetary tech _sophistication_ into normal tech rating so these additional methods were unnecessary.