### PR TITLE
Implement missing Mountain Troops rules from TO:AUE p.153 less the full climbing rules.

### DIFF
--- a/megamek/resources/megamek/common/messages.properties
+++ b/megamek/resources/megamek/common/messages.properties
@@ -829,6 +829,7 @@ BV.DermalArmor=Dermal Armor:
 Compute.VariableRangeTargetingShort=Variable Range Targeting (Short mode)
 Compute.VariableRangeTargetingLong=Variable Range Targeting (Long mode)
 Compute.EnhancedImaging=Enhanced Imaging
+Compute.MountainTroops=Mountain Troops
 Compute.ProstheticEnhancement=Prosthetic Enhancement
 Compute.ProstheticTail=Prosthetic Tail
 # Suicide Implants Attack Action (IO pg. 83)

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -5869,6 +5869,12 @@ public class Compute {
             }
         }
 
+        // Mountain Troops anti-Mek bonus - TO:AUE p.153
+        // "Mountain troops apply a -2 modifier to any Anti-Mek Skill Rolls"
+        if (attacker.hasSpecialization(Infantry.MOUNTAIN_TROOPS)) {
+            data.addModifier(-2, Messages.getString("Compute.MountainTroops"));
+        }
+
         // Enhanced Imaging bonus for anti-Mek attacks - IO p.69
         // "All Piloting Skill rolls required for the EI-equipped unit receives a -1
         // target number modifier. This includes checks made for physical attacks,

--- a/megamek/src/megamek/common/moves/MoveStep.java
+++ b/megamek/src/megamek/common/moves/MoveStep.java
@@ -2919,13 +2919,19 @@ public class MoveStep implements Serializable {
                 mp = 4;
                 return;
             }
