### PR TITLE
Hopefully fixing the checkstyle.yml

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -16,13 +16,22 @@ jobs:
       fail-fast: false
 
     steps:
+      - name: Checkout Data Repo
+        uses: actions/checkout@v6
+        with:
+          repository: megamek/mm-data
+          path: mm-data
+
       - name: "Check out MegaMek"
         uses: actions/checkout@v6
+        with:
+          path: megamek
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
       - name: Checkstyle
+        working-directory: megamek
         run: ./gradlew checkstyleMain
 
       - name: Upload Test Logs on Failure
@@ -30,4 +39,4 @@ jobs:
         if: failure()
         with:
           name: cd-failure-logs
-          path: ./megamek/megamek/build/reports/
+          path: megamek/megamek/build/reports/


### PR DESCRIPTION
Root Cause: The checkstyle workflow was missing the checkout of the mm-data repository, which is required as an included
  Gradle build.

  Fix: Added the same checkout pattern used in ci.yml:
  - Checkout megamek/mm-data to mm-data path
  - Checkout megamek to megamek path
  - Run gradle from the megamek working directory