### PR TITLE
Fix for Issue #7794 - Incorrect BV mod for IS BA Reactive Armor.

### DIFF
--- a/megamek/src/megamek/common/battleArmor/BattleArmor.java
+++ b/megamek/src/megamek/common/battleArmor/BattleArmor.java
@@ -1323,7 +1323,7 @@ public class BattleArmor extends Infantry {
     }
 
     /**
-     * return if this BA has reactive armor (fix for #7794)
+     * return if this BA has reactive armor
      */
     public boolean isReactive() {
         return getArmorType(LOC_TROOPER_1) == EquipmentType.T_ARMOR_BA_REACTIVE;


### PR DESCRIPTION
Root Cause: The isReactive(), isFireResistant(), and isReflective() methods in BattleArmor.java were checking for misc equipment flags, but BA special armor types are stored as armor types (via getArmorType()), not as misc equipment. The old code never matched anything.

  Fix: Simplified all three methods to directly check the armor type:

```
  public boolean isFireResistant() {
      return getArmorType(LOC_TROOPER_1) == EquipmentType.T_ARMOR_BA_FIRE_RESIST;
  }

  public boolean isReflective() {
      return getArmorType(LOC_TROOPER_1) == EquipmentType.T_ARMOR_BA_REFLECTIVE;
  }

  public boolean isReactive() {
      return getArmorType(LOC_TROOPER_1) == EquipmentType.T_ARMOR_BA_REACTIVE;
  }

```
  File changed: megamek/src/megamek/common/battleArmor/BattleArmor.java
  
  Fixes #7794 