### PR TITLE
Fix 3821: Add support for environmental sealing when checking moves and deployment

### DIFF
--- a/megamek/src/megamek/common/board/AllowedDeploymentHelper.java
+++ b/megamek/src/megamek/common/board/AllowedDeploymentHelper.java
@@ -42,6 +42,7 @@ import java.util.List;
 import megamek.common.Hex;
 import megamek.common.annotations.Nullable;
 import megamek.common.compute.Compute;
+import megamek.common.equipment.MiscType;
 import megamek.common.game.Game;
 import megamek.common.units.AbstractBuildingEntity;
 import megamek.common.units.Entity;
@@ -235,6 +236,9 @@ public record AllowedDeploymentHelper(Entity entity, Coords coords, Board board,
 
     private List<ElevationOption> allowedElevationsWithWater() {
         List<ElevationOption> result = new ArrayList<>();
+        boolean hasFlotationHull = entity.hasWorkingMisc(MiscType.F_FLOTATION_HULL);
+        boolean isAmphibious = entity.hasWorkingMisc(MiscType.F_FULLY_AMPHIBIOUS);
+        boolean sealed = entity.hasEnvironmentalSealing();
         int depth = hex.terrainLevel(Terrains.WATER);
         // Ice matters only when there is water
         boolean hasIce = hex.containsTerrain(Terrains.ICE);
@@ -252,6 +256,8 @@ public record AllowedDeploymentHelper(Entity entity, Coords coords, Board board,
             }
         } else if (!moveMode.isTrackedWheeledOrHover() && (!hasIce || (depth > entity.height()))) {
             // when there is ice over depth 1 water, don't allow standing Meks to deploy under the ice
+            result.add(new ElevationOption(hex.floor() - hex.getLevel(), ON_SEAFLOOR));
+        } else if (hasFlotationHull || sealed || isAmphibious) {
             result.add(new ElevationOption(hex.floor() - hex.getLevel(), ON_SEAFLOOR));
         }
         if (hasIce && !entity.getMovementMode().isSubmarine()) {

--- a/megamek/src/megamek/common/units/Entity.java
+++ b/megamek/src/megamek/common/units/Entity.java
@@ -2682,8 +2682,8 @@ public abstract class Entity extends TurnOrdered
             // only Meks can move underwater
             if (hex.containsTerrain(Terrains.WATER) &&
                   (assumedAlt < hex.getLevel()) &&
-                  !(this instanceof Mek) &&
-                  !(this instanceof ProtoMek)) {
+                  !((this instanceof Mek) || (this instanceof ProtoMek)) &&
+                  !(hasEnvironmentalSealing())) {
                 return false;
             }
             // can move on the ground unless its underwater

--- a/megamek/src/megamek/common/units/Tank.java
+++ b/megamek/src/megamek/common/units/Tank.java
@@ -744,6 +744,7 @@ public class Tank extends Entity {
 
         boolean hasFlotationHull = hasWorkingMisc(MiscType.F_FLOTATION_HULL);
         boolean isAmphibious = hasWorkingMisc(MiscType.F_FULLY_AMPHIBIOUS);
+        boolean sealed = hasEnvironmentalSealing();
         boolean hexHasRoad = hex.containsTerrain(Terrains.ROAD);
         boolean scoutBikeIntoLightWoods = (hex.terrainLevel(Terrains.WOODS) == 1) &&
               hasQuirk(OptionsConstants.QUIRK_POS_SCOUT_BIKE);
@@ -757,28 +758,27 @@ public class Tank extends Entity {
         switch (movementMode) {
             case TRACKED:
                 if (isCrossCountry && !isSuperHeavy()) {
+                    // Water, no ice, no amphibious measures... or magma?  Bad.
                     return ((hex.terrainLevel(Terrains.WATER) > 0) &&
                           !hex.containsTerrain(Terrains.ICE) &&
-                          !hasFlotationHull &&
-                          !isAmphibious) || (hex.terrainLevel(Terrains.MAGMA) > 1);
+                          !(hasFlotationHull || sealed || isAmphibious) ||
+                          (hex.terrainLevel(Terrains.MAGMA) > 1));
                 }
 
                 if (!isSuperHeavy()) {
                     return ((hex.terrainLevel(Terrains.WOODS) > 1) && !hexHasRoad) ||
                           ((hex.terrainLevel(Terrains.WATER) > 0) &&
                                 !hex.containsTerrain(Terrains.ICE) &&
-                                !hasFlotationHull &&
-                                !isAmphibious) ||
+                                !(hasFlotationHull || sealed || isAmphibious)) ||
                           (hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad) ||
                           (hex.terrainLevel(Terrains.MAGMA) > 1) ||
                           (hex.terrainLevel(Terrains.ROUGH) > 1) ||
                           ((hex.terrainLevel(Terrains.RUBBLE) > 5) && !hexHasRoad);
                 } else {
                     return ((hex.terrainLevel(Terrains.WOODS) > 1) && !hexHasRoad) ||
-                          ((hex.terrainLevel(Terrains.WATER) > 0) &&
+                          ((hex.terrainLevel(Terrains.WATER) > 1) &&
                                 !hex.containsTerrain(Terrains.ICE) &&
-                                !hasFlotationHull &&
-                                !isAmphibious) ||
+                                !(hasFlotationHull || sealed || isAmphibious)) ||
                           (hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad) ||
                           (hex.terrainLevel(Terrains.MAGMA) > 1);
                 }
@@ -786,8 +786,7 @@ public class Tank extends Entity {
                 if (isCrossCountry && !isSuperHeavy()) {
                     return ((hex.terrainLevel(Terrains.WATER) > 0) &&
                           !hex.containsTerrain(Terrains.ICE) &&
-                          !hasFlotationHull &&
-                          !isAmphibious) ||
+                          !(hasFlotationHull || sealed || isAmphibious)) ||
                           hex.containsTerrain(Terrains.MAGMA) ||
                           ((hex.terrainLevel(Terrains.SNOW) > 1) && !hexHasRoad) ||
                           (hex.terrainLevel(Terrains.GEYSER) == 2);
@@ -798,8 +797,7 @@ public class Tank extends Entity {
                           (hex.containsTerrain(Terrains.ROUGH) && !hexHasRoad) ||
                           ((hex.terrainLevel(Terrains.WATER) > 0) &&
                                 !hex.containsTerrain(Terrains.ICE) &&
-                                !hasFlotationHull &&
-                                !isAmphibious) ||
+                                !(hasFlotationHull || sealed || isAmphibious)) ||
                           (hex.containsTerrain(Terrains.RUBBLE) && !hexHasRoad) ||
                           hex.containsTerrain(Terrains.MAGMA) ||
                           (hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad) ||
@@ -808,10 +806,9 @@ public class Tank extends Entity {
                 } else {
                     return (hex.containsTerrain(Terrains.WOODS) && !hexHasRoad) ||
                           (hex.containsTerrain(Terrains.ROUGH) && !hexHasRoad) ||
-                          ((hex.terrainLevel(Terrains.WATER) > 0) &&
+                          ((hex.terrainLevel(Terrains.WATER) > 1) &&
                                 !hex.containsTerrain(Terrains.ICE) &&
-                                !hasFlotationHull &&
-                                !isAmphibious) ||
+                                !(hasFlotationHull || sealed || isAmphibious)) ||
                           (hex.containsTerrain(Terrains.RUBBLE) && !hexHasRoad) ||
                           hex.containsTerrain(Terrains.MAGMA) ||
                           (hex.containsTerrain(Terrains.JUNGLE) && !hexHasRoad) ||


### PR DESCRIPTION
While we had support for flotation hulls and full amphibious mods, environmentally-sealed vehicles (CVs and SVs) were not being allowed to deploy in or enter water hexes.
This patch adds that support.

Testing:
- Ran all 3 projects' unit tests
- Tested with multiple units on various maps.

Fix #3821 