### PR TITLE
Fix LOS not blocked by combined intervening woods and smoke 

### DIFF
--- a/megamek/src/megamek/common/LosEffects.java
+++ b/megamek/src/megamek/common/LosEffects.java
@@ -58,15 +58,24 @@ import megamek.common.units.Mek;
 import megamek.common.units.Targetable;
 import megamek.common.units.Terrain;
 import megamek.common.units.Terrains;
+import megamek.logging.MMLogger;
 import megamek.server.SmokeCloud;
 
 /**
- * Keeps track of the cumulative effects of intervening terrain on LOS
+ * Keeps track of the cumulative effects of intervening terrain on LOS.
+ *
+ * <p><b>Diagnostic logging:</b> This class has extensive DEBUG-level logging for LOS calculations.
+ * To enable it, set the log level for {@code megamek.common.LosEffects} to DEBUG in the logging
+ * configuration. This will log: the LOS rule set in use, attacker/target positions and heights,
+ * per-hex terrain accumulation (woods, smoke, buildings), and the final blocking decision with
+ * all accumulated modifier totals. Useful for diagnosing LOS discrepancies in bug reports.</p>
  *
  * @author Ben
  * @since October 14, 2002, 11:19 PM
  */
 public class LosEffects {
+
+    private static final MMLogger logger = MMLogger.create(LosEffects.class);
 
     public static class AttackInfo {
         public boolean attUnderWater;
@@ -777,6 +786,16 @@ public class LosEffects {
     }
 
     public static LosEffects calculateLos(Game game, AttackInfo ai) {
+        boolean useDiagramLos = game.getOptions().booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_LOS1);
+        boolean useDeadZones = game.getOptions().booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_DEAD_ZONES);
+        boolean usePartialCover = game.getOptions()
+              .booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_PARTIAL_COVER);
+        logger.debug("=== LOS CALC START === rules: {} | deadZones:{} partialCover:{} | "
+                    + "attacker@{} (absH:{}, h:{}, isMek:{}) -> target@{} (absH:{}, h:{}, isMek:{})",
+              useDiagramLos ? "TacOps Diagrammed LOS" : "Standard TW LOS",
+              useDeadZones, usePartialCover,
+              ai.attackPos, ai.attackAbsHeight, ai.attackHeight, ai.attackerIsMek,
+              ai.targetPos, ai.targetAbsHeight, ai.targetHeight, ai.targetIsMek);
         if (ai.attOffBoard) {
             LosEffects los = new LosEffects();
             los.blocked = true;
@@ -822,6 +841,22 @@ public class LosEffects {
                     ((finalLoS.heavyWoods + finalLoS.heavySmoke) * 2) +
                     (finalLoS.ultraWoods * 3) < 3);
 
+        int combinedWoodsSmoke = (finalLoS.lightWoods + finalLoS.lightSmoke)
+              + ((finalLoS.heavyWoods + finalLoS.heavySmoke) * 2)
+              + (finalLoS.ultraWoods * 3);
+        logger.debug("=== LOS CALC RESULT === blocked:{} hasLoS:{} | "
+                    + "lightWoods:{} heavyWoods:{} ultraWoods:{} | "
+                    + "lightSmoke:{} heavySmoke:{} | "
+                    + "combinedWoodsSmoke:{} (blocks if >=3) | "
+                    + "screen:{} plantedFields:{} heavyIndustrial:{} | "
+                    + "buildingLevels:{} softBldg:{} hardBldg:{}",
+              finalLoS.blocked, finalLoS.hasLoS,
+              finalLoS.lightWoods, finalLoS.heavyWoods, finalLoS.ultraWoods,
+              finalLoS.lightSmoke, finalLoS.heavySmoke,
+              combinedWoodsSmoke,
+              finalLoS.screen, finalLoS.plantedFields, finalLoS.heavyIndustrial,
+              finalLoS.buildingLevelsOrHexes, finalLoS.softBuildings, finalLoS.hardBuildings);
+
         finalLoS.targetLoc = ai.targetPos;
         return finalLoS;
     }
