### PR TITLE
Fix 8179: infantry damage report not complete

### DIFF
--- a/megamek/resources/megamek/common/report-messages.properties
+++ b/megamek/resources/megamek/common/report-messages.properties
@@ -1429,6 +1429,9 @@
 9973=<data> weapon (treated as <data> due to MOS) against infantry in building, damage changed from <data> to <data>
 9975=Burst-fire weapon against infantry in building, damage changed from <data> to <data>
 9976=Building provides no protection when units are on the same level!
+9977=Calculating infantry damage from <data> weapon dealing <data> damage...
+9978=Non-infantry <data> weapon damage against mechanized infantry, damage changed from <data> to <data>
+9979=Base <data> weapon modifier of <data> gives <data>...
 9980=Direct fire
 9981=Ballistic cluster
 9982=Pulse

--- a/megamek/resources/megamek/common/report-messages.properties
+++ b/megamek/resources/megamek/common/report-messages.properties
@@ -1430,11 +1430,6 @@
 9973=in building
 9974=Mechanized
 
-# 9970=<data> weapon against infantry, damage changed from <data> to <data>
-# 9971=<data> weapon against infantry in building, damage changed from <data> to <data>
-# 9972=<data> weapon (treated as <data> due to MOS) against infantry, damage changed from <data> to <data>
-# 9973=<data> weapon (treated as <data> due to MOS) against infantry in building, damage changed from <data> to <data>
-# 9975=Burst-fire weapon against infantry in building, damage changed from <data> to <data>
 9976=Building provides no protection when units are on the same level!
 9980=Direct fire
 9981=Ballistic cluster

--- a/megamek/resources/megamek/common/report-messages.properties
+++ b/megamek/resources/megamek/common/report-messages.properties
@@ -1423,15 +1423,19 @@
 9961=Hidden unit <data> (<data>) prevents <data> (<data>) from entering hex <data>!
 9962=<data> (<data>) was unable to enter hex <data> because it would create a stacking violation with a hidden unit, movement ended!
 9963=Hidden unit <data> (<data>) suffered AE damage and was revealed!
-9970=<data> weapon against infantry, damage changed from <data> to <data>
-9971=<data> weapon against infantry in building, damage changed from <data> to <data>
-9972=<data> weapon (treated as <data> due to MOS) against infantry, damage changed from <data> to <data>
-9973=<data> weapon (treated as <data> due to MOS) against infantry in building, damage changed from <data> to <data>
-9975=Burst-fire weapon against infantry in building, damage changed from <data> to <data>
+# 9970 - 9984: Direct Blow against Infantry reporting
+9970=<data> dmg <data> weapon against infantry
+9971=\ treated as <data> due to MOS
+9972=, damage changed to <data> (<data>)
+9973=in building
+9974=Mechanized
+
+# 9970=<data> weapon against infantry, damage changed from <data> to <data>
+# 9971=<data> weapon against infantry in building, damage changed from <data> to <data>
+# 9972=<data> weapon (treated as <data> due to MOS) against infantry, damage changed from <data> to <data>
+# 9973=<data> weapon (treated as <data> due to MOS) against infantry in building, damage changed from <data> to <data>
+# 9975=Burst-fire weapon against infantry in building, damage changed from <data> to <data>
 9976=Building provides no protection when units are on the same level!
-9977=Calculating infantry damage from <data> weapon dealing <data> damage...
-9978=Non-infantry <data> weapon damage against mechanized infantry, damage changed from <data> to <data>
-9979=Base <data> weapon modifier of <data> gives <data>...
 9980=Direct fire
 9981=Ballistic cluster
 9982=Pulse

--- a/megamek/resources/megamek/common/report-messages_es.properties
+++ b/megamek/resources/megamek/common/report-messages_es.properties
@@ -1217,7 +1217,7 @@
 9960=<data> (<data>) detecta una unidad oculta en el hex. <data>!
 9961=\u00A1La unidad oculta <data> (<data>) evita que <data> (<data>) ingrese en el hex. <data>!
 9962=<data> (<data>) no pudo ingresar <data> en el hex. porque crear\u00EDa una violaci\u00F3n de apilamiento con una unidad oculta, \u00A1el movimiento termin\u00F3!
-9970=Arma de <data> de da\u00F1o de <data> contra infantería
+9970=Arma de <data> de da\u00F1o de <data> contra infanter\u00EDa
 9971=\ tratada como <data> debido a MOS
 9972=, da\u00F1o cambiado a <data> (<data>)
 9973=en el edificio

--- a/megamek/resources/megamek/common/report-messages_es.properties
+++ b/megamek/resources/megamek/common/report-messages_es.properties
@@ -1217,11 +1217,11 @@
 9960=<data> (<data>) detecta una unidad oculta en el hex. <data>!
 9961=\u00A1La unidad oculta <data> (<data>) evita que <data> (<data>) ingrese en el hex. <data>!
 9962=<data> (<data>) no pudo ingresar <data> en el hex. porque crear\u00EDa una violaci\u00F3n de apilamiento con una unidad oculta, \u00A1el movimiento termin\u00F3!
-9970=<data> arma contra infanter\u00EDa, da\u00F1o cambiado de <data> a <data>
-9971=<data> arma contra infanter\u00EDa en edificio, da\u00F1o cambiado de <data> a <data>
-9972=<data> arma (tratada como <data> debido a MOS) contra infanter\u00EDa, el da\u00F1o cambi\u00F3 de <data> a <data>
-9973=<data> arma (tratada como <data> debido a MOS) contra infanter\u00EDa en el edificio, el da\u00F1o cambi\u00F3 de <data> a <data>
-9975=Arma de r\u00E1faga contra infanter\u00EDa en el edificio, el da\u00F1o cambi\u00F3 de <data> a <data>
+9970=Arma de <data> de da\u00F1o de <data> contra infantería
+9971=\ tratada como <data> debido a MOS
+9972=, da\u00F1o cambiado a <data> (<data>)
+9973=en el edificio
+9974=mecanizada
 9976=\u00A1El edificio no ofrece protecci\u00F3n cuando las unidades est\u00E1n en el mismo nivel!
 9980=Fuego directo
 9981=Racimo bal\u00EDstico

--- a/megamek/src/megamek/common/Report.java
+++ b/megamek/src/megamek/common/Report.java
@@ -39,7 +39,9 @@ import static megamek.client.ui.util.UIUtil.uiGray;
 import java.awt.Color;
 import java.awt.Font;
 import java.io.Serial;
+import java.util.ArrayList;
 import java.util.Hashtable;
