### PR TITLE
Fix NullPointerException in artillery modifier handling

### DIFF
--- a/megamek/src/megamek/common/util/SerializationHelper.java
+++ b/megamek/src/megamek/common/util/SerializationHelper.java
@@ -288,13 +288,17 @@ public class SerializationHelper {
                             case "description" -> description = reader.getValue();
                             case "cumulative" -> cumulative = Boolean.parseBoolean(reader.getValue());
                         }
-                        reader.moveUp();
                     } catch (NumberFormatException e) {
-                        // Narc Pods with malformed entries will be silently ignored
-                        return null;
+                        // Malformed value field - continue to try remaining fields
                     }
+                    reader.moveUp();
                 }
-                return (value > Integer.MIN_VALUE) ? new TargetRollModifier(value, description, cumulative) : null;
+                // Return a valid modifier even if corrupted - prevents null entries in lists
+                // which cause NPE when iterating (see GitHub issue #7791)
+                if (value <= Integer.MIN_VALUE) {
+                    return new TargetRollModifier(0, "corrupted save entry", false);
+                }
+                return new TargetRollModifier(value, description, cumulative);
             }
 
             @Override


### PR DESCRIPTION
  Fixes #7791

  Root cause: The TargetRollModifier XStream converter returned null on
  malformed save data. When XStream deserialized a List<TargetRollModifier>,
  it added null directly to the list. Later, TargetRoll.getDesc() crashed
  when calling modifier.value() on the null element.

  Fix:
  1. SerializationHelper.java - Converter now returns a placeholder modifier instead of null, preventing list corruption
  2. TargetRoll.java - Added defensive null checks in all methods that iterate the modifiers list, allowing existing corrupted saves to load

  Tested by loading the provided corrupted save (Round 12) and playing
  through Round 15 with no crashes.

  ---
  PR Note

  ## Summary
  - Fixed game lockup caused by NullPointerException when processing artillery modifiers
  - Root cause was XStream converter returning null on malformed data, corrupting the modifiers list
  - Added defensive null checks throughout TargetRoll to handle existing corrupted saves

  ## Test plan
  - [x] Loaded corrupted save file from issue (Round 12 autosave)
  - [x] Played through to Round 15 with no crashes
  - [x] Compilation successful with no new warnings
  
  
  ### Detail Analysis (needs human verification)
  
[Battle Lockup after end of movement turn.md](https://github.com/user-attachments/files/24180057/Battle.Lockup.after.end.of.movement.turn.md)
