### PR TITLE
Fix ACAR deployment: formations scheduled for round 0 never deploy

### DIFF
--- a/megamek/src/megamek/common/autoResolve/acar/SimulationContext.java
+++ b/megamek/src/megamek/common/autoResolve/acar/SimulationContext.java
@@ -708,7 +708,7 @@ public class SimulationContext implements IGame, PlanetaryConditionsUsing {
     }
 
     public boolean shouldDeployForRound(int round) {
-        return deploymentTable.keySet().stream().anyMatch(k -> k <= round);
+        return !deploymentTable.isEmpty() && Collections.min(deploymentTable.keySet()) <= round;
     }
 
     /**

--- a/megamek/src/megamek/common/autoResolve/acar/phase/DeploymentPhase.java
+++ b/megamek/src/megamek/common/autoResolve/acar/phase/DeploymentPhase.java
@@ -65,7 +65,7 @@ public class DeploymentPhase extends PhaseHandler {
     @Override
     protected void executePhase() {
         headerLatch.set(false);
-        // Automatically deploy all formations that are set to deploy this round
+        // Automatically deploy all formations that are set to deploy this round or earlier
         getSimulationManager().getGame().getActiveFormations().stream()
               .filter(f -> !f.isDeployed())
               .filter(f -> f.getDeployRound() <= getSimulationManager().getGame().getCurrentRound())


### PR DESCRIPTION
## Description
Fixes a deployment timing bug in the ACAR auto-resolve simulation where formations with deployRound=0 were never deployed.

The ACAR game loop increments the round counter to 1 before the first deployment check. Both shouldDeployForRound() and DeploymentPhase used exact equality (==) to match the current round against a formation's deploy round. Since all formations default to deployRound=0 and the first round is 1, the deployment phase was always skipped — no formations from either side ever deployed, and every simulation ended as a draw.

## Changes
SimulationContext.shouldDeployForRound(): Changed from containsKey(round) to check for any pending deployment at or before the current round (<= round).
DeploymentPhase.executePhase(): Changed deployment filter from == currentRound to <= currentRound so formations whose deploy round has already passed are still deployed.

##Related
[MekHQ companion PR](https://github.com/MegaMek/mekhq/pull/8809)