-            // non-flying Infantry and ground vehicles are charged double.
-            if ((isInfantry &&
+            // Mountain Troops only expend 1 MP per 2 levels moved up or down
+            // TO:AUE p.153
+            boolean isMountainTroop = isInfantry
+                  && ((Infantry) entity).hasSpecialization(Infantry.MOUNTAIN_TROOPS);
+            if (isMountainTroop) {
+                delta_e = (int) Math.ceil(delta_e / 2.0);
+            } else if ((isInfantry &&
                   !((getMovementType(false) == EntityMovementType.MOVE_VTOL_WALK) ||
                         (getMovementType(false) == EntityMovementType.MOVE_VTOL_RUN))) ||
                   ((moveMode == EntityMovementMode.TRACKED) ||
                         (moveMode == EntityMovementMode.WHEELED) ||
                         (moveMode == EntityMovementMode.HOVER))) {
+                // non-flying Infantry and ground vehicles are charged double.
                 delta_e *= 2;
             }
             if (entity.hasAbility(OptionsConstants.PILOT_TM_MOUNTAINEER)) {

--- a/megamek/src/megamek/common/moves/MoveStep.java
+++ b/megamek/src/megamek/common/moves/MoveStep.java
@@ -2919,8 +2919,9 @@ public class MoveStep implements Serializable {
                 mp = 4;
                 return;
             }
-            // Mountain Troops only expend 1 MP per 2 levels moved up or down
-            // TO:AUE p.153
+            // Mountain Troops only expend 1 MP per 2 levels moved up or down (TO:AUE p.153).
+            // This stacks with the Mountaineer ability (PILOT_TM_MOUNTAINEER) which reduces
+            // elevation cost by 1 MP. Combined, a 1-level change can cost 0 MP elevation.
             boolean isMountainTroop = isInfantry
                   && ((Infantry) entity).hasSpecialization(Infantry.MOUNTAIN_TROOPS);
             if (isMountainTroop) {

--- a/megamek/src/megamek/common/moves/MoveStep.java
+++ b/megamek/src/megamek/common/moves/MoveStep.java
@@ -2909,10 +2909,10 @@ public class MoveStep implements Serializable {
 
         // non-WIGEs pay for elevation differences
         if ((nSrcEl != nDestEl) && (moveMode != EntityMovementMode.WIGE)) {
-            int delta_e = Math.abs(nSrcEl - nDestEl);
+            int deltaElevation = Math.abs(nSrcEl - nDestEl);
             if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_GROUND_MOVEMENT_TAC_OPS_LEAPING) &&
                   isMek &&
-                  (delta_e > 2) &&
+                  (deltaElevation > 2) &&
                   (nDestEl < nSrcEl)) {
                 // leaping (moving down more than 2 hexes) always costs 4 mp
                 // regardless of anything else
@@ -2925,7 +2925,7 @@ public class MoveStep implements Serializable {
             boolean isMountainTroop = isInfantry
                   && ((Infantry) entity).hasSpecialization(Infantry.MOUNTAIN_TROOPS);
             if (isMountainTroop) {
-                delta_e = (int) Math.ceil(delta_e / 2.0);
+                deltaElevation = (int) Math.ceil(deltaElevation / 2.0);
             } else if ((isInfantry &&
                   !((getMovementType(false) == EntityMovementType.MOVE_VTOL_WALK) ||
                         (getMovementType(false) == EntityMovementType.MOVE_VTOL_RUN))) ||
@@ -2933,12 +2933,12 @@ public class MoveStep implements Serializable {
                         (moveMode == EntityMovementMode.WHEELED) ||
                         (moveMode == EntityMovementMode.HOVER))) {
                 // non-flying Infantry and ground vehicles are charged double.
-                delta_e *= 2;
+                deltaElevation *= 2;
             }
             if (entity.hasAbility(OptionsConstants.PILOT_TM_MOUNTAINEER)) {
-                mp += delta_e - 1;
+                mp += deltaElevation - 1;
             } else {
-                mp += delta_e;
+                mp += deltaElevation;
             }
         }
 

--- a/megamek/unittests/megamek/common/compute/AntiMekAttackTest.java
+++ b/megamek/unittests/megamek/common/compute/AntiMekAttackTest.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import megamek.common.Messages;
 import megamek.common.Player;
 import megamek.common.TechConstants;
 import megamek.common.ToHitData;
@@ -507,44 +508,56 @@ class AntiMekAttackTest {
         @Test
         @DisplayName("Mountain Troops get -2 anti-mek modifier on leg attacks (TO:AUE p.153)")
         void mountainTroopsGetMinusTwoOnLegAttack() {
-            Infantry attacker = createMountainTroops(22);
+            Infantry mountainAttacker = createMountainTroops(22);
+            Infantry standardAttacker = createConventionalInfantry(22);
             Mek defender = createTargetMek();
 
-            attacker.setPosition(new Coords(5, 5));
+            mountainAttacker.setPosition(new Coords(5, 5));
+            standardAttacker.setPosition(new Coords(5, 5));
             defender.setPosition(new Coords(5, 5));
 
-            game.addEntity(attacker);
+            game.addEntity(mountainAttacker);
+            game.addEntity(standardAttacker);
             game.addEntity(defender);
 
-            assertTrue(attacker.hasSpecialization(Infantry.MOUNTAIN_TROOPS),
+            assertTrue(mountainAttacker.hasSpecialization(Infantry.MOUNTAIN_TROOPS),
                   "Test setup: infantry should have Mountain Troops specialization");
 
-            ToHitData toHit = Compute.getLegAttackBaseToHit(attacker, defender, game);
+            ToHitData mountainToHit = Compute.getLegAttackBaseToHit(mountainAttacker, defender, game);
+            ToHitData standardToHit = Compute.getLegAttackBaseToHit(standardAttacker, defender, game);
 
-            assertNotEquals(TargetRoll.IMPOSSIBLE, toHit.getValue(),
+            assertNotEquals(TargetRoll.IMPOSSIBLE, mountainToHit.getValue(),
                   "Mountain troops should be able to leg attack");
-            assertTrue(toHit.getDesc().contains("Mountain Troops"),
-                  "ToHit description should mention Mountain Troops modifier");
+            assertNotEquals(TargetRoll.IMPOSSIBLE, standardToHit.getValue(),
+                  "Standard infantry should be able to leg attack");
+            assertEquals(standardToHit.getValue() - 2, mountainToHit.getValue(),
+                  "Mountain troops should have -2 modifier compared to standard infantry");
         }
 
         @Test
         @DisplayName("Mountain Troops get -2 anti-mek modifier on swarm attacks (TO:AUE p.153)")
         void mountainTroopsGetMinusTwoOnSwarmAttack() {
-            Infantry attacker = createMountainTroops(22);
+            Infantry mountainAttacker = createMountainTroops(22);
+            Infantry standardAttacker = createConventionalInfantry(22);
             Mek defender = createTargetMek();
 
-            attacker.setPosition(new Coords(5, 5));
+            mountainAttacker.setPosition(new Coords(5, 5));
+            standardAttacker.setPosition(new Coords(5, 5));
             defender.setPosition(new Coords(5, 5));
 
-            game.addEntity(attacker);
+            game.addEntity(mountainAttacker);
+            game.addEntity(standardAttacker);
             game.addEntity(defender);
 
-            ToHitData toHit = Compute.getSwarmMekBaseToHit(attacker, defender, game);
+            ToHitData mountainToHit = Compute.getSwarmMekBaseToHit(mountainAttacker, defender, game);
+            ToHitData standardToHit = Compute.getSwarmMekBaseToHit(standardAttacker, defender, game);
 
-            assertNotEquals(TargetRoll.IMPOSSIBLE, toHit.getValue(),
+            assertNotEquals(TargetRoll.IMPOSSIBLE, mountainToHit.getValue(),
                   "Mountain troops should be able to swarm attack");
-            assertTrue(toHit.getDesc().contains("Mountain Troops"),
-                  "ToHit description should mention Mountain Troops modifier");
+            assertNotEquals(TargetRoll.IMPOSSIBLE, standardToHit.getValue(),
+                  "Standard infantry should be able to swarm attack");
+            assertEquals(standardToHit.getValue() - 2, mountainToHit.getValue(),
+                  "Mountain troops should have -2 modifier compared to standard infantry");
         }
 
         @Test
@@ -566,7 +579,7 @@ class AntiMekAttackTest {
 
             assertNotEquals(TargetRoll.IMPOSSIBLE, toHit.getValue(),
                   "Standard infantry should be able to leg attack");
-            assertFalse(toHit.getDesc().contains("Mountain Troops"),
+            assertFalse(toHit.getDesc().contains(Messages.getString("Compute.MountainTroops")),
                   "ToHit description should NOT mention Mountain Troops modifier");
         }
     }

--- a/megamek/unittests/megamek/common/compute/AntiMekAttackTest.java
+++ b/megamek/unittests/megamek/common/compute/AntiMekAttackTest.java
@@ -215,6 +215,15 @@ class AntiMekAttackTest {
         return infantry;
     }
 
+    /**
+     * Creates mountain troops infantry with the MOUNTAIN_TROOPS specialization.
+     */
+    private Infantry createMountainTroops(int troopers) {
+        Infantry infantry = createConventionalInfantry(troopers);
+        infantry.setSpecializations(Infantry.MOUNTAIN_TROOPS);
+        return infantry;
+    }
+
     @Nested
     @DisplayName("isBurdened() Mock Verification")
     class IsBurdenedTests {
@@ -488,6 +497,77 @@ class AntiMekAttackTest {
                   "Leg attack should be possible for Clan BA");
             assertNotEquals(TargetRoll.IMPOSSIBLE, swarmAttack.getValue(),
                   "Swarm attack should be possible for Clan BA");
+        }
+    }
+
+    @Nested
+    @DisplayName("Mountain Troops Anti-Mek Modifier Tests")
+    class MountainTroopsAntiMekTests {
+
+        @Test
+        @DisplayName("Mountain Troops get -2 anti-mek modifier on leg attacks (TO:AUE p.153)")
+        void mountainTroopsGetMinusTwoOnLegAttack() {
+            Infantry attacker = createMountainTroops(22);
+            Mek defender = createTargetMek();
+
+            attacker.setPosition(new Coords(5, 5));
+            defender.setPosition(new Coords(5, 5));
+
+            game.addEntity(attacker);
+            game.addEntity(defender);
+
+            assertTrue(attacker.hasSpecialization(Infantry.MOUNTAIN_TROOPS),
+                  "Test setup: infantry should have Mountain Troops specialization");
+
+            ToHitData toHit = Compute.getLegAttackBaseToHit(attacker, defender, game);
+
+            assertNotEquals(TargetRoll.IMPOSSIBLE, toHit.getValue(),
+                  "Mountain troops should be able to leg attack");
+            assertTrue(toHit.getDesc().contains("Mountain Troops"),
+                  "ToHit description should mention Mountain Troops modifier");
+        }
+
+        @Test
+        @DisplayName("Mountain Troops get -2 anti-mek modifier on swarm attacks (TO:AUE p.153)")
+        void mountainTroopsGetMinusTwoOnSwarmAttack() {
+            Infantry attacker = createMountainTroops(22);
+            Mek defender = createTargetMek();
+
+            attacker.setPosition(new Coords(5, 5));
+            defender.setPosition(new Coords(5, 5));
+
+            game.addEntity(attacker);
+            game.addEntity(defender);
+
+            ToHitData toHit = Compute.getSwarmMekBaseToHit(attacker, defender, game);
+
+            assertNotEquals(TargetRoll.IMPOSSIBLE, toHit.getValue(),
+                  "Mountain troops should be able to swarm attack");
+            assertTrue(toHit.getDesc().contains("Mountain Troops"),
+                  "ToHit description should mention Mountain Troops modifier");
+        }
+
+        @Test
+        @DisplayName("Standard infantry does NOT get -2 anti-mek modifier")
+        void standardInfantryDoesNotGetMountainBonus() {
+            Infantry attacker = createConventionalInfantry(22);
+            Mek defender = createTargetMek();
+
+            attacker.setPosition(new Coords(5, 5));
+            defender.setPosition(new Coords(5, 5));
+
+            game.addEntity(attacker);
+            game.addEntity(defender);
+
+            assertFalse(attacker.hasSpecialization(Infantry.MOUNTAIN_TROOPS),
+                  "Test setup: standard infantry should NOT have Mountain Troops specialization");
+
+            ToHitData toHit = Compute.getLegAttackBaseToHit(attacker, defender, game);
+
+            assertNotEquals(TargetRoll.IMPOSSIBLE, toHit.getValue(),
+                  "Standard infantry should be able to leg attack");
+            assertFalse(toHit.getDesc().contains("Mountain Troops"),
+                  "ToHit description should NOT mention Mountain Troops modifier");
         }
     }
 }

--- a/megamek/unittests/megamek/common/moves/MountainInfantryMovementTest.java
+++ b/megamek/unittests/megamek/common/moves/MountainInfantryMovementTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.moves;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import megamek.common.GameBoardTestCase;
+import megamek.common.enums.MoveStepType;
+import megamek.common.units.Infantry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for Mountain Troops infantry elevation movement costs.
+ * <p>
+ * Per TO:AUE p.153, Mountain Troops "only expend 1 MP per 2 levels moved up or down" instead of the normal infantry
+ * cost of 2 MP per level of elevation change.
+ * </p>
+ */
+public class MountainInfantryMovementTest extends GameBoardTestCase {
+
+    private static Infantry createStandardInfantry() {
+        Infantry infantry = new Infantry();
+        infantry.setId(2);
+        infantry.setWeight(2.0f);
+        infantry.initializeInternal(10, Infantry.LOC_INFANTRY);
+        return infantry;
+    }
+
+    private static Infantry createMountainInfantry() {
+        Infantry infantry = createStandardInfantry();
+        infantry.setSpecializations(Infantry.MOUNTAIN_TROOPS);
+        return infantry;
+    }
+
+    @Nested
+    @DisplayName("Mountain Troops Elevation Movement Cost (TO:AUE p.153)")
+    class ElevationMovementCost {
+
+        static {
+            // 1-level elevation change: level 0 -> level 1
+            initializeBoard("BOARD_1_LEVEL_UP", """
+                  size 1 2
+                  hex 0101 0 "" ""
+                  hex 0102 1 "" ""
+                  end""");
+
+            // 2-level elevation change: level 0 -> level 2
+            initializeBoard("BOARD_2_LEVEL_UP", """
+                  size 1 2
+                  hex 0101 0 "" ""
+                  hex 0102 2 "" ""
+                  end""");
+
+            // 3-level elevation change: level 0 -> level 3
+            initializeBoard("BOARD_3_LEVEL_UP", """
+                  size 1 2
+                  hex 0101 0 "" ""
+                  hex 0102 3 "" ""
+                  end""");
+
+            // Flat board for baseline MP comparison
+            initializeBoard("BOARD_FLAT", """
+                  size 1 2
+                  hex 0101 0 "" ""
+                  hex 0102 0 "" ""
+                  end""");
+        }
+
+        @Test
+        @DisplayName("Flat terrain costs 1 MP for both standard and mountain infantry")
+        void flatTerrainCostsSameForBoth() {
+            setBoard("BOARD_FLAT");
+
+            MovePath standardPath = getMovePathFor(createStandardInfantry(), 0, null,
+                  MoveStepType.FORWARDS);
+            MovePath mountainPath = getMovePathFor(createMountainInfantry(), 0, null,
+                  MoveStepType.FORWARDS);
+
+            assertTrue(standardPath.isMoveLegal(), "Standard infantry move on flat should be legal");
+            assertTrue(mountainPath.isMoveLegal(), "Mountain infantry move on flat should be legal");
+            assertEquals(standardPath.getMpUsed(), mountainPath.getMpUsed(),
+                  "Flat terrain should cost the same MP for both unit types");
+        }
+
+        @Test
+        @DisplayName("1-level up: standard infantry pays 2 MP, mountain troops pay 1 MP")
+        void oneLevelUpMountainTroopsPayLess() {
+            setBoard("BOARD_1_LEVEL_UP");
+
+            // Standard infantry: 1 MP base + (1 level * 2 doubled) = 3 MP
+            MovePath standardPath = getMovePathFor(createStandardInfantry(), 0, null,
+                  MoveStepType.FORWARDS);
+            // Mountain troops: 1 MP base + ceil(1/2) = 1 MP elevation = 2 MP total
+            MovePath mountainPath = getMovePathFor(createMountainInfantry(), 0, null,
+                  MoveStepType.FORWARDS);
+
+            assertTrue(standardPath.isMoveLegal(), "Standard infantry 1-level climb should be legal");
+            assertTrue(mountainPath.isMoveLegal(), "Mountain infantry 1-level climb should be legal");
+
+            int standardMp = standardPath.getMpUsed();
+            int mountainMp = mountainPath.getMpUsed();
+
+            assertTrue(mountainMp < standardMp,
+                  "Mountain troops should pay less MP than standard infantry for 1-level climb. " +
+                        "Mountain: " + mountainMp + " MP, Standard: " + standardMp + " MP");
+        }
+
+        @Test
+        @DisplayName("2-level up: standard infantry CANNOT climb 2 levels (max is 1)")
+        void twoLevelUpStandardInfantryCannotClimb() {
+            setBoard("BOARD_2_LEVEL_UP");
+
+            MovePath standardPath = getMovePathFor(createStandardInfantry(), 0, null,
+                  MoveStepType.FORWARDS);
+
+            assertTrue(!standardPath.isMoveLegal(),
+                  "Standard infantry should NOT be able to climb 2 levels (max elevation change is 1)");
+        }
+
+        @Test
+        @DisplayName("2-level up: mountain troops can climb 2 levels")
+        void twoLevelUpMountainTroopsCanClimb() {
+            setBoard("BOARD_2_LEVEL_UP");
+
+            MovePath mountainPath = getMovePathFor(createMountainInfantry(), 0, null,
+                  MoveStepType.FORWARDS);
+
+            assertTrue(mountainPath.isMoveLegal(),
+                  "Mountain troops should be able to climb 2 levels (max elevation change is 3)");
+        }
+
+        @Test
+        @DisplayName("3-level up: mountain troops can climb 3 levels (their max elevation change)")
+        void threeLevelUpMountainTroopsCanClimb() {
+            setBoard("BOARD_3_LEVEL_UP");
+
+            MovePath mountainPath = getMovePathFor(createMountainInfantry(), 0, null,
+                  MoveStepType.FORWARDS);
+
+            assertTrue(mountainPath.isMoveLegal(),
+                  "Mountain troops should be able to climb 3 levels in one hex (their max elevation change)");
+        }
+
+        @Test
+        @DisplayName("3-level up: standard infantry CANNOT climb 3 levels (max is 1)")
+        void threeLevelUpStandardInfantryCannotClimb() {
+            setBoard("BOARD_3_LEVEL_UP");
+
+            MovePath standardPath = getMovePathFor(createStandardInfantry(), 0, null,
+                  MoveStepType.FORWARDS);
+
+            assertTrue(!standardPath.isMoveLegal(),
+                  "Standard infantry should NOT be able to climb 3 levels (max elevation change is 1)");
+        }
+    }
+}

--- a/megamek/unittests/megamek/common/moves/MountainInfantryMovementTest.java
+++ b/megamek/unittests/megamek/common/moves/MountainInfantryMovementTest.java
@@ -33,6 +33,7 @@
 package megamek.common.moves;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import megamek.common.GameBoardTestCase;
@@ -146,7 +147,7 @@ public class MountainInfantryMovementTest extends GameBoardTestCase {
             MovePath standardPath = getMovePathFor(createStandardInfantry(), 0, null,
                   MoveStepType.FORWARDS);
 
-            assertTrue(!standardPath.isMoveLegal(),
+            assertFalse(standardPath.isMoveLegal(),
                   "Standard infantry should NOT be able to climb 2 levels (max elevation change is 1)");
         }
 
@@ -182,7 +183,7 @@ public class MountainInfantryMovementTest extends GameBoardTestCase {
             MovePath standardPath = getMovePathFor(createStandardInfantry(), 0, null,
                   MoveStepType.FORWARDS);
 
-            assertTrue(!standardPath.isMoveLegal(),
+            assertFalse(standardPath.isMoveLegal(),
                   "Standard infantry should NOT be able to climb 3 levels (max elevation change is 1)");
         }
     }


### PR DESCRIPTION
## Summary: 
  
  Root Cause: Mountain Troops specialization was missing two rules:
  1. No -2 Anti-Mek Skill Roll modifier
  2. No reduced elevation movement cost (1 MP per 2 levels)

##  Changes:
  1. megamek/src/megamek/common/compute/Compute.java — Added -2 anti-mek modifier for Mountain Troops in getAntiMekMods()
  2. megamek/src/megamek/common/moves/MoveStep.java — Mountain Troops pay ceil(delta_e / 2) for elevation instead of doubled infantry rate
  3. megamek/resources/megamek/common/messages.properties — Added Compute.MountainTroops i18n string
  4. megamek/unittests/megamek/common/compute/AntiMekAttackTest.java — 3 new tests for mountain troops anti-mek modifier
  5. megamek/unittests/megamek/common/moves/MountainInfantryMovementTest.java — New test file, 6 tests for elevation MP costs

##  Files Changed:
  - megamek/src/megamek/common/compute/Compute.java
  - megamek/src/megamek/common/moves/MoveStep.java
  - megamek/resources/megamek/common/messages.properties
  - megamek/unittests/megamek/common/compute/AntiMekAttackTest.java
  - megamek/unittests/megamek/common/moves/MountainInfantryMovementTest.java (new)

##  Testing:
  - 9 new unit tests all passing
  - Manual in-game: 1-level climb = 2 MP, 3-level climb = 3 MP, 4-level = blocked (all correct)
  - Anti-Mek -2 modifier: unit tested, not yet verified in-game

  Rules Reference: TO:AUE p.153, TO:AR p.20 (climbing context)