### PR TITLE
Issue MML#2133 Stealth armor validation on superheavy meks

### DIFF
--- a/megamek/src/megamek/common/verifier/TestMek.java
+++ b/megamek/src/megamek/common/verifier/TestMek.java
@@ -324,7 +324,6 @@ public class TestMek extends TestEntity {
         MiscType mt = (MiscType) mounted.getType();
         if (mt.hasFlag(MiscType.F_STEALTH) && !mek.hasPatchworkArmor()) {
             int stealthCritsPerLocation = mek.isSuperHeavy() ? 1 : 2;
-            // stealth needs to have 2 crits in legs arm and side torso
             if (countCriticalSlotsFromEquipInLocation(mek, mounted, Mek.LOC_LEFT_ARM) != stealthCritsPerLocation) {
                 buff.append("incorrect number of stealth crits in left arm\n");
                 return false;


### PR DESCRIPTION
Fixes Megamek/megameklab#2133

Lots of formatting changes, the real change is using "stealthCritsPerLocation", l.325 instead of a fixed 2 slots.

Stealth armor is allowed on superheavy meks and so it validates without error even if it has no effect.