### PR TITLE
MML #1917 Omni meks, heavy guns and arm actuators

### DIFF
--- a/megamek/src/megamek/common/units/Mek.java
+++ b/megamek/src/megamek/common/units/Mek.java
@@ -2755,16 +2755,9 @@ public abstract class Mek extends Entity {
         if (isSuperHeavy()) {
             reqSlots = (int) Math.ceil(((double) reqSlots / 2.0f));
         }
-        // gauss and AC weapons on omni arms means no arm actuators, so we
-        // remove them
-        if (isOmni()
-              && (this instanceof BipedMek)
-              && ((loc == LOC_LEFT_ARM) || (loc == LOC_RIGHT_ARM))
-              && ((mounted.getType() instanceof GaussWeapon)
-              || (mounted.getType() instanceof ACWeapon)
-              || (mounted.getType() instanceof UACWeapon)
-              || (mounted.getType() instanceof LBXACWeapon) || (mounted
-              .getType() instanceof PPCWeapon))) {
+
+        // various weapons on omni arms forbid lower arm+hand actuators, so remove them, TM p.57
+        if (isOmni() && isArm(loc) && MekConstructionUtil.removesHandAndLowerArmSlotsOnOmni(mounted.getType())) {
             if (hasSystem(Mek.ACTUATOR_LOWER_ARM, loc)) {
                 setCritical(loc, 2, null);
             }
@@ -5680,7 +5673,7 @@ public abstract class Mek extends Entity {
     }
 
     /**
-     * Is the passed in location an arm?
+     * @return True if the given location is an arm; always returns false for QuadMeks
      */
     public boolean isArm(int loc) {
         return (loc == Mek.LOC_LEFT_ARM) || (loc == Mek.LOC_RIGHT_ARM);

--- a/megamek/src/megamek/common/units/Mek.java
+++ b/megamek/src/megamek/common/units/Mek.java
@@ -70,10 +70,6 @@ import megamek.common.preference.PreferenceManager;
 import megamek.common.rolls.PilotingRollData;
 import megamek.common.rolls.Roll;
 import megamek.common.rolls.TargetRoll;
-import megamek.common.weapons.autoCannons.ACWeapon;
-import megamek.common.weapons.autoCannons.LBXACWeapon;
-import megamek.common.weapons.autoCannons.UACWeapon;
-import megamek.common.weapons.gaussRifles.GaussWeapon;
 import megamek.common.weapons.ppc.PPCWeapon;
 import megamek.logging.MMLogger;
 

--- a/megamek/src/megamek/common/units/MekConstructionUtil.java
+++ b/megamek/src/megamek/common/units/MekConstructionUtil.java
@@ -36,12 +36,17 @@ package megamek.common.units;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.equipment.EquipmentTypeLookup;
 import megamek.common.equipment.Mounted;
+import megamek.common.equipment.WeaponType;
+import megamek.common.weapons.autoCannons.ACWeapon;
+import megamek.common.weapons.autoCannons.LBXACWeapon;
+import megamek.common.weapons.autoCannons.UACWeapon;
+import megamek.common.weapons.gaussRifles.GaussWeapon;
+import megamek.common.weapons.ppc.PPCWeapon;
 import megamek.logging.MMLogger;
 
 /**
- * Helper methods for constructing/changing Mek units. This happens mostly in MML but some units have modular
- * equipment which MM must be able to switch out and the code for this is involved and should be unified as much as
- * possible.
+ * Helper methods for constructing/changing Mek units. This happens mostly in MML but some units have modular equipment
+ * which MM must be able to switch out and the code for this is involved and should be unified as much as possible.
  * <p>
  * This is the MM extension of MekUtil.
  */
@@ -110,4 +115,17 @@ public class MekConstructionUtil {
         }
     }
 
+    /**
+     * @param equipmentType The equipment type to check
+     *
+     * @return True when given type of equipment is one that forbids lower arm and hand actuators on an omni mek, see TM
+     *       p.57
+     */
+    public static boolean removesHandAndLowerArmSlotsOnOmni(EquipmentType equipmentType) {
+        return (equipmentType instanceof GaussWeapon)
+              || (equipmentType instanceof ACWeapon)
+              || (equipmentType instanceof UACWeapon)
+              || (equipmentType instanceof LBXACWeapon)
+              || (equipmentType instanceof PPCWeapon);
+    }
 }

--- a/megamek/src/megamek/common/verifier/TestMek.java
+++ b/megamek/src/megamek/common/verifier/TestMek.java
@@ -59,17 +59,11 @@ import megamek.common.units.Entity;
 import megamek.common.units.LandAirMek;
 import megamek.common.units.Mek;
 import megamek.common.units.MekConstructionUtil;
-import megamek.common.units.MekWithArms;
 import megamek.common.units.QuadMek;
 import megamek.common.units.QuadVee;
 import megamek.common.util.StringUtil;
 import megamek.common.weapons.artillery.ArtilleryWeapon;
-import megamek.common.weapons.autoCannons.ACWeapon;
-import megamek.common.weapons.autoCannons.LBXACWeapon;
-import megamek.common.weapons.autoCannons.UACWeapon;
-import megamek.common.weapons.gaussRifles.GaussWeapon;
 import megamek.common.weapons.lasers.EnergyWeapon;
-import megamek.common.weapons.ppc.PPCWeapon;
 
 /**
  * @author Reinhard Vicinus

--- a/megamek/src/megamek/common/verifier/TestMek.java
+++ b/megamek/src/megamek/common/verifier/TestMek.java
@@ -55,10 +55,11 @@ import megamek.common.equipment.*;
 import megamek.common.equipment.enums.MiscTypeFlag;
 import megamek.common.interfaces.ITechManager;
 import megamek.common.options.OptionsConstants;
-import megamek.common.units.BipedMek;
 import megamek.common.units.Entity;
 import megamek.common.units.LandAirMek;
 import megamek.common.units.Mek;
+import megamek.common.units.MekConstructionUtil;
+import megamek.common.units.MekWithArms;
 import megamek.common.units.QuadMek;
 import megamek.common.units.QuadVee;
 import megamek.common.util.StringUtil;
@@ -472,8 +473,7 @@ public class TestMek extends TestEntity {
         for (Mounted<?> m : mek.getEquipment()) {
             int loc = m.getLocation();
             if (loc == Entity.LOC_NONE) {
-                if ((m.getType() instanceof AmmoType)
-                      && (m.getUsableShotsLeft() <= 1)) {
+                if ((m.getType() instanceof AmmoType) && (m.getUsableShotsLeft() <= 1)) {
                     continue;
                 }
                 if (m.getNumCriticalSlots() == 0) {
@@ -492,33 +492,17 @@ public class TestMek extends TestEntity {
                     continue;
                 }
             }
-            // Check for illegal allocations
-            if (mek.isOmni()
-                  && (mek instanceof BipedMek)
-                  && ((loc == Mek.LOC_LEFT_ARM) || (loc == Mek.LOC_RIGHT_ARM))
-                  && ((m.getType() instanceof GaussWeapon)
-                  || (m.getType() instanceof ACWeapon)
-                  || (m.getType() instanceof UACWeapon)
-                  || (m.getType() instanceof LBXACWeapon)
-                  || (m.getType() instanceof PPCWeapon))) {
-                String weapon = "";
-                if (m.getType() instanceof GaussWeapon) {
-                    weapon = "gauss rifles";
-                } else if ((m.getType() instanceof ACWeapon)
-                      || (m.getType() instanceof UACWeapon)
-                      || (m.getType() instanceof LBXACWeapon)) {
-                    weapon = "autocannons";
-                } else if (m.getType() instanceof PPCWeapon) {
-                    weapon = "PPCs";
-                }
-                if (mek.hasSystem(Mek.ACTUATOR_LOWER_ARM, loc)
-                      || mek.hasSystem(Mek.ACTUATOR_HAND, loc)) {
-                    buff.append("Omni meks with arm mounted ").append(weapon)
-                          .append(" cannot have lower armor or hand actuators!\n");
+
+            // TM p.57
+            if (mek.isOmni() && mek.isArm(loc) && MekConstructionUtil.removesHandAndLowerArmSlotsOnOmni(m.getType())) {
+                if (mek.hasSystem(Mek.ACTUATOR_LOWER_ARM, loc) || mek.hasSystem(Mek.ACTUATOR_HAND, loc)) {
+                    buff.append("Omni meks with arm mounted gauss weapons, PPCs or "
+                          + "ACs cannot have lower armor or hand actuators!\n");
                     legal = false;
                 }
             }
         }
+
         if ((countInternalHeatSinks > engine.integralHeatSinkCapacity(this.mek.hasCompactHeatSinks()))
               || ((countInternalHeatSinks < engine.integralHeatSinkCapacity(this.mek.hasCompactHeatSinks()))
               && (countInternalHeatSinks != mek.heatSinks(false))


### PR DESCRIPTION
Fixes Megamek/megameklab#1917
main problem was the instanceof BipedMek check which did not catch Tripods in both TestMek (validity) and Mek (removing actuators when placing a heavy weapon in an arm on an omni mek