### PR TITLE
Fix Mechanical Jump Booster shortname

### DIFF
--- a/megamek/src/megamek/common/equipment/MiscType.java
+++ b/megamek/src/megamek/common/equipment/MiscType.java
@@ -11330,11 +11330,11 @@ public class MiscType extends EquipmentType {
 
     public static MiscType createISBAMechanicalJumpBooster() {
         MiscType misc = new MiscType();
-        misc.name = "Mechanical Jump Booster";
+        misc.name = "Mechanical Jump Booster [BA]";
         misc.setInternalName(EquipmentTypeLookup.BA_MECHANICAL_JUMP_BOOSTER);
         misc.addLookupName("ISMechanicalJumpBooster");
         misc.addLookupName("CLMechanicalJumpBooster");
-        misc.shortName = "Jump Booster";
+        misc.shortName = "Mechanical Jump Booster";
         misc.tonnage = TONNAGE_VARIABLE;
         misc.cost = COST_VARIABLE;
         misc.flags = misc.flags.or(F_MECHANICAL_JUMP_BOOSTER).or(F_BA_EQUIPMENT);


### PR DESCRIPTION
I can see the logic for that shortening, but when there's already an equipment called a "Jump Booster", it doesn't make sense to shorten "Mechanical Jump Booster" to "Jump Booster".