### PR TITLE
Null safety for missing options in older savegames

### DIFF
--- a/megamek/src/megamek/common/units/Crew.java
+++ b/megamek/src/megamek/common/units/Crew.java
@@ -826,7 +826,9 @@ public class Crew implements Serializable {
             for (Enumeration<IOption> j = group.getOptions(); j.hasMoreElements(); ) {
                 IOption option = j.nextElement();
 
-                option.clearValue();
+                if (option != null) {
+                    option.clearValue();
+                }
             }
         }
 


### PR DESCRIPTION
Prevents attempting to clear null option entries, which can happen when loading an older save into MegaMek after a new option (in this case `MD_CYBER_IMP_TELE` in the `MD_ADVANTAGES` group) is added.

Testing:
- Ran all 3 projects' unit tests
- Loaded previously-affected game
- Loaded an older MHQ campaign save and ran a scenario