### PR TITLE
Fix TSM implant incorrectly reducing damage divisor when armor kit has divisor 1.0 (Fixes #8111)

### DIFF
--- a/megamek/src/megamek/common/units/Infantry.java
+++ b/megamek/src/megamek/common/units/Infantry.java
@@ -1617,7 +1617,7 @@ public class Infantry extends Entity {
             divisor = getCustomArmorDamageDivisor();
         }
         // TSM implant reduces divisor to 0.5 if no other armor is worn
-        if ((divisor == 1.0) && hasAbility(OptionsConstants.MD_TSM_IMPLANT)) {
+        if ((armorKit == null) && (divisor == 1.0) && hasAbility(OptionsConstants.MD_TSM_IMPLANT)) {
             divisor = 0.5;
         }
         // Dermal camo armor provides divisor of 1.0 (prevents 0.5 from TSM alone)

--- a/megamek/unittests/megamek/common/units/InfantryDermalArmorTest.java
+++ b/megamek/unittests/megamek/common/units/InfantryDermalArmorTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.units;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import megamek.common.equipment.EquipmentType;
+import megamek.common.exceptions.LocationFullException;
+import megamek.common.options.OptionsConstants;
+import megamek.common.options.PilotOptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for MD_DERMAL_ARMOR and MD_TSM_IMPLANT damage divisor interactions on Infantry units. Verifies fix for GitHub
+ * issue #8111: TSM should only reduce divisor to 0.5 when no armor kit is equipped, not when an armor kit happens to
+ * have divisor 1.0.
+ *
+ * <p>Per IO p.81:</p>
+ * <ul>
+ *   <li>Dermal Armor: adds +1 to the unit's damage divisor</li>
+ *   <li>TSM alone, no armor: divisor of 0.5</li>
+ *   <li>TSM + Dermal Armor, no other armor: combination becomes 1.5</li>
+ *   <li>TSM with armor present: adds nothing to divisor</li>
+ * </ul>
+ */
+class InfantryDermalArmorTest {
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    private Infantry createInfantry(boolean hasDermalArmor, boolean hasTSM) {
+        Infantry infantry = new Infantry();
+        infantry.setId(1);
+        infantry.setMovementMode(EntityMovementMode.INF_LEG);
+        infantry.setSquadSize(7);
+        infantry.setSquadCount(4);
+        infantry.autoSetInternal();
+
+        Crew crew = new Crew(CrewType.INFANTRY_CREW);
+        crew.setGunnery(4, crew.getCrewType().getGunnerPos());
+        crew.setPiloting(5, crew.getCrewType().getPilotPos());
+        crew.setName("Test Crew", 0);
+
+        PilotOptions options = new PilotOptions();
+        if (hasDermalArmor) {
+            options.getOption(OptionsConstants.MD_DERMAL_ARMOR).setValue(true);
+        }
+        if (hasTSM) {
+            options.getOption(OptionsConstants.MD_TSM_IMPLANT).setValue(true);
+        }
+        crew.setOptions(options);
+        infantry.setCrew(crew);
+
+        return infantry;
+    }
+
+    private void addArmorKit(Infantry infantry, String armorKitName) throws LocationFullException {
+        EquipmentType armorKit = EquipmentType.get(armorKitName);
+        if (armorKit != null) {
+            infantry.addEquipment(armorKit, Infantry.LOC_INFANTRY);
+        }
+    }
+
+    // --- No armor kit equipped ---
+
+    @Test
+    @DisplayName("Dermal Armor alone, no armor kit: divisor = 2.0 (base 1.0 + 1.0)")
+    void dermalArmorAloneNoKit() {
+        Infantry infantry = createInfantry(true, false);
+        assertEquals(2.0, infantry.calcDamageDivisor(), 0.001);
+    }
+
+    @Test
+    @DisplayName("TSM alone, no armor kit: divisor = 0.5")
+    void tsmAloneNoKit() {
+        Infantry infantry = createInfantry(false, true);
+        assertEquals(0.5, infantry.calcDamageDivisor(), 0.001);
+    }
+
+    @Test
+    @DisplayName("TSM + Dermal Armor, no armor kit: divisor = 1.5 (0.5 + 1.0)")
+    void tsmAndDermalArmorNoKit() {
+        Infantry infantry = createInfantry(true, true);
+        assertEquals(1.5, infantry.calcDamageDivisor(), 0.001);
+    }
+
+    // --- With armor kit (divisor 1.0) - the bug scenario ---
+
+    @Test
+    @DisplayName("TSM + armor kit (div 1.0): divisor = 1.0 (TSM adds nothing when armor present)")
+    void tsmWithArmorKitDivisorOne() throws LocationFullException {
+        Infantry infantry = createInfantry(false, true);
+        addArmorKit(infantry, "Generic Infantry Kit");
+        assertEquals(1.0, infantry.calcDamageDivisor(), 0.001);
+    }
+
+    @Test
+    @DisplayName("TSM + Dermal Armor + armor kit (div 1.0): divisor = 2.0 (kit 1.0 + dermal 1.0)")
+    void tsmAndDermalArmorWithArmorKitDivisorOne() throws LocationFullException {
+        Infantry infantry = createInfantry(true, true);
+        addArmorKit(infantry, "Generic Infantry Kit");
+        assertEquals(2.0, infantry.calcDamageDivisor(), 0.001);
+    }
+
+    @Test
+    @DisplayName("Dermal Armor + armor kit (div 1.0): divisor = 2.0 (kit 1.0 + dermal 1.0)")
+    void dermalArmorWithArmorKitDivisorOne() throws LocationFullException {
+        Infantry infantry = createInfantry(true, false);
+        addArmorKit(infantry, "Generic Infantry Kit");
+        assertEquals(2.0, infantry.calcDamageDivisor(), 0.001);
+    }
+
+    // --- With armor kit (divisor > 1.0) - should be unaffected by fix ---
+
+    @Test
+    @DisplayName("TSM + armor kit (div 2.0): divisor = 2.0 (TSM adds nothing when armor present)")
+    void tsmWithHighDivisorArmorKit() throws LocationFullException {
+        Infantry infantry = createInfantry(false, true);
+        addArmorKit(infantry, "Ballistic Plate, Standard");
+        assertEquals(2.0, infantry.calcDamageDivisor(), 0.001);
+    }
+
+    @Test
+    @DisplayName("TSM + Dermal Armor + armor kit (div 2.0): divisor = 3.0 (kit 2.0 + dermal 1.0)")
+    void tsmAndDermalArmorWithHighDivisorArmorKit() throws LocationFullException {
+        Infantry infantry = createInfantry(true, true);
+        addArmorKit(infantry, "Ballistic Plate, Standard");
+        assertEquals(3.0, infantry.calcDamageDivisor(), 0.001);
+    }
+}


### PR DESCRIPTION
Root Cause

Infantry.calcDamageDivisor() used divisor == 1.0 to determine if "no armor is worn" before applying the TSM 0.5 penalty. This check cannot distinguish between infantry with no armor kit (default divisor 1.0) and infantry wearing an armor kit that happens to have divisor 1.0 (e.g., Generic Infantry Kit, Engineering Suit). As a result, adding TSM to infantry already wearing such armor actually reduced their damage divisor instead of having no effect.

Per IO p.75, TSM "adds nothing to the unit's damage divisor" when armor is present; the 0.5 divisor only applies when "no  other personal armor is present."

Changes

  1. Infantry.calcDamageDivisor() - Added armorKit == null check so the TSM 0.5 penalty only triggers when no armor kit is
  equipped, not when an armor kit has divisor 1.0

  Files Changed

  - megamek/megamek/src/megamek/common/units/Infantry.java - One-line fix to TSM divisor condition
  - megamek/megamek/unittests/megamek/common/units/InfantryDermalArmorTest.java - New test class with 8 tests covering Dermal Armor and TSM divisor interactions

  Testing

 Unit tests covering all combinations:

  - TSM + armor kit (div 1.0): was 0.5, now 1.0 (per IO: 1.0)
  - TSM + Dermal + armor kit (div 1.0): was 1.5, now 2.0 (per IO: 2.0)
  - TSM alone, no kit: 0.5 (unchanged, correct)
  - TSM + Dermal, no kit: 1.5 (unchanged, correct)
  - Dermal + armor kit (div 1.0): 2.0 (unchanged, correct)
  - TSM + armor kit (div 2.0): 2.0 (unchanged, correct)
  - TSM + Dermal + armor kit (div 2.0): 3.0 (unchanged, correct)
  All existing InfantryDermalCamoArmorTest tests continue to pass.

  Fixes #8111