### PR TITLE
Fix Complete

### DIFF
--- a/megamek/src/megamek/server/totalWarfare/TWDamageManagerModular.java
+++ b/megamek/src/megamek/server/totalWarfare/TWDamageManagerModular.java
@@ -759,7 +759,7 @@ public class TWDamageManagerModular extends TWDamageManager implements IDamageMa
                     return;
                 }
                 // is this a mek dumping ammo being hit in the rear torso?
-                if (List.of(Mek.LOC_CENTER_TORSO, Mek.LOC_RIGHT_TORSO, Mek.LOC_LEFT_TORSO)
+                if (hit.isRear() && List.of(Mek.LOC_CENTER_TORSO, Mek.LOC_RIGHT_TORSO, Mek.LOC_LEFT_TORSO)
                       .contains(hit.getLocation())) {
                     for (Mounted<?> mAmmo : mek.getAmmo()) {
                         if (mAmmo.isDumping() && !mAmmo.isDestroyed() && !mAmmo.isHit()) {


### PR DESCRIPTION
  File: megamek/src/megamek/server/totalWarfare/TWDamageManagerModular.java line 762

  Change: Added hit.isRear() && to the condition so dumping ammo only explodes when hit from the rear arc.

  - if (List.of(Mek.LOC_CENTER_TORSO, Mek.LOC_RIGHT_TORSO, Mek.LOC_LEFT_TORSO)
  + if (hit.isRear() && List.of(Mek.LOC_CENTER_TORSO, Mek.LOC_RIGHT_TORSO, Mek.LOC_LEFT_TORSO)
  
  Fix #7637 