### PR TITLE
Fix BV Calculation for Capital Fighters. 

### DIFF
--- a/megamek/src/megamek/common/battleValue/HeatTrackingBVCalculator.java
+++ b/megamek/src/megamek/common/battleValue/HeatTrackingBVCalculator.java
@@ -82,7 +82,7 @@ public abstract class HeatTrackingBVCalculator extends BVCalculator {
         }
 
         List<WeaponBvHeatRecord> weaponRecords = new ArrayList<>();
-        for (WeaponMounted mounted : entity.getWeaponList()) {
+        for (WeaponMounted mounted : entity.getTotalWeaponList()) {
             if (!countAsOffensiveWeapon(mounted)) {
                 continue;
             }
@@ -228,7 +228,7 @@ public abstract class HeatTrackingBVCalculator extends BVCalculator {
     }
 
     protected double totalWeaponHeat() {
-        return entity.getWeaponList().stream()
+        return entity.getTotalWeaponList().stream()
               .filter(this::countAsOffensiveWeapon)
               .mapToDouble(this::weaponHeat)
               .sum();


### PR DESCRIPTION
  Root Cause: When STRATOPS_CAPITAL_FIGHTER game option is enabled, Entity.getWeaponList() returns weaponGroupList (empty for regular fighters) instead of weaponList (where weapons are actually stored).

  Fix Applied: Changed HeatTrackingBVCalculator.java to use getTotalWeaponList() instead of getWeaponList() at two locations:

  1. Line 85 - processWeapons() loop that iterates over weapons
  2. Line 231 - totalWeaponHeat() stream calculation

  This is consistent with how LargeAeroBVCalculator and WarShipBVCalculator already handle this.

  Test Results: Build compiles and all tests pass.

  ---
  The Striga S-STR-O Invictus and other aerospace fighters should now correctly count their weapons (Gauss Rifle, Heavy PPCs, ER Medium Lasers, etc.) for BV calculation when STRATOPS_CAPITAL_FIGHTER is enabled, instead of showing "Weapons: - None".