### PR TITLE
Fix swarm LRMs transferring immobile status to secondary targets

### DIFF
--- a/megamek/src/megamek/common/ToHitData.java
+++ b/megamek/src/megamek/common/ToHitData.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2002-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2002-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *


### PR DESCRIPTION
Fixes #7901 

Swarm LRMs were transferring immobile status from any immobile target, not just buildings.
Adding immobile status to the list of statuses to be removed fixed the issue.

I confirmed immobile status is correctly added to immobile secondary targets.