### PR TITLE
Fix Dazzle mode persisting when option is disabled (Fixes MekHQ #8700)

### DIFF
--- a/megamek/src/megamek/common/weapons/lasers/LaserWeapon.java
+++ b/megamek/src/megamek/common/weapons/lasers/LaserWeapon.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2004, 2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2007-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2007-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -75,13 +75,16 @@ public abstract class LaserWeapon extends EnergyWeapon {
     public void adaptToGameOptions(IGameOptions gameOptions) {
         super.adaptToGameOptions(gameOptions);
 
-        // Add Dazzle mode first (before Pulse modes) for Gothic BattleTech
-        // This ensures Pulse modes remain last for proper filtering
+        // Add or remove Dazzle mode for Gothic BattleTech
+        // Dazzle must be added before Pulse modes to ensure proper filtering
         if (gameOptions.booleanOption(megamek.common.options.OptionsConstants.ADVANCED_COMBAT_GOTHIC_DAZZLE_MODE)) {
             if (!hasModes()) {
                 addMode("");
             }
             addMode("Dazzle");
+        } else {
+            removeMode("Dazzle");
+            removeMode("Pulse Dazzle");
         }
 
         // Add Pulse modes last so they can be filtered by getModesCount()


### PR DESCRIPTION
  ## Root Cause
  `LaserWeapon.adaptToGameOptions()` added the "Dazzle" mode when the gothic_dazzle_mode option was enabled, but never removed it when disabled. This caused lasers to retain Dazzle mode even after unchecking the option.

  ## Changes
  1. `LaserWeapon.adaptToGameOptions()` - Add else block to remove "Dazzle" and "Pulse Dazzle" modes when option is disabled

  ## Files Changed
  - `megamek/src/megamek/common/weapons/lasers/LaserWeapon.java` - Add mode removal logic

  ## Tested
  - Enable Dazzle option, start game, verify lasers have Dazzle mode
  - Disable Dazzle option, start new game, verify lasers no longer have Dazzle mode
  
  Fixes https://github.com/MegaMek/mekhq/issues/8700