### PR TITLE
Fix: Updated Unified Log Save Policy

### DIFF
--- a/megamek/mmconf/log4j2.xml
+++ b/megamek/mmconf/log4j2.xml
@@ -19,7 +19,7 @@
 
             <DefaultRolloverStrategy max="10">
                 <Delete basePath="logs" maxDepth="1">
-                    <IfFileName regex="(unified_log|bot_path_ranker).*\.log(\.gz)?$" />
+                    <IfFileName regex="(unified_log|bot_path_ranker)_\d+\.log(\.gz)?$" />
                     <IfAccumulatedFileSize exceeds="15MB" />
                 </Delete>
             </DefaultRolloverStrategy>
@@ -37,7 +37,7 @@
 
             <DefaultRolloverStrategy max="5">
                 <Delete basePath="logs" maxDepth="1">
-                    <IfFileName regex="(unified_log|bot_path_ranker).*\.log(\.gz)?$" />
+                    <IfFileName regex="(unified_log|bot_path_ranker)_\d+\.log(\.gz)?$" />
                     <IfAccumulatedFileSize exceeds="15MB" />
                 </Delete>
             </DefaultRolloverStrategy>


### PR DESCRIPTION
Under our current implementation we add unified logs to the log folder on app restart. However, while individual logs have a maximum size there was no overall maximum size. This meant that unless users empty their log folder regularly it can end up several gigs large over the course of a single development cycle.

This PR updates our log policy in the following ways:

- Removed in-game date logging. I considered this superfluous.
- Reduced individual log sizes (before rollover) from 25MB to 1MB (for a log this is already pretty chunky).
- Reduced Bot Path log retention from 10 logs to 5. This allows us to retain more unified_logs before we hit the size cap.
- Implemented a policy where once all bot path and unified logs exceed 15MB we start removing old logs.

For that last policy 15MB was chosen because of GitHub's maximum upload size of 25MB. It leaves 15MB for logs and 10MB for a players' saves. Even exceptionally large MekHQ campaigns normally only hit around 10MB so this should leave ample room for both in a single upload.