### PR TITLE
Fix LAM fly-off crash by using IAero interface instead of Aero class (Fixes #7932)

### DIFF
--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -5817,7 +5817,7 @@ public class TWGameManager extends AbstractGameManager {
      *
      * @param entity Unit leaving the map using Thrust MPs (must implement IAero)
      *
-     * @return Vector of reports
+     * @return Report describing the unit flying off the map
      */
     protected Report processFlyingOff(Entity entity) {
         IAero aero = (IAero) entity;

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -5688,11 +5688,9 @@ public class TWGameManager extends AbstractGameManager {
 
         // Aerospace that fly off to return in a later round must be handled
         // at the end of the round, but set some state here for simplicity
-        if (entity.isAero() && flewOff) {
-            Aero aero = (Aero) entity;
-
+        if ((aeroUnit != null) && flewOff) {
             // Record direction
-            aero.setFlyingOff(fleeDirection);
+            aeroUnit.setFlyingOff(fleeDirection);
 
             // Currently only Aerospace can fly off and return.
             if (returnable > -1) {
@@ -5803,9 +5801,10 @@ public class TWGameManager extends AbstractGameManager {
             // Handle Aerospace units that flew off the board this round but lingered through the
             // various phases for full attack opportunities.
             // TODO: use off-board state with flown-off aerospace units
-            if (entity instanceof Aero aero) {
+            if (entity.isAero()) {
+                IAero aero = (IAero) entity;
                 if (aero.isFlyingOff()) {
-                    reports.add(processFlyingOff(aero));
+                    reports.add(processFlyingOff(entity));
                 }
             }
         }
@@ -5816,21 +5815,22 @@ public class TWGameManager extends AbstractGameManager {
     /**
      * Compile report for Aerospace unit flying off the map at the end of the round, and finalize the unit's state.
      *
-     * @param aero Unit leaving the map using Thrust MPs
+     * @param entity Unit leaving the map using Thrust MPs (must implement IAero)
      *
      * @return Vector of reports
      */
-    protected Report processFlyingOff(Aero aero) {
-        String retreatEdge = setRetreatEdge(aero, aero.getFlyingOffDirection());
+    protected Report processFlyingOff(Entity entity) {
+        IAero aero = (IAero) entity;
+        String retreatEdge = setRetreatEdge(entity, aero.getFlyingOffDirection());
 
         // Report aerospace flying off at the end of the round
         Report r = new Report(9370, Report.PUBLIC);
-        r.addDesc(aero);
+        r.addDesc(entity);
         r.add(retreatEdge);
 
         // Set un-deployed state
-        aero.setDeployed(false);
-        aero.setPosition(null);
+        entity.setDeployed(false);
+        entity.setPosition(null);
         aero.setFlyingOff(OffBoardDirection.NONE);
 
         // If we're flying off because we're OOC, when we come back we

--- a/megamek/unittests/megamek/common/units/LandAirMekTest.java
+++ b/megamek/unittests/megamek/common/units/LandAirMekTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import megamek.common.OffBoardDirection;
 import megamek.common.equipment.EquipmentType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -175,6 +176,53 @@ class LandAirMekTest {
             lam.setConversionMode(LandAirMek.CONV_MODE_AIR_MEK);
 
             assertFalse(lam.isAero(), "AirMek mode LAM should not pass isAero() check for strafing");
+        }
+    }
+
+    @Nested
+    @DisplayName("Fly Off Eligibility Tests (Issue #7932)")
+    class FlyOffEligibilityTests {
+
+        @Test
+        @DisplayName("LAM in Fighter mode can use IAero fly off methods")
+        void fighterModeCanUseFlyOffMethods() {
+            // This test verifies the fix for issue #7932:
+            // LAMs in fighter mode must be able to fly off the map.
+            // The fix changed instanceof Aero checks to isAero() with IAero casts.
+            lam.setConversionMode(LandAirMek.CONV_MODE_FIGHTER);
+
+            // LAM should pass isAero() check used in handleFlyOffs()
+            assertTrue(lam.isAero(), "Fighter mode LAM should pass isAero() check");
+
+            // LAM should be castable to IAero (pattern used in processFlyingOff)
+            IAero aero = (IAero) lam;
+
+            // IAero fly off methods should work
+            aero.setFlyingOff(OffBoardDirection.EAST);
+            assertTrue(aero.isFlyingOff(), "LAM should be marked as flying off");
+            assertEquals(OffBoardDirection.EAST, aero.getFlyingOffDirection());
+
+            // Reset
+            aero.setFlyingOff(OffBoardDirection.NONE);
+            assertFalse(aero.isFlyingOff(), "LAM should no longer be flying off after reset");
+        }
+
+        @Test
+        @DisplayName("LAM in Mek mode is not eligible for fly off")
+        void mekModeNotEligibleForFlyOff() {
+            lam.setConversionMode(LandAirMek.CONV_MODE_MEK);
+
+            // Mek mode LAM should not pass the isAero() check used in handleFlyOffs()
+            assertFalse(lam.isAero(), "Mek mode LAM should not pass isAero() check for fly off");
+        }
+
+        @Test
+        @DisplayName("LAM in AirMek mode is not eligible for fly off")
+        void airMekModeNotEligibleForFlyOff() {
+            lam.setConversionMode(LandAirMek.CONV_MODE_AIR_MEK);
+
+            // AirMek mode LAM should not pass the isAero() check used in handleFlyOffs()
+            assertFalse(lam.isAero(), "AirMek mode LAM should not pass isAero() check for fly off");
         }
     }
 }


### PR DESCRIPTION
Root Cause: Three places in TWGameManager.java used Aero class directly instead of the IAero interface. LAMs in fighter mode implement IAero but extend Mek, not Aero, so they failed these checks.

  Changes made:
  1. processLeaveMap() - Line 5691: Use existing IAero aeroUnit instead of casting to Aero
  2. handleFlyOffs() - Line 5804: Change instanceof Aero to entity.isAero() with IAero cast
  3. processFlyingOff() - Line 5822: Change parameter from Aero to Entity with internal IAero cast

  All changes are in megamek/src/megamek/server/totalWarfare/TWGameManager.java
  
  Fixes #7932
  
  Was unable to test with save from the issue, but tested with Aero and LAMs and things worked. 