### PR TITLE
Sentry: Fixed Preference Saving for Several Dialogs

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/EntityViewPane.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/EntityViewPane.java
@@ -71,6 +71,8 @@ public class EntityViewPane extends EnhancedTabbedPane {
      * don't want to remember the selected tab between the different locations.
      */
     protected void initialize() {
+        setName("EntityViewPane");
+
         JButton menuButton = new MenuButton();
         menuButton.setToolTipText("Show/hide menus");
         menuButton.addActionListener(ev -> toggleMenus());


### PR DESCRIPTION
[Sentry Report 1](https://sentry.tapenvy.us/organizations/tapenvyus/issues/7049/events/7d17a70978b74bedb6d70f8c1057bb46/)
[Sentry Report 2](https://sentry.tapenvy.us/organizations/tapenvyus/issues/7048/events/e41c6efeece04f55b90fafb5df5fdde0/)
[Sentry Report 3](https://sentry.tapenvy.us/organizations/tapenvyus/issues/7145/events/a770c71e09d04c6086efead98f88a59b/)
[Sentry Report 4](https://sentry.tapenvy.us/organizations/tapenvyus/issues/8327/events/3a8204d0e5a74fcdb8ff42a31c5c58eb/)
[Sentry Report 5](https://sentry.tapenvy.us/organizations/tapenvyus/issues/8191/events/12fd4edc52e7470583713a3f76d53144/)
[Sentry Report 6](https://sentry.tapenvy.us/organizations/tapenvyus/issues/8108/events/44a6da25d579415ca5cfdaa1eb841a45/)
[Sentry Report 7](https://sentry.tapenvy.us/organizations/tapenvyus/issues/7539/events/24d301c0e8ac48eaaf9b3d6effeba766/)
[Sentry Report 8](https://sentry.tapenvy.us/organizations/tapenvyus/issues/6934/events/47b685b5bdc64b3096a6d663e4940367/)
[Sentry Report 9](https://sentry.tapenvy.us/organizations/tapenvyus/issues/8243/events/710fc76e7c154599bc60a74a9c31c0d0/)
[Sentry Report 10](https://sentry.tapenvy.us/organizations/tapenvyus/issues/7837/events/662d0a61d5784ac897ec687d5e6808bd/)
[Sentry Report 11](https://sentry.tapenvy.us/organizations/tapenvyus/issues/8111/events/e2cd5753254842a0bb39c037c933ef2a/)

While I wasn't able to replicate this issue in testing, the JavaDocs for `setPreferences` explicitly state preference setting will fail if the component is not named. I tracked down where we weren't naming components and `EntityViewPane` was the only relevant component that both wasn't named and was a common through line for all of the above reports.