### PR TITLE
Issue MegaMek/mekhq#8427: Prevent array index OOB from troop size

### DIFF
--- a/megamek/src/megamek/common/units/NavalRepairFacility.java
+++ b/megamek/src/megamek/common/units/NavalRepairFacility.java
@@ -264,6 +264,7 @@ public class NavalRepairFacility extends UnitBay {
      *
      * @return The amount of bay space taken up by the unit.
      */
+    @Override
     public double spaceForUnit(Entity unit) {
         return unit.getTonnage();
     }


### PR DESCRIPTION
One of two PRs for fixing issues in MegaMek/mekhq#8427. Naval repair facilities also have a tonnage based space, but limit it to two units via `canLoad()`. This was only partially implemented - this is the rest of that.