### PR TITLE
Sentry: Fixed Loading of ProtoMek & BattleMek Units Created Prior to 50.0

### DIFF
--- a/megamek/src/megamek/common/loaders/MekFileParser.java
+++ b/megamek/src/megamek/common/loaders/MekFileParser.java
@@ -213,7 +213,7 @@ public class MekFileParser {
                     // Do not remove <50.0 compatibility handler 'ProtoMech' as this will break our cross-version
                     // compatibility promise
                     case "ProtoMech", "ProtoMek" -> new BLKProtoMekFile(bb);
-                    // Do not remove <50.0 compatibility handler 'ProtoMech' as this will break our cross-version
+                    // Do not remove <50.0 compatibility handler 'Mech' as this will break our cross-version
                     // compatibility promise
                     case "Mek", "Mech" -> new BLKMekFile(bb);
                     case "VTOL" -> new BLKVTOLFile(bb);


### PR DESCRIPTION
[Sentry Report 1](https://sentry.tapenvy.us/organizations/tapenvyus/issues/8233/events/7b05f97f9c314430a0c3ffc0f092d21b/)
[Sentry Report 2](https://sentry.tapenvy.us/organizations/tapenvyus/issues/7516/events/d2cab388af594b6fa5bb78c7299278fb/)
[Sentry Report 3](https://sentry.tapenvy.us/organizations/tapenvyus/issues/8246/events/0b7a7d04f6554235b9901b2a8d7862f3/)
[Sentry Report 4](https://sentry.tapenvy.us/organizations/tapenvyus/issues/7146/events/ff9c5da6e4c34a6d9f3e8ac0073dcf0f/)
[Sentry Report 5](https://sentry.tapenvy.us/organizations/tapenvyus/issues/8204/events/2da375da89394b11808abc82d4aa193c/)

This PR restores a pair of compatibility handlers that were removed at some point. Due to our cross-version (with no limits) policy for custom units we cannot remove these handlers. Doing so prevents pre-50.0 ProtoMeks and BattleMeks from being loaded.