### PR TITLE
Fix support vehicle engine weight rounding to use nearest half-ton

### DIFF
--- a/megamek/src/megamek/common/equipment/Engine.java
+++ b/megamek/src/megamek/common/equipment/Engine.java
@@ -378,7 +378,8 @@ public class Engine implements Serializable, ITechnology {
               && isValidEngine()) {
             double weight = getWeight(entity);
 
-            return roundWeight.round(weight, entity);
+            // SV engine weight rounds to nearest half-ton (or kg for small SVs) per TM p.133
+            return RoundWeight.SV_ENGINE.round(weight, entity);
         } else if (entity.hasETypeFlag(Entity.ETYPE_PROTOMEK) && (engineRating < 40)) {
             // ProtoMek engines with rating < 40 use a special calculation
             return roundWeight.round(engineRating * 0.025, entity);

--- a/megamek/src/megamek/common/util/RoundWeight.java
+++ b/megamek/src/megamek/common/util/RoundWeight.java
@@ -65,6 +65,14 @@ public enum RoundWeight {
         } else {
             return RoundWeight.NEXT_HALF_TON.round(w, e);
         }
+    }),
+    /** Round kg standard to nearest kg, ton-standard to nearest half ton (used for SV engine weight per TM p.133) */
+    SV_ENGINE((w, e) -> {
+        if (null != e && usesKilogramStandard(e)) {
+            return RoundWeight.NEAREST_KG.round(w, e);
+        } else {
+            return RoundWeight.NEAREST_HALF_TON.round(w, e);
+        }
     });
 
     private final BiFunction<Double, Entity, Double> calc;


### PR DESCRIPTION
  Fixes #7350

  Root cause: Support vehicle engine weight was using RoundWeight.STANDARD
  which delegates to NEXT_HALF_TON (ceiling rounding). Per TM p.133, engine
  weight should round to the nearest half-ton for vehicles 5+ tons, or
  nearest kg for small support vehicles.

  Fix: Added new RoundWeight.SV_ENGINE enum that uses NEAREST_HALF_TON for
  ton-standard vehicles and NEAREST_KG for small SVs. Updated Engine.java
  to use this rounding mode specifically for support vehicle engines.

  Example: A 5-ton WiGE with 5/8 movement, ICE engine, and tech rating D
  calculates to 1.0875 tons raw weight. This now correctly rounds to 1.0
  ton instead of 1.5 tons.