### PR TITLE
Fix report line breaks introduced by PR #7665

### DIFF
--- a/megamek/src/megamek/common/Report.java
+++ b/megamek/src/megamek/common/Report.java
@@ -727,8 +727,9 @@ public class Report implements ReportEntry {
         } else {
             finalReport = text.toString();
         }
-        
-        return "<div class='report-entry'>" + finalReport + "</div>";
+
+        // Use span to keep reports inline - <br> tags handle line breaks
+        return "<span class='report-entry'>" + finalReport + "</span>";
     }
 
     @Override

--- a/megamek/unittests/megamek/common/ReportTest.java
+++ b/megamek/unittests/megamek/common/ReportTest.java
@@ -33,15 +33,11 @@
 package megamek.common;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import megamek.common.units.Crew;
+import megamek.common.units.Mek;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-import megamek.common.Report;
-import megamek.common.units.Crew;
-import megamek.common.units.Entity;
-import megamek.common.units.Mek;
 
 public class ReportTest {
 
@@ -53,10 +49,10 @@ public class ReportTest {
         report.add("1");
 
         String text = report.text();
-        // Check for wrapping div
-        assertTrue(text.startsWith("<div class='report-entry'>"),
-                "Report should be wrapped in a div with class report-entry");
-        assertTrue(text.endsWith("</div>"), "Report should end with closing div");
+        // Check for wrapping span (using span instead of div to keep reports inline)
+        assertTrue(text.startsWith("<span class='report-entry'>"),
+              "Report should be wrapped in a span with class report-entry");
+        assertTrue(text.endsWith("</span>"), "Report should end with closing span");
 
         // Check for Bold tag
         assertTrue(text.contains("<B>"), "Report should use bold tag");


### PR DESCRIPTION
  PR #7665 wrapped all report entries in <div class='report-entry'> tags
  for CSS styling support. Since <div> is a block-level element, it forced
  each report to start on a new line - breaking weapon attack sequences
  that use noNL() to display on a single line.

  Before: "AC/10 at Target; needs 9, rolls 3:" then "misses" on next line
  After:  "AC/10 at Target; needs 9, rolls 3: misses" on same line

  Fix: Use <span> instead of <div> for the report-entry wrapper. <span> is
  inline, so reports flow naturally. The existing <br> tags from
  getNewlines() continue to handle actual line breaks.

  Updated ReportTest to expect <span> wrapper.
  
  
<img width="765" height="713" alt="image" src="https://github.com/user-attachments/assets/6531e6fd-7b12-4b12-8fa4-62c6f66d6de2" />

  
  
  
  If this doesn't work in larger testing then we can revert with this PR https://github.com/MegaMek/megamek/pull/7744