### PR TITLE
PR: Generate MekHQ-usable MUL at end of PACAR

### DIFF
--- a/megamek/src/megamek/client/HeadlessClient.java
+++ b/megamek/src/megamek/client/HeadlessClient.java
@@ -147,17 +147,16 @@ public class HeadlessClient extends Client {
     private void saveVictoryList() {
         String filename = getLocalPlayer().getName();
 
-        // Did the we select a file?
+        // Did we select a file?
         File unitFile = new File(filename + CG_FILE_EXTENSION_MUL);
-        if (unitFile != null) {
-            if (!(unitFile.getName().toLowerCase().endsWith(CG_FILE_EXTENSION_MUL))) {
-                try {
-                    unitFile = new File(unitFile.getCanonicalPath() + CG_FILE_EXTENSION_MUL);
-                } catch (Exception ignored) {
-                    // nothing needs to be done here
-                    return;
-                }
+        if (!(unitFile.getName().toLowerCase().endsWith(CG_FILE_EXTENSION_MUL))) {
+            try {
+                unitFile = new File(unitFile.getCanonicalPath() + CG_FILE_EXTENSION_MUL);
+            } catch (Exception ignored) {
+                // nothing needs to be done here
+                return;
             }
+
 
             // What bot was this player? We need it to get the propper salvage MUL, just in case
             Player botPlayer =

--- a/megamek/src/megamek/client/HeadlessClient.java
+++ b/megamek/src/megamek/client/HeadlessClient.java
@@ -41,6 +41,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Enumeration;
 
+import megamek.client.ui.Messages;
+import megamek.common.Player;
 import megamek.common.units.Entity;
 import megamek.common.units.EntityListFile;
 import megamek.common.enums.GamePhase;
@@ -50,6 +52,9 @@ import megamek.common.preference.ClientPreferences;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.util.StringUtil;
 import megamek.logging.MMLogger;
+
+import javax.swing.JFileChooser;
+import javax.swing.filechooser.FileNameExtensionFilter;
 
 /**
  * This class is instantiated for the player. It allows to communicate with the server with no GUI attached.
@@ -117,6 +122,7 @@ public class HeadlessClient extends Client {
                         logger.error(ex, "Failed to save entity list file");
                     }
                 }
+                saveVictoryList();
             }
         };
 
@@ -137,4 +143,35 @@ public class HeadlessClient extends Client {
         super.changePhase(phase);
     }
 
+
+    private void saveVictoryList() {
+        String filename = getLocalPlayer().getName();
+
+        // Did the we select a file?
+        File unitFile = new File(filename + CG_FILE_EXTENSION_MUL);
+        if (unitFile != null) {
+            if (!(unitFile.getName().toLowerCase().endsWith(CG_FILE_EXTENSION_MUL))) {
+                try {
+                    unitFile = new File(unitFile.getCanonicalPath() + CG_FILE_EXTENSION_MUL);
+                } catch (Exception ignored) {
+                    // nothing needs to be done here
+                    return;
+                }
+            }
+
+            // What bot was this player? We need it to get the propper salvage MUL, just in case
+            Player botPlayer =
+                  getGame().getPlayersList().stream().filter(p -> p.isBot() && p.getName().equals(getLocalPlayer().getName() +
+                        "@AI")).findFirst().orElse(null);
+
+            if (botPlayer != null) {
+                try {
+                    // Save the player's entities to the file.
+                    EntityListFile.saveTo(unitFile, this, botPlayer);
+                } catch (Exception ex) {
+                    logger.error(ex, "saveVictoryList");
+                }
+            }
+        }
+    }
 }

--- a/megamek/src/megamek/common/units/EntityListFile.java
+++ b/megamek/src/megamek/common/units/EntityListFile.java
@@ -54,6 +54,7 @@ import megamek.MMConstants;
 import megamek.client.Client;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.CriticalSlot;
+import megamek.common.Player;
 import megamek.common.battleArmor.BattleArmor;
 import megamek.common.bays.Bay;
 import megamek.common.equipment.*;
@@ -697,7 +698,25 @@ public class EntityListFile {
      * @throws IOException is thrown on any error.
      */
     public static void saveTo(File file, Client client) throws IOException {
-        if (null == client.getGame()) {
+        saveTo(file, client, client.getLocalPlayer());
+    }
+
+    /**
+     * Save the entities from the game of client to the given file. This will create separate sections for salvage,
+     * devastated, and ejected crews in addition to the surviving units
+     * <p>
+     * The <code>Entity</code>s pilots, damage, ammo loads, ammo usage, and other campaign-related information are
+     * retained but data specific to a particular game is ignored.
+     *
+     * @param file        - The current contents of the file will be discarded and all
+     *                    <code>Entity</code>s in the list will be written to the file.
+     * @param client      - a <code>Client</code> containing the <code>Game</code>s to be used
+     * @param localPlayer - What player should we treat as "the" player?
+     *
+     * @throws IOException is thrown on any error.
+     */
+    public static void saveTo(File file, Client client, Player localPlayer) throws IOException {
+        if (null == client.getGame() || !client.playerExists(localPlayer.getId())) {
             return;
         }
 
@@ -718,9 +737,9 @@ public class EntityListFile {
         // Sort entities into player's, enemies, and allies and add to survivors,
         // salvage, and allies.
         for (Entity entity : client.getGame().inGameTWEntities()) {
-            if (entity.getOwner().getId() == client.getLocalPlayer().getId()) {
+            if (entity.getOwner().getId() == localPlayer.getId()) {
                 living.add(entity);
-            } else if (entity.getOwner().isEnemyOf(client.getLocalPlayer())) {
+            } else if (entity.getOwner().isEnemyOf(localPlayer)) {
                 if (!entity.canEscape()) {
                     kills.put(entity.getDisplayName(), MULParser.VALUE_NONE);
                 }
@@ -734,9 +753,9 @@ public class EntityListFile {
         // sections
         for (Enumeration<Entity> iter = client.getGame().getRetreatedEntities(); iter.hasMoreElements(); ) {
             Entity ent = iter.nextElement();
-            if (ent.getOwner().getId() == client.getLocalPlayer().getId()) {
+            if (ent.getOwner().getId() == localPlayer.getId()) {
                 living.add(ent);
-            } else if (!ent.getOwner().isEnemyOf(client.getLocalPlayer())) {
+            } else if (!ent.getOwner().isEnemyOf(localPlayer)) {
                 allied.add(ent);
             } else {
                 retreated.add(ent);
@@ -747,7 +766,7 @@ public class EntityListFile {
         Enumeration<Entity> graveyard = client.getGame().getGraveyardEntities();
         while (graveyard.hasMoreElements()) {
             Entity entity = graveyard.nextElement();
-            if (entity.getOwner().isEnemyOf(client.getLocalPlayer())) {
+            if (entity.getOwner().isEnemyOf(localPlayer)) {
                 Entity killer = client.getGame().getEntityFromAllSources(entity.getKillerId());
                 if (null != killer && !killer.getExternalIdAsString().equals("-1")) {
                     kills.put(entity.getDisplayName(), killer.getExternalIdAsString());
@@ -762,7 +781,7 @@ public class EntityListFile {
         Enumeration<Entity> devastation = client.getGame().getDevastatedEntities();
         while (devastation.hasMoreElements()) {
             Entity entity = devastation.nextElement();
-            if (entity.getOwner().isEnemyOf(client.getLocalPlayer())) {
+            if (entity.getOwner().isEnemyOf(localPlayer)) {
                 Entity killer = client.getGame().getEntityFromAllSources(entity.getKillerId());
                 if (null != killer && !killer.getExternalIdAsString().equals("-1")) {
                     kills.put(entity.getDisplayName(), killer.getExternalIdAsString());

--- a/megamek/src/megamek/common/units/EntityListFile.java
+++ b/megamek/src/megamek/common/units/EntityListFile.java
@@ -591,7 +591,7 @@ public class EntityListFile {
 
     /**
      * Save the <code>Entity</code>s in the list to the given file.
-     * <p>
+     * <br><br>
      * The <code>Entity</code>'s pilots, damage, ammo loads, ammo usage, and other campaign-related information are
      * retained, but data specific to a particular game is ignored. This method is a simpler version of the overloaded
      * method {@code saveTo}, with a default generic battle value of 0 (this causes GBV to be ignored), and with unit
@@ -609,7 +609,7 @@ public class EntityListFile {
 
     /**
      * Save the <code>Entity</code>s in the list to the given file.
-     * <p>
+     * <br><br>
      * The <code>Entity</code>'s pilots, damage, ammo loads, ammo usage, and other campaign-related information are
      * retained, but data specific to a particular game is ignored. This method is a simpler version of the overloaded
      * method {@code saveTo}, with a default generic battle value of 0 (this causes GBV to be ignored).
@@ -629,7 +629,7 @@ public class EntityListFile {
 
     /**
      * Save the <code>Entity</code>s in the list to the given file.
-     * <p>
+     * <br><br>
      * The <code>Entity</code>'s pilots, damage, ammo loads, ammo usage, and other campaign-related information are
      * retained, but data specific to a particular game is ignored. Unit embedding is off, see
      * {@link #saveTo(File, ArrayList, int, boolean) the overloaded version of this function}
@@ -648,7 +648,7 @@ public class EntityListFile {
 
     /**
      * Save the <code>Entity</code>s in the list to the given file.
-     * <p>
+     * <br><br>
      * The <code>Entity</code>'s pilots, damage, ammo loads, ammo usage, and other campaign-related information are
      * retained, but data specific to a particular game is ignored.
      *
@@ -687,7 +687,7 @@ public class EntityListFile {
     /**
      * Save the entities from the game of client to the given file. This will create separate sections for salvage,
      * devastated, and ejected crews in addition to the surviving units
-     * <p>
+     * <br><br>
      * The <code>Entity</code>s pilots, damage, ammo loads, ammo usage, and other campaign-related information are
      * retained but data specific to a particular game is ignored.
      *
@@ -704,7 +704,7 @@ public class EntityListFile {
     /**
      * Save the entities from the game of client to the given file. This will create separate sections for salvage,
      * devastated, and ejected crews in addition to the surviving units
-     * <p>
+     * <br><br>
      * The <code>Entity</code>s pilots, damage, ammo loads, ammo usage, and other campaign-related information are
      * retained but data specific to a particular game is ignored.
      *


### PR DESCRIPTION
Did you know PACAR doesn't generate a MUL that can be used by MekHQ? That's pretty weird. What if it did? With this PR after a PACAR game it will generate the "request victory" MUL that is generated by a normal MegaMek game. 