### PR TITLE
Add the ability to set bot priority target IDs by range (-)

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/buttonDialogs/BotConfigTargetUnitDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/buttonDialogs/BotConfigTargetUnitDialog.java
@@ -112,6 +112,17 @@ public class BotConfigTargetUnitDialog extends AbstractButtonDialog {
         Set<Integer> result = new HashSet<>();
         String[] tokens = unitIDField.getText().split(",");
         for (String token : tokens) {
+            // This allows for Priority targets to be specified with ranges, as well as comma separated
+            String[] inclusive = token.split("-");
+            if (inclusive.length == 2) {
+                try {
+                    for (int i = Integer.parseInt(inclusive[0]); i <= Integer.parseInt(inclusive[1]); i++) {
+                        result.add(i);
+                    }
+                } catch (NumberFormatException e) {
+                    // Unit ID could not be parsed
+                }
+            }
             try {
                 result.add(Integer.parseInt(token));
             } catch (NumberFormatException e) {

--- a/megamek/src/megamek/client/ui/dialogs/buttonDialogs/BotConfigTargetUnitDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/buttonDialogs/BotConfigTargetUnitDialog.java
@@ -116,17 +116,22 @@ public class BotConfigTargetUnitDialog extends AbstractButtonDialog {
             String[] inclusive = token.split("-");
             if (inclusive.length == 2) {
                 try {
-                    for (int i = Integer.parseInt(inclusive[0]); i <= Integer.parseInt(inclusive[1]); i++) {
-                        result.add(i);
+                    int start = Integer.parseInt(inclusive[0]);
+                    int end = Integer.parseInt(inclusive[0]);
+                    if (start <= end) {
+                        for (int i = start; i <= end; i++) {
+                            result.add(i);
+                        }
                     }
                 } catch (NumberFormatException e) {
                     // Unit ID could not be parsed
                 }
-            }
-            try {
-                result.add(Integer.parseInt(token));
-            } catch (NumberFormatException e) {
-                // No unit ID if it cannot be parsed
+            } else {
+                try {
+                    result.add(Integer.parseInt(token));
+                } catch (NumberFormatException e) {
+                    // No unit ID if it cannot be parsed
+                }
             }
         }
         return result;


### PR DESCRIPTION
A member asked about adding priority units for the bot by range (-).

This parses any ranges in the CSV list and adds all inclusive numbers