### PR TITLE
Fix NPE in player done packet and incorrect flag check in Infantry specializations

### DIFF
--- a/megamek/src/megamek/common/units/Infantry.java
+++ b/megamek/src/megamek/common/units/Infantry.java
@@ -1770,7 +1770,7 @@ public class Infantry extends Entity {
         // Equipment for Demolition Engineers
         if ((spec & DEMO_ENGINEERS) > 0 && (infSpecs & DEMO_ENGINEERS) == 0) {
             // Add demolition charge if not already present (may already be loaded from file)
-            boolean hasCharge = getEquipment().stream()
+            boolean hasCharge = getMisc().stream()
                   .anyMatch(m -> m.getType().hasFlag(MiscType.F_TOOLS)
                         && m.getType().hasFlag(MiscTypeFlag.S_DEMOLITION_CHARGE));
             if (!hasCharge) {
@@ -1782,9 +1782,9 @@ public class Infantry extends Entity {
                 }
             }
         } else if ((spec & DEMO_ENGINEERS) == 0 && (infSpecs & DEMO_ENGINEERS) > 0) {
-            // Need to remove vibro shovels
+            // Need to remove demolition charges
             List<Mounted<?>> eqToRemove = new ArrayList<>();
-            for (Mounted<?> eq : getEquipment()) {
+            for (Mounted<?> eq : getMisc()) {
                 if (eq.getType().hasFlag(MiscType.F_TOOLS) && eq.getType().hasFlag(MiscTypeFlag.S_DEMOLITION_CHARGE)) {
                     eqToRemove.add(eq);
                 }

--- a/megamek/src/megamek/server/AbstractGameManager.java
+++ b/megamek/src/megamek/server/AbstractGameManager.java
@@ -33,9 +33,9 @@
 
 package megamek.server;
 
-import megamek.common.game.IGame;
 import megamek.common.Player;
 import megamek.common.enums.GamePhase;
+import megamek.common.game.IGame;
 import megamek.common.net.enums.PacketCommand;
 import megamek.common.net.packets.InvalidPacketDataException;
 import megamek.common.net.packets.Packet;
@@ -78,8 +78,10 @@ public abstract class AbstractGameManager implements IGameManager {
         if (packet.command() == PacketCommand.PLAYER_READY) {
             try {
                 receivePlayerDone(packet, connId);
-                send(packetHelper.createPlayerDonePacket(connId));
-                checkReady();
+                if (getGame().getPlayer(connId) != null) {
+                    send(packetHelper.createPlayerDonePacket(connId));
+                    checkReady();
+                }
             } catch (InvalidPacketDataException e) {
                 logger.error("Invalid packet data:", e);
             }


### PR DESCRIPTION
##  Root Cause

Two unrelated bugs found in server logs: (Fixes https://github.com/MegaMek/megamek/issues/8159)
  1. NPE in createPlayerDonePacket: When a PLAYER_READY packet is processed after the player has disconnected, getPlayer(connId) returns null. receivePlayerDone() already null-checks this and logs an error, but execution continues to createPlayerDonePacket() which calls .isDone() on the null player.
  2
  3. Incorrect flag type in Infantry.setSpecializations: The demolition charge presence check and removal loop iterate getEquipment() (all equipment including weapons) but test MiscTypeFlag flags. When a WeaponType is encountered, hasFlag(MiscTypeFlag) logs a warning. The vibro shovel section correctly uses getMisc(), but the demolition charge section was a copy-paste that used getEquipment() instead.

##  Changes

  Player done packet guard (AbstractGameManager.java)

  - Added null check on getPlayer(connId) before calling createPlayerDonePacket() and checkReady(), skipping both if the player no longer exists

  Infantry specialization flag fix (Infantry.java)

  - Changed demolition charge presence check from getEquipment().stream() to getMisc().stream(), matching the vibro shovel pattern
  - Changed demolition charge removal loop from iterating getEquipment() to getMisc()
  - Fixed copy-paste comment "Need to remove vibro shovels" to "Need to remove demolition charges"

##  Files Changed

  - megamek/megamek/src/megamek/server/AbstractGameManager.java - Null-guard player done broadcast
  - megamek/megamek/src/megamek/common/units/Infantry.java - Use getMisc() for demolition charge checks

##  Testing

  - Both fixes compile cleanly
  - NPE fix: race condition, not unit-testable without threading harness
  - Infantry fix: eliminates spurious WARN log spam during mek cache loading
  - Tested in game with the Demolition charges before and after the errors disappeared.