### PR TITLE
Fix reporting all AE victims as being revealed by the blast

### DIFF
--- a/megamek/src/megamek/common/weapons/handlers/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/handlers/AreaEffectHelper.java
@@ -599,11 +599,11 @@ public class AreaEffectHelper {
         // Reveal hidden entity caught in the blast (per TW pg. 259)
         if (entity.isHidden()) {
             entity.setHidden(false);
+            report = new Report(9963);
+            report.subject = entity.getId();
+            report.addDesc(entity);
+            vPhaseReport.add(report);
         }
-        report = new Report(9963);
-        report.subject = entity.getId();
-        report.addDesc(entity);
-        vPhaseReport.add(report);
 
         if (entity instanceof BattleArmor) {
             // BA take full damage to each trooper, ouch!


### PR DESCRIPTION
Somehow the report block ended up outside the conditional... for no reason I can discern -_-;

This was actually mentioned last week but I don't think an issue has been filed.

Testing:
- Ran all three projects' unit tests
- Reran a bot-vs-bot scenario that was producing the issue and confirmed it no longer happens.