### PR TITLE
PR: Prevent NPE from null position during infantry vs infantry combat

### DIFF
--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/PreEndDeclarationsDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/PreEndDeclarationsDisplay.java
@@ -190,7 +190,7 @@ public class PreEndDeclarationsDisplay extends AttackPhaseDisplay {
         // Check if combat already exists in this building
         boolean combatExists = game.getEntitiesVector().stream()
               .filter(e -> e instanceof Infantry)
-              .filter(e -> e.getPosition().equals(targetEntity.getPosition()))
+              .filter(e -> e.getPosition() != null && e.getPosition().equals(targetEntity.getPosition()))
               .map(e -> (Infantry) e)
               .anyMatch(e -> e.getInfantryCombatTargetId() != Entity.NONE);
 
@@ -385,7 +385,7 @@ public class PreEndDeclarationsDisplay extends AttackPhaseDisplay {
         // Check if combat already exists in this building
         boolean combatExists = game.getEntitiesVector().stream()
               .filter(e -> e instanceof Infantry)
-              .filter(e -> e.getPosition().equals(targetEntity.getPosition()))
+              .filter(e -> e.getPosition() != null && e.getPosition().equals(targetEntity.getPosition()))
               .map(e -> (Infantry) e)
               .anyMatch(e -> e.getInfantryCombatTargetId() != Entity.NONE);
 

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -15710,6 +15710,7 @@ public class TWGameManager extends AbstractGameManager {
             // Find enemy infantry in the building (additional defenders)
             for (Entity e : game.getEntitiesVector()) {
                 if (e instanceof Infantry &&
+                    e.getPosition() != null &&
                     e.getPosition().equals(building.getPosition()) &&
                     e.getOwner().isEnemyOf(entity.getOwner())) {
                     defenders.add(e);


### PR DESCRIPTION
When testing MekHQ<->MegaMek's logic for infantry vs infantry combat I came across several null pointer exceptions from units that had null positions. Let's make sure it isn't.