### PR TITLE
Fix-8598-Tank-NPE-applyMovementDamage

### DIFF
--- a/megamek/src/megamek/common/units/Tank.java
+++ b/megamek/src/megamek/common/units/Tank.java
@@ -943,6 +943,11 @@ public class Tank extends Entity {
         immobilized |= markForImmobilize;
 
         // Towed trailers need to use the values of the tractor, or they return Immobile due to 0 MP...
+        // Skip tractor lookup if not in a game (e.g., during MUL parsing)
+        if (game == null) {
+            return;
+        }
+
         Entity tractor = game.getEntity(getTractor());
         if (isTrailer()
               && (getTractor() != Entity.NONE)


### PR DESCRIPTION
Change: Added null guard for game in Tank.applyMovementDamage() at line 947

```
           immobilized |= markForImmobilize;

           // Towed trailers need to use the values of the tractor...
          // Skip tractor lookup if not in a game (e.g., during MUL parsing)
          if (game == null) {
              return;
          }
           Entity tractor = game.getEntity(getTractor());
```

  Build: Compiles successfully

  The fix ensures that when MULParser loads a Tank with engine damage and calls applyDamage(), the null game reference is safely handled. The trailer/tractor sync logic is skipped during parsing (which is correct since you can't look up related entities without a game context anyway).
  
 Fixes https://github.com/MegaMek/mekhq/issues/8598