### PR TITLE
Fix: Prevent NPE when selecting an un-deployed unit's weapons during deployment

### DIFF
--- a/megamek/src/megamek/client/ui/clientGUI/boardview/spriteHandler/FiringSolutionSpriteHandler.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/spriteHandler/FiringSolutionSpriteHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *


### PR DESCRIPTION
Fixes Sentry/MEKHQ-352: NullPointerException Cannot invoke "megamek.common.board.Coords.distance(megamek.common.board.Coords)" because the return value of "megamek.common.units.Entity.getPosition()" is null

When a unit is not yet deployed but available to be deployed you can click through the unit's different weapons. Prior to this fix it would throw a NullPointerException because the source entity's location was `null`. If a unit has a `null` position then we won't be able to determine `ToHitData`, so let's break early. 