### PR TITLE
Small constructor update to SmallFontHelpTextLabel

### DIFF
--- a/megamek/src/megamek/common/ui/SmallFontHelpTextLabel.java
+++ b/megamek/src/megamek/common/ui/SmallFontHelpTextLabel.java
@@ -65,6 +65,28 @@ public class SmallFontHelpTextLabel extends FlatLabel {
         initialize();
     }
 
+    /**
+     * Constructs an empty help text label with the given alignment, e.g. SwingConstants.CENTER. The label uses a small
+     * font and is disabled, meaning its text is greyed out. By default, the label uses an EmptyBorder with 4 thickness
+     * on the bottom and 0 elsewhere (the border can be replaced). The default * horizontal alignment is (as with
+     * JLabel) SwingConstants.LEADING.
+     */
+    public SmallFontHelpTextLabel(int horizontalAlignment) {
+        initialize();
+        setHorizontalAlignment(horizontalAlignment);
+    }
+
+    /**
+     * Constructs an empty help text label with the given text and the given alignment, e.g. SwingConstants.CENTER. The
+     * label uses a small font and is disabled, meaning its text is greyed out. By default, the label uses an
+     * EmptyBorder with 4 thickness on the bottom and 0 elsewhere (the border can be replaced). The default horizontal
+     * alignment is (as with JLabel) SwingConstants.LEADING.
+     */
+    public SmallFontHelpTextLabel(String text, int horizontalAlignment) {
+        this(text);
+        setHorizontalAlignment(horizontalAlignment);
+    }
+
     private void initialize() {
         setLabelType(LabelType.mini);
         setEnabled(false);


### PR DESCRIPTION
Small change, added constructors to help configuration. SmallFontHelpTextLabel is a specialized label for small info texts as in the screenshot:

<img width="421" height="70" alt="image" src="https://github.com/user-attachments/assets/5343f22e-6849-4c11-9336-6cc5b220feae" />
