### PR TITLE
Fix #673 - Area Effect revealing units. 

### DIFF
--- a/megamek/src/megamek/common/weapons/handlers/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/handlers/AreaEffectHelper.java
@@ -911,6 +911,15 @@ public class AreaEffectHelper {
         r.add(damage);
         vDesc.addElement(r);
 
+        // Reveal hidden entity caught in the blast (per TW pg. 259)
+        if (entity.isHidden()) {
+            entity.setHidden(false);
+            Report revealReport = new Report(9963);
+            revealReport.subject = entity.getId();
+            revealReport.addDesc(entity);
+            vDesc.addElement(revealReport);
+        }
+
         while (damage > 0) {
             int cluster = Math.min(clusterAmt, damage);
             if (entity instanceof Infantry) {


### PR DESCRIPTION
  Summary

  Fix area-effect explosions (fuel tanks, building collapses, nuclear blasts) not revealing hidden units as required by TW pg. 259.  Investigating this it looks like a variety of units wouldn't be revealed.
  
  This needs a lot of testing. 

  Problem

  Hidden units caught in fuel tank/building explosions were being damaged but NOT revealed. The applyExplosionClusterDamageToEntity() method was missing the reveal logic that already existed in artilleryDamageEntity().

  Fix #673 

  Added hidden unit reveal code to AreaEffectHelper.applyExplosionClusterDamageToEntity() to match the existing pattern in artilleryDamageEntity().

  Files Changed

  | File                                                               | Change                             |
  |--------------------------------------------------------------------|------------------------------------|
  | megamek/src/megamek/common/weapons/handlers/AreaEffectHelper.java  | Added reveal logic (lines 914-921) |
  | megamek/unittests/megamek/common/weapons/AreaEffectHelperTest.java | Added 2 unit tests                 |

  Rules Reference

  TW pg. 259: "Area-Effect Attacks: Area-effect attacks automatically reveal any hidden unit in the blast area, and damage them as normal."

  Unit Tests Added

  - testExplosionRevealsHiddenUnit() - Verifies hidden units generate reveal report (9963) when hit by explosion
  - testExplosionDoesNotGenerateRevealReportForVisibleUnit() - Verifies non-hidden units don't generate spurious reveal reports

  Test Results

  All 12 AreaEffectHelperTest tests pass.