### PR TITLE
Fix MegaMek/mekhq#8013: FIx missing ammunition bins on units 

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/randomArmy/ForceGeneratorOptionsView.java
+++ b/megamek/src/megamek/client/ui/dialogs/randomArmy/ForceGeneratorOptionsView.java
@@ -574,10 +574,10 @@ public class ForceGeneratorOptionsView extends JPanel implements FocusListener, 
         fd.setDropshipPct(dropShipPCT);
         txtDropshipPct.setText(String.valueOf(dropShipPCT));
 
-        double jumpShipPCT = MathUtility.parseDouble(txtJumpshipPct.getText(), 0) * 0.01;
+        double jumpShipPCT = MathUtility.parseDouble(txtJumpshipPct.getText(), 0.0) * 0.01;
         txtJumpshipPct.setText(String.valueOf(jumpShipPCT));
 
-        double cargo = MathUtility.parseDouble(txtCargo.getText(), 0);
+        double cargo = MathUtility.parseDouble(txtCargo.getText(), 0.0);
         txtCargo.setText(String.valueOf(cargo));
 
         ProgressMonitor monitor = new ProgressMonitor(this,

--- a/megamek/src/megamek/codeUtilities/MathUtility.java
+++ b/megamek/src/megamek/codeUtilities/MathUtility.java
@@ -482,7 +482,7 @@ public class MathUtility {
      *
      * @return The <code>double</code> value or defaultValue.
      */
-    public static double parseDouble(final String value, double defaultValue) {
+    public static Double parseDouble(final String value, Double defaultValue) {
         if (value == null || value.isEmpty()) {
             return defaultValue;
         }
@@ -497,7 +497,7 @@ public class MathUtility {
 
     /**
      * Parses the provided string into a double. If parsing fails, a default value of 0.0 is returned. This method
-     * delegates to {@link #parseDouble(String, double)} with a default value.
+     * delegates to {@link #parseDouble(String, Double)} with a default value.
      *
      * @param value the string to parse. Can be a numeric string or {@code null}.
      *

--- a/megamek/src/megamek/common/loaders/MULParser.java
+++ b/megamek/src/megamek/common/loaders/MULParser.java
@@ -1861,8 +1861,11 @@ public class MULParser {
 
                         } // End have-good-shots-value
 
-                        double capVal = MathUtility.parseDouble(capacity);
-                        ((AmmoMounted) mounted).setAmmoCapacity(capVal);
+                        Double capVal = MathUtility.parseDouble(capacity, null);
+                        if (capVal != null) {
+                            ((AmmoMounted) mounted).setAmmoCapacity(capVal);
+                        }
+
 
                         if (capacity.equals(VALUE_NA)) {
                             if (entity.hasETypeFlag(Entity.ETYPE_BATTLEARMOR)


### PR DESCRIPTION
Fixes MegaMek/mekhq#8013

When parsing the `size` we should not use the value of "0" as default. If we do not get a value when we `parseDouble`, we should not `setAmmoCapacity`. Prior to an April change, this was wrapped in a try/catch block. If the value wasn't there, it would throw an exception and not call `setAmmoCapacity`. This brings that functionality back.