### PR TITLE
Fix #7629: Fix Princess Not Targetting Infantry In Buildings etc.

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControlState.java
+++ b/megamek/src/megamek/client/bot/princess/FireControlState.java
@@ -67,7 +67,7 @@ public class FireControlState {
     /**
      * The list of "additional targets", such as buildings, bridges and arbitrary hexes that the bot will want to shoot
      *
-     * @return Additional target list.
+     * @return A new list from the additional target list.
      */
     public List<Targetable> getAdditionalTargets() {
         return new ArrayList<>(additionalTargets);
@@ -80,6 +80,15 @@ public class FireControlState {
      */
     public void setAdditionalTargets(List<Targetable> value) {
         additionalTargets = value;
+    }
+
+    /**
+     * Add a single value to the additional targets list.
+     *
+     * @param target
+     */
+    public void addAdditionalTarget(Targetable target) {
+        additionalTargets.add(target);
     }
 
     public void clearEntityIDFStates() {

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -2450,7 +2450,7 @@ public class Princess extends BotClient {
                             if (isEnemyInfantry(entity, coords) &&
                                   entity.isInBuilding() &&
                                   !entity.isHidden()) {
-                                fireControlState.getAdditionalTargets().add(bt);
+                                fireControlState.addAdditionalTarget(bt);
                                 sendChat("Building in Hex " +
                                       coords.toFriendlyString() +
                                       " designated target due to infantry inside building.", Level.INFO);
@@ -2537,7 +2537,7 @@ public class Princess extends BotClient {
                 if (bulldozerPaths.get(0).needsLeveling()) {
                     levelingTarget = getAppropriateTarget(bulldozerPaths.get(0).getCoordsToLevel().get(0),
                           mover.getBoardId());
-                    getFireControlState().getAdditionalTargets().add(levelingTarget);
+                    getFireControlState().addAdditionalTarget(levelingTarget);
                     sendChat("Hex " +
                           levelingTarget.getPosition().toFriendlyString() +
                           " impedes route to destination, targeting for clearing.", Level.INFO);
@@ -2683,12 +2683,12 @@ public class Princess extends BotClient {
             fireControlState.setAdditionalTargets(new ArrayList<>());
             for (final Coords strategicTarget : getStrategicBuildingTargets()) {
                 if (null == game.getBoard().getBuildingAt(strategicTarget)) {
-                    fireControlState.getAdditionalTargets().add(getAppropriateTarget(strategicTarget));
+                    fireControlState.addAdditionalTarget(getAppropriateTarget(strategicTarget));
                     sendChat("No building to target in Hex " +
                           strategicTarget.toFriendlyString() +
                           ", targeting for clearing.", Level.INFO);
                 } else {
-                    fireControlState.getAdditionalTargets().add(getAppropriateTarget(strategicTarget));
+                    fireControlState.addAdditionalTarget(getAppropriateTarget(strategicTarget));
                     sendChat("Building in Hex " + strategicTarget.toFriendlyString() + " designated strategic target.",
                           Level.INFO);
                 }
@@ -2706,7 +2706,7 @@ public class Princess extends BotClient {
                             final Targetable bt = getAppropriateTarget(coords, board.getBoardId());
 
                             if (isEnemyGunEmplacement(entity, coords)) {
-                                fireControlState.getAdditionalTargets().add(bt);
+                                fireControlState.addAdditionalTarget(bt);
                                 sendChat("Building in Hex " +
                                       coords.toFriendlyString() +
                                       " designated target due to Gun Emplacement.", Level.INFO);


### PR DESCRIPTION
Fixes #7629

During the Refactor™️`FireControlState.getAdditionalTargets()` was changed from
```
  public List<Targetable> getAdditionalTargets() {
      return additionalTargets;
  }
```
to
```
  public List<Targetable> getAdditionalTargets() {
      return new ArrayList<>(additionalTargets);
  }
```

This broke a bit of Princess's logic because several instances of `getAdditionalTargets` were used for `getAdditionalTargets().add(target)`, which does not work if the list being returned isn't the actual FireControlState's additional target list..

During #7737 I reverted the change, but copilot didn't like that. So I'm fixing it properly in this separate PR.