### PR TITLE
Fix #7955: Allow Princess to Fire on Advanced Buildings

### DIFF
--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -2740,7 +2740,7 @@ public class Princess extends BotClient {
                             }
 
                             if (isEnemyBuildingEntity(entity, coords)) {
-                                fireControlState.getAdditionalTargets().add(bt);
+                                fireControlState.addAdditionalTarget(bt);
                                 sendChat("Building in Hex " +
                                       coords.toFriendlyString() +
                                       " designated target due to Building Entity.", Level.INFO);


### PR DESCRIPTION
Fixes #7955

The other cases were already updated to use `addAdditionalTarget`. This one needed updated.

See #7846 for more information on why it should use `addAdditionalTarget`. 