### PR TITLE
Fix MHQ 8679: failure to load saves

### DIFF
--- a/megamek/src/megamek/common/util/SerializationHelper.java
+++ b/megamek/src/megamek/common/util/SerializationHelper.java
@@ -40,6 +40,7 @@ import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
 import megamek.common.TargetRollModifier;
+import megamek.common.board.Board;
 import megamek.common.board.BoardLocation;
 import megamek.common.board.Coords;
 import megamek.common.board.CubeCoords;
@@ -398,7 +399,7 @@ public class SerializationHelper {
             @Override
             public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
                 Coords coords = null;
-                int boardId = -1;
+                int boardId = Board.BOARD_NONE - 1; // -1 is a valid board ID now.
                 boolean isNoLocation = false;
                 try {
                     while (reader.hasMoreChildren()) {
@@ -422,7 +423,7 @@ public class SerializationHelper {
                 } catch (NumberFormatException e) {
                     return null;
                 }
-                if (coords != null && boardId != -1) {
+                if (coords != null && boardId >= Board.BOARD_NONE) {
                     return new BoardLocation(coords, boardId, isNoLocation);
                 } else {
                     return null;

--- a/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
@@ -35,7 +35,6 @@
 package megamek.common.weapons.handlers;
 
 import static java.lang.Math.floor;
-import static megamek.common.equipment.AmmoType.INCENDIARY_MOD;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -47,7 +46,6 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Vector;
 
-import com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter;
 import megamek.common.Hex;
 import megamek.common.HitData;
 import megamek.common.LosEffects;


### PR DESCRIPTION
This fixes an issue where some save game files - including autosaves - could not be loaded at all due to XStream stupidity regarding Records.
Huge props to @BTSS88 for tracking down the root cause: auto-hit artillery markers (or to be more precise, the BoardLocation data storing those markers' locations, which _used_ to be a class but got refactored to a Record)

XStream 1.4, the version we currently depend on, does not natively support deserializing Records.
This is deeply stupid, but made even more offensive by the fact that it can _serialize_ them just fine.

So every time we add a Record data type that is Serializable, we have to also add a new Converter in `SerializationHelper.java` to ensure that this data type can be loaded after saving it.
This was not done when BoardLocation was converted to a Record, but it turns out XStream doesn't care if there are no actual BoardLocation entries populated in the save game file so few players noticed.

This patch adds the missing Converter, as well as making sure to call `context.convertAnother()` so that any Coords created as part of the BoardLocation load are also registered with proper ID references so that later things like the special hex HashTable don't explode.

Testing:
- Loaded the OP failing save game and played through some turns
- Ran all 3 projects' unit tests

Fix MegaMek/MekHQ#8679