### PR TITLE
Enable Princess to deploy EMP mines like other minefields.

### DIFF
--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -219,7 +219,7 @@ public abstract class BotClient extends Client {
                         // Picks the WAA with the highest expected damage,
                         // essentially same as if the auto_ams option was on
                         waa = Compute.getHighestExpectedDamage(game, evt.getWAAs(), true);
-                        
+
                         // Add second weapon attack counter for the bot when playtest 3 is active
                         WeaponAttackAction secondWaa = null;
                         if (game.getOptions().booleanOption(OptionsConstants.PLAYTEST_3)) {
@@ -236,7 +236,7 @@ public abstract class BotClient extends Client {
                         if (numInts == 2) {
                             indexes[1] = evt.getWAAs().indexOf(secondWaa);
                         }
-                        
+
                         sendAMSAssignCFRResponse(indexes);
                         break;
                     case CFR_APDS_ASSIGN:
@@ -1336,6 +1336,7 @@ public abstract class BotClient extends Client {
         getLocalPlayer().setNbrMFConventional(0);
         getLocalPlayer().setNbrMFInferno(0);
         getLocalPlayer().setNbrMFVibra(0);
+        getLocalPlayer().setNbrMFEMP(0);
         sendPlayerInfo();
     }
 
@@ -1374,10 +1375,11 @@ public abstract class BotClient extends Client {
                                               Minefield.TYPE_CONVENTIONAL),
                                         new MinefieldNumbers(getLocalPlayer().getNbrMFVibra(),
                                               Minefield.TYPE_VIBRABOMB),
+                                        new MinefieldNumbers(getLocalPlayer().getNbrMFEMP(),
+                                              Minefield.TYPE_EMP),
                                         // the following are added for completeness, but are not used by the bot
                                         new MinefieldNumbers(0, Minefield.TYPE_COMMAND_DETONATED),
                                         // no command detonated mines
-                                        new MinefieldNumbers(0, Minefield.TYPE_EMP), // no field for EMP mines exists
         };
     }
 


### PR DESCRIPTION
This change enables Princess to deploy EMP Minefields assigned prior to the start of a match in a similar manner to other minefield types.

Deployment was tested with both EMP mines only and with mixed field types, in both cases EMP mines were correctly deployed and deployment of other mine types was not degraded.

<img width="942" height="1011" alt="Screenshot 2026-02-08 090532" src="https://github.com/user-attachments/assets/ec03d598-728b-46b2-944e-1b0eca518f4e" />
