### PR TITLE
Title: Fix Battle Armor slotless equipment failing to load ammo with :Shots# suffix

### DIFF
--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -388,6 +388,23 @@ public class BLKFile {
             }
             String equipName = s.trim();
 
+            // Backward compatibility: strip BA/Handheld ammo :Shots#, BA mount location,
+            // and ProtoMek ammo (N) suffixes that older versions of encodeEquipmentLine()
+            // wrote into the slotless_equipment block.
+            int numShots = 0;
+            int shotsIndex = equipName.indexOf(":Shots");
+            if (shotsIndex > 0) {
+                int shotsEndIndex = equipName.indexOf("#", shotsIndex);
+                if (shotsEndIndex <= 0) {
+                    throw new EntityLoadingException("Improperly formatted ammo count");
+                }
+                numShots = Integer.parseInt(
+                      equipName.substring(shotsIndex + ":Shots".length(), shotsEndIndex));
+                equipName = equipName.substring(0, shotsIndex);
+            }
+            equipName = equipName.replace(":Body", "").replace(":LA", "")
+                  .replace(":RA", "").replace(":TU", "");
+
             EquipmentType etype = EquipmentType.get(equipName);
             if (etype == null) {
                 etype = EquipmentType.get(prefix + equipName);
@@ -404,7 +421,12 @@ public class BLKFile {
                     }
                 }
                 try {
-                    t.addEquipment(etype, Entity.LOC_NONE);
+                    Mounted<?> mount = t.addEquipment(etype, Entity.LOC_NONE);
+                    if (numShots > 0 && (mount.getType() instanceof AmmoType)) {
+                        mount.setShotsLeft(numShots);
+                        mount.setOriginalShots(numShots);
+                        mount.setSize(numShots * ((AmmoType) mount.getType()).getKgPerShot() / 1000.0);
+                    }
                 } catch (LocationFullException ex) {
                     throw new EntityLoadingException(ex.getMessage());
                 }
@@ -951,13 +973,18 @@ public class BLKFile {
             blk.writeBlockData(t.getLocationName(i) + " Equipment", eq.get(i));
         }
 
