### PR TITLE
Allow getting the mutator name of an ammo type

### DIFF
--- a/megamek/src/megamek/common/equipment/AmmoType.java
+++ b/megamek/src/megamek/common/equipment/AmmoType.java
@@ -3805,6 +3805,12 @@ public class AmmoType extends EquipmentType {
         }
         incendiary.name = nameBuf.toString();
 
+        if (base.mutatorName != null) {
+            incendiary.mutatorName = base.mutatorName + spacedIncendiaryMod;
+        } else {
+            incendiary.mutatorName = INCENDIARY_MOD;
+        }
+
         incendiary.shortName = base.shortName + spacedIncendiaryMod;
         incendiary.setInternalName(base.getInternalName() + spacedIncendiaryMod);
         incendiary.subMunitionName = (base.subMunitionName.isBlank()) ? INCENDIARY_MOD : base.subMunitionName + spacedIncendiaryMod;


### PR DESCRIPTION
Instead of getting the full ammo name ("SRM 6 Inferno"), allow getting just the name of the mutator "Inferno". 
Needed for MML.