### PR TITLE
Issue #7361: Fix aerospace visual detection on non-ground maps

### DIFF
--- a/megamek/src/megamek/common/planetaryConditions/PlanetaryConditions.java
+++ b/megamek/src/megamek/common/planetaryConditions/PlanetaryConditions.java
@@ -620,8 +620,8 @@ public class PlanetaryConditions implements Serializable {
 
         // anything else is infantry
 
-        // Beyond altitude 9, Aerospace can't see. No need to repeat this test.
-        if (isAero && (en.getAltitude() > 9)) {
+        // Beyond altitude 9, on ground maps, Aerospace can't see. No need to repeat this test.
+        if (isAero && en.isAirborneAeroOnGroundMap() && (en.getAltitude() > 9)) {
             return 0;
         }
 

--- a/megamek/unittests/megamek/common/ComputeVisualRangeTest.java
+++ b/megamek/unittests/megamek/common/ComputeVisualRangeTest.java
@@ -41,9 +41,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Vector;
+import java.util.stream.Stream;
 
 import megamek.common.board.Board;
+import megamek.common.board.BoardType;
 import megamek.common.board.Coords;
 import megamek.common.compute.Compute;
 import megamek.common.game.Game;
@@ -52,7 +55,11 @@ import megamek.common.planetaryConditions.PlanetaryConditions;
 import megamek.common.units.Aero;
 import megamek.common.units.Entity;
 import megamek.common.units.Tank;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ComputeVisualRangeTest {
 
@@ -142,11 +149,15 @@ public class ComputeVisualRangeTest {
         when(mockAttackingEntity.getAltitude()).thenReturn(5);
         when(mockAttackingEntity.isAirborne()).thenReturn(true);
         when(mockAttackingEntity.isAero()).thenReturn(true);
+        when(mockAttackingEntity.isAirborneAeroOnGroundMap()).thenReturn(true);
+        Vector<Coords> position = new Vector<>(List.of(mockAttackingEntity.getPosition()));
+        when(mockAttackingEntity.getPassedThrough()).thenReturn(position);
 
         Entity mockTarget = mock(Tank.class);
         when(mockTarget.getPosition()).thenReturn(new Coords(0, 7));
         when(mockTarget.isIlluminated()).thenReturn(true);
         when(mockTarget.isAirborne()).thenReturn(false);
+        when(mockTarget.isAirborneAeroOnGroundMap()).thenReturn(false);
 
         assertTrue(Compute.inVisualRange(mockGame, mockLos, mockAttackingEntity, mockTarget));
 
@@ -208,6 +219,7 @@ public class ComputeVisualRangeTest {
         Tank mockAttackingEntity = mock(Tank.class);
         when(mockAttackingEntity.getPosition()).thenReturn(new Coords(0, 0));
         when(mockAttackingEntity.isAirborne()).thenReturn(false);
+        when(mockAttackingEntity.isAirborneAeroOnGroundMap()).thenReturn(false);
 
 
         Aero mockTarget = mock(Aero.class);
@@ -215,6 +227,7 @@ public class ComputeVisualRangeTest {
         when(mockTarget.getPosition()).thenReturn(new Coords(0, 7));
         when(mockTarget.isIlluminated()).thenReturn(true);
         when(mockTarget.isAirborne()).thenReturn(true);
+        when(mockTarget.isAirborneAeroOnGroundMap()).thenReturn(true);
         when(mockTarget.isAero()).thenReturn(true);
         when(mockTarget.getPassedThrough()).thenReturn(new Vector<>(Collections.singleton(new Coords(0, 7))));
 
@@ -230,5 +243,160 @@ public class ComputeVisualRangeTest {
         when(mockTarget.getPassedThrough()).thenReturn(new Vector<>(Collections.singleton(new Coords(0, 50))));
         assertTrue(Compute.inVisualRange(mockGame, mockLos, mockAttackingEntity, mockTarget));
 
+    }
+
+    /**
+     * Nested test class for visual range testing at different altitudes on a low altitude board.
+     * Tests altitudes 1 through 10 to verify visibility of targets at different elevations.
+     */
+    @Nested
+    public class LowAltitudeVisibilityTests {
+
+        private Game mockGame;
+        private Board mockBoard;
+        private LosEffects mockLos;
+        private GameOptions mockOptions;
+        private PlanetaryConditions mockPlanetaryConditions;
+        private Player mockPlayer;
+
+        @BeforeEach
+        void setUp() {
+            // Mock Player
+            mockPlayer = mock(Player.class);
+
+            // Mock the board - LOW_ALTITUDE board (SKY type)
+            mockBoard = mock(Board.class);
+            when(mockBoard.isSpace()).thenReturn(false);
+            when(mockBoard.isLowAltitude()).thenReturn(true);
+
+            // Mock Options
+            mockOptions = mock(GameOptions.class);
+            when(mockOptions.booleanOption(anyString())).thenReturn(false);
+
+            // Mock Planetary Conditions
+            mockPlanetaryConditions = new PlanetaryConditions();
+
+            // Mock Game
+            mockGame = mock(Game.class);
+            when(mockGame.getOptions()).thenReturn(mockOptions);
+            when(mockGame.getBoard()).thenReturn(mockBoard);
+            when(mockGame.getPlayer(anyInt())).thenReturn(mockPlayer);
+            when(mockGame.getFlares()).thenReturn(new Vector<>());
+            when(mockGame.getPlanetaryConditions()).thenReturn(mockPlanetaryConditions);
+
+            // Mock LOS
+            mockLos = mock(LosEffects.class);
+        }
+
+        /**
+         * Provides altitudes 1 through 10 for parameterized tests.
+         */
+        private static Stream<Integer> getAltitudes() {
+            return Stream.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+        }
+
+        /**
+         * Tests air-to-air visibility at different altitudes on a low altitude board.
+         * Verifies that an airborne entity at a specific altitude can see other airborne targets at different altitudes.
+         *
+         * @param altitude the altitude of the attacking entity (1-10)
+         */
+        @ParameterizedTest
+        @MethodSource("getAltitudes")
+        void testVisibilityAtAltitude(int altitude) {
+            // Arrange - Create attacking entity at specified altitude
+            Aero mockAttackingEntity = mock(Aero.class);
+            when(mockAttackingEntity.getPosition()).thenReturn(new Coords(0, 0));
+            when(mockAttackingEntity.getAltitude()).thenReturn(altitude);
+            when(mockAttackingEntity.isAirborne()).thenReturn(true);
+            when(mockAttackingEntity.isAero()).thenReturn(true);
+            // Board is low altitude, so this is not on a ground map.
+            when(mockAttackingEntity.isAirborneAeroOnGroundMap()).thenReturn(false);
+
+            // Create mock airborne target at close range
+            Aero mockTarget = mock(Aero.class);
+            when(mockTarget.getPosition()).thenReturn(new Coords(0, 10));
+            when(mockTarget.isIlluminated()).thenReturn(true);
+            when(mockTarget.isAirborne()).thenReturn(true);
+            when(mockTarget.isAero()).thenReturn(true);
+            // Board is low altitude, so this is not on a ground map.
+            when(mockTarget.isAirborneAeroOnGroundMap()).thenReturn(false);
+            when(mockTarget.getPassedThrough()).thenReturn(new Vector<>(Collections.singleton(new Coords(0, 10))));
+
+            // Test at different altitudes for the target
+            for (int targetAltitude = 1; targetAltitude <= 10; targetAltitude++) {
+                when(mockTarget.getAltitude()).thenReturn(targetAltitude);
+                when(mockTarget.getPassedThrough()).thenReturn(new Vector<>(Collections.singleton(new Coords(0, 10))));
+
+                // Act & Assert - Close range should be visible
+                assertTrue(Compute.inVisualRange(mockGame, mockLos, mockAttackingEntity, mockTarget),
+                    String.format("Entity at altitude %d should see airborne target at altitude %d, range 10",
+                        altitude, targetAltitude));
+            }
+        }
+
+        /**
+         * Tests that airborne targets beyond visual range are not visible.
+         *
+         * @param altitude the altitude of the attacking entity (1-10)
+         */
+        @ParameterizedTest
+        @MethodSource("getAltitudes")
+        void testBeyondVisualRangeAtAltitude(int altitude) {
+            // Arrange
+            Aero mockAttackingEntity = mock(Aero.class);
+            when(mockAttackingEntity.getPosition()).thenReturn(new Coords(0, 0));
+            when(mockAttackingEntity.getAltitude()).thenReturn(altitude);
+            when(mockAttackingEntity.isAirborne()).thenReturn(true);
+            when(mockAttackingEntity.isAero()).thenReturn(true);
+            // Board is low altitude, so this is not on a ground map.
+            when(mockAttackingEntity.isAirborneAeroOnGroundMap()).thenReturn(false);
+
+            Aero mockTarget = mock(Aero.class);
+            when(mockTarget.getPosition()).thenReturn(new Coords(0, 150)); // Very far away
+            when(mockTarget.getAltitude()).thenReturn(altitude);
+            when(mockTarget.isIlluminated()).thenReturn(true);
+            when(mockTarget.isAirborne()).thenReturn(true);
+            when(mockTarget.isAero()).thenReturn(true);
+            // Board is low altitude, so this is not on a ground map.
+            when(mockTarget.isAirborneAeroOnGroundMap()).thenReturn(false);
+            when(mockTarget.getPassedThrough()).thenReturn(new Vector<>(Collections.singleton(new Coords(0, 150))));
+
+            // Act & Assert - Target should be out of visual range
+            assertFalse(Compute.inVisualRange(mockGame, mockLos, mockAttackingEntity, mockTarget),
+                String.format("Entity at altitude %d should NOT see airborne target at range 150", altitude));
+        }
+
+        /**
+         * Tests visibility of airborne targets at the same altitude.
+         *
+         * @param altitude the altitude of both entities (1-10)
+         */
+        @ParameterizedTest
+        @MethodSource("getAltitudes")
+        void testAirToAirAtSameAltitude(int altitude) {
+            // Arrange - Both entities at same altitude
+            Aero mockAttackingEntity = mock(Aero.class);
+            when(mockAttackingEntity.getPosition()).thenReturn(new Coords(0, 0));
+            when(mockAttackingEntity.getAltitude()).thenReturn(altitude);
+            when(mockAttackingEntity.isAirborne()).thenReturn(true);
+            when(mockAttackingEntity.isAero()).thenReturn(true);
+            // Board is low altitude, so this is not on a ground map.
+            when(mockAttackingEntity.isAirborneAeroOnGroundMap()).thenReturn(false);
+
+            Aero mockTarget = mock(Aero.class);
+            when(mockTarget.getPosition()).thenReturn(new Coords(0, 20));
+            when(mockTarget.getAltitude()).thenReturn(altitude);
+            when(mockTarget.isIlluminated()).thenReturn(true);
+            when(mockTarget.isAirborne()).thenReturn(true);
+            when(mockTarget.isAero()).thenReturn(true);
+            // Board is low altitude, so this is not on a ground map.
+            when(mockTarget.isAirborneAeroOnGroundMap()).thenReturn(false);
+            when(mockTarget.getPassedThrough()).thenReturn(new Vector<>(Collections.singleton(new Coords(0, 20))));
+
+            // Act & Assert - Should see target at same altitude
+            assertTrue(Compute.inVisualRange(mockGame, mockLos, mockAttackingEntity, mockTarget),
+                String.format("Entities at same altitude %d should see each other at range 20", altitude));
+        }
     }
 }


### PR DESCRIPTION
Fixes #7361

Airborne aeros should have full visual range on **low altitude** maps (not to be confused with ground maps).