### PR TITLE
Fix 7880 industrial meks assigned movement heat incorrectly

### DIFF
--- a/megamek/src/megamek/common/equipment/Engine.java
+++ b/megamek/src/megamek/common/equipment/Engine.java
@@ -1,7 +1,7 @@
 /*
 
  * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2005-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2005-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/unittests/megamek/common/NonFusionEngineTest.java
+++ b/megamek/unittests/megamek/common/NonFusionEngineTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *


### PR DESCRIPTION
We recently changed how movement heat is calculated and now IndustrialMeks are overheating when moving around.
It looks like the refactor last month assumed that IndustrialMeks were distinct from Meks (which would make sense!) but in fact we implemented them as regular Meks with special Industrial structure.
The upshot is that the code logic is fine, we just need to specifically check for IndustrialMeks.

Testing:
- Ran all 3 projects' unit tests
- Added new unit tests specifically for the reported combinations of IM:Fuel Cell and IM:ICE
- Ran a couple games with IndustrialMeks

Fix #7880 