### PR TITLE
Issue MML2111 backward compat for mekbay BLK loading

### DIFF
--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -1495,6 +1495,8 @@ public class BLKFile {
                                   hasARTS), isPod);
                             break;
                         case "mekbay":
+                            // CHECKSTYLE IGNORE ForbiddenWords FOR 1 LINES
+                        case "mechbay": // for compatibility with older custom units
                             pbi = new ParsedBayInfo(numbers, usedBayNumbers);
                             e.addTransporter(new MekBay(pbi.getSize(), pbi.getDoors(), pbi.getBayNumber()), isPod);
                             break;


### PR DESCRIPTION
Fixes Megamek/megameklab#2111
Allows loading older custom units with mekbays that used the old spelling