### PR TITLE
Fix #7690: Use `weaponEntity` not `attackingEntity` for anything related to loading etc.

### DIFF
--- a/megamek/src/megamek/common/weapons/handlers/ATMHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/ATMHandler.java
@@ -91,7 +91,7 @@ public class ATMHandler extends MissileWeaponHandler {
                   weaponType.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
                   weaponType.getInfantryDamageClass(),
                   ((Infantry) target).isMechanized(),
-                  toHit.getThruBldg() != null, attackingEntity.getId(), calcDmgPerHitReport);
+                  toHit.getThruBldg() != null, weaponEntity.getId(), calcDmgPerHitReport);
             toReturn = applyGlancingBlowModifier(toReturn, true);
         }
 
@@ -128,7 +128,7 @@ public class ATMHandler extends MissileWeaponHandler {
             return 5;
         }
     }
-    
+
     /**
      * Calculate the attack value based on range
      *

--- a/megamek/src/megamek/common/weapons/handlers/AmmoBayWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/AmmoBayWeaponHandler.java
@@ -88,14 +88,14 @@ public class AmmoBayWeaponHandler extends BayWeaponHandler {
             AmmoMounted bayWAmmo = bayW.getLinkedAmmo();
             if (null == bayWAmmo || bayWAmmo.getUsableShotsLeft() < 1) {
                 // try loading something else
-                attackingEntity.loadWeaponWithSameAmmo(bayW);
+                weaponEntity.loadWeaponWithSameAmmo(bayW);
                 bayWAmmo = bayW.getLinkedAmmo();
             }
             if (!bayW.isBreached()
                   && !bayW.isDestroyed()
                   && !bayW.isJammed()
                   && bayWAmmo != null
-                  && attackingEntity.getTotalAmmoOfType(bayWAmmo.getType()) >= bayW.getCurrentShots()) {
+                  && weaponEntity.getTotalAmmoOfType(bayWAmmo.getType()) >= bayW.getCurrentShots()) {
                 WeaponType bayWType = bayW.getType();
                 // need to cycle through weapons and add av
                 double current_av = 0;
@@ -120,7 +120,7 @@ public class AmmoBayWeaponHandler extends BayWeaponHandler {
                         if (null == bayWAmmo
                               || bayWAmmo.getUsableShotsLeft() < 1) {
                             // try loading something else
-                            attackingEntity.loadWeaponWithSameAmmo(bayW);
+                            weaponEntity.loadWeaponWithSameAmmo(bayW);
                             bayWAmmo = bayW.getLinkedAmmo();
                         }
                         if (null != bayWAmmo) {

--- a/megamek/src/megamek/common/weapons/handlers/AmmoWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/AmmoWeaponHandler.java
@@ -79,13 +79,13 @@ public class AmmoWeaponHandler extends WeaponHandler {
         }
 
         if (ammo.getUsableShotsLeft() <= 0) {
-            attackingEntity.loadWeaponWithSameAmmo(weapon);
+            weaponEntity.loadWeaponWithSameAmmo(weapon);
             ammo = (AmmoMounted) weapon.getLinked();
         }
         ammo.setShotsLeft(ammo.getBaseShotsLeft() - 1);
 
         if (weapon.isInternalBomb()) {
-            ((IBomber) attackingEntity).increaseUsedInternalBombs(1);
+            ((IBomber) weaponEntity).increaseUsedInternalBombs(1);
         }
 
         super.useAmmo();
@@ -95,7 +95,7 @@ public class AmmoWeaponHandler extends WeaponHandler {
         if (weapon.getLinked() instanceof AmmoMounted ammoMounted) {
             ammo = ammoMounted;
         } else {
-            attackingEntity.loadWeapon(weapon);
+            weaponEntity.loadWeapon(weapon);
             if (weapon.getLinked() instanceof AmmoMounted ammoMounted) {
                 ammo = ammoMounted;
             } else {
@@ -115,7 +115,7 @@ public class AmmoWeaponHandler extends WeaponHandler {
             // shouldn't happen
             return weapon.getNWeapons();
         }
-        int totalShots = attackingEntity.getTotalAmmoOfType(ammo.getType());
+        int totalShots = weaponEntity.getTotalAmmoOfType(ammo.getType());
         return Math.min(weapon.getNWeapons(),
               (int) Math.floor((double) totalShots / (double) weapon.getCurrentShots()));
     }
@@ -133,7 +133,7 @@ public class AmmoWeaponHandler extends WeaponHandler {
         // don't have neg ammo feed problem quirk
         if (!weapon.hasQuirk(OptionsConstants.QUIRK_WEAPON_NEG_AMMO_FEED_PROBLEMS)) {
             return false;
-        } else if ((roll.getIntValue() <= 2) && !attackingEntity.isConventionalInfantry()) {
+        } else if ((roll.getIntValue() <= 2) && !weaponEntity.isConventionalInfantry()) {
             // attack roll was a 2, may explode
             Roll diceRoll = Compute.rollD6(2);
 
@@ -179,19 +179,19 @@ public class AmmoWeaponHandler extends WeaponHandler {
         weapon.setHit(true);
 
         int weaponLocation = weapon.getLocation();
-        for (int i = 0; i < attackingEntity.getNumberOfCriticalSlots(weaponLocation); i++) {
-            CriticalSlot slot1 = attackingEntity.getCritical(weaponLocation, i);
+        for (int i = 0; i < weaponEntity.getNumberOfCriticalSlots(weaponLocation); i++) {
+            CriticalSlot slot1 = weaponEntity.getCritical(weaponLocation, i);
             if ((slot1 == null) || (slot1.getType() == CriticalSlot.TYPE_SYSTEM)) {
                 continue;
             }
             Mounted<?> mounted = slot1.getMount();
             if (mounted.equals(weapon)) {
-                attackingEntity.hitAllCriticalSlots(weaponLocation, i);
+                weaponEntity.hitAllCriticalSlots(weaponLocation, i);
                 break;
             }
         }
 
         // if we're here, the weapon is going to explode whether it's flagged as explosive or not
-        vPhaseReport.addAll(gameManager.explodeEquipment(attackingEntity, weaponLocation, weapon, true));
+        vPhaseReport.addAll(gameManager.explodeEquipment(weaponEntity, weaponLocation, weapon, true));
     }
 }

--- a/megamek/src/megamek/common/weapons/handlers/CLIATMHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/CLIATMHandler.java
@@ -108,7 +108,7 @@ public class CLIATMHandler extends ATMHandler {
                   weaponType.getRackSize(), bDirect ? toHit.getMoS() / 3 : 0,
                   weaponType.getInfantryDamageClass(),
                   ((Infantry) target).isMechanized(),
-                  toHit.getThruBldg() != null, attackingEntity.getId(), calcDmgPerHitReport);
+                  toHit.getThruBldg() != null, weaponEntity.getId(), calcDmgPerHitReport);
 
             // some question here about "partial streak missiles"
             if (streakInactive()) {
@@ -397,7 +397,7 @@ public class CLIATMHandler extends ATMHandler {
         }
 
         if (ammo.getUsableShotsLeft() <= 0) {
-            attackingEntity.loadWeaponWithSameAmmo(weapon);
+            weaponEntity.loadWeaponWithSameAmmo(weapon);
             if (weapon.getLinked() instanceof AmmoMounted ammoMounted) {
                 ammo = ammoMounted;
             } else {
@@ -581,7 +581,7 @@ public class CLIATMHandler extends ATMHandler {
 
             if (!bMissed) {
                 // light inferno missiles all at once, if not missed
-                vPhaseReport.addAll(gameManager.deliverInfernoMissiles(attackingEntity, target,
+                vPhaseReport.addAll(gameManager.deliverInfernoMissiles(weaponEntity, target,
                       hits, weapon.getCalledShot().getCall()));
             }
             return false;
@@ -634,9 +634,9 @@ public class CLIATMHandler extends ATMHandler {
                     vPhaseReport.addElement(report);
                     weapon.setUsedThisRound(false);
                     WeaponAttackAction newWaa = new WeaponAttackAction(
-                          attackingEntity.getId(), entity.getId(), weaponAttackAction.getWeaponId());
+                          weaponEntity.getId(), entity.getId(), weaponAttackAction.getWeaponId());
                     newWaa.setNemesisConfused(true);
-                    Mounted<?> m = attackingEntity.getEquipment(weaponAttackAction.getWeaponId());
+                    Mounted<?> m = weaponEntity.getEquipment(weaponAttackAction.getWeaponId());
                     Weapon w = (Weapon) m.getType();
                     AttackHandler attackHandler = w.fire(newWaa, game, gameManager);
                     // increase ammo by one, because we just incorrectly used

--- a/megamek/src/megamek/common/weapons/handlers/ChemicalLaserHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/ChemicalLaserHandler.java
@@ -102,7 +102,7 @@ public class ChemicalLaserHandler extends AmmoWeaponHandler {
                   toReturn, bDirect ? toHit.getMoS() / 3 : 0,
                   weaponType.getInfantryDamageClass(),
                   ((Infantry) target).isMechanized(),
-                  toHit.getThruBldg() != null, attackingEntity.getId(), calcDmgPerHitReport);
+                  toHit.getThruBldg() != null, weaponEntity.getId(), calcDmgPerHitReport);
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (int) floor(toHit.getMoS() / 3.0), toReturn * 2);
         }

--- a/megamek/src/megamek/common/weapons/handlers/HyperLaserHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/HyperLaserHandler.java
@@ -73,21 +73,21 @@ public class HyperLaserHandler extends EnergyWeaponHandler {
             r.newlines = 1;
             weapon.setHit(true);
             int weaponLocation = weapon.getLocation();
-            for (int i = 0; i < attackingEntity.getNumberOfCriticalSlots(weaponLocation); i++) {
-                CriticalSlot slot1 = attackingEntity.getCritical(weaponLocation, i);
+            for (int i = 0; i < weaponEntity.getNumberOfCriticalSlots(weaponLocation); i++) {
+                CriticalSlot slot1 = weaponEntity.getCritical(weaponLocation, i);
                 if ((slot1 == null) ||
                       (slot1.getType() == CriticalSlot.TYPE_SYSTEM)) {
                     continue;
                 }
                 Mounted<?> mounted = slot1.getMount();
                 if (mounted.equals(weapon)) {
-                    attackingEntity.hitAllCriticalSlots(weaponLocation, i);
+                    weaponEntity.hitAllCriticalSlots(weaponLocation, i);
                     break;
                 }
             }
             r.choose(false);
             vPhaseReport.addElement(r);
-            vPhaseReport.addAll(gameManager.explodeEquipment(attackingEntity, weaponLocation, weapon));
+            vPhaseReport.addAll(gameManager.explodeEquipment(weaponEntity, weaponLocation, weapon));
             return true;
         }
         return false;
@@ -122,7 +122,7 @@ public class HyperLaserHandler extends EnergyWeaponHandler {
                   bDirect ? toHit.getMoS() / 3 : 0,
                   weaponType.getInfantryDamageClass(),
                   ((Infantry) target).isMechanized(),
-                  toHit.getThruBldg() != null, attackingEntity.getId(), calcDmgPerHitReport);
+                  toHit.getThruBldg() != null, weaponEntity.getId(), calcDmgPerHitReport);
             if (nRange <= nRanges[RangeType.RANGE_SHORT]) {
                 toReturn += 3;
             } else if (nRange <= nRanges[RangeType.RANGE_MEDIUM]) {

--- a/megamek/src/megamek/common/weapons/handlers/MGAWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/MGAWeaponHandler.java
@@ -80,7 +80,7 @@ public class MGAWeaponHandler extends MGHandler {
                   weaponType.getDamage(), bDirect ? toHit.getMoS() / 3 : 0,
                   weaponType.getInfantryDamageClass(),
                   ((Infantry) target).isMechanized(),
-                  toHit.getThruBldg() != null, attackingEntity.getId(), calcDmgPerHitReport, howManyShots);
+                  toHit.getThruBldg() != null, weaponEntity.getId(), calcDmgPerHitReport, howManyShots);
             damage = applyGlancingBlowModifier(damage, true);
             if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_RANGE)) {
                 if (nRange > weaponType.getRanges(weapon)[RangeType.RANGE_LONG]) {
@@ -106,13 +106,13 @@ public class MGAWeaponHandler extends MGHandler {
         setDone();
         checkAmmo();
         howManyShots = weapon.getCurrentShots();
-        int total = attackingEntity.getTotalAmmoOfType(ammo.getType());
+        int total = weaponEntity.getTotalAmmoOfType(ammo.getType());
         if (total <= howManyShots) {
             howManyShots = total;
         }
         shotsNeedFiring = howManyShots;
         if (ammo.getUsableShotsLeft() == 0) {
-            attackingEntity.loadWeapon(weapon);
+            weaponEntity.loadWeapon(weapon);
             ammo = (AmmoMounted) weapon.getLinked();
             // there will be some ammo somewhere, otherwise shot will not have
             // been fired.
@@ -120,7 +120,7 @@ public class MGAWeaponHandler extends MGHandler {
         while (shotsNeedFiring > ammo.getUsableShotsLeft()) {
             shotsNeedFiring -= ammo.getBaseShotsLeft();
             ammo.setShotsLeft(0);
-            attackingEntity.loadWeapon(weapon);
+            weaponEntity.loadWeapon(weapon);
             ammo = (AmmoMounted) weapon.getLinked();
         }
         ammo.setShotsLeft(ammo.getBaseShotsLeft() - shotsNeedFiring);
@@ -255,7 +255,7 @@ public class MGAWeaponHandler extends MGHandler {
             }
             vPhaseReport
                   .addAll(gameManager.damageEntity(entityTarget, hit, nDamage,
-                        false, attackingEntity.getSwarmTargetId() == entityTarget
+                        false, weaponEntity.getSwarmTargetId() == entityTarget
                               .getId() ? DamageType.IGNORE_PASSENGER
                               : damageType, false, false, throughFront,
                         underWater));

--- a/megamek/src/megamek/common/weapons/handlers/MGHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/MGHandler.java
@@ -93,7 +93,7 @@ public class MGHandler extends AmmoWeaponHandler {
                       weaponType.getDamage(), bDirect ? toHit.getMoS() / 3 : 0,
                       weaponType.getInfantryDamageClass(),
                       ((Infantry) target).isMechanized(),
-                      toHit.getThruBldg() != null, attackingEntity.getId(), calcDmgPerHitReport);
+                      toHit.getThruBldg() != null, weaponEntity.getId(), calcDmgPerHitReport);
 
                 toReturn = applyGlancingBlowModifier(toReturn, true);
             } else {
@@ -129,7 +129,7 @@ public class MGHandler extends AmmoWeaponHandler {
     protected void addHeat() {
         if (!(toHit.getValue() == TargetRoll.IMPOSSIBLE)) {
             if (weapon.isRapidFire()) {
-                attackingEntity.heatBuildup += nRapidDamHeatPerHit;
+                weaponEntity.heatBuildup += nRapidDamHeatPerHit;
             } else {
                 super.addHeat();
             }
@@ -188,7 +188,7 @@ public class MGHandler extends AmmoWeaponHandler {
             int ammoUsage = 3 * nRapidDamHeatPerHit;
             for (int i = 0; i < ammoUsage; i++) {
                 if (ammo.getUsableShotsLeft() <= 0) {
-                    attackingEntity.loadWeapon(weapon);
+                    weaponEntity.loadWeapon(weapon);
                     ammo = (AmmoMounted) weapon.getLinked();
                 }
                 ammo.setShotsLeft(ammo.getBaseShotsLeft() - 1);

--- a/megamek/src/megamek/common/weapons/handlers/MicroBombHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/MicroBombHandler.java
@@ -129,7 +129,7 @@ public class MicroBombHandler extends AmmoWeaponHandler {
         // Deal bomb damage to the hit coordinates, with all that entails
         HexTarget dropHex = new HexTarget(coords, target.getBoardId(), target.getTargetType());
         Vector<Integer> hitIds = gameManager.deliverBombDamage(dropHex,
-              BombType.BombTypeEnum.HE, subjectId, attackingEntity,
+              BombType.BombTypeEnum.HE, subjectId, weaponEntity,
               vPhaseReport);
 
         // Display drifts that hit nothing separately from drifts that dealt damage

--- a/megamek/src/megamek/common/weapons/handlers/NarcHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/NarcHandler.java
@@ -214,7 +214,7 @@ public class NarcHandler extends MissileWeaponHandler {
         }
 
         if (entityTarget.removePartialCoverHits(hit.getLocation(), toHit
-              .getCover(), ComputeSideTable.sideTable(attackingEntity, entityTarget, weapon
+              .getCover(), ComputeSideTable.sideTable(weaponEntity, entityTarget, weapon
               .getCalledShot().getCall()))) {
             // Weapon strikes Partial Cover.
             handlePartialCoverHit(entityTarget, vPhaseReport, hit, bldg, hits,
@@ -243,7 +243,7 @@ public class NarcHandler extends MissileWeaponHandler {
         AmmoType ammoType = ammo.getType();
         if (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.NARC) {
             // narced
-            NarcPod pod = new NarcPod(attackingEntity.getOwner().getTeam(),
+            NarcPod pod = new NarcPod(weaponEntity.getOwner().getTeam(),
                   hit.getLocation());
             Report r = new Report(3250);
             r.subject = subjectId;

--- a/megamek/src/megamek/common/weapons/handlers/PopUpMineLauncherHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/PopUpMineLauncherHandler.java
@@ -145,7 +145,7 @@ public class PopUpMineLauncherHandler extends AmmoWeaponHandler {
                         hit,
                         damage,
                         false,
-                        attackingEntity.getSwarmTargetId() == entityTarget.getId() ? DamageType.IGNORE_PASSENGER
+                        weaponEntity.getSwarmTargetId() == entityTarget.getId() ? DamageType.IGNORE_PASSENGER
                               : damageType,
                         false, false, throughFront,
                         underWater);
@@ -175,7 +175,7 @@ public class PopUpMineLauncherHandler extends AmmoWeaponHandler {
 
         // do we need to revert to single shot?
         if (nShots > 1) {
-            int nAvail = attackingEntity.getTotalAmmoOfType(ammo.getType());
+            int nAvail = weaponEntity.getTotalAmmoOfType(ammo.getType());
             while (nAvail < nShots) {
                 nShots--;
             }
@@ -184,7 +184,7 @@ public class PopUpMineLauncherHandler extends AmmoWeaponHandler {
         // use up ammo
         for (int i = 0; i < nShots; i++) {
             if (ammo.getUsableShotsLeft() <= 0) {
-                attackingEntity.loadWeaponWithSameAmmo(weapon);
+                weaponEntity.loadWeaponWithSameAmmo(weapon);
                 ammo = (AmmoMounted) weapon.getLinked();
             }
             ammo.setShotsLeft(ammo.getBaseShotsLeft() - 1);

--- a/megamek/src/megamek/common/weapons/handlers/PrimitiveACWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/PrimitiveACWeaponHandler.java
@@ -63,7 +63,7 @@ public class PrimitiveACWeaponHandler extends ACWeaponHandler {
             return true;
         }
 
-        if ((roll.getIntValue() == 2) && !attackingEntity.isConventionalInfantry()) {
+        if ((roll.getIntValue() == 2) && !weaponEntity.isConventionalInfantry()) {
             Report r = new Report(3161);
             r.subject = subjectId;
             r.newlines = 0;

--- a/megamek/src/megamek/common/weapons/handlers/SmallPulseLaserPrototypeHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/SmallPulseLaserPrototypeHandler.java
@@ -76,7 +76,7 @@ public class SmallPulseLaserPrototypeHandler extends EnergyWeaponHandler {
         }
         if (!(toHit.getValue() == TargetRoll.IMPOSSIBLE)) {
             super.addHeat();
-            attackingEntity.heatBuildup += Compute.d6() / 2;
+            weaponEntity.heatBuildup += Compute.d6() / 2;
         }
 
     }

--- a/megamek/src/megamek/common/weapons/handlers/TeleMissileHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/TeleMissileHandler.java
@@ -96,7 +96,7 @@ public class TeleMissileHandler extends CapitalMissileBayHandler {
         for (WeaponMounted bayW : weapon.getBayWeapons()) {
             WeaponType bayWType = bayW.getType();
             damage += (int) bayWType.getShortAV();
-            attackingEntity.heatBuildup += bayW.getCurrentHeat();
+            weaponEntity.heatBuildup += bayW.getCurrentHeat();
             missileArmor = bayWType.getMissileArmor();
         }
         return damage;
@@ -117,7 +117,7 @@ public class TeleMissileHandler extends CapitalMissileBayHandler {
                 if (null == bayWAmmo
                       || bayWAmmo.getUsableShotsLeft() < 1) {
                     // try loading something else
-                    attackingEntity.loadWeaponWithSameAmmo(bayW);
+                    weaponEntity.loadWeaponWithSameAmmo(bayW);
                     bayWAmmo = bayW.getLinkedAmmo();
                 }
                 if (null != bayWAmmo) {
@@ -135,10 +135,10 @@ public class TeleMissileHandler extends CapitalMissileBayHandler {
     @Override
     public boolean handle(GamePhase phase, Vector<Report> vPhaseReport) {
         // just launch the tele-missile
-        gameManager.deployTeleMissile(attackingEntity,
+        gameManager.deployTeleMissile(weaponEntity,
               weaponType,
               getBayAmmoType(),
-              attackingEntity.getEquipmentNum(weapon),
+              weaponEntity.getEquipmentNum(weapon),
               getCapMisMod(), calcBayDamageAndHeat(), missileArmor, vPhaseReport);
 
         return false;

--- a/megamek/src/megamek/common/weapons/handlers/UltraWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/UltraWeaponHandler.java
@@ -81,7 +81,7 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
         setDone();
         checkAmmo();
         howManyShots = (weapon.curMode().equals(Weapon.MODE_AC_SINGLE) ? 1 : 2);
-        int total = attackingEntity.getTotalAmmoOfType(ammo.getType());
+        int total = weaponEntity.getTotalAmmoOfType(ammo.getType());
         if (total == 1) {
             howManyShots = 1;
         } else if (total < 1) {
@@ -97,7 +97,7 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
         // We _may_ be able to reload from another ammo source, but in case
         // a previous attack burned through all the ammo, this attack may be SOL.
         if (ammo.getUsableShotsLeft() == 0) {
-            attackingEntity.loadWeapon(weapon);
+            weaponEntity.loadWeapon(weapon);
             ammo = (AmmoMounted) weapon.getLinked();
         }
     }
@@ -162,7 +162,7 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
         }
 
         if (!game.getOptions().booleanOption(OptionsConstants.PLAYTEST_3)) {
-            if ((roll.getIntValue() == 2) && (howManyShots == 2) && !attackingEntity.isConventionalInfantry()) {
+            if ((roll.getIntValue() == 2) && (howManyShots == 2) && !weaponEntity.isConventionalInfantry()) {
                 Report r = new Report();
                 r.subject = subjectId;
                 weapon.setJammed(true);
@@ -191,14 +191,14 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
                       bDirect ? toHit.getMoS() / 3 : 0,
                       WeaponType.WEAPON_CLUSTER_BALLISTIC, // treat as cluster
                       ((Infantry) target).isMechanized(),
-                      toHit.getThruBldg() != null, attackingEntity.getId(),
+                      toHit.getThruBldg() != null, weaponEntity.getId(),
                       calcDmgPerHitReport);
             } else { // No - only one shot fired
                 toReturn = Compute.directBlowInfantryDamage(weaponType.getDamage(),
                       bDirect ? toHit.getMoS() / 3 : 0,
                       weaponType.getInfantryDamageClass(),
                       ((Infantry) target).isMechanized(),
-                      toHit.getThruBldg() != null, attackingEntity.getId(),
+                      toHit.getThruBldg() != null, weaponEntity.getId(),
                       calcDmgPerHitReport);
             }
             // Cluster bonuses or penalties can't apply to "two rolls" UACs, so
@@ -229,7 +229,7 @@ public class UltraWeaponHandler extends AmmoWeaponHandler {
 
     @Override
     protected int calculateNumClusterAero(Entity entityTarget) {
-        if (usesClusterTable() && !attackingEntity.isCapitalFighter() && (entityTarget != null)
+        if (usesClusterTable() && !weaponEntity.isCapitalFighter() && (entityTarget != null)
               && !entityTarget.isCapitalScale()) {
             return (int) Math.ceil(attackValue / 2.0);
         } else {

--- a/megamek/src/megamek/common/weapons/handlers/VariableSpeedPulseLaserWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/VariableSpeedPulseLaserWeaponHandler.java
@@ -86,7 +86,7 @@ public class VariableSpeedPulseLaserWeaponHandler extends EnergyWeaponHandler {
                   bDirect ? toHit.getMoS() / 3 : 0,
                   weaponType.getInfantryDamageClass(),
                   ((Infantry) target).isMechanized(),
-                  toHit.getThruBldg() != null, attackingEntity.getId(), calcDmgPerHitReport);
+                  toHit.getThruBldg() != null, weaponEntity.getId(), calcDmgPerHitReport);
             if (nRange <= nRanges[RangeType.RANGE_SHORT]) {
                 toReturn += 3;
             } else if (nRange <= nRanges[RangeType.RANGE_MEDIUM]) {

--- a/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
@@ -114,7 +114,14 @@ public class WeaponHandler implements AttackHandler, Serializable {
     protected AmmoType ammoType;
     protected String typeName;
     protected WeaponMounted weapon;
+    /**
+     * Attacking Entity is the {@link Entity}  where the attack is coming from
+     */
     protected Entity attackingEntity;
