### PR TITLE
Set the reroll for ties code to send initiative compensation flag.

### DIFF
--- a/megamek/src/megamek/common/turns/TurnOrdered.java
+++ b/megamek/src/megamek/common/turns/TurnOrdered.java
@@ -513,9 +513,8 @@ public abstract class TurnOrdered implements ITurnOrdered {
             }
 
             if (ties.size() > 1) {
-                // We want to ignore initiative compensation here, because it will
-                // get dealt with once we're done resolving ties
-                rollInitAndResolveTies(ties, null, false, initiativeAptitude);
+                // Initiative compensation is retained here, as it should persist in the reroll, like all other bonuses
+                rollInitAndResolveTies(ties, null, bInitCompBonus, initiativeAptitude);
             }
         }
     }


### PR DESCRIPTION
Previously turned off in 2014, saying it was handled elsewhere. it is no longer handled elsewhere. 

Fixes #7055