### PR TITLE
Move TacOps Picking Up Units option above unofficial options (Fixes #7933)

### DIFF
--- a/megamek/src/megamek/common/options/GameOptions.java
+++ b/megamek/src/megamek/common/options/GameOptions.java
@@ -212,6 +212,7 @@ public class GameOptions extends BasicGameOptions {
         addOption(advancedCombat, OptionsConstants.ADVANCED_COMBAT_TAC_OPS_ADVANCED_MEK_HIT_LOCATIONS, false);
         addOption(advancedCombat, OptionsConstants.ADVANCED_COMBAT_TAC_OPS_COOLANT_FAILURE, false);
         addOption(advancedCombat, OptionsConstants.ADVANCED_COMBAT_TAC_OPS_BA_VS_BA, false);
+        addOption(advancedCombat, OptionsConstants.ADVANCED_COMBAT_PICKING_UP_AND_THROWING_UNITS, false);
         addOption(advancedCombat, OptionsConstants.ADVANCED_COMBAT_NO_TAC, false);
         addOption(advancedCombat, OptionsConstants.ADVANCED_COMBAT_VTOL_STRAFING, false);
         addOption(advancedCombat, OptionsConstants.ADVANCED_COMBAT_VEHICLES_SAFE_FROM_INFERNOS, false);
@@ -231,7 +232,6 @@ public class GameOptions extends BasicGameOptions {
         addOption(advancedCombat, OptionsConstants.ADVANCED_COMBAT_FOREST_FIRES_NO_SMOKE, false);
         addOption(advancedCombat, OptionsConstants.ADVANCED_COMBAT_HOT_LOAD_IN_GAME, false);
         addOption(advancedCombat, OptionsConstants.ADVANCED_COMBAT_MULTI_USE_AMS, false);
-        addOption(advancedCombat, OptionsConstants.ADVANCED_COMBAT_PICKING_UP_AND_THROWING_UNITS, false);
 
         IBasicOptionGroup advancedGroundMovement = addGroup("advancedGroundMovement");
         addOption(advancedGroundMovement, OptionsConstants.ADVANCED_GROUND_MOVEMENT_TAC_OPS_SPRINT, false);


### PR DESCRIPTION
  Moved the "TacOps Picking Up Units" option from the bottom of the Advanced Combat tab (after all unofficial options)
  to its correct position with other official TacOps rules (before unofficial options).

  Change in GameOptions.java:
  - Inserted ADVANCED_COMBAT_PICKING_UP_AND_THROWING_UNITS after ADVANCED_COMBAT_TAC_OPS_BA_VS_BA
  - Removed the duplicate entry that was at the end of the advancedCombat group

  The option will now appear above all "(Unofficial)" options in the Game Options dialog, maintaining style consistency
  with other official TacOps rules.

Fixes #7933