-        // Write slotless equipment (LOC_NONE) - e.g., cockpit modifications like DNI
+        // Write slotless equipment (LOC_NONE) - e.g., cockpit modifications like DNI.
+        // Use the internal name only; positional suffixes like :Shots#, :Body, :LA
+        // are not meaningful for LOC_NONE and loadSlotlessEquipment() does not expect them.
+        // Skip auto-created one-shot ammo (linkedBy != null) since it is recreated by
+        // addOneShotAmmo() when the parent weapon loads.
         Vector<String> slotlessEquipment = new Vector<>();
         for (Mounted<?> m : t.getEquipment()) {
             if (m.getLocation() == Entity.LOC_NONE && !m.isWeaponGroup() && !m.isAPMMounted()
                   && !(m.getType() instanceof InfantryAttack)
-                  && !(m.getType() instanceof BayWeapon)) {
-                slotlessEquipment.add(encodeEquipmentLine(m));
+                  && !(m.getType() instanceof BayWeapon)
+                  && !(m.getType() instanceof AmmoType && m.getLinkedBy() != null)) {
+                slotlessEquipment.add(m.getType().getInternalName());
             }
         }
         if (!slotlessEquipment.isEmpty()) {

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -388,22 +388,27 @@ public class BLKFile {
             }
             String equipName = s.trim();
 
-            // Backward compatibility: strip BA/Handheld ammo :Shots#, BA mount location,
-            // and ProtoMek ammo (N) suffixes that older versions of encodeEquipmentLine()
-            // wrote into the slotless_equipment block.
+            // Backward compatibility: strip suffixes that older versions of
+            // encodeEquipmentLine() wrote into the slotless_equipment block.
             int numShots = 0;
             int shotsIndex = equipName.indexOf(":Shots");
             if (shotsIndex > 0) {
                 int shotsEndIndex = equipName.indexOf("#", shotsIndex);
                 if (shotsEndIndex <= 0) {
-                    throw new EntityLoadingException("Improperly formatted ammo count");
+                    throw new EntityLoadingException(
+                          "Improperly formatted ammo count for equipment: " + equipName);
                 }
-                numShots = Integer.parseInt(
-                      equipName.substring(shotsIndex + ":Shots".length(), shotsEndIndex));
+                try {
+                    numShots = Integer.parseInt(
+                          equipName.substring(shotsIndex + ":Shots".length(), shotsEndIndex));
+                } catch (NumberFormatException ex) {
+                    throw new EntityLoadingException(
+                          "Improperly formatted ammo count for equipment: " + equipName, ex);
+                }
                 equipName = equipName.substring(0, shotsIndex);
             }
             equipName = equipName.replace(":Body", "").replace(":LA", "")
-                  .replace(":RA", "").replace(":TU", "");
+                  .replace(":RA", "").replace(":TU", "").replace(":OMNI", "");
 
             EquipmentType etype = EquipmentType.get(equipName);
             if (etype == null) {

--- a/megamek/testresources/megamek/common/units/Afreet Med BA (HH) (Sqd4).blk
+++ b/megamek/testresources/megamek/common/units/Afreet Med BA (HH) (Sqd4).blk
@@ -1,0 +1,117 @@
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+#building block data file
+<BlockVersion>
+1
+</BlockVersion>
+
+##Write the version number just in case...
+<Version>
+MAM0
+</Version>
+
+<UnitType>
+BattleArmor
+</UnitType>
+
+<Name>
+Afreet Medium Battle Armor
+</Name>
+
+<Model>
+(Hell's Horses)(Sqd4)
+</Model>
+
+<mul id:>
+3677
+</mul id:>
+
+<year>
+3072
+</year>
+
+<originalBuildYear>
+3072
+</originalBuildYear>
+
+<type>
+Clan Level 2
+</type>
+
+<role>
+Scout
+</role>
+
+<motion_type>
+Jump
+</motion_type>
+
+<cruiseMP>
+1
+</cruiseMP>
+
+<armor_type>
+28
+</armor_type>
+
+<armor_tech>
+2
+</armor_tech>
+
+<Point Equipment>
+Machine Gun (Bearhunter AC):RA
+CLBASRM3 (OS):Body
+BAJumpBooster:Body
+BABattleClawVibro:LA
+BABattleClawVibro:RA
+</Point Equipment>
+
+<Trooper 1 Equipment>
+</Trooper 1 Equipment>
+
+<Trooper 2 Equipment>
+</Trooper 2 Equipment>
+
+<Trooper 3 Equipment>
+</Trooper 3 Equipment>
+
+<Trooper 4 Equipment>
+</Trooper 4 Equipment>
+
+<source>
+TR:3075
+</source>
+
+<chassis>
+biped
+</chassis>
+
+<jumpingMP>
+3
+</jumpingMP>
+
+<armor>
+5
+</armor>
+
+<Trooper Count>
+4
+</Trooper Count>
+
+<weightclass>
+2
+</weightclass>

--- a/megamek/unittests/megamek/common/loaders/BLKFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/BLKFileTest.java
@@ -34,22 +34,29 @@ package megamek.common.loaders;
 
 import static megamek.common.bays.Bay.UNSET_BAY;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.File;
 import java.util.HashSet;
 
 import megamek.common.TechConstants;
+import megamek.common.battleArmor.BattleArmor;
 import megamek.common.bays.BattleArmorBay;
 import megamek.common.bays.Bay;
 import megamek.common.bays.InfantryBay;
 import megamek.common.bays.MekBay;
 import megamek.common.enums.Faction;
+import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.Engine;
 import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.Mounted;
 import megamek.common.loaders.BLKFile.ParsedBayInfo;
 import megamek.common.units.DropShuttleBay;
+import megamek.common.units.Entity;
 import megamek.common.units.EntityMovementMode;
 import megamek.common.units.Jumpship;
 import megamek.common.units.NavalRepairFacility;
@@ -367,6 +374,75 @@ class BLKFileTest {
 
         assertEquals(Faction.NONE, loaded.getTechFaction(),
               "NONE faction should remain NONE after roundtrip");
+    }
+
+    /**
+     * Loads a BattleArmor entity from the test resources directory.
+     */
+    private BattleArmor loadBattleArmor(String filename) throws EntityLoadingException {
+        File file = new File("testresources/megamek/common/units/" + filename);
+        MekFileParser parser = new MekFileParser(file);
+        Entity entity = parser.getEntity();
+        assertNotNull(entity, "Failed to load entity from " + filename);
+        assertTrue(entity instanceof BattleArmor, "Entity should be BattleArmor");
+        return (BattleArmor) entity;
+    }
+
+    /**
+     * Verifies that a BattleArmor unit with a one-shot weapon (which creates LOC_NONE ammo) can be saved and reloaded
+     * without the ammo appearing in the failed equipment list. Regression test for the :Shots# suffix not being
+     * stripped in loadSlotlessEquipment().
+     */
+    @Test
+    void battleArmorOneShotAmmoRoundTrip() throws Exception {
+        // Load BA with one-shot SRM3 - this creates auto-linked ammo at LOC_NONE
+        BattleArmor original = loadBattleArmor("Afreet Med BA (HH) (Sqd4).blk");
+        assertFalse(original.getFailedEquipment().hasNext(),
+              "Original entity should have no failed equipment");
+
+        // Verify the one-shot ammo exists at LOC_NONE
+        boolean hasOneShotAmmo = false;
+        for (Mounted<?> mounted : original.getAmmo()) {
+            if (mounted.getLocation() == Entity.LOC_NONE
+                  && mounted.getType() instanceof AmmoType
+                  && mounted.getLinkedBy() != null) {
+                hasOneShotAmmo = true;
+                break;
+            }
+        }
+        assertTrue(hasOneShotAmmo, "BA should have one-shot ammo at LOC_NONE");
+
+        // Save to BLK and reload
+        BuildingBlock blk = BLKFile.getBlock(original);
+        BLKBattleArmorFile loader = new BLKBattleArmorFile(blk);
+        BattleArmor reloaded = (BattleArmor) loader.getEntity();
+
+        assertNotNull(reloaded, "Reloaded entity should not be null");
+        assertFalse(reloaded.getFailedEquipment().hasNext(),
+              "Reloaded entity should have no failed equipment");
+    }
+
+    /**
+     * Verifies backward compatibility: a BA slotless_equipment block containing the old :Shots# suffix format loads
+     * correctly without failed equipment.
+     */
+    @Test
+    void battleArmorSlotlessAmmoWithShotsSuffixLoads() throws Exception {
+        // Build a BLK that mimics the old save format with :Shots# in slotless_equipment
+        BattleArmor original = loadBattleArmor("Afreet Med BA (HH) (Sqd4).blk");
+        BuildingBlock blk = BLKFile.getBlock(original);
+
+        // Inject a slotless_equipment entry with the old :Shots# format
+        // to simulate files saved before the fix
+        blk.writeBlockData("slotless_equipment",
+              new String[] { "BAJumpJet", "BA-SRM3 Ammo:Shots1#" });
+
+        BLKBattleArmorFile loader = new BLKBattleArmorFile(blk);
+        BattleArmor reloaded = (BattleArmor) loader.getEntity();
+
+        assertNotNull(reloaded, "Reloaded entity should not be null");
+        assertFalse(reloaded.getFailedEquipment().hasNext(),
+              "Reloaded entity should have no failed equipment even with old :Shots# format");
     }
 
 }


### PR DESCRIPTION
Fixes Megamek/megameklab#2160

##  Root Cause

  Commit 95868e4c5d (2026-01-30) added slotless_equipment save/load support for LOC_NONE equipment like cockpit
  modifications. The save side used encodeEquipmentLine() which appends BA-specific suffixes (:Shots#, :Body, :LA, etc.)
   to ammo entries. The load side (loadSlotlessEquipment()) only handled plain internal names, so these suffixes were
  never stripped.

  The bug became active when commit 8da9d833cd (2026-02-27) added a loadSlotlessEquipment() call to BLKBattleArmorFile,
  causing BA one-shot weapon ammo (e.g. BA-SRM3 Ammo:Shots1#) to flow through the broken path. This caused all Battle
  Armor with one-shot weapons to fail validation.

##  Changes

  1. Save side (BLKFile.getBlock()) - Write getInternalName() instead of encodeEquipmentLine() for slotless equipment. Positional suffixes are not meaningful for LOC_NONE. Also skip auto-created one-shot ammo (linkedBy != null) since it is recreated by addOneShotAmmo() when the parent weapon loads.
  2. Load side (BLKFile.loadSlotlessEquipment()) - Strip :Shots# and BA mount location suffixes (:Body, :LA, :RA, :TU) for backward compatibility with existing custom BLK files saved with the old encoding. Apply shot counts to loaded ammo.
  3. Regression tests - Two new tests in BLKFileTest plus a test resource BLK file for the Afreet Medium Battle Armor (Hell's Horses)(Sqd4) which has a one-shot SRM3.

##  Files Changed

  - megamek/src/megamek/common/loaders/BLKFile.java - Save and load fixes
  - megamek/unittests/megamek/common/loaders/BLKFileTest.java - Two new regression tests
  - megamek/testresources/megamek/common/units/Afreet Med BA (HH) (Sqd4).blk - Test resource BLK file

##  Testing

  - battleArmorOneShotAmmoRoundTrip - Loads Afreet HH, verifies LOC_NONE one-shot ammo exists, saves via BLKFile.getBlock(), reloads via BLKBattleArmorFile, asserts no failed equipment
  - battleArmorSlotlessAmmoWithShotsSuffixLoads - Injects old-format BA-SRM3 Ammo:Shots1# into slotless_equipment block, reloads, asserts backward compatibility
  - All existing loader tests pass
  - Confirmed failing BA no longer failing in MegaMek