### PR TITLE
  Fix #7852 Command Console mechs with only one crew member were applying head hit damage twice to the single pilot instead of once.

### DIFF
--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -17267,6 +17267,9 @@ public class TWGameManager extends AbstractGameManager {
                 if (crewPos >= 0 && (crewPos != pos || crew.isDead(crewPos))) {
                     continue;
                 }
+                if (crew.isMissing(pos)) {
+                    continue;
+                }
                 boolean wasPilot = crew.getCurrentPilotIndex() == pos;
                 boolean wasGunner = crew.getCurrentGunnerIndex() == pos;
                 crew.setHits(crew.getHits(pos) + damage, pos);


### PR DESCRIPTION
  Fixes #7852

  Command Console mechs with only one crew member were applying head hit damage twice to the single pilot instead of once.

  ## Root Cause

  The `damageCrew()` method in `TWGameManager.java` iterates through all crew slots based on `getSlotCount()`, but did not check if a slot was actually occupied. For Command Console cockpits (which have 2 slots: Pilot + Commander), when only one crew member is present, the loop would still process both slots - applying damage to the missing slot as well.

  ## Fix

  Added a check for `crew.isMissing(pos)` to skip empty crew slots when applying damage. This is consistent with how other crew iteration loops handle missing slots (e.g., `Crew.java:932-935`).

  ```java
  if (crew.isMissing(pos)) {
      continue;
  }

  Behavior

  | Scenario           | Before Fix         | After Fix         |
  |--------------------|--------------------|-------------------|
  | Both crew present  | Both take 1 hit    | Both take 1 hit   |
  | Only pilot present | Pilot takes 2 hits | Pilot takes 1 hit |

  This aligns with the Command Console rules: "damage done to the cockpit location does affect both warriors" - meaning all present warriors, not empty slots.

  Test Plan

  - Load Command Console mech with single pilot, take head hit - verify 1 injury
  - Load Command Console mech with both crew, take head hit - verify both take 1 injury
  - Verify other multi-crew cockpits (Tripod, Dual) behave correctly