### PR TITLE
A simple change to reduce confusion about fortified hexes.

### DIFF
--- a/megamek/src/megamek/common/units/Terrains.java
+++ b/megamek/src/megamek/common/units/Terrains.java
@@ -379,7 +379,7 @@ public class Terrains implements Serializable {
             case BLACK_ICE:
                 return "Black Ice";
             case FORTIFIED:
-                return "Improved position";
+                return "Fortified";
             case GEYSER:
                 if (level == 1) {
                     return "Dormant";
@@ -620,7 +620,6 @@ public class Terrains implements Serializable {
 
     /**
      * Returns true if the terrain is a base terrain type, excluding "Clear"
-     *
      */
     public static boolean isBaseTerrain(int terrainType) {
         return terrainType == WOODS || terrainType == WATER || terrainType == ROUGH


### PR DESCRIPTION
For a long time, MegaMek has used "Improved Position" as the display text for the fortified hex type in the map editor and the hover pop-up. This has caused confusion among the player base many times as fortified hexes and Improved Positions are two distinct concepts in TacOps:AR. This change simply alters the display name for the hex type to "Fortified". It does not impact the actual mechanics of the hex type, and does not negatively impact any currently existing maps using this hex type. Infantry interactions with the hex type were tested after the change just to be on the safe side and they behaved as expected.

Would close #2364 and #7976.     