### PR TITLE
Remove incorrect validation limiting Mission Equipment Storage to one per unit

### DIFF
--- a/megamek/src/megamek/common/verifier/TestBattleArmor.java
+++ b/megamek/src/megamek/common/verifier/TestBattleArmor.java
@@ -1362,9 +1362,6 @@ public class TestBattleArmor extends TestEntity {
         if (equipmentCount.getOrDefault(EquipmentTypeLookup.BA_PARAFOIL, 0) > 1) {
             currentErrors.add("Cannot mount multiple parafoils");
         }
-        if (equipmentCount.getOrDefault(EquipmentTypeLookup.BA_MISSION_EQUIPMENT, 0) > 1) {
-            currentErrors.add("Cannot mount multiple mission equipment items");
-        }
         if (equipmentCount.containsKey(EquipmentTypeLookup.BA_DWP)) {
             if ((battleArmor.getWeightClass() == EntityWeightClass.WEIGHT_LIGHT)
                   || (battleArmor.getWeightClass() == EntityWeightClass.WEIGHT_ULTRA_LIGHT)) {


### PR DESCRIPTION
Summary

  Removes erroneous validation that prevented BattleArmor units from mounting multiple Mission Equipment Storage items.

  Changes

  - Removed validation check in TestBattleArmor.hasIllegalEquipmentCombinations() that rejected units with more than one
   Mission Equipment Storage

  Root Cause

  The validation incorrectly treated Mission Equipment Storage like unique equipment (partial wings, magnetic clamps,
  parafoils) which are legitimately limited to one per unit. Mission Equipment Storage has no such restriction in the
  rules.

  Files Changed

  - megamek/src/megamek/common/verifier/TestBattleArmor.java