### PR TITLE
Fix Artillery Cluster Munitions using hits from above table for meks and front table for tanks. Several other issues found in the process

### DIFF
--- a/megamek/src/megamek/common/weapons/handlers/AreaEffectHelper.java
+++ b/megamek/src/megamek/common/weapons/handlers/AreaEffectHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -479,10 +479,9 @@ public class AreaEffectHelper {
                 } else if (ammo.getMunitionType().contains(AmmoType.Munitions.M_CLUSTER)
                       && attackSource.equals(coords)) {
                     if (entity instanceof Mek) {
-                        toHit.setHitTable(ToHitData.HIT_ABOVE);
+                        toHit.setHitTable(ToHitData.HIT_NORMAL);
                     } else if (entity instanceof Tank) {
-                        toHit.setSideTable(ToHitData.SIDE_FRONT);
-                        toHit.addModifier(2, "cluster artillery hitting a Tank");
+                        toHit.setHitTable(ToHitData.HIT_NORMAL);
                     }
                 }
 
@@ -506,7 +505,9 @@ public class AreaEffectHelper {
         // Entity/ammo specific damage modifiers
         if (ammo != null) {
             if (ammo.getMunitionType().contains(AmmoType.Munitions.M_CLUSTER)) {
-                if (hex != null && hex.containsTerrain(Terrains.FORTIFIED) && entity.isConventionalInfantry()) {
+                if (hex != null &&
+                      (hex.containsTerrain(Terrains.FORTIFIED) || hex.containsTerrain(Terrains.WOODS)) &&
+                      entity.isConventionalInfantry()) {
                     hits *= 2;
                 }
             }


### PR DESCRIPTION
Closes #8023 

Updated the tables used for cluster artillery attacks against meks and tanks. Added woods to bypassed terrain for cluster artillery attacks against infantry.

Meks and vehicles will now use the standard tables when occupying a hex hit by artillery cluster munitions, and when taking damage in hexes adjacent to ones hit by artillery.

Conventional infantry will now take double damage when occupying a wooded hex hit by artillery cluster munitions, and when taking damage in a wooded hex adjacent to a hex hit by artillery. They previously only took double damage when occupying fortified hexes.

Opens 4 more... I will make new issue reports for these.

1) Meks and vehicles in a hex directly hit by offboard artillery should use the facing table as if attacked from the center of the edge of the board. Now they are only using the front table when hit by offboard artillery attacks - standard or cluster munitions.

2) Artillery attacks against CI in clear hexes should take double damage for the clear hex and for area effect damage, for a multiplier of 4. Now it is not doubling damage for being in a clear hex. It is doubling for area effect damage. 

3) Artillery cluster munitions are not rules-compliant in most cases. They only reapply the clear hex double damage multiplier in fortified, and with this change now wooded hexes. They should do so in all but building hexes. I didn't immediately come up with an elegant way to code this. Cluster munitions also should not damage units in buildings - this is in their equipment-specific rules.

4) I believe all artillery munitions should damage the building directly, and units inside only indirectly. Now standard artillery munitions are damaging units inside of buildings, and probably other types as well.

