### PR TITLE
Fix #7791: Fix game locking up during indirect phase

### DIFF
--- a/megamek/src/megamek/common/util/SerializationHelper.java
+++ b/megamek/src/megamek/common/util/SerializationHelper.java
@@ -276,7 +276,7 @@ public class SerializationHelper {
 
             @Override
             public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
-                int value = Integer.MIN_VALUE;
+                Integer value = null;
                 String description = "";
                 boolean cumulative = false;
 
@@ -294,7 +294,7 @@ public class SerializationHelper {
                         return null;
                     }
                 }
-                return (value > Integer.MIN_VALUE) ? new TargetRollModifier(value, description, cumulative) : null;
+                return (value != null) ? new TargetRollModifier(value, description, cumulative) : null;
             }
 
             @Override


### PR DESCRIPTION
Fixes #7791 

Use `null` as the default Integer value when loading TargetRolls instead of `Integer.MINIMUM_VALUE` because having `Integer.MINIMUM_VALUE` is a valid value.

Specifically, this was causing the game to crash because one of the artillery's `ArtilleryTracker aTracker` had an "automatic success" as a value for a coord. After loading the save, the serialization helper wasn't able to differentiate it from the uninitialized int and returned a null value. 