### PR TITLE
Use automatic alternate table row coloring

### DIFF
--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -83,6 +83,7 @@ public class MegaMek {
 
     private static final MMLogger LOGGER = MMLogger.create(MegaMek.class);
     private static final SanityInputFilter sanityInputFilter = new SanityInputFilter();
+    private static final Color TABLE_ALTERNATE_ROW_COLOR = new Color(125, 125, 125, 50);
 
     public static void main(String... args) {
         ObjectInputFilter.Config.setSerialFilter(sanityInputFilter);
@@ -135,9 +136,6 @@ public class MegaMek {
             startDedicatedServer(restArgs);
             return;
         }
-
-        // Set an alternate table row color; it uses alpha and is valid for both dark and light UIs
-        UIManager.put("Table.alternateRowColor", new Color(125, 125, 125, 50));
 
         getMMPreferences().loadFromFile(SuiteConstants.MM_PREFERENCES_FILE);
         initializeSuiteGraphicalSetups(MMConstants.PROJECT_NAME);
@@ -422,5 +420,8 @@ public class MegaMek {
 
         // Setup Button Order Preferences
         ButtonOrderPreferences.getInstance().setButtonPriorities();
+
+        // Set an alternate table row color; it uses alpha and is valid for both dark and light UIs
+        UIManager.put("Table.alternateRowColor", TABLE_ALTERNATE_ROW_COLOR);
     }
 }

--- a/megamek/src/megamek/MegaMek.java
+++ b/megamek/src/megamek/MegaMek.java
@@ -1,7 +1,7 @@
 /*
   Copyright (C) 2005, 2006 Ben Mazur (bmazur@sev.org)
  * Copyright © 2013 Edward Cullen (eddy@obsessedcomputers.co.uk)
- * Copyright (C) 2005-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2005-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -35,6 +35,7 @@
 
 package megamek;
 
+import java.awt.Color;
 import java.io.File;
 import java.io.IOException;
 import java.io.ObjectInputFilter;
@@ -134,6 +135,9 @@ public class MegaMek {
             startDedicatedServer(restArgs);
             return;
         }
+
+        // Set an alternate table row color; it uses alpha and is valid for both dark and light UIs
+        UIManager.put("Table.alternateRowColor", new Color(125, 125, 125, 50));
 
         getMMPreferences().loadFromFile(SuiteConstants.MM_PREFERENCES_FILE);
         initializeSuiteGraphicalSetups(MMConstants.PROJECT_NAME);

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/RulerDialog.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/RulerDialog.java
@@ -36,6 +36,7 @@ package megamek.client.ui.clientGUI.boardview;
 import java.awt.AWTEvent;
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -973,13 +974,11 @@ public class RulerDialog extends JDialog implements BoardViewListener {
      * differ from the active mode with a subtle background.
      */
     private class CompareTableRenderer extends DefaultTableCellRenderer {
-        @Serial
-        private static final long serialVersionUID = 1L;
 
         @Override
-        public java.awt.Component getTableCellRendererComponent(JTable table, Object value,
+        public Component getTableCellRendererComponent(JTable table, Object value,
               boolean isSelected, boolean hasFocus, int row, int column) {
-            java.awt.Component component = super.getTableCellRendererComponent(
+            Component component = super.getTableCellRendererComponent(
                   table, value, isSelected, hasFocus, row, column);
 
             int activeModeRow = getActiveModeRow();

--- a/megamek/src/megamek/client/ui/dialogs/advancedsearch/EquipmentCostRenderer.java
+++ b/megamek/src/megamek/client/ui/dialogs/advancedsearch/EquipmentCostRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2002-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2002-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -40,7 +40,6 @@ import javax.swing.table.DefaultTableCellRenderer;
 class EquipmentCostRenderer extends DefaultTableCellRenderer {
 
     EquipmentCostRenderer() {
-        super();
         setHorizontalAlignment(SwingConstants.RIGHT);
     }
 

--- a/megamek/src/megamek/client/ui/dialogs/advancedsearch/EquipmentDataRenderer.java
+++ b/megamek/src/megamek/client/ui/dialogs/advancedsearch/EquipmentDataRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2002-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2002-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -43,7 +43,6 @@ import javax.swing.table.DefaultTableCellRenderer;
 class EquipmentDataRenderer extends DefaultTableCellRenderer {
 
     EquipmentDataRenderer() {
-        super();
         setHorizontalAlignment(SwingConstants.CENTER);
     }
 

--- a/megamek/src/megamek/client/ui/dialogs/advancedsearch/TechBaseRenderer.java
+++ b/megamek/src/megamek/client/ui/dialogs/advancedsearch/TechBaseRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2002-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2002-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -40,7 +40,6 @@ import javax.swing.table.DefaultTableCellRenderer;
 class TechBaseRenderer extends DefaultTableCellRenderer {
 
     TechBaseRenderer() {
-        super();
         setHorizontalAlignment(SwingConstants.CENTER);
     }
 

--- a/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/AbstractUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/AbstractUnitSelectorDialog.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2002, 2004 Josh Yockey
- * Copyright (C) 2002-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2002-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -1093,42 +1093,44 @@ public abstract class AbstractUnitSelectorDialog extends JDialog implements Runn
     /** A specialized renderer for the mek table (formats the unit tonnage). */
     public static class TonnageRenderer extends DefaultTableCellRenderer {
 
+        public TonnageRenderer() {
+            setHorizontalAlignment(JLabel.RIGHT);
+        }
+
         @Override
         public Component getTableCellRendererComponent(final JTable table, final @Nullable Object value,
               final boolean isSelected, final boolean hasFocus, final int row, final int column) {
-            if (value instanceof Double) {
-                setHorizontalAlignment(JLabel.RIGHT);
-                double weight = (Double) value;
-                super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
+
+            String text = "?";
+            if (value instanceof Double weight) {
                 if (weight < 2) {
-                    setText(String.format(MegaMek.getMMOptions().getLocale(), "%,d kg ", (int) (weight * 1000)));
+                    text = String.format(MegaMek.getMMOptions().getLocale(), "%,d kg ", (int) (weight * 1000));
                 } else if (Math.round(weight) == weight) {
-                    setText(String.format(MegaMek.getMMOptions().getLocale(), "%,d t ", Math.round(weight)));
+                    text = String.format(MegaMek.getMMOptions().getLocale(), "%,d t ", Math.round(weight));
                 } else {
-                    setText(String.format(MegaMek.getMMOptions().getLocale(), "%.1f t ", weight));
+                    text = String.format(MegaMek.getMMOptions().getLocale(), "%.1f t ", weight);
                 }
-                return this;
-            } else {
-                return null;
             }
+            return super.getTableCellRendererComponent(table, text, isSelected, hasFocus, row, column);
         }
     }
 
     /** A specialized renderer for the mek table (formats the unit price). */
     public static class PriceRenderer extends DefaultTableCellRenderer {
 
+        public PriceRenderer() {
+            setHorizontalAlignment(JLabel.RIGHT);
+        }
+
         @Override
-        public Component getTableCellRendererComponent(final JTable table, final @Nullable Object value,
-              final boolean isSelected, final boolean hasFocus,
-              final int row, final int column) {
-            if (value instanceof Long) {
-                setHorizontalAlignment(JLabel.RIGHT);
-                super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
-                setText(String.format(MegaMek.getMMOptions().getLocale(), "%,d ", (Long) value));
-                return this;
-            } else {
-                return null;
+        public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected, boolean hasFocus,
+              int row, int column) {
+
+            String text = "?";
+            if (value instanceof Long price) {
+                text = String.format(MegaMek.getMMOptions().getLocale(), "%,d ", price);
             }
+            return super.getTableCellRendererComponent(table, text, isSelected, hasFocus, row, column);
         }
     }
 }

--- a/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/AvailabilityPanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/AvailabilityPanel.java
@@ -47,6 +47,7 @@ import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.swing.*;
+import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
 import javax.swing.event.TableModelEvent;
 import javax.swing.event.TableModelListener;
@@ -100,9 +101,7 @@ public class AvailabilityPanel {
 
         private static class FactionCellRenderer extends DefaultTableCellRenderer {
 
-            public FactionCellRenderer() {
-                setBorder(new EmptyBorder(2, 5, 2, 5)); // Padding for the whole cell
-            }
+            private static final EmptyBorder CELL_PADDING = new EmptyBorder(4, 10, 4, 2);
 
             @Override
             public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
@@ -115,7 +114,9 @@ public class AvailabilityPanel {
                 } else {
                     setIcon(null);
                 }
-                return super.getTableCellRendererComponent(table, text, isSelected, hasFocus, row, column);
+                super.getTableCellRendererComponent(table, text, isSelected, hasFocus, row, column);
+                setBorder(new CompoundBorder(getBorder(), CELL_PADDING));
+                return this;
             }
         }
 
@@ -545,8 +546,10 @@ public class AvailabilityPanel {
                 List<Object> rowData = new ArrayList<>();
                 String baseAbbr = factionCode.split("\\.")[0];
                 ImageIcon factionIcon = RAT_GENERATOR.getFactionLogo(0, baseAbbr, Color.WHITE);
-                var i = new ImageIcon(ImageUtil.getScaledImage(factionIcon.getImage(), ICON_SIZE, ICON_SIZE));
-                rowData.add(new FixedColumnGrid.FactionCellData(i, factionCode));
+                if (factionIcon != null) {
+                    factionIcon = new ImageIcon(ImageUtil.getScaledImage(factionIcon.getImage(), ICON_SIZE, ICON_SIZE));
+                }
+                rowData.add(new FixedColumnGrid.FactionCellData(factionIcon, factionCode));
 
                 for (Era era : erasToDisplay) {
                     String availabilityText = eraFactionAvailabilityCache

--- a/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/AvailabilityPanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/AvailabilityPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -37,7 +37,6 @@ import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.awt.image.VolatileImage;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -57,7 +56,6 @@ import javax.swing.table.JTableHeader;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
 import javax.swing.table.TableColumnModel;
-import javax.swing.text.View;
 
 import megamek.client.ratgenerator.AvailabilityRating;
 import megamek.client.ratgenerator.FactionRecord;
@@ -66,12 +64,14 @@ import megamek.client.ratgenerator.RATGenerator;
 import megamek.client.ui.util.UIUtil;
 import megamek.common.eras.Era;
 import megamek.common.eras.Eras;
-import megamek.common.util.ManagedVolatileImage;
+import megamek.common.util.ImageUtil;
 import megamek.logging.MMLogger;
 
 public class AvailabilityPanel {
+
     private static final MMLogger logger = MMLogger.create(AvailabilityPanel.class);
 
+    private static final int ICON_SIZE = UIUtil.scaleForGUI(32);
 
     private static class FixedColumnGrid extends JPanel {
         private final JTable fixedTable;
@@ -79,7 +79,7 @@ public class AvailabilityPanel {
         private final JScrollPane fixedScrollPane;
         private final JScrollPane scrollableScrollPane;
         private final DefaultTableModel model;
-        private static final int FIXED_COLUMN_WIDTH = 200;
+        private static final int FIXED_COLUMN_WIDTH = UIUtil.scaleForGUI(210);
 
         public static class FactionCellData {
             ImageIcon icon;
@@ -98,110 +98,24 @@ public class AvailabilityPanel {
             }
         }
 
-        private static class FactionCellRenderer extends JPanel implements TableCellRenderer {
-            private ManagedVolatileImage factionImage;
-            private final JLabel textLabel = new JLabel();
-            private boolean showIcon = false;
-            private int textContentWidth = 0;
-            private static final int ICON_SIZE = 32; // Fixed height for icon
-            private static final int ICON_MARGIN = 5;
+        private static class FactionCellRenderer extends DefaultTableCellRenderer {
 
             public FactionCellRenderer() {
-                setLayout(new BoxLayout(this, BoxLayout.X_AXIS));
-                setOpaque(true);
                 setBorder(new EmptyBorder(2, 5, 2, 5)); // Padding for the whole cell
-                textLabel.setAlignmentY(Component.CENTER_ALIGNMENT);
-                textLabel.setVerticalAlignment(SwingConstants.CENTER);
-                add(textLabel, BorderLayout.CENTER);
-            }
-
-            @Override
-            protected void paintComponent(Graphics g) {
-                super.paintComponent(g);
-
-                if (showIcon && factionImage != null) {
-                    Graphics2D g2d = (Graphics2D) g.create();
-                    UIUtil.setHighQualityRendering(g2d);
-
-                    // Draw the icon on the left side, vertically centered
-                    VolatileImage img = factionImage.getImage();
-                    int iconY = (getHeight() - ICON_SIZE) / 2;
-                    g2d.drawImage(img, ICON_MARGIN, iconY, null);
-
-                    g2d.dispose();
-                }
             }
 
             @Override
             public Component getTableCellRendererComponent(JTable table, Object value, boolean isSelected,
                   boolean hasFocus, int row, int column) {
+
+                String text = "?";
                 if (value instanceof FactionCellData data) {
-                    this.textContentWidth = FIXED_COLUMN_WIDTH -
-                          getInsets().left - getInsets().right - // Panel border
-                          ICON_SIZE -
-                          ICON_MARGIN -
-                          30;
-                    // Create ManagedVolatileImage for the icon
-                    if (data.icon != null) {
-                        factionImage = new ManagedVolatileImage(data.icon.getImage(),
-                              Transparency.TRANSLUCENT, ICON_SIZE, ICON_SIZE);
-                        showIcon = true;
-                    } else {
-                        factionImage = null;
-                        showIcon = false;
-                    }
-                    textLabel.setBorder(new EmptyBorder(0, ICON_SIZE + ICON_MARGIN, 0, 0));
-                    textLabel.setText("<html><body style='width: " + textContentWidth + "px'>" +
-                          (data.factionName != null ? data.factionName : "Unknown") +
-                          "</body></html>");
-                }
-
-                if (isSelected) {
-                    setBackground(table.getSelectionBackground());
-                    setForeground(table.getSelectionForeground());
-                    textLabel.setForeground(table.getSelectionForeground()); // Ensure text color changes
+                    setIcon(data.icon);
+                    text = data.factionName != null ? data.factionName : "Unknown";
                 } else {
-                    setBackground(row % 2 == 0 ? table.getBackground() : slightlyDarker(table.getBackground()));
-                    setForeground(table.getForeground());
-                    textLabel.setForeground(table.getForeground());
+                    setIcon(null);
                 }
-                return this;
-            }
-
-            @Override
-            public Dimension getPreferredSize() {
-                Dimension size = super.getPreferredSize();
-                int minHeight = showIcon ? ICON_SIZE : 0;
-                String text = textLabel.getText();
-                int textHeight = 0;
-                if (text != null && text.contains("<html>")) {
-                    if (this.textContentWidth > 0) {
-                        try {
-                            JLabel tempLabel = new JLabel(text);
-                            tempLabel.setFont(textLabel.getFont());
-                            tempLabel.setSize(this.textContentWidth, Integer.MAX_VALUE);
-                            View view = (View) tempLabel.getClientProperty("html");
-                            if (view == null) {
-                                tempLabel.getPreferredSize();
-                                view = (View) tempLabel.getClientProperty("html");
-                            }
-                            if (view != null) {
-                                view.setSize(this.textContentWidth, 0);
-                                textHeight = (int) view.getPreferredSpan(View.Y_AXIS);
-                            }
-                        } catch (NumberFormatException ignored) {
-                            // Fallback
-                            textHeight = textLabel.getPreferredSize().height;
-                        }
-                    }
-                } else {
-                    textHeight = textLabel.getPreferredSize().height;
-                }
-                int contentHeight = Math.max(minHeight, textHeight);
-                Insets insets = getInsets();
-                int totalHeight = contentHeight + insets.top + insets.bottom;
-                size.height = Math.max(size.height, totalHeight);
-                return size;
+                return super.getTableCellRendererComponent(table, text, isSelected, hasFocus, row, column);
             }
         }
 
@@ -382,30 +296,10 @@ public class AvailabilityPanel {
                 col.setHeaderValue(model.getColumnName(col.getModelIndex()));
                 DefaultTableCellRenderer renderer = new DefaultTableCellRenderer();
                 renderer.setHorizontalAlignment(SwingConstants.CENTER);
-                col.setCellRenderer(new DefaultTableCellRenderer() {
-                    @Override
-                    public Component getTableCellRendererComponent(JTable table, Object value,
-                          boolean isSelected, boolean hasFocus,
-                          int row, int column) {
-                        Component c = super.getTableCellRendererComponent(table, value,
-                              isSelected, hasFocus, row, column);
-                        if (!isSelected) {
-                            c.setBackground(row % 2 == 0 ?
-                                  table.getBackground() :
-                                  slightlyDarker(table.getBackground()));
-                        }
-                        setHorizontalAlignment(SwingConstants.CENTER);
-                        return c;
-                    }
-                });
+                col.setCellRenderer(renderer);
             }
             scrollableTable.getTableHeader().revalidate();
             scrollableTable.getTableHeader().repaint();
-        }
-
-        private static Color slightlyDarker(Color color) {
-            if (color == null) {return Color.LIGHT_GRAY;}
-            return color.darker();
         }
 
         /**
@@ -651,7 +545,8 @@ public class AvailabilityPanel {
                 List<Object> rowData = new ArrayList<>();
                 String baseAbbr = factionCode.split("\\.")[0];
                 ImageIcon factionIcon = RAT_GENERATOR.getFactionLogo(0, baseAbbr, Color.WHITE);
-                rowData.add(new FixedColumnGrid.FactionCellData(factionIcon, factionCode));
+                var i = new ImageIcon(ImageUtil.getScaledImage(factionIcon.getImage(), ICON_SIZE, ICON_SIZE));
+                rowData.add(new FixedColumnGrid.FactionCellData(i, factionCode));
 
                 for (Era era : erasToDisplay) {
                     String availabilityText = eraFactionAvailabilityCache

--- a/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/MegaMekUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/MegaMekUnitSelectorDialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -219,6 +219,7 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
         return entity;
     }
 
+    @Override
     protected Entity refreshUnitView() {
         Entity selectedEntity = super.refreshUnitView();
         if (selectedEntity != null) {

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/MekTableModel.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/MekTableModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,7 +32,6 @@
  */
 package megamek.client.ui.panels.phaseDisplay.lobby;
 
-import static megamek.client.ui.util.UIUtil.alternateTableBGColor;
 import static megamek.client.ui.util.UIUtil.fontHTML;
 import static megamek.client.ui.util.UIUtil.uiGreen;
 
@@ -59,7 +58,6 @@ import megamek.common.units.Entity;
 import megamek.common.game.InGameObject;
 import megamek.common.loaders.MapSettings;
 import megamek.common.Player;
-import megamek.common.annotations.Nullable;
 import megamek.common.icons.Camouflage;
 import megamek.common.icons.Portrait;
 import megamek.common.options.OptionsConstants;
@@ -304,36 +302,22 @@ public class MekTableModel extends AbstractTableModel {
     public class Renderer extends DefaultTableCellRenderer {
 
         @Override
-        public Component getTableCellRendererComponent(final JTable table,
-              final @Nullable Object value,
-              final boolean isSelected,
-              final boolean hasFocus,
-              final int row, final int column) {
-            final InGameObject entity = getEntityAt(row);
-            if ((entity == null) || (value == null)) {
+        public Component getTableCellRendererComponent(final JTable table, Object value, boolean isSelected,
+              boolean hasFocus, int row, final int column) {
+
+            final InGameObject unit = getEntityAt(row);
+            if ((unit == null) || (value == null)) {
                 return null;
             }
 
             setIconTextGap(UIUtil.scaleForGUI(10));
-            setText("<HTML>" + value);
+            super.getTableCellRendererComponent(table, "<HTML>" + value, isSelected, hasFocus, row, column);
             boolean compact = chatLounge.isCompact();
             if (compact) {
                 setIcon(null);
             }
 
-            if (isSelected) {
-                setForeground(table.getSelectionForeground());
-                setBackground(table.getSelectionBackground());
-            } else {
-                setForeground(table.getForeground());
-                Color background = table.getBackground();
-                if (row % 2 != 0) {
-                    background = alternateTableBGColor();
-                }
-                setBackground(background);
-            }
-
-            Player owner = ownerOf(entity);
+            Player owner = ownerOf(unit);
             boolean localGM = clientGui.getClient().getLocalPlayer().isGameMaster();
             boolean showAsUnknown = !localGM && clientGui.getClient().getLocalPlayer().isEnemyOf(owner)
                   && clientGui.getClient().getGame().getOptions().booleanOption(OptionsConstants.BASE_BLIND_DROP);
@@ -353,10 +337,10 @@ public class MekTableModel extends AbstractTableModel {
             } else {
                 if (column == COLS.UNIT.ordinal()) {
                     setToolTipText(unitTooltips.get(row));
-                    if (entity instanceof Entity) {
-                        final Camouflage camouflage = ((Entity) entity).getCamouflageOrElseOwners();
-                        final Image base = MMStaticDirectoryManager.getMekTileset().imageFor((Entity) entity);
-                        final Image icon = new EntityImage(base, camouflage, this, (Entity) entity).loadPreviewImage(
+                    if (unit instanceof Entity entity) {
+                        final Camouflage camouflage = entity.getCamouflageOrElseOwners();
+                        final Image base = MMStaticDirectoryManager.getMekTileset().imageFor(entity);
+                        final Image icon = new EntityImage(base, camouflage, this, entity).loadPreviewImage(
                               true);
                         if (!compact) {
                             setIcon(icon, size);
@@ -368,19 +352,15 @@ public class MekTableModel extends AbstractTableModel {
                     }
                 } else if (column == COLS.PILOT.ordinal()) {
                     setToolTipText(pilotTooltips.get(row));
-                    if (!compact && (entity instanceof Entity)) {
-                        setIcon(new ImageIcon(((Entity) entity).getCrew().getPortrait(0).getImage(size)));
+                    if (!compact && (unit instanceof Entity entity)) {
+                        setIcon(new ImageIcon(entity.getCrew().getPortrait(0).getImage(size)));
                     }
                 } else {
                     setToolTipText(null);
                 }
             }
 
-            if (column == COLS.BV.ordinal()) {
-                setHorizontalAlignment(JLabel.CENTER);
-            } else {
-                setHorizontalAlignment(JLabel.LEFT);
-            }
+            setHorizontalAlignment(column == COLS.BV.ordinal() ? JLabel.CENTER : JLabel.LEFT);
 
             return this;
         }

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/MekTableModel.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/MekTableModel.java
@@ -307,7 +307,7 @@ public class MekTableModel extends AbstractTableModel {
 
             final InGameObject unit = getEntityAt(row);
             if ((unit == null) || (value == null)) {
-                return null;
+                return super.getTableCellRendererComponent(table, "", isSelected, hasFocus, row, column);
             }
 
             setIconTextGap(UIUtil.scaleForGUI(10));

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/PlayerTable.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/PlayerTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -33,7 +33,6 @@
 package megamek.client.ui.panels.phaseDisplay.lobby;
 
 import static megamek.client.ui.util.UIUtil.WARNING_SIGN;
-import static megamek.client.ui.util.UIUtil.alternateTableBGColor;
 import static megamek.client.ui.util.UIUtil.scaleForGUI;
 import static megamek.client.ui.util.UIUtil.uiGreen;
 import static megamek.client.ui.util.UIUtil.uiYellow;
@@ -51,7 +50,6 @@ import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JTable;
 import javax.swing.ListSelectionModel;
-import javax.swing.UIManager;
 import javax.swing.event.ChangeEvent;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -141,7 +139,6 @@ class PlayerTable extends JTable {
 
     public static class PlayerTableModel extends AbstractTableModel {
 
-        static final int COL_PLAYER = 0;
         static final int N_COL = 1;
 
         private final ArrayList<Player> players;
@@ -191,6 +188,7 @@ class PlayerTable extends JTable {
         public PlayerRenderer() {
             setLayout(new GridLayout(1, 1, 5, 0));
             setBorder(BorderFactory.createEmptyBorder(0, 5, 0, 0));
+            setIconTextGap(10);
         }
 
         private void setImage(Image img) {
@@ -202,7 +200,14 @@ class PlayerTable extends JTable {
               boolean hasFocus, int row, int column) {
 
             Player player = (Player) value;
+            super.getTableCellRendererComponent(table, getPlayerDescription(player), isSelected, hasFocus, row, column);
+            Image camo = player.getCamouflage().getImage();
+            int size = scaleForGUI(PLAYER_TABLE_ROW_HEIGHT) / 2;
+            setImage(camo.getScaledInstance(-1, size, Image.SCALE_SMOOTH));
+            return this;
+        }
 
+        private StringBuilder getPlayerDescription(Player player) {
             StringBuilder result = new StringBuilder("<HTML><NOBR>");
             // First Line - Player Name
             if ((lobby.client() instanceof BotClient) && player.equals(lobby.localPlayer())
@@ -305,39 +310,7 @@ class PlayerTable extends JTable {
                 result.append("\uD83D\uDD2E  GM");
                 result.append("</FONT>");
             }
-
-            setText(result.toString());
-
-            setIconTextGap(10);
-            Image camo = player.getCamouflage().getImage();
-            int size = scaleForGUI(PLAYER_TABLE_ROW_HEIGHT) / 2;
-            setImage(camo.getScaledInstance(-1, size, Image.SCALE_SMOOTH));
-
-            if (isSelected) {
-                setForeground(table.getSelectionForeground());
-                setBackground(table.getSelectionBackground());
-            } else {
-                setForeground(table.getForeground());
-                Color background = table.getBackground();
-                if (row % 2 != 0) {
-                    background = alternateTableBGColor();
-                }
-                setBackground(background);
-            }
-
-            if (hasFocus) {
-                if (!isSelected) {
-                    Color col = UIManager.getColor("Table.focusCellForeground");
-                    if (col != null) {
-                        setForeground(col);
-                    }
-                    col = UIManager.getColor("Table.focusCellBackground");
-                    if (col != null) {
-                        setBackground(col);
-                    }
-                }
-            }
-            return this;
+            return result;
         }
     }
 }

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/TeamOverviewPanel.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/TeamOverviewPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -49,15 +49,7 @@ import java.io.Serial;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.List;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
-import javax.swing.ImageIcon;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.ListSelectionModel;
-import javax.swing.ScrollPaneConstants;
+import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
@@ -89,9 +81,6 @@ import megamek.common.units.Tank;
  * the stored ClientGUI.
  */
 public class TeamOverviewPanel extends JPanel {
-
-    @Serial
-    private static final long serialVersionUID = -4754010220963493049L;
 
     private enum TOP_COLS {
         TEAM, MEMBERS, TONNAGE, COST, BV, HIDDEN, UNITS
@@ -452,11 +441,8 @@ public class TeamOverviewPanel extends JPanel {
 
     /** A specialized renderer for the mek table. */
     private class MemberListRenderer extends JPanel implements TableCellRenderer {
-        @Serial
-        private static final long serialVersionUID = 6379065972840999336L;
 
         MemberListRenderer() {
-            super();
             setLayout(new BoxLayout(this, BoxLayout.PAGE_AXIS));
         }
 
@@ -491,7 +477,11 @@ public class TeamOverviewPanel extends JPanel {
                 setBackground(table.getSelectionBackground());
             } else {
                 setForeground(table.getForeground());
-                setBackground(table.getBackground());
+                if (row % 2 == 0) {
+                    setBackground(table.getBackground());
+                } else {
+                    setBackground(UIManager.getColor("Table.alternateRowColor"));
+                }
             }
             return this;
         }


### PR DESCRIPTION
See also Megamek/megameklab#2174

This makes MM use automatic alternate table row coloring. This removes the need for table renderers to do this and it applies to all tables, e.g. the lobby unit, the unit selector and the advanced search (as long as the renderer does not explicitly change it)
I chose a medium gray with high alpha, this is equally ok for light and dark UI and the color difference between rows is softer than it currently is in some tables where we do it manually.
Also some other, minor code changes