### PR TITLE
Fix #8141: Prevent HHW weapons from generating heat on the entity carrying it when attacking

### DIFF
--- a/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
@@ -1949,7 +1949,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
                     attackingEntity.setArcFired(loc, rearMount);
                 }
             } else {
-                attackingEntity.heatBuildup += (weapon.getHeatByBay());
+                weaponEntity.heatBuildup += (weapon.getHeatByBay());
             }
         }
     }


### PR DESCRIPTION
Fixes #8141

Heat should be generated on the `weaponEntity` not the `attackingEntity`. The Handheld Weapon should be able to appropriate deal with (ignore) the heat.