### PR TITLE
Fix: Unstreamlined quirk now prevents atmospheric and ground operations

### DIFF
--- a/megamek/src/megamek/common/units/Aero.java
+++ b/megamek/src/megamek/common/units/Aero.java
@@ -1791,7 +1791,12 @@ public abstract class Aero extends Entity implements IAero, IBomber {
 
     @Override
     public boolean doomedInAtmosphere() {
-        return false;
+        return hasQuirk(OptionsConstants.QUIRK_NEG_UNSTREAMLINED);
+    }
+
+    @Override
+    public boolean doomedOnGround() {
+        return hasQuirk(OptionsConstants.QUIRK_NEG_UNSTREAMLINED);
     }
 
     @Override


### PR DESCRIPTION
Units with the `unstreamlined` negative quirk (e.g., Behemoth) are now correctly marked as doomed in atmosphere and on ground maps via `Aero.doomedInAtmosphere()` and `Aero.doomedOnGround()`. Previously the quirk existed but had no gameplay effect.

Fixes MegaMek/mekhq#6834 (along with companion PRs in mekhq and mm-data).