### PR TITLE
Update HarJel III BV to correct BV.

### DIFF
--- a/megamek/src/megamek/common/equipment/MiscType.java
+++ b/megamek/src/megamek/common/equipment/MiscType.java
@@ -8336,7 +8336,7 @@ public class MiscType extends EquipmentType {
         misc.cost = 360000;
         misc.flags = misc.flags.or(F_HARJEL_III).or(F_MEK_EQUIPMENT);
         misc.omniFixedOnly = true;
-        misc.bv = -1;
+        misc.bv = -2;
         misc.setInstantModeSwitch(true);
         String[] modes = { S_HARJEL_III_2F2R, S_HARJEL_III_4F0R, S_HARJEL_III_3F1R, S_HARJEL_III_1F3R,
                            S_HARJEL_III_0F4R };


### PR DESCRIPTION
I saw the BV for HarJel repair systems was -1, so I thought something was wrong. Apparently it gives negative BV with a multiplier to BV cost of armor, who knew! HarJel repair systems give -1 BV per critical slot (IO:AE pg. 185), which means the BV value for HarJel III (which has 2 crit slots) should be -2.