### PR TITLE
Fix #8080: Prevent buildings with dead crew from being targets of new infantry vs infantry action

### DIFF
--- a/megamek/src/megamek/common/units/Infantry.java
+++ b/megamek/src/megamek/common/units/Infantry.java
@@ -2827,9 +2827,12 @@ public class Infantry extends Entity {
         }
 
         // Look for enemy boardable entities at this location
+        // TODO: Once buildings can be captured & change owner, allow this for building carcass
         Entity enemyBoardableEntity = null;
         for (Entity e : game.getEntitiesVector(getBoardLocation())) {
-            if (e.isBoardable() && e.getOwner().isEnemyOf(getOwner())) {
+            if (e.isBoardable()
+                  && (e.getOwner().isEnemyOf(getOwner())
+                  && (e.getCrew() != null && !e.getCrew().isDead()))) {
                 enemyBoardableEntity = e;
                 break;
             }


### PR DESCRIPTION
Fixes #8080 

Eventually it should be possible to capture (change owners?) of buildings, and we will want to include dead buildings in that, so I've included a TODO noting that.