### PR TITLE
Add @JsonCreator to Atmosphere enum for backwards-compatible deserialization

### DIFF
--- a/megamek/src/megamek/common/planetaryConditions/Atmosphere.java
+++ b/megamek/src/megamek/common/planetaryConditions/Atmosphere.java
@@ -147,24 +147,27 @@ public enum Atmosphere {
             throw new IllegalArgumentException("Atmosphere value must not be null or blank");
         }
 
+        String trimmed = value.strip();
+
         // Try exact enum name first
         for (Atmosphere atmo : values()) {
-            if (atmo.name().equals(value)) {
+            if (atmo.name().equals(trimmed)) {
                 return atmo;
             }
         }
 
         // Try case-insensitive enum name match
         for (Atmosphere atmo : values()) {
-            if (atmo.name().equalsIgnoreCase(value)) {
+            if (atmo.name().equalsIgnoreCase(trimmed)) {
                 return atmo;
             }
         }
 
-        // Try legacy aliases
-        Atmosphere legacy = LEGACY_ALIASES.get(value);
-        if (legacy != null) {
-            return legacy;
+        // Try legacy aliases (case-insensitive)
+        for (var entry : LEGACY_ALIASES.entrySet()) {
+            if (entry.getKey().equalsIgnoreCase(trimmed)) {
+                return entry.getValue();
+            }
         }
 
         throw new IllegalArgumentException("Unknown Atmosphere value: '" + value + "'");

--- a/megamek/src/megamek/common/planetaryConditions/Atmosphere.java
+++ b/megamek/src/megamek/common/planetaryConditions/Atmosphere.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,6 +32,10 @@
  */
 
 package megamek.common.planetaryConditions;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
 
 import megamek.common.Messages;
 
@@ -120,5 +124,49 @@ public enum Atmosphere {
             }
         }
         return Atmosphere.STANDARD;
+    }
+
+    /**
+     * Legacy aliases used in older planetary system YAML data files.
+     */
+    private static final Map<String, Atmosphere> LEGACY_ALIASES = Map.of(
+          "Low", THIN
+    );
+
+    /**
+     * Deserializes an Atmosphere from a string value, supporting both canonical
+     * enum names (case-insensitive) and legacy aliases from older data files.
+     *
+     * @param value the string to parse
+     * @return the matching Atmosphere, never null
+     * @throws IllegalArgumentException if the value cannot be mapped
+     */
+    @JsonCreator
+    public static Atmosphere fromString(String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("Atmosphere value must not be null or blank");
+        }
+
+        // Try exact enum name first
+        for (Atmosphere atmo : values()) {
+            if (atmo.name().equals(value)) {
+                return atmo;
+            }
+        }
+
+        // Try case-insensitive enum name match
+        for (Atmosphere atmo : values()) {
+            if (atmo.name().equalsIgnoreCase(value)) {
+                return atmo;
+            }
+        }
+
+        // Try legacy aliases
+        Atmosphere legacy = LEGACY_ALIASES.get(value);
+        if (legacy != null) {
+            return legacy;
+        }
+
+        throw new IllegalArgumentException("Unknown Atmosphere value: '" + value + "'");
     }
 }

--- a/megamek/unittests/megamek/common/planetaryConditions/AtmosphereTest.java
+++ b/megamek/unittests/megamek/common/planetaryConditions/AtmosphereTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.planetaryConditions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class AtmosphereTest {
+
+    @Test
+    void fromStringExactEnumNames() {
+        assertEquals(Atmosphere.VACUUM, Atmosphere.fromString("VACUUM"));
+        assertEquals(Atmosphere.TRACE, Atmosphere.fromString("TRACE"));
+        assertEquals(Atmosphere.THIN, Atmosphere.fromString("THIN"));
+        assertEquals(Atmosphere.STANDARD, Atmosphere.fromString("STANDARD"));
+        assertEquals(Atmosphere.HIGH, Atmosphere.fromString("HIGH"));
+        assertEquals(Atmosphere.VERY_HIGH, Atmosphere.fromString("VERY_HIGH"));
+    }
+
+    @Test
+    void fromStringCaseInsensitive() {
+        assertEquals(Atmosphere.VACUUM, Atmosphere.fromString("Vacuum"));
+        assertEquals(Atmosphere.VACUUM, Atmosphere.fromString("vacuum"));
+        assertEquals(Atmosphere.THIN, Atmosphere.fromString("Thin"));
+        assertEquals(Atmosphere.STANDARD, Atmosphere.fromString("standard"));
+        assertEquals(Atmosphere.VERY_HIGH, Atmosphere.fromString("very_high"));
+    }
+
+    @Test
+    void fromStringLegacyAliasLow() {
+        assertEquals(Atmosphere.THIN, Atmosphere.fromString("Low"));
+        assertEquals(Atmosphere.THIN, Atmosphere.fromString("low"));
+        assertEquals(Atmosphere.THIN, Atmosphere.fromString("LOW"));
+    }
+
+    @Test
+    void fromStringTrimsWhitespace() {
+        assertEquals(Atmosphere.VACUUM, Atmosphere.fromString("  VACUUM  "));
+        assertEquals(Atmosphere.THIN, Atmosphere.fromString(" Low "));
+    }
+
+    @Test
+    void fromStringRejectsNull() {
+        assertThrows(IllegalArgumentException.class, () -> Atmosphere.fromString(null));
+    }
+
+    @Test
+    void fromStringRejectsBlank() {
+        assertThrows(IllegalArgumentException.class, () -> Atmosphere.fromString(""));
+        assertThrows(IllegalArgumentException.class, () -> Atmosphere.fromString("   "));
+    }
+
+    @Test
+    void fromStringRejectsUnknown() {
+        assertThrows(IllegalArgumentException.class, () -> Atmosphere.fromString("Bogus"));
+    }
+}


### PR DESCRIPTION
The Atmosphere enum had no custom deserializer, so YAML planetary data using legacy values like "Vacuum" (wrong case) or "Low" (unmapped) caused Jackson parse failures in SystemValidatorTest.

Add fromString() with @JsonCreator that supports:
- Exact enum name matching
- Case-insensitive enum name matching
- Legacy alias mapping ("Low" -> THIN)