@@ -838,6 +873,18 @@ public class LosEffects {
     }
 
     public ToHitData losModifiers(Game game, int eiStatus, boolean underwaterWeapon) {
+        logger.debug("--- losModifiers() --- blocked:{} arcedShot:{} ei:{} underwater:{} | "
+                    + "lightWoods:{} heavyWoods:{} ultraWoods:{} | "
+                    + "lightSmoke:{} heavySmoke:{} | "
+                    + "woodsOnly:{} smokeOnly:{} combined:{} | "
+                    + "buildingLvls:{} screen:{} fields:{} heavyInd:{}",
+              blocked, arcedShot, eiStatus, underwaterWeapon,
+              lightWoods, heavyWoods, ultraWoods,
+              lightSmoke, heavySmoke,
+              lightWoods + (heavyWoods * 2),
+              lightSmoke + (heavySmoke * 2),
+              (lightWoods + lightSmoke) + ((heavyWoods + heavySmoke) * 2) + (ultraWoods * 3),
+              buildingLevelsOrHexes, screen, plantedFields, heavyIndustrial);
         ToHitData modifiers = new ToHitData();
 
         if (arcedShot) {
@@ -852,24 +899,42 @@ public class LosEffects {
          */
 
         if (blocked) {
+            logger.debug("losModifiers: BLOCKED by terrain (hill/elevation)");
             return new ToHitData(TargetRoll.IMPOSSIBLE, "LOS blocked by terrain.");
         }
 
         if (infProtected) {
+            logger.debug("losModifiers: BLOCKED - infantry protected by building");
             return new ToHitData(TargetRoll.IMPOSSIBLE, "Infantry protected by building.");
         }
 
         if (buildingLevelsOrHexes > 2) {
+            logger.debug("losModifiers: BLOCKED by {} building levels/hexes (>2)", buildingLevelsOrHexes);
             return new ToHitData(TargetRoll.IMPOSSIBLE, "LOS blocked by building hexes or levels.");
         }
 
         // LOS blocking is not affected by EI - EI only reduces to-hit modifiers (IO p.69)
-        if ((ultraWoods >= 1) || (lightWoods + (heavyWoods * 2) > 2)) {
-            return new ToHitData(TargetRoll.IMPOSSIBLE, "LOS blocked by woods.");
+        // Woods and smoke effects are combined for blocking threshold (TW LOS rules).
+        // This matches the hasLoS calculation in calculateLos().
+        int combinedWoodsSmokeTotal = (lightWoods + lightSmoke)
+              + ((heavyWoods + heavySmoke) * 2)
+              + (ultraWoods * 3);
+        if (!underwaterWeapon && combinedWoodsSmokeTotal >= 3) {
+            logger.debug("losModifiers: BLOCKED by woods+smoke (combined:{}, "
+                        + "lightWoods:{} heavyWoods:{} ultraWoods:{} lightSmoke:{} heavySmoke:{})",
+                  combinedWoodsSmokeTotal, lightWoods, heavyWoods, ultraWoods, lightSmoke, heavySmoke);
+            return new ToHitData(TargetRoll.IMPOSSIBLE, "LOS blocked by intervening woods/smoke.");
         }
-
-        if (!underwaterWeapon && (lightSmoke + (heavySmoke * 2) > 2)) {
-            return new ToHitData(TargetRoll.IMPOSSIBLE, "LOS blocked by smoke.");
+        // Ultra woods alone always blocks regardless of underwater
+        if (ultraWoods >= 1) {
+            logger.debug("losModifiers: BLOCKED by ultra woods ({})", ultraWoods);
+            return new ToHitData(TargetRoll.IMPOSSIBLE, "LOS blocked by ultra woods.");
+        }
+        // Woods alone can block even for underwater weapons (smoke doesn't apply underwater)
+        if (underwaterWeapon && (lightWoods + (heavyWoods * 2) > 2)) {
+            logger.debug("losModifiers: BLOCKED by woods underwater (woodsTotal:{})",
+                  lightWoods + (heavyWoods * 2));
+            return new ToHitData(TargetRoll.IMPOSSIBLE, "LOS blocked by woods.");
         }
 
         if (plantedFields > 5) {
@@ -1411,6 +1476,14 @@ public class LosEffects {
             int smokeLevel = hex.terrainLevel(Terrains.SMOKE);
             boolean hasFoliage = (woodsLevel != Terrain.LEVEL_NONE) || (jungleLevel != Terrain.LEVEL_NONE);
 
+            if (hasFoliage || smokeLevel != Terrain.LEVEL_NONE) {
+                logger.debug("  Hex {} (elev:{}) terrain: woods:{} jungle:{} foliageElev:{} smoke:{} | "
+                            + "losElev:{:.1f} maxUnitH:{} attAbsH:{} tgtAbsH:{} attAdj:{} tgtAdj:{}",
+                      coords, hexEl, woodsLevel, jungleLevel, foliageElev, smokeLevel,
+                      losElevation, maxUnitHeight, ai.attackAbsHeight, ai.targetAbsHeight,
+                      attackerAdjacent, targetAdjacent);
+            }
+
             // Check 1 level high woods and jungle
             if (hasFoliage && foliageElev == 1) {
                 int terrainEl = hexEl + 1;
@@ -1424,11 +1497,16 @@ public class LosEffects {
                 if (affectsLos) {
                     if ((woodsLevel == 1) || (jungleLevel == 1)) {
                         los.lightWoods++;
+                        logger.debug("    -> {} counted as LIGHT WOODS (1-level foliage)", coords);
                     } else if ((woodsLevel == 2) || (jungleLevel == 2)) {
                         los.heavyWoods++;
+                        logger.debug("    -> {} counted as HEAVY WOODS (1-level foliage)", coords);
                     } else {
                         los.ultraWoods++;
+                        logger.debug("    -> {} counted as ULTRA WOODS (1-level foliage)", coords);
                     }
+                } else {
+                    logger.debug("    -> {} 1-level foliage does NOT affect LOS (below line)", coords);
                 }
             }
 
@@ -1451,16 +1529,24 @@ public class LosEffects {
                         case SmokeCloud.SMOKE_CHAFF_LIGHT:
                         case SmokeCloud.SMOKE_GREEN:
                             los.lightSmoke++;
+                            logger.debug("    -> {} counted as LIGHT SMOKE (2-level check)", coords);
                             break;
                         case SmokeCloud.SMOKE_HEAVY:
                             los.heavySmoke++;
+                            logger.debug("    -> {} counted as HEAVY SMOKE (2-level check)", coords);
                             break;
                     }
                     // Check woods/jungle
                     if ((woodsLevel == 1) || (jungleLevel == 1)) {
                         los.lightWoods++;
+                        logger.debug("    -> {} counted as LIGHT WOODS (2-level foliage)", coords);
                     } else if ((woodsLevel == 2) || (jungleLevel == 2)) {
                         los.heavyWoods++;
+                        logger.debug("    -> {} counted as HEAVY WOODS (2-level foliage)", coords);
+                    }
+                } else {
+                    if (smokeLevel != Terrain.LEVEL_NONE || hasFoliage) {
+                        logger.debug("    -> {} 2-level smoke/foliage does NOT affect LOS (below line)", coords);
                     }
                 }
 

--- a/megamek/src/megamek/common/LosEffects.java
+++ b/megamek/src/megamek/common/LosEffects.java
@@ -914,27 +914,30 @@ public class LosEffects {
         }
 
         // LOS blocking is not affected by EI - EI only reduces to-hit modifiers (IO p.69)
-        // Woods and smoke effects are combined for blocking threshold (TW LOS rules).
-        // This matches the hasLoS calculation in calculateLos().
-        int combinedWoodsSmokeTotal = (lightWoods + lightSmoke)
-              + ((heavyWoods + heavySmoke) * 2)
-              + (ultraWoods * 3);
-        if (!underwaterWeapon && combinedWoodsSmokeTotal >= 3) {
-            logger.debug("losModifiers: BLOCKED by woods+smoke (combined:{}, "
-                        + "lightWoods:{} heavyWoods:{} ultraWoods:{} lightSmoke:{} heavySmoke:{})",
-                  combinedWoodsSmokeTotal, lightWoods, heavyWoods, ultraWoods, lightSmoke, heavySmoke);
-            return new ToHitData(TargetRoll.IMPOSSIBLE, "LOS blocked by intervening woods/smoke.");
-        }
-        // Ultra woods alone always blocks regardless of underwater
+        // Ultra woods always blocks regardless of underwater weapon status
         if (ultraWoods >= 1) {
             logger.debug("losModifiers: BLOCKED by ultra woods ({})", ultraWoods);
             return new ToHitData(TargetRoll.IMPOSSIBLE, "LOS blocked by ultra woods.");
         }
-        // Woods alone can block even for underwater weapons (smoke doesn't apply underwater)
-        if (underwaterWeapon && (lightWoods + (heavyWoods * 2) > 2)) {
-            logger.debug("losModifiers: BLOCKED by woods underwater (woodsTotal:{})",
-                  lightWoods + (heavyWoods * 2));
-            return new ToHitData(TargetRoll.IMPOSSIBLE, "LOS blocked by woods.");
+
+        if (underwaterWeapon) {
+            // Underwater: smoke doesn't apply, only woods count
+            if (lightWoods + (heavyWoods * 2) > 2) {
+                logger.debug("losModifiers: BLOCKED by woods underwater (woodsTotal:{})",
+                      lightWoods + (heavyWoods * 2));
+                return new ToHitData(TargetRoll.IMPOSSIBLE, "LOS blocked by woods.");
+            }
+        } else {
+            // Woods and smoke effects are combined for blocking threshold (TW LOS rules).
+            // This matches the hasLoS calculation in calculateLos().
+            int combinedWoodsSmokeTotal = (lightWoods + lightSmoke)
+                  + ((heavyWoods + heavySmoke) * 2);
+            if (combinedWoodsSmokeTotal >= 3) {
+                logger.debug("losModifiers: BLOCKED by woods+smoke (combined:{}, "
+                            + "lightWoods:{} heavyWoods:{} lightSmoke:{} heavySmoke:{})",
+                      combinedWoodsSmokeTotal, lightWoods, heavyWoods, lightSmoke, heavySmoke);
+                return new ToHitData(TargetRoll.IMPOSSIBLE, "LOS blocked by intervening woods/smoke.");
+            }
         }
 
         if (plantedFields > 5) {
@@ -1478,9 +1481,10 @@ public class LosEffects {
 
             if (hasFoliage || smokeLevel != Terrain.LEVEL_NONE) {
                 logger.debug("  Hex {} (elev:{}) terrain: woods:{} jungle:{} foliageElev:{} smoke:{} | "
-                            + "losElev:{:.1f} maxUnitH:{} attAbsH:{} tgtAbsH:{} attAdj:{} tgtAdj:{}",
+                            + "losElev:{} maxUnitH:{} attAbsH:{} tgtAbsH:{} attAdj:{} tgtAdj:{}",
                       coords, hexEl, woodsLevel, jungleLevel, foliageElev, smokeLevel,
-                      losElevation, maxUnitHeight, ai.attackAbsHeight, ai.targetAbsHeight,
+                      String.format("%.1f", losElevation), maxUnitHeight,
+                      ai.attackAbsHeight, ai.targetAbsHeight,
                       attackerAdjacent, targetAdjacent);
             }
 

--- a/megamek/unittests/megamek/common/LosEffectsTest.java
+++ b/megamek/unittests/megamek/common/LosEffectsTest.java
@@ -51,6 +51,7 @@ import megamek.common.options.GameOptions;
 import megamek.common.options.IOption;
 import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
+import megamek.common.rolls.TargetRoll;
 import megamek.common.units.BipedMek;
 import megamek.common.units.BuildingEntity;
 import megamek.common.units.Crew;
@@ -97,6 +98,59 @@ public class LosEffectsTest extends GameBoardTestCase {
               hex 0207 0 "planted_fields:1" ""
               hex 0108 0 "planted_fields:1" ""
               hex 0208 0 "planted_fields:1" ""
+              end"""
+        );
+
+        // Board with 1 light woods + 2 light smoke intervening (bug #8167 scenario)
+        initializeBoard("01_BY_05_WOODS_SMOKE_COMBINED", """
+              size 1 5
+              hex 0101 0 "" ""
+              hex 0102 0 "woods:1;foliage_elev:2" ""
+              hex 0103 0 "smoke:1" ""
+              hex 0104 0 "smoke:1" ""
+              hex 0105 0 "" ""
+              end"""
+        );
+
+        // Board with 3 light woods intervening
+        initializeBoard("01_BY_05_THREE_LIGHT_WOODS", """
+              size 1 5
+              hex 0101 0 "" ""
+              hex 0102 0 "woods:1;foliage_elev:2" ""
+              hex 0103 0 "woods:1;foliage_elev:2" ""
+              hex 0104 0 "woods:1;foliage_elev:2" ""
+              hex 0105 0 "" ""
+              end"""
+        );
+
+        // Board with 3 light smoke intervening
+        initializeBoard("01_BY_05_THREE_LIGHT_SMOKE", """
+              size 1 5
+              hex 0101 0 "" ""
+              hex 0102 0 "smoke:1" ""
+              hex 0103 0 "smoke:1" ""
+              hex 0104 0 "smoke:1" ""
+              hex 0105 0 "" ""
+              end"""
+        );
+
+        // Board with 1 light woods + 1 light smoke (should NOT block)
+        initializeBoard("01_BY_04_WOODS_SMOKE_PARTIAL", """
+              size 1 4
+              hex 0101 0 "" ""
+              hex 0102 0 "woods:1;foliage_elev:2" ""
+              hex 0103 0 "smoke:1" ""
+              hex 0104 0 "" ""
+              end"""
+        );
+
+        // Board with 1 heavy woods + 1 light smoke (combined = 3, should block)
+        initializeBoard("01_BY_04_HEAVY_WOODS_LIGHT_SMOKE", """
+              size 1 4
+              hex 0101 0 "" ""
+              hex 0102 0 "woods:2;foliage_elev:2" ""
+              hex 0103 0 "smoke:1" ""
+              hex 0104 0 "" ""
               end"""
         );
 
@@ -390,6 +444,144 @@ public class LosEffectsTest extends GameBoardTestCase {
             assertEquals(1, result.plantedFields, """
                   Should have exactly 1 intervening planted field""");
             assertTrue(result.hasLoS, "Should have line of sight thru 1 raised planted field");
+        }
+    }
+
+    /**
+     * Tests for woods and smoke combined LOS blocking (issue #8167). TW rules: woods and smoke modifiers are combined
+     * for the blocking threshold. LOS is blocked when (lightWoods + lightSmoke) + ((heavyWoods + heavySmoke) * 2) +
+     * (ultraWoods * 3) >= 3.
+     */
+    @Nested
+    @DisplayName("Woods and Smoke Combined LOS Blocking Tests (Issue #8167)")
+    class WoodsSmokeBlockingTests {
+
+        @BeforeEach
+        void setUp() {
+        }
+
+        private LosEffects.AttackInfo buildGroundAttackInfo(Coords attackPos, Coords targetPos) {
+            LosEffects.AttackInfo ai = new LosEffects.AttackInfo();
+            ai.attackPos = attackPos;
+            ai.targetPos = targetPos;
+            ai.attackAbsHeight = 0;
+            ai.targetAbsHeight = 0;
+            ai.attOnLand = true;
+            ai.targetOnLand = true;
+            ai.targetEntity = true;
+            return ai;
+        }
+
+        @Test
+        @DisplayName("1 light wood + 2 light smoke should block LOS (combined = 3)")
+        void shouldBlockLos_WoodsAndSmokeCombined() {
+            // This is the exact scenario from bug #8167
+            setBoard("01_BY_05_WOODS_SMOKE_COMBINED");
+            LosEffects.AttackInfo ai = buildGroundAttackInfo(new Coords(0, 0), new Coords(0, 4));
+
+            LosEffects result = LosEffects.calculateLos(game, ai);
+
+            assertNotNull(result);
+            assertEquals(1, result.lightWoods, "Should count 1 light woods");
+            assertEquals(2, result.lightSmoke, "Should count 2 light smoke");
+            assertFalse(result.hasLoS, "hasLoS should be false (combined woods+smoke = 3)");
+
+            // The critical check: losModifiers must also return IMPOSSIBLE
+            ToHitData thd = result.losModifiers(game);
+            assertEquals(TargetRoll.IMPOSSIBLE, thd.getValue(),
+                  "losModifiers should return IMPOSSIBLE when combined woods+smoke >= 3");
+        }
+
+        @Test
+        @DisplayName("3 light woods should block LOS (woods alone = 3)")
+        void shouldBlockLos_ThreeLightWoods() {
+            setBoard("01_BY_05_THREE_LIGHT_WOODS");
+            LosEffects.AttackInfo ai = buildGroundAttackInfo(new Coords(0, 0), new Coords(0, 4));
+
+            LosEffects result = LosEffects.calculateLos(game, ai);
+
+            assertNotNull(result);
+            assertEquals(3, result.lightWoods, "Should count 3 light woods");
+            assertFalse(result.hasLoS, "hasLoS should be false (3 light woods)");
+
+            ToHitData thd = result.losModifiers(game);
+            assertEquals(TargetRoll.IMPOSSIBLE, thd.getValue(),
+                  "losModifiers should return IMPOSSIBLE for 3 light woods");
+        }
+
+        @Test
+        @DisplayName("3 light smoke should block LOS (smoke alone = 3)")
+        void shouldBlockLos_ThreeLightSmoke() {
+            setBoard("01_BY_05_THREE_LIGHT_SMOKE");
+            LosEffects.AttackInfo ai = buildGroundAttackInfo(new Coords(0, 0), new Coords(0, 4));
+
+            LosEffects result = LosEffects.calculateLos(game, ai);
+
+            assertNotNull(result);
+            assertEquals(3, result.lightSmoke, "Should count 3 light smoke");
+            assertFalse(result.hasLoS, "hasLoS should be false (3 light smoke)");
+
+            ToHitData thd = result.losModifiers(game);
+            assertEquals(TargetRoll.IMPOSSIBLE, thd.getValue(),
+                  "losModifiers should return IMPOSSIBLE for 3 light smoke");
+        }
+
+        @Test
+        @DisplayName("1 light wood + 1 light smoke should NOT block LOS (combined = 2)")
+        void shouldNotBlockLos_WoodsAndSmokePartial() {
+            setBoard("01_BY_04_WOODS_SMOKE_PARTIAL");
+            LosEffects.AttackInfo ai = buildGroundAttackInfo(new Coords(0, 0), new Coords(0, 3));
+
+            LosEffects result = LosEffects.calculateLos(game, ai);
+
+            assertNotNull(result);
+            assertEquals(1, result.lightWoods, "Should count 1 light woods");
+            assertEquals(1, result.lightSmoke, "Should count 1 light smoke");
+            assertTrue(result.hasLoS, "hasLoS should be true (combined woods+smoke = 2)");
+
+            ToHitData thd = result.losModifiers(game);
+            assertFalse(thd.getValue() == TargetRoll.IMPOSSIBLE,
+                  "losModifiers should NOT return IMPOSSIBLE when combined < 3");
+        }
+
+        @Test
+        @DisplayName("1 heavy wood + 1 light smoke should block LOS (combined = 3)")
+        void shouldBlockLos_HeavyWoodsAndLightSmoke() {
+            setBoard("01_BY_04_HEAVY_WOODS_LIGHT_SMOKE");
+            LosEffects.AttackInfo ai = buildGroundAttackInfo(new Coords(0, 0), new Coords(0, 3));
+
+            LosEffects result = LosEffects.calculateLos(game, ai);
+
+            assertNotNull(result);
+            assertEquals(1, result.heavyWoods, "Should count 1 heavy woods");
+            assertEquals(1, result.lightSmoke, "Should count 1 light smoke");
+            assertFalse(result.hasLoS,
+                  "hasLoS should be false (1 heavy woods * 2 + 1 light smoke = 3)");
+
+            ToHitData thd = result.losModifiers(game);
+            assertEquals(TargetRoll.IMPOSSIBLE, thd.getValue(),
+                  "losModifiers should return IMPOSSIBLE when combined >= 3");
+        }
+
+        @Test
+        @DisplayName("hasLoS and losModifiers should agree on blocking decision")
+        void hasLoSAndLosModifiersShouldAgree() {
+            // Test the exact bug: hasLoS says blocked but losModifiers says not blocked
+            setBoard("01_BY_05_WOODS_SMOKE_COMBINED");
+            LosEffects.AttackInfo ai = buildGroundAttackInfo(new Coords(0, 0), new Coords(0, 4));
+
+            LosEffects result = LosEffects.calculateLos(game, ai);
+            ToHitData thd = result.losModifiers(game);
+
+            // These MUST agree - this is the core of bug #8167
+            if (!result.hasLoS) {
+                assertEquals(TargetRoll.IMPOSSIBLE, thd.getValue(),
+                      "When hasLoS is false, losModifiers must return IMPOSSIBLE. "
+                            + "Combined woods+smoke: lightWoods=" + result.lightWoods
+                            + " heavyWoods=" + result.heavyWoods
+                            + " lightSmoke=" + result.lightSmoke
+                            + " heavySmoke=" + result.heavySmoke);
+            }
         }
     }
 


### PR DESCRIPTION
##  Root Cause

losModifiers() checked woods and smoke separately against the blocking threshold (> 2), but calculateLos() / hasLoS correctly combined them. This caused canSee() to return false (LOS blocked) while losModifiers() returned modifiers instead of IMPOSSIBLE, allowing units to fire through terrain
that should block LOS.

  Example: 1 light wood + 2 light smoke
  - Woods check: 1 > 2 = false (passes)
  - Smoke check: 2 > 2 = false (passes)
  - Combined: 1 + 2 = 3 >= 3 = should block

##  Changes

  1. LosEffects.losModifiers() - Combined the separate woods and smoke blocking checks into a single check matching the hasLoS formula: (lightWoods + lightSmoke) + ((heavyWoods + heavySmoke) * 2) + (ultraWoods * 3) >= 3
  2. Ultra woods still blocks independently regardless of underwater weapon status
  3. Underwater weapons: woods-only check preserved (smoke doesn't apply underwater)
  4. Added DEBUG-level diagnostic logging throughout LOS calculations (silent at default INFO level)
  5. Logging covers: LOS rule set in use, attacker/target positions, per-hex terrain accumulation, blocking decisions with full modifier totals

##  Diagnostic Logging (kept intentionally)

LOS bugs are historically difficult to reproduce and diagnose. The DEBUG-level logging added here is silent during normal play (default log level is INFO) but can be enabled by setting megamek.common.LosEffects to DEBUG in the logging config. This gives developers and testers a complete trace of every LOS calculation -- which hexes contribute woods/smoke, what the accumulated totals are, and why the blocking decision was made -- without needing to add temporary logging each time a new LOS issue is reported. The class javadoc documents this capability.

##  Testing

  - Loaded the reporter's save file (1 light wood + 2 light smoke path)
  - Before fix: BUG warning fires repeatedly in logs confirming the mismatch
  - After fix: firing phase correctly blocks the shot with "LOS blocked by intervening woods/smoke"

  Fixes #8167