### PR TITLE
PR: HHW Fix Incorrect Impossible Shots

### DIFF
--- a/megamek/src/megamek/common/equipment/HandheldWeapon.java
+++ b/megamek/src/megamek/common/equipment/HandheldWeapon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *


### PR DESCRIPTION
Bug I encountered while debugging. 

MegaMek was reporting certain shots were impossible but only for the Mek's Handheld Weapon weapons. Handheld Weapons need to use their attacking entity's location & height when applicable. 