### PR TITLE
Fix incorrect defender damage message in physical attacks

### DIFF
--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -14588,7 +14588,6 @@ public class TWGameManager extends AbstractGameManager {
 
         r = new Report(4230);
         r.subject = te.getId();
-        r.addDesc(te);
         r.add(damage);
         r.add(toHit.getTableDesc());
         r.indent();
@@ -14757,7 +14756,6 @@ public class TWGameManager extends AbstractGameManager {
         r = new Report(4230);
         if (te != null) {
             r.subject = te.getId();
-            r.addDesc(te);
         } else {
             r.subject = ae.getId();
         }
@@ -15315,7 +15313,6 @@ public class TWGameManager extends AbstractGameManager {
             r = new Report(4230);
             if (targetEntity != null) {
                 r.subject = targetEntity.getId();
-                r.addDesc(targetEntity);
             } else {
                 r.subject = ae.getId();
             }


### PR DESCRIPTION
  Fixes #7321  (Sorry @Sleet01)

  The damage message for defending units during charge and DFA attacks
  displayed incorrectly as "Defender takes [Unit Name] damage [Player Name]"
  instead of "Defender takes X damage (hit table)".

  Root cause: addDesc(entity) adds TWO data items (unit name + owner name)
  to the report, but message 4230 only has two <data> placeholders intended
  for damage amount and hit table description.

  Fix: Remove the erroneous r.addDesc(te) calls from all three Report(4230)
  usages. The r.subject is already set to reference the entity correctly.

  Bug introduced in db501fe2e8 (May 5, 2025).