### PR TITLE
Fix #7848 - Prevent aerodyne aircraft from flying backwards in atmosphere

### DIFF
--- a/megamek/src/megamek/common/moves/MoveStep.java
+++ b/megamek/src/megamek/common/moves/MoveStep.java
@@ -1624,6 +1624,14 @@ public class MoveStep implements Serializable {
                 return;
             }
 
+            // aerodynes cannot fly backwards in atmosphere
+            if (useAeroAtmosphere(game, entity) &&
+                  ((type == MoveStepType.BACKWARDS) ||
+                        (type == MoveStepType.LATERAL_LEFT_BACKWARDS) ||
+                        (type == MoveStepType.LATERAL_RIGHT_BACKWARDS))) {
+                return;
+            }
+
             // spheroids in atmosphere can move a max of 1 hex on the low atmosphere map and 8 hexes on the ground
             // map, regardless of any other considerations unless they're out of control, in which case, well...
             if (useSpheroidAtmosphere(game, entity) &&


### PR DESCRIPTION
 ## Summary

  Fixes #7848

  Aerodyne aircraft (fighters, aerospace fighters, aerodyne DropShips) could move backwards in atmosphere using Shift+S keybind, allowing them to fly in reverse while retaining full combat functionality.

  ## Root Cause

  The airborne movement legality section in `MoveStep.java` had no restriction preventing BACKWARDS movement for aerodyne aircraft in atmosphere. While non-Aero airborne units (like LandAirMek in flight mode) were already restricted to only turns and conversion, true Aero units could use any movement type including backwards.

  ## Fix

  Added a check in the atmosphere movement rules section (after the turning rules) to prevent backwards movement for aerodyne aircraft:

```
  ```java
  // aerodynes cannot fly backwards in atmosphere
  if (useAeroAtmosphere(game, entity) &&
        ((type == MoveStepType.BACKWARDS) ||
              (type == MoveStepType.LATERAL_LEFT_BACKWARDS) ||
              (type == MoveStepType.LATERAL_RIGHT_BACKWARDS))) {
      return;
  }
```

  Scope

  | Unit Type            | Affected? | Reason                               |
  |----------------------|-----------|--------------------------------------|
  | Conventional Fighter | Yes       | Aerodyne, requires forward flight    |
  | Aerospace Fighter    | Yes       | Aerodyne, requires forward flight    |
  | Aerodyne DropShip    | Yes       | Aerodyne, requires forward flight    |
  | Spheroid DropShip    | No        | Hovers like VTOL, different movement |
  | Landed aircraft      | No        | At altitude 0, different code path   |
  | Space movement       | No        | Different movement rules             |