### PR TITLE
Clean up saw tracker when fire burns away woods (Fixes #8147 follow-up)

### DIFF
--- a/megamek/src/megamek/common/WoodsClearingTracker.java
+++ b/megamek/src/megamek/common/WoodsClearingTracker.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Set;
 
 import megamek.common.board.BoardLocation;
+import megamek.common.units.Terrains;
 
 /**
  * Tracks ongoing woods-clearing operations using chainsaws and dual saws.
@@ -232,6 +233,20 @@ public class WoodsClearingTracker implements Serializable {
             result.put(entry.getKey(), remaining);
         }
         return result;
+    }
+
+    /**
+     * Removes tracker entries for hexes that no longer contain woods or jungle. This handles cases where fire or other
+     * effects removed the woods before the saw clearing completed.
+     *
+     * @param hexLookup a function that returns the Hex at a given BoardLocation, or null
+     */
+    public void removeStaleEntries(java.util.function.Function<BoardLocation, Hex> hexLookup) {
+        clearingOperations.entrySet().removeIf(entry -> {
+            Hex hex = hexLookup.apply(entry.getKey());
+            return hex == null
+                  || (!hex.containsTerrain(Terrains.WOODS) && !hex.containsTerrain(Terrains.JUNGLE));
+        });
     }
 
     /**

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -16392,6 +16392,10 @@ public class TWGameManager extends AbstractGameManager {
             sendChangedHexes();
         }
 
+        // Clean up tracker entries for hexes that no longer have woods (e.g., burned down by fire)
+        game.getWoodsClearingTracker().removeStaleEntries(
+              loc -> game.getBoard(loc.boardId()).getHex(loc.coords()));
+
         // Sync remaining clearing state to Game for board view rendering and send to clients
         sendCutHexesUpdate();
 

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -16393,8 +16393,10 @@ public class TWGameManager extends AbstractGameManager {
         }
 
         // Clean up tracker entries for hexes that no longer have woods (e.g., burned down by fire)
-        game.getWoodsClearingTracker().removeStaleEntries(
-              loc -> game.getBoard(loc.boardId()).getHex(loc.coords()));
+        game.getWoodsClearingTracker().removeStaleEntries(loc -> {
+            Board board = game.getBoard(loc.boardId());
+            return (board != null) ? board.getHex(loc.coords()) : null;
+        });
 
         // Sync remaining clearing state to Game for board view rendering and send to clients
         sendCutHexesUpdate();

--- a/megamek/unittests/megamek/common/WoodsClearingTrackerTest.java
+++ b/megamek/unittests/megamek/common/WoodsClearingTrackerTest.java
@@ -41,6 +41,8 @@ import java.util.List;
 
 import megamek.common.board.BoardLocation;
 import megamek.common.board.Coords;
+import megamek.common.units.Terrain;
+import megamek.common.units.Terrains;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -280,6 +282,57 @@ class WoodsClearingTrackerTest {
             assertFalse(tracker.isClearingThisRound(1));
             assertFalse(tracker.isClearingThisRound(2));
             assertTrue(tracker.getAllClearingEntities().isEmpty());
+        }
+    }
+
+    @Nested
+    @DisplayName("Stale Entry Cleanup")
+    class StaleEntryTests {
+
+        @Test
+        @DisplayName("Removes entry when hex lookup returns null")
+        void removesEntryWhenHexIsNull() {
+            tracker.declareClearing(1, hexA);
+            tracker.removeStaleEntries(loc -> null);
+
+            assertFalse(tracker.isClearingThisRound(1),
+                  "Entry should be removed when hex lookup returns null");
+        }
+
+        @Test
+        @DisplayName("Removes entry when hex has no woods or jungle")
+        void removesEntryWhenNoWoods() {
+            tracker.declareClearing(1, hexA);
+            Hex roughHex = new Hex();
+            roughHex.addTerrain(new Terrain(Terrains.ROUGH, 1));
+            tracker.removeStaleEntries(loc -> roughHex);
+
+            assertFalse(tracker.isClearingThisRound(1),
+                  "Entry should be removed when hex has no woods or jungle");
+        }
+
+        @Test
+        @DisplayName("Retains entry when hex still has woods")
+        void retainsEntryWithWoods() {
+            tracker.declareClearing(1, hexA);
+            Hex woodsHex = new Hex();
+            woodsHex.addTerrain(new Terrain(Terrains.WOODS, 1));
+            tracker.removeStaleEntries(loc -> woodsHex);
+
+            assertTrue(tracker.isClearingThisRound(1),
+                  "Entry should be retained when hex still has woods");
+        }
+
+        @Test
+        @DisplayName("Retains entry when hex still has jungle")
+        void retainsEntryWithJungle() {
+            tracker.declareClearing(1, hexA);
+            Hex jungleHex = new Hex();
+            jungleHex.addTerrain(new Terrain(Terrains.JUNGLE, 2));
+            tracker.removeStaleEntries(loc -> jungleHex);
+
+            assertTrue(tracker.isClearingThisRound(1),
+                  "Entry should be retained when hex still has jungle");
         }
     }
 }


### PR DESCRIPTION
## Summary

When fire (or other terrain effects) burns away woods before a saw finishes clearing, the WoodsClearingTracker was left with stale entries causing the saw blade indicator to persist on hexes that no longer had trees Added removeStaleEntries() to WoodsClearingTracker that removes tracker entries for hexes where the woods/jungle terrain no longer exists Called during processWoodsClearingCompletions() before syncing rendering state to clients Changes

WoodsClearingTracker.java - Added removeStaleEntries(Function<BoardLocation, Hex>) method that checks each tracked hex and removes entries where the terrain no longer has woods or jungle 

TWGameManager.java - Call removeStaleEntries() in processWoodsClearingCompletions() before sendCutHexesUpdate(), passing a lambda for hex lookup with multi-board support Testing
Existing WoodsClearingTracker unit tests pass

## Scenario: 
Fire burns away woods on a hex being cleared → tracker entry and saw blade indicator are removed on the next physical phase No interaction issues: if fire reduces heavy→light while saw is also working, both systems operate independently per TW rules (saw still reduces by one level as intended)