+    /**
+     * Weapon Entity is the {@link Entity} that has the {@link WeaponMounted} {@link WeaponHandler#weapon}
+     */
+    protected Entity weaponEntity;
     protected Targetable target;
     protected int subjectId;
     protected int nRange;
@@ -213,20 +220,20 @@ public class WeaponHandler implements AttackHandler, Serializable {
                     int loc = prevWeapon.getLocation();
 
                     // create an array of booleans of locations
-                    boolean[] usedFrontArc = new boolean[attackingEntity.locations()];
-                    boolean[] usedRearArc = new boolean[attackingEntity.locations()];
-                    for (int i = 0; i < attackingEntity.locations(); i++) {
+                    boolean[] usedFrontArc = new boolean[weaponEntity.locations()];
+                    boolean[] usedRearArc = new boolean[weaponEntity.locations()];
+                    for (int i = 0; i < weaponEntity.locations(); i++) {
                         usedFrontArc[i] = false;
                         usedRearArc[i] = false;
                     }
                     if (!rearMount) {
                         if (!usedFrontArc[loc]) {
-                            totalHeat += attackingEntity.getHeatInArc(loc, rearMount);
+                            totalHeat += weaponEntity.getHeatInArc(loc, rearMount);
                             usedFrontArc[loc] = true;
                         }
                     } else {
                         if (!usedRearArc[loc]) {
-                            totalHeat += attackingEntity.getHeatInArc(loc, rearMount);
+                            totalHeat += weaponEntity.getHeatInArc(loc, rearMount);
                             usedRearArc[loc] = true;
                         }
                     }
@@ -1814,7 +1821,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
         this.weaponAttackAction = weaponAttackAction;
         this.game = game;
 
-        Entity weaponEntity = this.game.getEntity(this.weaponAttackAction.getEntityId());
+        weaponEntity = this.game.getEntity(this.weaponAttackAction.getEntityId());
         if (weaponEntity == null) {
             throw new EntityLoadingException("Weapon Entity is NULL");
         }


### PR DESCRIPTION
Fixes #7690 


Usually in the WeaponHandlers we'll want to use `weaponEntity` (the `Entity` that physically mounts the `WeaponMounted`). `attackingEntity` is still used occasionally for ECM / LoS related checks. 

I need to figure out how to properly configure Git on my laptop so my commits come from me...