### PR TITLE
Add fluffDate field to EntityFluff with MTF and BLK support

### DIFF
--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -553,6 +553,10 @@ public class BLKFile {
             e.getFluff().setNotes(dataFile.getDataAsString("notes")[0]);
         }
 
+        if (dataFile.exists("fluffDate")) {
+            e.getFluff().setFluffDate(dataFile.getDataAsString("fluffDate")[0]);
+        }
+
         if (dataFile.exists("use")) {
             e.getFluff().setUse(dataFile.getDataAsString("use")[0]);
         }
@@ -1013,6 +1017,10 @@ public class BLKFile {
 
         if (!t.getFluff().getNotes().isBlank()) {
             blk.writeBlockData("notes", t.getFluff().getNotes());
+        }
+
+        if (!t.getFluff().getFluffDate().isBlank()) {
+            blk.writeBlockData("fluffDate", t.getFluff().getFluffDate());
         }
 
         if (!t.getFluff().getUse().isBlank()) {

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -548,6 +548,10 @@ public class BLKFile {
             e.getFluff().setNotes(dataFile.getDataAsString("notes")[0]);
         }
 
+        if (dataFile.exists("fluffDate")) {
+            e.getFluff().setFluffDate(dataFile.getDataAsString("fluffDate")[0]);
+        }
+
         if (dataFile.exists("use")) {
             e.getFluff().setUse(dataFile.getDataAsString("use")[0]);
         }
@@ -1008,6 +1012,10 @@ public class BLKFile {
 
         if (!t.getFluff().getNotes().isBlank()) {
             blk.writeBlockData("notes", t.getFluff().getNotes());
+        }
+
+        if (!t.getFluff().getFluffDate().isBlank()) {
+            blk.writeBlockData("fluffDate", t.getFluff().getFluffDate());
         }
 
         if (!t.getFluff().getUse().isBlank()) {

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -124,6 +124,7 @@ public class MtfFile implements IMekLoader {
     private final Map<System, String> systemManufacturers = new EnumMap<>(System.class);
     private final Map<System, String> systemModels = new EnumMap<>(System.class);
     private String notes = "";
+    private String fluffDate = "";
 
     private String fluffImageEncoded = "";
     private String iconEncoded = "";
@@ -183,6 +184,7 @@ public class MtfFile implements IMekLoader {
     public static final String SYSTEM_MANUFACTURER = "systemmanufacturer:";
     public static final String SYSTEM_MODEL = "systemmode:";
     public static final String NOTES = "notes:";
+    public static final String FLUFF_DATE = "fluffdate:";
     public static final String BV = "bv:";
     public static final String WEAPONS = "weapons:";
     public static final String EMPTY = "-Empty-";
@@ -198,6 +200,8 @@ public class MtfFile implements IMekLoader {
     public static final String CLAN_CASE_OPT_OUT = "clancaseoptedoutlocs:";
     public static final String FLUFF_IMAGE = "fluffimage:";
     public static final String ICON = "icon:";
+
+    private static final String LEGACY_FLUFF_DATE_PREFIX = "# Fluff Date: ";
 
     private static final Pattern LEGACY_SIZE_PATTERN = Pattern.compile("\\((\\d+(?:\\.\\d+)?)\\s*(?:ton|tons|m|kg)\\)",
           Pattern.CASE_INSENSITIVE);
@@ -553,6 +557,7 @@ public class MtfFile implements IMekLoader {
             mek.getFluff().setManufacturer(manufacturer);
             mek.getFluff().setPrimaryFactory(primaryFactory);
             mek.getFluff().setNotes(notes);
+            mek.getFluff().setFluffDate(fluffDate);
             mek.getFluff().setFluffImage(fluffImageEncoded);
             mek.setIcon(iconEncoded);
             systemManufacturers.forEach((k, v) -> mek.getFluff().setSystemManufacturer(k, v));
@@ -623,6 +628,11 @@ public class MtfFile implements IMekLoader {
         int armorLocation;
         while (r.ready()) {
             String line = r.readLine().trim();
+
+            if (line.startsWith(LEGACY_FLUFF_DATE_PREFIX)) {
+                fluffDate = line.substring(LEGACY_FLUFF_DATE_PREFIX.length()).trim();
+                continue;
+            }
 
             if (line.isBlank() || line.startsWith(COMMENT) || line.startsWith(GENERATOR)) {
                 continue;
@@ -1609,6 +1619,11 @@ public class MtfFile implements IMekLoader {
 
         if (lineLower.startsWith(NOTES)) {
             notes = line.substring(NOTES.length());
+            return true;
+        }
+
+        if (lineLower.startsWith(FLUFF_DATE)) {
+            fluffDate = line.substring(FLUFF_DATE.length());
             return true;
         }
 

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -122,6 +122,7 @@ public class MtfFile implements IMekLoader {
     private final Map<System, String> systemManufacturers = new EnumMap<>(System.class);
     private final Map<System, String> systemModels = new EnumMap<>(System.class);
     private String notes = "";
+    private String fluffDate = "";
 
     private String fluffImageEncoded = "";
     private String iconEncoded = "";
@@ -180,6 +181,7 @@ public class MtfFile implements IMekLoader {
     public static final String SYSTEM_MANUFACTURER = "systemmanufacturer:";
     public static final String SYSTEM_MODEL = "systemmode:";
     public static final String NOTES = "notes:";
+    public static final String FLUFF_DATE = "fluffdate:";
     public static final String BV = "bv:";
     public static final String WEAPONS = "weapons:";
     public static final String EMPTY = "-Empty-";
@@ -193,6 +195,8 @@ public class MtfFile implements IMekLoader {
     public static final String ROLE = "role:";
     public static final String FLUFF_IMAGE = "fluffimage:";
     public static final String ICON = "icon:";
+
+    private static final String LEGACY_FLUFF_DATE_PREFIX = "# Fluff Date: ";
 
     private static final Pattern LEGACY_SIZE_PATTERN = Pattern.compile("\\((\\d+(?:\\.\\d+)?)\\s*(?:ton|tons|m|kg)\\)",
           Pattern.CASE_INSENSITIVE);
@@ -534,6 +538,7 @@ public class MtfFile implements IMekLoader {
             mek.getFluff().setManufacturer(manufacturer);
             mek.getFluff().setPrimaryFactory(primaryFactory);
             mek.getFluff().setNotes(notes);
+            mek.getFluff().setFluffDate(fluffDate);
             mek.getFluff().setFluffImage(fluffImageEncoded);
             mek.setIcon(iconEncoded);
             systemManufacturers.forEach((k, v) -> mek.getFluff().setSystemManufacturer(k, v));
@@ -604,6 +609,11 @@ public class MtfFile implements IMekLoader {
         int armorLocation;
         while (r.ready()) {
             String line = r.readLine().trim();
+
+            if (line.startsWith(LEGACY_FLUFF_DATE_PREFIX)) {
+                fluffDate = line.substring(LEGACY_FLUFF_DATE_PREFIX.length()).trim();
+                continue;
+            }
 
             if (line.isBlank() || line.startsWith(COMMENT) || line.startsWith(GENERATOR)) {
                 continue;
@@ -1590,6 +1600,11 @@ public class MtfFile implements IMekLoader {
 
         if (lineLower.startsWith(NOTES)) {
             notes = line.substring(NOTES.length());
+            return true;
+        }
+
+        if (lineLower.startsWith(FLUFF_DATE)) {
+            fluffDate = line.substring(FLUFF_DATE.length());
             return true;
         }
 

--- a/megamek/src/megamek/common/units/EntityFluff.java
+++ b/megamek/src/megamek/common/units/EntityFluff.java
@@ -64,6 +64,7 @@ public class EntityFluff implements Serializable {
     private final Map<System, String> systemManufacturers = new EnumMap<>(System.class);
     private final Map<System, String> systemModels = new EnumMap<>(System.class);
     private String notes = "";
+    private String fluffDate = "";
 
     private Base64Image fluffImage = new Base64Image();
 
@@ -177,6 +178,14 @@ public class EntityFluff implements Serializable {
 
     public void setNotes(String notes) {
         this.notes = Objects.requireNonNullElse(notes, "");
+    }
+
+    public String getFluffDate() {
+        return fluffDate;
+    }
+
+    public void setFluffDate(String fluffDate) {
+        this.fluffDate = Objects.requireNonNullElse(fluffDate, "");
     }
 
     public String getUse() {

--- a/megamek/src/megamek/common/units/EntityFluff.java
+++ b/megamek/src/megamek/common/units/EntityFluff.java
@@ -180,8 +180,11 @@ public class EntityFluff implements Serializable {
         this.notes = Objects.requireNonNullElse(notes, "");
     }
 
+    /**
+     * @return The fluff date string, never null. Handles null from deserialization of older objects.
+     */
     public String getFluffDate() {
-        return fluffDate;
+        return fluffDate == null ? "" : fluffDate;
     }
 
     public void setFluffDate(String fluffDate) {

--- a/megamek/src/megamek/common/units/Mek.java
+++ b/megamek/src/megamek/common/units/Mek.java
@@ -4631,6 +4631,12 @@ public abstract class Mek extends Entity {
             sb.append(newLine);
         }
 
+        if (!getFluff().getFluffDate().isBlank()) {
+            sb.append(MtfFile.FLUFF_DATE);
+            sb.append(getFluff().getFluffDate());
+            sb.append(newLine);
+        }
+
         for (System system : System.values()) {
             if (!getFluff().getSystemManufacturer(system).isBlank()) {
                 sb.append(MtfFile.SYSTEM_MANUFACTURER);

--- a/megamek/src/megamek/common/units/Mek.java
+++ b/megamek/src/megamek/common/units/Mek.java
@@ -4553,6 +4553,12 @@ public abstract class Mek extends Entity {
             sb.append(newLine);
         }
 
+        if (!getFluff().getFluffDate().isBlank()) {
+            sb.append(MtfFile.FLUFF_DATE);
+            sb.append(getFluff().getFluffDate());
+            sb.append(newLine);
+        }
+
         for (System system : System.values()) {
             if (!getFluff().getSystemManufacturer(system).isBlank()) {
                 sb.append(MtfFile.SYSTEM_MANUFACTURER);

--- a/megamek/unittests/megamek/common/loaders/MtfFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/MtfFileTest.java
@@ -498,4 +498,74 @@ class MtfFileTest {
         assertEquals(mek.getLocationAbbr(Mek.LOC_LEFT_TORSO), abbrs[1]);
         assertEquals(mek.getLocationAbbr(Mek.LOC_RIGHT_LEG), abbrs[2]);
     }
+
+    @Test
+    void testFluffDateRoundTrip() throws Exception {
+        Mek mek = new BipedMek();
+        String expectedDate = "2026-03-01 14:30:00";
+        mek.getFluff().setFluffDate(expectedDate);
+
+        MtfFile loader = toMtfFile(mek);
+        Entity loaded = loader.getEntity();
+
+        assertEquals(expectedDate, loaded.getFluff().getFluffDate());
+    }
+
+    @Test
+    void testFluffDateEmittedWhenSet() throws Exception {
+        Mek mek = new BipedMek();
+        mek.setWeight(20.0);
+        mek.setEngine(new Engine(100, Engine.NORMAL_ENGINE, 0));
+
+        mek.getFluff().setFluffDate("2026-03-01 14:30:00");
+        String mtf = mek.getMtf();
+        assertTrue(mtf.contains("fluffdate:2026-03-01 14:30:00"),
+              "MTF output should contain fluffdate field");
+    }
+
+    @Test
+    void testFluffDateNotEmittedWhenEmpty() throws Exception {
+        Mek mek = new BipedMek();
+        mek.setWeight(20.0);
+        mek.setEngine(new Engine(100, Engine.NORMAL_ENGINE, 0));
+
+        String mtf = mek.getMtf();
+        assertFalse(mtf.contains("fluffdate:"),
+              "MTF output should not contain fluffdate field when empty");
+    }
+
+    @Test
+    void testLegacyFluffDateCommentParsed() throws Exception {
+        Mek mek = new BipedMek();
+        mek.setWeight(20.0);
+        mek.setEngine(new Engine(100, Engine.NORMAL_ENGINE, 0));
+        String mtf = mek.getMtf();
+
+        // Insert a legacy # Fluff Date: comment line before the first non-empty line
+        mtf = "# Fluff Date: 2026-02-26 19:50:04\n" + mtf;
+
+        MtfFile loader = toMtfFile(mtf);
+        Entity loaded = loader.getEntity();
+
+        assertEquals("2026-02-26 19:50:04", loaded.getFluff().getFluffDate());
+    }
+
+    @Test
+    void testFluffDateFieldOverridesLegacyComment() throws Exception {
+        Mek mek = new BipedMek();
+        mek.setWeight(20.0);
+        mek.setEngine(new Engine(100, Engine.NORMAL_ENGINE, 0));
+
+        mek.getFluff().setFluffDate("2026-03-01 10:00:00");
+        String mtf = mek.getMtf();
+
+        // Prepend a legacy comment with a different date
+        mtf = "# Fluff Date: 2025-01-01 00:00:00\n" + mtf;
+
+        MtfFile loader = toMtfFile(mtf);
+        Entity loaded = loader.getEntity();
+
+        // The fluffdate: field should win over the legacy comment
+        assertEquals("2026-03-01 10:00:00", loaded.getFluff().getFluffDate());
+    }
 }

--- a/megamek/unittests/megamek/common/loaders/MtfFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/MtfFileTest.java
@@ -387,4 +387,74 @@ class MtfFileTest {
         assertTrue(slot6 == null || slot6.getIndex() != Mek.SYSTEM_ENGINE,
               "CT slot 6 should not be engine (gyro is None, engine should be contiguous 0-5)");
     }
+
+    @Test
+    void testFluffDateRoundTrip() throws Exception {
+        Mek mek = new BipedMek();
+        String expectedDate = "2026-03-01 14:30:00";
+        mek.getFluff().setFluffDate(expectedDate);
+
+        MtfFile loader = toMtfFile(mek);
+        Entity loaded = loader.getEntity();
+
+        assertEquals(expectedDate, loaded.getFluff().getFluffDate());
+    }
+
+    @Test
+    void testFluffDateEmittedWhenSet() throws Exception {
+        Mek mek = new BipedMek();
+        mek.setWeight(20.0);
+        mek.setEngine(new Engine(100, Engine.NORMAL_ENGINE, 0));
+
+        mek.getFluff().setFluffDate("2026-03-01 14:30:00");
+        String mtf = mek.getMtf();
+        assertTrue(mtf.contains("fluffdate:2026-03-01 14:30:00"),
+              "MTF output should contain fluffdate field");
+    }
+
+    @Test
+    void testFluffDateNotEmittedWhenEmpty() throws Exception {
+        Mek mek = new BipedMek();
+        mek.setWeight(20.0);
+        mek.setEngine(new Engine(100, Engine.NORMAL_ENGINE, 0));
+
+        String mtf = mek.getMtf();
+        assertFalse(mtf.contains("fluffdate:"),
+              "MTF output should not contain fluffdate field when empty");
+    }
+
+    @Test
+    void testLegacyFluffDateCommentParsed() throws Exception {
+        Mek mek = new BipedMek();
+        mek.setWeight(20.0);
+        mek.setEngine(new Engine(100, Engine.NORMAL_ENGINE, 0));
+        String mtf = mek.getMtf();
+
+        // Insert a legacy # Fluff Date: comment line before the first non-empty line
+        mtf = "# Fluff Date: 2026-02-26 19:50:04\n" + mtf;
+
+        MtfFile loader = toMtfFile(mtf);
+        Entity loaded = loader.getEntity();
+
+        assertEquals("2026-02-26 19:50:04", loaded.getFluff().getFluffDate());
+    }
+
+    @Test
+    void testFluffDateFieldOverridesLegacyComment() throws Exception {
+        Mek mek = new BipedMek();
+        mek.setWeight(20.0);
+        mek.setEngine(new Engine(100, Engine.NORMAL_ENGINE, 0));
+
+        mek.getFluff().setFluffDate("2026-03-01 10:00:00");
+        String mtf = mek.getMtf();
+
+        // Prepend a legacy comment with a different date
+        mtf = "# Fluff Date: 2025-01-01 00:00:00\n" + mtf;
+
+        MtfFile loader = toMtfFile(mtf);
+        Entity loaded = loader.getEntity();
+
+        // The fluffdate: field should win over the legacy comment
+        assertEquals("2026-03-01 10:00:00", loaded.getFluff().getFluffDate());
+    }
 }


### PR DESCRIPTION
  ## Summary
  Add a new `fluffDate` field to `EntityFluff` for tracking when unit fluff was last updated, with full read/write support in both MTF and BLK file formats. This is helping support a new Fluff data project currently in progress. 

  ## Changes
  1. `EntityFluff.java` - Add `fluffDate` String field with getter/setter following existing pattern
  2. `MtfFile.java` - Add `fluffdate:` field parsing and legacy `# Fluff Date:` comment support
  3. `Mek.java` - Write `fluffdate:` field in `getMtf()` after `notes:`
  4. `BLKFile.java` - Read/write `fluffDate` block after `notes`

  ## Files Changed
  - `megamek/src/megamek/common/units/EntityFluff.java` - New field, getter, setter
  - `megamek/src/megamek/common/loaders/MtfFile.java` - Constants, instance variable, parsing in `readLines()` and
  `isProcessedComponent()`, applied in entity creation
  - `megamek/src/megamek/common/units/Mek.java` - Write fluffdate in `getMtf()`
  - `megamek/src/megamek/common/loaders/BLKFile.java` - Read in `setFluff()`, write in `getBlock()`

  ## Backward Compatibility
  - Existing `# Fluff Date: ...` comment lines in MTF files are parsed and loaded
  - On next save, the date is written as the proper `fluffdate:` field (no longer a comment)
  - Files without a fluff date simply have an empty string (no impact)

  ## Testing
  Manual testing with MTF files containing legacy `# Fluff Date:` comments and round-trip save/load verification.