+import java.util.Optional;
 import java.util.Vector;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -169,6 +171,11 @@ public class Report implements ReportEntry {
      * Required - associates this object with its text.
      */
     public int messageId = Report.MESSAGE_NONE;
+
+    /**
+     * Additional sections to add to raw message prior to inserting tags
+     */
+    public Vector<Integer> extensions = new Vector<>();
 
     /**
      * The number of spaces this report should be indented.
@@ -336,6 +343,14 @@ public class Report implements ReportEntry {
      */
     public Report noNL() {
         return newLines(0);
+    }
+
+    /**
+     * Add an additional message id that will extend the base message
+     * @param id
+     */
+    public void extend(int id) {
+        this.extensions.add(id);
     }
 
     /**
@@ -630,12 +645,17 @@ public class Report implements ReportEntry {
     @Override
     public String text() {
         // The raw text of the message, with tags.
-        String raw = ReportMessages.getString(String.valueOf(messageId));
+        StringBuilder raw = new StringBuilder();
+        raw.append(Optional.ofNullable(ReportMessages.getString(String.valueOf(messageId))).orElse(""));
+
+        for (int extension: this.extensions) {
+            raw.append(ReportMessages.getString(String.valueOf(extension)));
+        }
 
         // This will be the finished product, with data substituted for tags.
         StringBuffer text = new StringBuffer();
 
-        if (raw == null) {
+        if (raw.isEmpty()) {
             // Should we handle this better? Check alternate language files?
             logger.error("No message found for ID {}", messageId);
             text.append("[Reporting Error for message ID ").append(messageId).append("]");
@@ -645,14 +665,14 @@ public class Report implements ReportEntry {
             while (i < raw.length()) {
                 if (raw.charAt(i) == '<') {
                     // find end of tag
-                    int endTagIdx = raw.indexOf('>', i);
-                    if ((raw.indexOf('<', i + 1) != -1) && (raw.indexOf('<', i + 1) < endTagIdx)) {
+                    int endTagIdx = raw.toString().indexOf('>', i);
+                    if ((raw.toString().indexOf('<', i + 1) != -1) && (raw.toString().indexOf('<', i + 1) < endTagIdx)) {
                         // hmm...this must be a literal '<' character
                         i++;
                         continue;
                     }
                     // copy the preceding characters into the buffer
-                    text.append(raw, mark, i);
+                    text.append(raw.toString(), mark, i);
                     if (raw.substring(i + 1, endTagIdx).equals("data")) {
                         text.append(getTag());
                         tagCounter++;
@@ -664,16 +684,16 @@ public class Report implements ReportEntry {
                     } else if (raw.substring(i + 1, endTagIdx).startsWith("msg:")) {
                         boolean selector = Boolean.parseBoolean(getTag());
                         if (selector) {
-                            text.append(ReportMessages.getString(raw.substring(i + 5, raw.indexOf(',', i))));
+                            text.append(ReportMessages.getString(raw.substring(i + 5, raw.toString().indexOf(',', i))));
                         } else {
-                            text.append(ReportMessages.getString(raw.substring(raw.indexOf(',', i) + 1, endTagIdx)));
+                            text.append(ReportMessages.getString(raw.substring(raw.toString().indexOf(',', i) + 1, endTagIdx)));
                         }
                         tagCounter++;
                     } else if (raw.substring(i + 1, endTagIdx).equals("newline")) {
                         text.append("<br>");
                     } else {
                         // not a special tag, so treat as literal text
-                        text.append(raw, i, endTagIdx + 1);
+                        text.append(raw.toString(), i, endTagIdx + 1);
                     }
                     mark = endTagIdx + 1;
                     i = endTagIdx;

--- a/megamek/src/megamek/common/Report.java
+++ b/megamek/src/megamek/common/Report.java
@@ -655,13 +655,16 @@ public class Report implements ReportEntry {
      */
     @Override
     public String text() {
-        // The raw text of the message, with tags.
-        StringBuilder raw = new StringBuilder();
-        raw.append(Optional.ofNullable(ReportMessages.getString(String.valueOf(messageId))).orElse(""));
+        // Build the raw text of the message, with tags.
+        StringBuilder rawBuilder = new StringBuilder();
+        rawBuilder.append(Optional.ofNullable(ReportMessages.getString(String.valueOf(messageId))).orElse(""));
 
         for (int extension: getExtensions()) {
-            raw.append(ReportMessages.getString(String.valueOf(extension)));
+            rawBuilder.append(Optional.ofNullable(ReportMessages.getString(String.valueOf(extension))).orElse(""));
         }
+
+        // Use string representation for actual work
+        String raw = rawBuilder.toString();
 
         // This will be the finished product, with data substituted for tags.
         StringBuffer text = new StringBuffer();
@@ -676,14 +679,14 @@ public class Report implements ReportEntry {
             while (i < raw.length()) {
                 if (raw.charAt(i) == '<') {
                     // find end of tag
-                    int endTagIdx = raw.toString().indexOf('>', i);
-                    if ((raw.toString().indexOf('<', i + 1) != -1) && (raw.toString().indexOf('<', i + 1) < endTagIdx)) {
+                    int endTagIdx = raw.indexOf('>', i);
+                    if ((raw.indexOf('<', i + 1) != -1) && (raw.indexOf('<', i + 1) < endTagIdx)) {
                         // hmm...this must be a literal '<' character
                         i++;
                         continue;
                     }
                     // copy the preceding characters into the buffer
-                    text.append(raw.toString(), mark, i);
+                    text.append(raw, mark, i);
                     if (raw.substring(i + 1, endTagIdx).equals("data")) {
                         text.append(getTag());
                         tagCounter++;
@@ -695,16 +698,16 @@ public class Report implements ReportEntry {
                     } else if (raw.substring(i + 1, endTagIdx).startsWith("msg:")) {
                         boolean selector = Boolean.parseBoolean(getTag());
                         if (selector) {
-                            text.append(ReportMessages.getString(raw.substring(i + 5, raw.toString().indexOf(',', i))));
+                            text.append(ReportMessages.getString(raw.substring(i + 5, raw.indexOf(',', i))));
                         } else {
-                            text.append(ReportMessages.getString(raw.substring(raw.toString().indexOf(',', i) + 1, endTagIdx)));
+                            text.append(ReportMessages.getString(raw.substring(raw.indexOf(',', i) + 1, endTagIdx)));
                         }
                         tagCounter++;
                     } else if (raw.substring(i + 1, endTagIdx).equals("newline")) {
                         text.append("<br>");
                     } else {
                         // not a special tag, so treat as literal text
-                        text.append(raw.toString(), i, endTagIdx + 1);
+                        text.append(raw, i, endTagIdx + 1);
                     }
                     mark = endTagIdx + 1;
                     i = endTagIdx;

--- a/megamek/src/megamek/common/Report.java
+++ b/megamek/src/megamek/common/Report.java
@@ -39,7 +39,6 @@ import static megamek.client.ui.util.UIUtil.uiGray;
 import java.awt.Color;
 import java.awt.Font;
 import java.io.Serial;
-import java.util.ArrayList;
 import java.util.Hashtable;
 import java.util.Optional;
 import java.util.Vector;
@@ -279,6 +278,7 @@ public class Report implements ReportEntry {
     @SuppressWarnings("unchecked")
     public Report(Report r) {
         messageId = r.messageId;
+        extensions = (Vector<Integer>) r.extensions.clone();
         indentation = r.indentation;
         newlines = r.newlines;
         tagData = (Vector<String>) r.tagData.clone();
@@ -350,7 +350,18 @@ public class Report implements ReportEntry {
      * @param id
      */
     public void extend(int id) {
-        this.extensions.add(id);
+        getExtensions().add(id);
+    }
+
+    /**
+     * Safety accessor for extensions
+     * @return extensions Vector of integer values of report messages
+     */
+    public Vector<Integer> getExtensions() {
+        if (this.extensions == null) {
+            this.extensions = new Vector<>();
+        }
+        return this.extensions;
     }
 
     /**
@@ -648,7 +659,7 @@ public class Report implements ReportEntry {
         StringBuilder raw = new StringBuilder();
         raw.append(Optional.ofNullable(ReportMessages.getString(String.valueOf(messageId))).orElse(""));
 
-        for (int extension: this.extensions) {
+        for (int extension: getExtensions()) {
             raw.append(ReportMessages.getString(String.valueOf(extension)));
         }
 

--- a/megamek/src/megamek/common/Report.java
+++ b/megamek/src/megamek/common/Report.java
@@ -278,7 +278,7 @@ public class Report implements ReportEntry {
     @SuppressWarnings("unchecked")
     public Report(Report r) {
         messageId = r.messageId;
-        extensions = (Vector<Integer>) r.extensions.clone();
+        extensions = (Vector<Integer>) r.getExtensions().clone();
         indentation = r.indentation;
         newlines = r.newlines;
         tagData = (Vector<String>) r.tagData.clone();

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -6751,6 +6751,9 @@ public class Compute {
           boolean isAttackThruBuilding, int attackerId, Vector<Report> vReport,
           int mgaSize) {
 
+        // TODO: compact reporting into two lines:
+        // 1. all mods to damage in order, including in/out of building
+        // 2. Mechanized damage mod (if applicable)
         // Report initial (original) damage (use dummy report if not provided)
         if (vReport == null) {
             vReport = new Vector<Report>();
@@ -6779,100 +6782,104 @@ public class Compute {
         switch (damageType) {
             case WeaponType.WEAPON_DIRECT_FIRE:
                 damage /= 10;
+                priorDamage = damage;
                 mod = "1/10";
                 break;
             case WeaponType.WEAPON_CLUSTER_BALLISTIC:
                 damage /= 10;
-                mod = "1/10 + 1";
                 damage++;
+                priorDamage = damage;
+                mod = "1/10 + 1";
                 break;
             case WeaponType.WEAPON_PULSE:
                 damage /= 10;
                 damage += 2;
+                priorDamage = damage;
                 mod = "1/10 + 2";
                 break;
             case WeaponType.WEAPON_CLUSTER_MISSILE:
                 damage /= 5;
+                priorDamage = damage;
                 mod = "1/5";
                 break;
             case WeaponType.WEAPON_CLUSTER_MISSILE_1D6:
                 damage /= 5;
-                mod = "1/5";
                 priorDamage = damage;
                 damage += Compute.d6();
+                mod = "1/5 + 1d6";
                 break;
             case WeaponType.WEAPON_CLUSTER_MISSILE_2D6:
                 damage /= 5;
-                mod = "1/5";
+                mod = "1/5 + 2d6";
                 priorDamage = damage;
                 damage += Compute.d6(2);
                 break;
             case WeaponType.WEAPON_CLUSTER_MISSILE_3D6:
                 damage /= 5;
-                mod = "1/5";
+                mod = "1/5 + 3d6";
                 priorDamage = damage;
                 damage += Compute.d6(3);
                 break;
             case WeaponType.WEAPON_BURST_HALF_D6:
                 damage = Compute.d6() / 2.0;
-                mod = "1d6 / 2";
                 priorDamage = damage;
+                mod = "+1d6 / 2";
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
                 break;
             case WeaponType.WEAPON_BURST_1D6:
                 damage = Compute.d6(mgaSize);
-                mod = "1d6";
                 priorDamage = damage;
+                mod = "+1d6";
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
                 break;
             case WeaponType.WEAPON_BURST_2D6:
                 damage = Compute.d6(2 * mgaSize);
-                mod = "2d6";
                 priorDamage = damage;
+                mod = "+2d6";
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
                 break;
             case WeaponType.WEAPON_BURST_3D6:
                 damage = Compute.d6(3 * mgaSize);
-                mod = "3d6";
                 priorDamage = damage;
+                mod = "+3d6";
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
                 break;
             case WeaponType.WEAPON_BURST_4D6:
                 damage = Compute.d6(4 * mgaSize);
-                mod = "4d6";
                 priorDamage = damage;
+                mod = "+4d6";
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
                 break;
             case WeaponType.WEAPON_BURST_5D6:
                 damage = Compute.d6(5 * mgaSize);
-                mod = "5d6";
                 priorDamage = damage;
+                mod = "+5d6";
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
                 break;
             case WeaponType.WEAPON_BURST_6D6:
                 damage = Compute.d6(6 * mgaSize);
-                mod = "6d6";
                 priorDamage = damage;
+                mod = "+6d6";
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
                 break;
             case WeaponType.WEAPON_BURST_7D6:
                 damage = Compute.d6(7 * mgaSize);
-                mod = "7d6";
                 priorDamage = damage;
+                mod = "+7d6";
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -6752,10 +6752,7 @@ public class Compute {
           boolean isAttackThruBuilding, int attackerId, Vector<Report> vReport,
           int mgaSize) {
 
-        // Report initial (original) damage (use dummy report if not provided)
-        if (vReport == null) {
-            vReport = new Vector<Report>();
-        }
+        // Report initial (original) damage
         Report r = new Report();
         r.subject = attackerId;
         r.indent(2);
@@ -6909,7 +6906,10 @@ public class Compute {
             r.add((int) damage);
             r.add(ReportMessages.getString(String.valueOf(9974)));
         }
-        vReport.addElement(r);
+
+        if (vReport != null) {
+            vReport.addElement(r);
+        }
 
         return (int) damage;
     }

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -6775,7 +6775,7 @@ public class Compute {
         r = new Report();
         r.subject = attackerId;
         r.indent(4);
-        r.add(getDamageTypeString(origDamageType, mgaSize));
+        r.add(getDamageTypeString(damageType, mgaSize));
         r.messageId = 9979;
         String mod = "1:1";
 
@@ -6886,14 +6886,17 @@ public class Compute {
                 break;
         }
         damage = Math.ceil(damage);
+        priorDamage = Math.ceil(priorDamage);
         r.add(mod);
         r.add((int) priorDamage);
         vReport.add(r);
 
         // Updated report for damage type and MOS mods
-        vReport.addElement(reportModifiedDamage(
-              4, attackerId, origDamageType, priorDamage, damageType, damage, mgaSize, isAttackThruBuilding, false
-        ));
+        if (priorDamage != damage) {
+            vReport.addElement(reportModifiedDamage(
+                  4, attackerId, origDamageType, priorDamage, damageType, damage, mgaSize, isAttackThruBuilding, false
+            ));
+        }
 
         // according to the following ruling, the half damage that mechanized
         // inf get against burst fire should trump the double damage they get

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -6664,11 +6664,11 @@ public class Compute {
             case WeaponType.WEAPON_CLUSTER_BALLISTIC -> Messages.getString("WeaponType.BallisticCluster");
             case WeaponType.WEAPON_PULSE -> Messages.getString("WeaponType.Pulse");
             case WeaponType.WEAPON_CLUSTER_MISSILE -> Messages.getString("WeaponType.Missile");
-            case WeaponType.WEAPON_CLUSTER_MISSILE_1D6,
-                 WeaponType.WEAPON_CLUSTER_MISSILE_2D6,
-                 WeaponType.WEAPON_CLUSTER_MISSILE_3D6 -> Messages.getString("WeaponType.Missile") + " (+X d6)";
+            case WeaponType.WEAPON_CLUSTER_MISSILE_1D6 -> Messages.getString("WeaponType.Missile") + " (+ 1d6)";
+            case WeaponType.WEAPON_CLUSTER_MISSILE_2D6 -> Messages.getString("WeaponType.Missile") + " (+ 2d6)";
+            case WeaponType.WEAPON_CLUSTER_MISSILE_3D6 -> Messages.getString("WeaponType.Missile") + " (+ 3d6)";
             case WeaponType.WEAPON_BURST_HALF_D6 -> Messages.getString("WeaponType.BurstHalf");
-            default -> String.format("%s (%dD6)", Messages.getString("WeaponType.Burst"),
+            default -> String.format("%s (%dd6)", Messages.getString("WeaponType.Burst"),
                   burstMultiplier * (damageType - WeaponType.WEAPON_BURST_HALF_D6));
         };
     }
@@ -6820,7 +6820,7 @@ public class Compute {
             case WeaponType.WEAPON_BURST_1D6:
                 damage = Compute.d6(mgaSize);
                 priorDamage = damage;
-                mod = "-> 1d6";
+                mod = "1d6 X " + mgaSize;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
@@ -6828,7 +6828,7 @@ public class Compute {
             case WeaponType.WEAPON_BURST_2D6:
                 damage = Compute.d6(2 * mgaSize);
                 priorDamage = damage;
-                mod = "-> 2d6";
+                mod = "2d6 X " + mgaSize;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
@@ -6836,7 +6836,7 @@ public class Compute {
             case WeaponType.WEAPON_BURST_3D6:
                 damage = Compute.d6(3 * mgaSize);
                 priorDamage = damage;
-                mod = "-> 3d6";
+                mod = "3d6 X " + mgaSize;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
@@ -6844,7 +6844,7 @@ public class Compute {
             case WeaponType.WEAPON_BURST_4D6:
                 damage = Compute.d6(4 * mgaSize);
                 priorDamage = damage;
-                mod = "-> 4d6";
+                mod = "4d6 X " + mgaSize;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
@@ -6852,7 +6852,7 @@ public class Compute {
             case WeaponType.WEAPON_BURST_5D6:
                 damage = Compute.d6(5 * mgaSize);
                 priorDamage = damage;
-                mod = "-> 5d6";
+                mod = "5d6 X " + mgaSize;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
@@ -6860,7 +6860,7 @@ public class Compute {
             case WeaponType.WEAPON_BURST_6D6:
                 damage = Compute.d6(6 * mgaSize);
                 priorDamage = damage;
-                mod = "-> 6d6";
+                mod = "6d6 X " + mgaSize;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
@@ -6868,7 +6868,7 @@ public class Compute {
             case WeaponType.WEAPON_BURST_7D6:
                 damage = Compute.d6(7 * mgaSize);
                 priorDamage = damage;
-                mod = "-> 7d6";
+                mod = "7d6 X " + mgaSize;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -3392,7 +3392,7 @@ public class Compute {
           List<WeaponAttackAction> vAttacks, boolean assumeHit) {
         WeaponAttackAction waaHighest;
         WeaponAttackAction waaSecondHighest;
-        
+
         // Copy the list to a new list
         List<WeaponAttackAction> attacksClone = new ArrayList<>(vAttacks);
         // Find the highest damage
@@ -6663,10 +6663,10 @@ public class Compute {
             case WeaponType.WEAPON_DIRECT_FIRE -> Messages.getString("WeaponType.DirectFire");
             case WeaponType.WEAPON_CLUSTER_BALLISTIC -> Messages.getString("WeaponType.BallisticCluster");
             case WeaponType.WEAPON_PULSE -> Messages.getString("WeaponType.Pulse");
-            case WeaponType.WEAPON_CLUSTER_MISSILE,
-                 WeaponType.WEAPON_CLUSTER_MISSILE_1D6,
+            case WeaponType.WEAPON_CLUSTER_MISSILE -> Messages.getString("WeaponType.Missile");
+            case WeaponType.WEAPON_CLUSTER_MISSILE_1D6,
                  WeaponType.WEAPON_CLUSTER_MISSILE_2D6,
-                 WeaponType.WEAPON_CLUSTER_MISSILE_3D6 -> Messages.getString("WeaponType.Missile");
+                 WeaponType.WEAPON_CLUSTER_MISSILE_3D6 -> Messages.getString("WeaponType.Missile") + " (+X d6)";
             case WeaponType.WEAPON_BURST_HALF_D6 -> Messages.getString("WeaponType.BurstHalf");
             default -> String.format("%s (%dD6)", Messages.getString("WeaponType.Burst"),
                   burstMultiplier * (damageType - WeaponType.WEAPON_BURST_HALF_D6));
@@ -6731,7 +6731,8 @@ public class Compute {
 
     /**
      * Method replicates the Non-Conventional Damage against Infantry damage table as well as shifting for direct blows.
-     * also adjust for non-infantry damaging mechanized infantry
+     * also adjust for non-infantry damaging mechanized infantry.
+     * No mods for Plasma weapons.
      *
      * @param damage                         The base amount of damage
      * @param mos                            The margin of success
@@ -6750,123 +6751,209 @@ public class Compute {
           boolean isAttackThruBuilding, int attackerId, Vector<Report> vReport,
           int mgaSize) {
 
+        // Report initial (original) damage (use dummy report if not provided)
+        if (vReport == null) {
+            vReport = new Vector<Report>();
+        }
+        Report r = new Report();
+        r.subject = attackerId;
+        r.indent(2);
+        r.add(getDamageTypeString(damageType, mgaSize));
+        r.add((int) damage);
+        r.messageId = 9977;
+        vReport.addElement(r);
+
+        // Update for MOS
         int origDamageType = damageType;
         damageType += mos;
-        double origDamage = damage;
+        double priorDamage = damage;
+
+        // Also record initial mod value
+        r = new Report();
+        r.subject = attackerId;
+        r.indent(4);
+        r.add(getDamageTypeString(origDamageType, mgaSize));
+        r.messageId = 9979;
+        String mod = "1:1";
+
         switch (damageType) {
             case WeaponType.WEAPON_DIRECT_FIRE:
                 damage /= 10;
+                mod = "1/10";
                 break;
             case WeaponType.WEAPON_CLUSTER_BALLISTIC:
                 damage /= 10;
+                mod = "1/10 + 1";
                 damage++;
                 break;
             case WeaponType.WEAPON_PULSE:
                 damage /= 10;
                 damage += 2;
+                mod = "1/10 + 2";
                 break;
             case WeaponType.WEAPON_CLUSTER_MISSILE:
                 damage /= 5;
+                mod = "1/5";
                 break;
             case WeaponType.WEAPON_CLUSTER_MISSILE_1D6:
                 damage /= 5;
+                mod = "1/5";
+                priorDamage = damage;
                 damage += Compute.d6();
                 break;
             case WeaponType.WEAPON_CLUSTER_MISSILE_2D6:
                 damage /= 5;
+                mod = "1/5";
+                priorDamage = damage;
                 damage += Compute.d6(2);
                 break;
             case WeaponType.WEAPON_CLUSTER_MISSILE_3D6:
                 damage /= 5;
+                mod = "1/5";
+                priorDamage = damage;
                 damage += Compute.d6(3);
                 break;
             case WeaponType.WEAPON_BURST_HALF_D6:
                 damage = Compute.d6() / 2.0;
+                mod = "1d6 / 2";
+                priorDamage = damage;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
                 break;
             case WeaponType.WEAPON_BURST_1D6:
                 damage = Compute.d6(mgaSize);
+                mod = "1d6";
+                priorDamage = damage;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
                 break;
             case WeaponType.WEAPON_BURST_2D6:
                 damage = Compute.d6(2 * mgaSize);
+                mod = "2d6";
+                priorDamage = damage;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
                 break;
             case WeaponType.WEAPON_BURST_3D6:
                 damage = Compute.d6(3 * mgaSize);
+                mod = "3d6";
+                priorDamage = damage;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
                 break;
             case WeaponType.WEAPON_BURST_4D6:
                 damage = Compute.d6(4 * mgaSize);
+                mod = "4d6";
+                priorDamage = damage;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
                 break;
             case WeaponType.WEAPON_BURST_5D6:
                 damage = Compute.d6(5 * mgaSize);
+                mod = "5d6";
+                priorDamage = damage;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
                 break;
             case WeaponType.WEAPON_BURST_6D6:
                 damage = Compute.d6(6 * mgaSize);
+                mod = "6d6";
+                priorDamage = damage;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
                 break;
             case WeaponType.WEAPON_BURST_7D6:
                 damage = Compute.d6(7 * mgaSize);
+                mod = "7d6";
+                priorDamage = damage;
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
                 break;
         }
         damage = Math.ceil(damage);
+        r.add(mod);
+        r.add((int) priorDamage);
+        vReport.add(r);
+
+        // Updated report for damage type and MOS mods
+        vReport.addElement(reportModifiedDamage(
+              4, attackerId, origDamageType, priorDamage, damageType, damage, mgaSize, isAttackThruBuilding, false
+        ));
 
         // according to the following ruling, the half damage that mechanized
         // inf get against burst fire should trump the double damage they get
         // from non-infantry rather than cancel it out
         // http://bg.battletech.com/forums/index.php/topic,23928.0.html
         if (isNonInfantryAgainstMechanized) {
+            priorDamage = damage;
             if (damageType < WeaponType.WEAPON_BURST_HALF_D6) {
                 damage *= 2;
             } else {
                 damage /= 2;
             }
+            vReport.addElement(reportModifiedDamage(
+                  4, attackerId, origDamageType, priorDamage, damageType, damage, mgaSize, false, true
+            ));
         }
 
-        if (vReport != null) {
-            Report r = new Report();
-            r.subject = attackerId;
-            r.indent(2);
-
-            r.add(getDamageTypeString(origDamageType, mgaSize));
-            if (origDamageType != damageType) {
-                if (isAttackThruBuilding) {
-                    r.messageId = 9973;
-                } else {
-                    r.messageId = 9972;
-                }
-                r.add(getDamageTypeString(damageType, mgaSize));
-            } else if (isAttackThruBuilding) {
-                r.messageId = 9971;
-            } else {
-                r.messageId = 9970;
-            }
-
-            r.add((int) origDamage);
-            r.add((int) damage);
-            vReport.addElement(r);
-        }
         return (int) damage;
+    }
+
+    /**
+     * Helper function for printing infantry damage calculation updates
+     * @param attackerId        Attacker ID (for attaching icon)
+     * @param origDamageType    Initial damage type of attack
+     * @param origDamage        Initial damage of the attack
+     * @param damageType        Current calculated damage type due to MOS
+     * @param damage            Current calculated damage due to MOS, mods
+     * @param mgaSize           Burst damage size for Machine Gun Arrays
+     * @param thruBuilding      Whether building will absorb burst damage
+     * @return Report           containing info on mods
+     */
+    private static Report reportModifiedDamage(
+          int indent,
+          int attackerId,
+          int origDamageType,
+          double origDamage,
+          int damageType,
+          double damage,
+          int mgaSize,
+          boolean thruBuilding,
+          boolean dueToMechanized) {
+        Report r = new Report();
+        r.indent(indent);
+
+        r.subject = attackerId;
+
+        r.add(getDamageTypeString(origDamageType, mgaSize));
+
+        if (dueToMechanized) {
+            r.messageId = 9978;
+        } else if (origDamageType != damageType) {
+            if (thruBuilding) {
+                r.messageId = 9973;
+            } else {
+                r.messageId = 9972;
+            }
+            r.add(getDamageTypeString(damageType, mgaSize));
+        } else if (thruBuilding) {
+            r.messageId = 9971;
+        } else {
+            r.messageId = 9970;
+        }
+
+        r.add((int) origDamage);
+        r.add((int) damage);
+
+        return r;
     }
 
     /**

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -6738,7 +6738,8 @@ public class Compute {
      * @param mos                            The margin of success
      * @param damageType                     The damage class of the weapon, used to adjust damage against infantry
      * @param isNonInfantryAgainstMechanized Whether this is a non-infantry attack against mechanized infantry
-     * @param isAttackThruBuilding           Whether the attack is coming through a building hex
+     * @param isAttackThruBuilding           Whether the attack involves attacker and target both within the same
+     *                                       building
      * @param attackerId                     The entity id of the attacking unit
      * @param vReport                        The report messages vector
      * @param mgaSize                        For machine gun array attacks, the number of linked weapons. For other
@@ -6751,9 +6752,6 @@ public class Compute {
           boolean isAttackThruBuilding, int attackerId, Vector<Report> vReport,
           int mgaSize) {
 
-        // TODO: compact reporting into two lines:
-        // 1. all mods to damage in order, including in/out of building
-        // 2. Mechanized damage mod (if applicable)
         // Report initial (original) damage (use dummy report if not provided)
         if (vReport == null) {
             vReport = new Vector<Report>();
@@ -6761,69 +6759,60 @@ public class Compute {
         Report r = new Report();
         r.subject = attackerId;
         r.indent(2);
-        r.add(getDamageTypeString(damageType, mgaSize));
-        r.add((int) damage);
-        r.messageId = 9977;
-        vReport.addElement(r);
+        r.add((int) damage); // field 1
+        r.add(getDamageTypeString(damageType, mgaSize)); // field 2
+        r.messageId = 9970;
+        String mod = "1:1";
 
         // Update for MOS
-        int origDamageType = damageType;
         damageType += mos;
         double priorDamage = damage;
-
-        // Also record initial mod value
-        r = new Report();
-        r.subject = attackerId;
-        r.indent(4);
-        r.add(getDamageTypeString(damageType, mgaSize));
-        r.messageId = 9979;
-        String mod = "1:1";
 
         switch (damageType) {
             case WeaponType.WEAPON_DIRECT_FIRE:
                 damage /= 10;
-                priorDamage = damage;
                 mod = "1/10";
+                priorDamage = damage;
                 break;
             case WeaponType.WEAPON_CLUSTER_BALLISTIC:
                 damage /= 10;
                 damage++;
-                priorDamage = damage;
                 mod = "1/10 + 1";
+                priorDamage = damage;
                 break;
             case WeaponType.WEAPON_PULSE:
                 damage /= 10;
                 damage += 2;
-                priorDamage = damage;
                 mod = "1/10 + 2";
+                priorDamage = damage;
                 break;
             case WeaponType.WEAPON_CLUSTER_MISSILE:
                 damage /= 5;
-                priorDamage = damage;
                 mod = "1/5";
+                priorDamage = damage;
                 break;
             case WeaponType.WEAPON_CLUSTER_MISSILE_1D6:
                 damage /= 5;
-                priorDamage = damage;
-                damage += Compute.d6();
                 mod = "1/5 + 1d6";
+                damage += Compute.d6();
+                priorDamage = damage;
                 break;
             case WeaponType.WEAPON_CLUSTER_MISSILE_2D6:
                 damage /= 5;
                 mod = "1/5 + 2d6";
-                priorDamage = damage;
                 damage += Compute.d6(2);
+                priorDamage = damage;
                 break;
             case WeaponType.WEAPON_CLUSTER_MISSILE_3D6:
                 damage /= 5;
                 mod = "1/5 + 3d6";
-                priorDamage = damage;
                 damage += Compute.d6(3);
+                priorDamage = damage;
                 break;
             case WeaponType.WEAPON_BURST_HALF_D6:
                 damage = Compute.d6() / 2.0;
                 priorDamage = damage;
-                mod = "+1d6 / 2";
+                mod = "-> 1d6 / 2";
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
@@ -6831,7 +6820,7 @@ public class Compute {
             case WeaponType.WEAPON_BURST_1D6:
                 damage = Compute.d6(mgaSize);
                 priorDamage = damage;
-                mod = "+1d6";
+                mod = "-> 1d6";
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
@@ -6839,7 +6828,7 @@ public class Compute {
             case WeaponType.WEAPON_BURST_2D6:
                 damage = Compute.d6(2 * mgaSize);
                 priorDamage = damage;
-                mod = "+2d6";
+                mod = "-> 2d6";
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
@@ -6847,7 +6836,7 @@ public class Compute {
             case WeaponType.WEAPON_BURST_3D6:
                 damage = Compute.d6(3 * mgaSize);
                 priorDamage = damage;
-                mod = "+3d6";
+                mod = "-> 3d6";
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
@@ -6855,7 +6844,7 @@ public class Compute {
             case WeaponType.WEAPON_BURST_4D6:
                 damage = Compute.d6(4 * mgaSize);
                 priorDamage = damage;
-                mod = "+4d6";
+                mod = "-> 4d6";
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
@@ -6863,7 +6852,7 @@ public class Compute {
             case WeaponType.WEAPON_BURST_5D6:
                 damage = Compute.d6(5 * mgaSize);
                 priorDamage = damage;
-                mod = "+5d6";
+                mod = "-> 5d6";
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
@@ -6871,7 +6860,7 @@ public class Compute {
             case WeaponType.WEAPON_BURST_6D6:
                 damage = Compute.d6(6 * mgaSize);
                 priorDamage = damage;
-                mod = "+6d6";
+                mod = "-> 6d6";
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
@@ -6879,7 +6868,7 @@ public class Compute {
             case WeaponType.WEAPON_BURST_7D6:
                 damage = Compute.d6(7 * mgaSize);
                 priorDamage = damage;
-                mod = "+7d6";
+                mod = "-> 7d6";
                 if (isAttackThruBuilding) {
                     damage *= 0.5;
                 }
@@ -6887,15 +6876,22 @@ public class Compute {
         }
         damage = Math.ceil(damage);
         priorDamage = Math.ceil(priorDamage);
-        r.add(mod);
-        r.add((int) priorDamage);
-        vReport.add(r);
 
-        // Updated report for damage type and MOS mods
-        if (priorDamage != damage) {
-            vReport.addElement(reportModifiedDamage(
-                  4, attackerId, origDamageType, priorDamage, damageType, damage, mgaSize, isAttackThruBuilding, false
-            ));
+        if (mos != 0) {
+            // List MOS change to damage
+            r.extend(9971);
+            r.add(getDamageTypeString(damageType, mgaSize)); // new field in 9971
+        }
+
+        r.extend(9972);
+        r.add((int) priorDamage);
+        r.add(mod);
+
+        if (isAttackThruBuilding && (priorDamage != damage)) {
+            // Indicates damage halved for thru-building attack; priorDamage != damage
+            r.extend(9972);
+            r.add((int) damage);
+            r.add(ReportMessages.getString(String.valueOf(9973)));
         }
 
         // according to the following ruling, the half damage that mechanized
@@ -6903,67 +6899,19 @@ public class Compute {
         // from non-infantry rather than cancel it out
         // http://bg.battletech.com/forums/index.php/topic,23928.0.html
         if (isNonInfantryAgainstMechanized) {
-            priorDamage = damage;
             if (damageType < WeaponType.WEAPON_BURST_HALF_D6) {
                 damage *= 2;
             } else {
                 damage /= 2;
             }
-            vReport.addElement(reportModifiedDamage(
-                  4, attackerId, origDamageType, priorDamage, damageType, damage, mgaSize, false, true
-            ));
+            r.extend(9972);
+            // Per TW 7th Ed. pg 217 (and our wonky implementation) this damage is *not* rounded up.
+            r.add((int) damage);
+            r.add(ReportMessages.getString(String.valueOf(9974)));
         }
+        vReport.addElement(r);
 
         return (int) damage;
-    }
-
-    /**
-     * Helper function for printing infantry damage calculation updates
-     * @param attackerId        Attacker ID (for attaching icon)
-     * @param origDamageType    Initial damage type of attack
-     * @param origDamage        Initial damage of the attack
-     * @param damageType        Current calculated damage type due to MOS
-     * @param damage            Current calculated damage due to MOS, mods
-     * @param mgaSize           Burst damage size for Machine Gun Arrays
-     * @param thruBuilding      Whether building will absorb burst damage
-     * @return Report           containing info on mods
-     */
-    private static Report reportModifiedDamage(
-          int indent,
-          int attackerId,
-          int origDamageType,
-          double origDamage,
-          int damageType,
-          double damage,
-          int mgaSize,
-          boolean thruBuilding,
-          boolean dueToMechanized) {
-        Report r = new Report();
-        r.indent(indent);
-
-        r.subject = attackerId;
-
-        r.add(getDamageTypeString(origDamageType, mgaSize));
-
-        if (dueToMechanized) {
-            r.messageId = 9978;
-        } else if (origDamageType != damageType) {
-            if (thruBuilding) {
-                r.messageId = 9973;
-            } else {
-                r.messageId = 9972;
-            }
-            r.add(getDamageTypeString(damageType, mgaSize));
-        } else if (thruBuilding) {
-            r.messageId = 9971;
-        } else {
-            r.messageId = 9970;
-        }
-
-        r.add((int) origDamage);
-        r.add((int) damage);
-
-        return r;
     }
 
     /**

--- a/megamek/src/megamek/common/units/Entity.java
+++ b/megamek/src/megamek/common/units/Entity.java
@@ -12090,12 +12090,8 @@ public abstract class Entity extends TurnOrdered
         if (game == null) {
             return OptionsConstants.NEURAL_INTERFACE_MODE_OFF;
         }
-        String mode = null;
-        try {
-            mode = gameOptions().stringOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE);
-        } catch (Exception _ignored) {
-            return OptionsConstants.NEURAL_INTERFACE_MODE_OFF;
-        }
+        IOption option = gameOptions().getOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE);
+        String mode = (option == null) ? null : option.stringValue();
         if ((mode == null) || mode.isBlank()) {
             return OptionsConstants.NEURAL_INTERFACE_MODE_OFF;
         }

--- a/megamek/src/megamek/common/units/Entity.java
+++ b/megamek/src/megamek/common/units/Entity.java
@@ -12090,7 +12090,12 @@ public abstract class Entity extends TurnOrdered
         if (game == null) {
             return OptionsConstants.NEURAL_INTERFACE_MODE_OFF;
         }
-        String mode = gameOptions().stringOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE);
+        String mode = null;
+        try {
+            mode = gameOptions().stringOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE);
+        } catch (Exception _ignored) {
+            return OptionsConstants.NEURAL_INTERFACE_MODE_OFF;
+        }
         if ((mode == null) || mode.isBlank()) {
             return OptionsConstants.NEURAL_INTERFACE_MODE_OFF;
         }

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -368,6 +368,9 @@ public class TWGameManager extends AbstractGameManager {
         // The packet will be sent when clients reconnect and receive the full game state.
         Map<BoardLocation, Integer> cutHexes = this.game.getWoodsClearingTracker().getTurnsRemainingPerHex();
         this.game.setHexesBeingCut(cutHexes);
+
+        // Update game's damage manager with new game instance
+        this.damager.setGame(this.game);
     }
 
     /**
@@ -10245,7 +10248,7 @@ public class TWGameManager extends AbstractGameManager {
                         int[] waaIndex = (int[]) rp.getPacket().data()[1];
                         if (waaIndex != null) {
                             for (int waaNum : waaIndex) {
-                                // -1 in the waaNum indicates that None was selected in addition to others, and can be 
+                                // -1 in the waaNum indicates that None was selected in addition to others, and can be
                                 // ignored
                                 if (waaNum == -1) {
                                     continue;

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -370,7 +370,9 @@ public class TWGameManager extends AbstractGameManager {
         this.game.setHexesBeingCut(cutHexes);
 
         // Update game's damage manager with new game instance
-        this.damager.setGame(this.game);
+        if (this.damager != null) {
+            this.damager.setGame(this.game);
+        }
     }
 
     /**

--- a/megamek/unittests/megamek/common/ComputeTest.java
+++ b/megamek/unittests/megamek/common/ComputeTest.java
@@ -905,7 +905,7 @@ class ComputeTest {
               0
         );
         assertEquals(1, newDamage, "5.0 / 10, rounded up.");
-        assertEquals(3, reports.size(), "Report size");
+        assertEquals(1, reports.size(), "Report size");
     }
 
     @Test
@@ -925,13 +925,13 @@ class ComputeTest {
               0
         );
         assertEquals(2, newDamage, "5.0 / 10, rounded up.");
-        assertEquals(4, reports.size(), "Report size");
+        assertEquals(1, reports.size(), "Report size");
     }
 
     @Test
     void testDirectBlowInfantryMechanizedBurstMod() {
-        // Damage should be divided by 10, then rounded, then halved due to burst damage
-        double originalDamage = 20.0;
+        // 5 BA LMGs -> 1D6 / 2, halved by Mechanized Armor vs Burst
+        double originalDamage = 5.0;
         int weaponType = WeaponType.WEAPON_BURST_HALF_D6;
         Vector<Report> reports = new Vector<Report>();
         int newDamage = directBlowInfantryDamage(
@@ -944,16 +944,16 @@ class ComputeTest {
               reports,
               0
         );
-        assertEquals(1, newDamage, "20.0 / 10, rounded up, halved.");
-        assertEquals(4, reports.size(), "Report size");
+        assertTrue(1 >= newDamage, "5 -> 1d6/2, rounded up, then halved and _not_ rounded.");
+        assertEquals(1, reports.size(), "Report size");
     }
 
     @Test
-    void testDirectBlowInfantryMOS3ClusterMissileInBuilding() {
-        // Damage should be divided by 5.0, have between 3 and 18 added, rounded up.
-        // Damage will be 3.0 <= damage <= 12
-        double originalDamage = 15.0;
-        int weaponType = WeaponType.WEAPON_CLUSTER_MISSILE;
+    void testDirectBlowInfantryMOS3BurstInBuilding() {
+        // Burst Weapon in the building attacking infantry also in the building.
+        // 1D6 -> 4D6 -> 4D6 / 2
+        double originalDamage = 10.0;
+        int weaponType = WeaponType.WEAPON_BURST_1D6;
         Vector<Report> reports = new Vector<Report>();
         int newDamage = directBlowInfantryDamage(
               originalDamage,
@@ -963,10 +963,10 @@ class ComputeTest {
               true,
               1,
               reports,
-              0
+              1
         );
-        assertTrue(newDamage >= 6.0 && newDamage <= 21.0, "15 / 5, +3d6, rounded up: " + newDamage);
-        assertEquals(3, reports.size(), "Report size");
-        assertTrue(reports.get(2).text().contains("in building"));
+        assertTrue(newDamage >= 2.0 && newDamage <= 12.0, "10 -> 4D6 / 2.0, rounded up: " + newDamage);
+        assertEquals(1, reports.size(), "Report size");
+        assertTrue(reports.get(0).text().contains("in building"));
     }
 }

--- a/megamek/unittests/megamek/common/ComputeTest.java
+++ b/megamek/unittests/megamek/common/ComputeTest.java
@@ -33,6 +33,7 @@
 
 package megamek.common;
 
+import static megamek.common.compute.Compute.directBlowInfantryDamage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -44,6 +45,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Vector;
 
 import megamek.client.Client;
 import megamek.client.ui.clientGUI.ClientGUI;
@@ -884,5 +886,87 @@ class ComputeTest {
                 assertEquals(4, result.getValue(), "Should have +4 range modifier at long range (3 hexes)");
             }
         }
+    }
+
+    @Test
+    void testDirectBlowInfantryStandardMod() {
+        // Damage should just be divided by 10
+        double originalDamage = 5.0;
+        int weaponType = WeaponType.WEAPON_DIRECT_FIRE;
+        Vector<Report> reports = new Vector<Report>();
+        int newDamage = directBlowInfantryDamage(
+             originalDamage,
+             0,
+             weaponType,
+             false,
+             false,
+             1,
+              reports,
+              0
+        );
+        assertEquals(1, newDamage, "5.0 / 10, rounded up.");
+        assertEquals(3, reports.size(), "Report size");
+    }
+
+    @Test
+    void testDirectBlowInfantryMechanizedMod() {
+        // Damage should be divided by 10, then rounded, then doubled due to non-burst damage
+        double originalDamage = 5.0;
+        int weaponType = WeaponType.WEAPON_DIRECT_FIRE;
+        Vector<Report> reports = new Vector<Report>();
+        int newDamage = directBlowInfantryDamage(
+              originalDamage,
+              0,
+              weaponType,
+              true,
+              false,
+              1,
+              reports,
+              0
+        );
+        assertEquals(2, newDamage, "5.0 / 10, rounded up.");
+        assertEquals(4, reports.size(), "Report size");
+    }
+
+    @Test
+    void testDirectBlowInfantryMechanizedBurstMod() {
+        // Damage should be divided by 10, then rounded, then halved due to burst damage
+        double originalDamage = 20.0;
+        int weaponType = WeaponType.WEAPON_BURST_HALF_D6;
+        Vector<Report> reports = new Vector<Report>();
+        int newDamage = directBlowInfantryDamage(
+              originalDamage,
+              0,
+              weaponType,
+              true,
+              false,
+              1,
+              reports,
+              0
+        );
+        assertEquals(1, newDamage, "20.0 / 10, rounded up, halved.");
+        assertEquals(4, reports.size(), "Report size");
+    }
+
+    @Test
+    void testDirectBlowInfantryMOS3ClusterMissileInBuilding() {
+        // Damage should be divided by 5.0, have between 3 and 18 added, rounded up.
+        // Damage will be 3.0 <= damage <= 12
+        double originalDamage = 15.0;
+        int weaponType = WeaponType.WEAPON_CLUSTER_MISSILE;
+        Vector<Report> reports = new Vector<Report>();
+        int newDamage = directBlowInfantryDamage(
+              originalDamage,
+              3,
+              weaponType,
+              false,
+              true,
+              1,
+              reports,
+              0
+        );
+        assertTrue(newDamage >= 6.0 && newDamage <= 21.0, "15 / 5, +3d6, rounded up: " + newDamage);
+        assertEquals(3, reports.size(), "Report size");
+        assertTrue(reports.get(2).text().contains("in building"));
     }
 }

--- a/megamek/unittests/megamek/common/DropShipMekLoadTest.java
+++ b/megamek/unittests/megamek/common/DropShipMekLoadTest.java
@@ -52,7 +52,6 @@ import megamek.common.units.Dropship;
 import megamek.common.units.Entity;
 import megamek.common.units.Mek;
 import megamek.common.verifier.TestEntity;
-import megamek.server.totalWarfare.TWDamageManager;
 import megamek.server.totalWarfare.TWGameManager;
 import org.junit.jupiter.api.Test;
 

--- a/megamek/unittests/megamek/common/DropShipMekLoadTest.java
+++ b/megamek/unittests/megamek/common/DropShipMekLoadTest.java
@@ -52,6 +52,7 @@ import megamek.common.units.Dropship;
 import megamek.common.units.Entity;
 import megamek.common.units.Mek;
 import megamek.common.verifier.TestEntity;
+import megamek.server.totalWarfare.TWDamageManager;
 import megamek.server.totalWarfare.TWGameManager;
 import org.junit.jupiter.api.Test;
 

--- a/megamek/unittests/megamek/common/units/ProtoMekEITest.java
+++ b/megamek/unittests/megamek/common/units/ProtoMekEITest.java
@@ -45,6 +45,7 @@ import megamek.common.equipment.EquipmentType;
 import megamek.common.game.Game;
 import megamek.common.options.GameOptions;
 import megamek.common.options.IOption;
+import megamek.common.options.Option;
 import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
 import org.junit.jupiter.api.BeforeAll;
@@ -140,8 +141,11 @@ class ProtoMekEITest extends GameBoardTestCase {
     }
 
     private void setNeuralInterfaceMode(String mode) {
+        IOption option = new Option(null, OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE, IOption.STRING, mode);
         when(mockGameOptions.stringOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE))
               .thenReturn(mode);
+        when(mockGameOptions.getOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE))
+              .thenReturn(option);
     }
 
     @Nested


### PR DESCRIPTION
This PR updates the infantry damage adjustment and direct blow reporting code to include information from each
step of the process, as well as updating the reports to be more concise.
- Consolidates and adds detail to infantry damage reporting in the direct blow vs Infantry code.
- Adds an "extend" functionality to Reports; this allows composition of reports by ID into a single report and simplifies constructing complex lines with data tags.
- Adds unit tests for basic `directBlowInfantryDamage()` functionality
- Fixes issue where TWDamageManager doesn't get the correct Game instance when loading a game saved during a turn.
- Fixes issue where loading a game without the new Neural Interface option entry can cause an NPE.

New report examples:
<img width="882" height="386" alt="Screenshot_20260416_095743" src="https://github.com/user-attachments/assets/5d1eb35a-0b35-4e97-98b9-042f59898510" />
<img width="882" height="374" alt="Screenshot_20260416_095656" src="https://github.com/user-attachments/assets/311a9c03-6815-43f8-b1ce-207c4c9e500b" />
<img width="882" height="250" alt="Screenshot_20260416_095600" src="https://github.com/user-attachments/assets/15782f33-ffc5-4f32-a145-1c2750d7994a" />
<img width="882" height="404" alt="Screenshot_20260416_095510" src="https://github.com/user-attachments/assets/b80dede6-e2e4-4b3f-b1f4-8e72bb7f90fa" />


Testing:
- Added new unit tests
- Ran existing unit tests for all projects
- Ran bot games with various types of infantry units, in and out of buildings, to confirm reporting.
Close #8179 
Close #1075 