### PR TITLE
Fix #8066: Advanced Buildings show toHit modifiers on the map

### DIFF
--- a/megamek/src/megamek/client/ui/clientGUI/boardview/spriteHandler/FiringSolutionSpriteHandler.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/spriteHandler/FiringSolutionSpriteHandler.java
@@ -35,6 +35,7 @@ package megamek.client.ui.clientGUI.boardview.spriteHandler;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import megamek.client.Client;
@@ -44,18 +45,21 @@ import megamek.client.ui.clientGUI.GUIPreferences;
 import megamek.client.ui.clientGUI.boardview.BoardView;
 import megamek.client.ui.clientGUI.boardview.IBoardView;
 import megamek.client.ui.clientGUI.boardview.sprite.FiringSolutionSprite;
-import megamek.common.equipment.AmmoMounted;
-import megamek.common.equipment.AmmoType;
-import megamek.common.equipment.AmmoType.Munitions;
-import megamek.common.equipment.WeaponMounted;
-import megamek.common.units.Entity;
-import megamek.common.units.EntityVisibilityUtils;
-import megamek.common.game.Game;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.board.Coords;
+import megamek.common.equipment.AmmoMounted;
+import megamek.common.equipment.AmmoType.Munitions;
+import megamek.common.equipment.WeaponMounted;
+import megamek.common.game.Game;
 import megamek.common.options.OptionsConstants;
 import megamek.common.preference.IPreferenceChangeListener;
 import megamek.common.preference.PreferenceChangeEvent;
+import megamek.common.units.AbstractBuildingEntity;
+import megamek.common.units.BuildingTarget;
+import megamek.common.units.Entity;
+import megamek.common.units.EntityVisibilityUtils;
+import megamek.common.units.Targetable;
 import megamek.common.util.FiringSolution;
 
 public class FiringSolutionSpriteHandler extends BoardViewSpriteHandler implements IPreferenceChangeListener {
@@ -114,6 +118,20 @@ public class FiringSolutionSpriteHandler extends BoardViewSpriteHandler implemen
                 thd.setLocation(target.getPosition());
                 thd.setRange(entity.getPosition().distance(target.getPosition()));
                 solutions.put(target.getId(), new FiringSolution(thd, spotter.isPresent()));
+            } else if (target instanceof AbstractBuildingEntity buildingEntity
+                  && game.onTheSameBoard(entity, buildingEntity)
+                  && (client.getGame().getOptions().booleanOption(OptionsConstants.BASE_FRIENDLY_FIRE)
+                  || target.getOwner().isEnemyOf(entity.getOwner()))) {
+                for (Coords buildingHex : buildingEntity.getCoordsList()) {
+                    BuildingTarget buildingTarget = new BuildingTarget(buildingHex,
+                          game.getBoard(buildingEntity.getBoardId()), Targetable.TYPE_BUILDING);
+                    ToHitData thd = WeaponAttackAction.toHit(game, entity.getId(), weapon, ammo,
+                          Optional.empty(), buildingTarget);
+                    thd.setLocation(buildingHex);
+                    thd.setRange(entity.getPosition().distance(buildingHex));
+                    solutions.put(Objects.hash(buildingEntity.getId(), buildingHex),
+                          new FiringSolution(thd, false));
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #8066

`BuildingEntity` is not directly targetable, it's the `Hex` that's targeted. This checks all the building's positions and shows the toHit from each.