### PR TITLE
Fix 8176: adf file does not apply

### DIFF
--- a/megamek/src/megamek/client/generator/TeamLoadOutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadOutGenerator.java
@@ -1726,6 +1726,7 @@ public class TeamLoadOutGenerator {
             String subType = (binType.contains(" w/")) ? binType.substring(0, binType.indexOf(" w/")) : null;
             Mounted<AmmoType> bin = binList.get(0);
             AmmoType desired;
+            HashMap<String, Integer> availInts = new HashMap<>();
             boolean available = false;
 
             // Load matching AmmoType
@@ -1756,19 +1757,18 @@ public class TeamLoadOutGenerator {
                             (subType == null || m.getName().contains(subType)))
                       .findFirst()
                       .orElse(null);
-                lookup = binType;
+                // The availability list will use mutator names without weapon type / rack size values;
+                // use that if available, or just the bin type name if not.
+                lookup = (desired != null && desired.getMutatorName() != null && !desired.getMutatorName().isEmpty()) ?
+                      desired.getMutatorName() : binType;
             }
 
-            // Does the lookup to see how many bins of the munition are available, and _if_
-            // bins are available, remove one.
+            // Does the lookup to see how many bins of the munition are available.
             for (String key: availMap.keySet()) {
                 if (binName.contains(key)) {
-                    HashMap<String, Integer> availInts = (HashMap<String, Integer>) availMap.getOrDefault(key, null);
+                    availInts = (HashMap<String, Integer>) availMap.getOrDefault(key, null);
                     available = (desired != null) && (availInts != null) && availInts.containsKey(lookup) &&
                           availInts.get(lookup) > 0;
-                    if (available) {
-                        availInts.put(lookup, availInts.get(lookup) - 1);
-                    }
                     break;
                 }
             }
@@ -1791,7 +1791,7 @@ public class TeamLoadOutGenerator {
             }
 
             // Continue filling with this munition type until count is fulfilled or there are no more bins
-            while (counts.getOrDefault(binType, 0) > 0 && !binList.isEmpty()) {
+            while (available && counts.getOrDefault(binType, 0) > 0 && !binList.isEmpty()) {
                 try {
                     // fill one ammo bin with the requested ammo type
 
@@ -1807,6 +1807,10 @@ public class TeamLoadOutGenerator {
                     }
                     // Apply ammo change
                     binList.get(0).changeAmmoType(desired);
+
+                    // Decrement available ammo bins and update availability
+                    availInts.put(lookup, availInts.get(lookup) - 1);
+                    available = availInts.get(lookup) > 0;
 
                     // Decrement count and remove bin from list
                     counts.put(binType, counts.get(binType) - 1);

--- a/megamek/src/megamek/client/generator/TeamLoadOutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadOutGenerator.java
@@ -940,7 +940,7 @@ public class TeamLoadOutGenerator {
      * @param availMap      An already-constructed munitions availability map
      * @param factor        The value to multiply the existing bin counts by.
      */
-    protected static void scaleAvailabilityMap(HashMap<String, Object> availMap, double factor) {
+    public static void scaleAvailabilityMap(HashMap<String, Object> availMap, double factor) {
         // Traverse all listed weapon types
         for (Map.Entry<String, Object> entry : availMap.entrySet()) {
             // Get the munition name : bin count sub-map for each
@@ -1583,27 +1583,30 @@ public class TeamLoadOutGenerator {
           ReconfigurationParameters reconfigurationParameters, @Nullable HashMap<String, Object> availMap) {
 
         // AvailMap lists how many bins of various munition types would be available to a given faction force at any
-        // given time.  If not provided, one will be generated.
+        // given time.
+        // If not provided, one will be generated.
+        // Generated availMap will also be scaled to account for unit size, availability, and load-out settings.
         // Pre-generating an availMap allows for modifying munition availability for one team/faction, e.g. for special
         // missions.
+        // Note: caller is responsible for calling scaleAvailabilityMap() on a pre-generated availMap, if desired.
         if (availMap == null) {
             availMap = generateValidMunitionsForFactionAndEra(faction);
-        }
 
-        // Increase or reduce availability of limited munitions depending on the total force count and faction quality
-        // Min and max factor are restricted by Defaults.Factors values from YAML.
-        double factor = Math.min(
-              castPropertyDouble("Defaults.Factors.maximumAvailFactor", 2.0),
-              Math.max(
-                    castPropertyDouble("Defaults.Factors.minimumAvailFactor", 0.25),
-                    (entities.size() / castPropertyDouble("Defaults.Factors.defaultForceSize", 36.0)) *
-                        (
-                              castPropertyDouble("Defaults.Factors.qualityRatingMultiplier", 1.0) *
-                              (reconfigurationParameters.friendlyQuality + 1.0) / 6.0
-                        )
-              )
-        );
-        scaleAvailabilityMap(availMap, factor);
+            // Increase or reduce availability of limited munitions depending on the total force count and faction quality
+            // Min and max factor are restricted by Defaults.Factors values from YAML.
+            double factor = Math.min(
+                  castPropertyDouble("Defaults.Factors.maximumAvailFactor", 2.0),
+                  Math.max(
+                        castPropertyDouble("Defaults.Factors.minimumAvailFactor", 0.25),
+                        (entities.size() / castPropertyDouble("Defaults.Factors.defaultForceSize", 36.0)) *
+                            (
+                                  castPropertyDouble("Defaults.Factors.qualityRatingMultiplier", 1.0) *
+                                  (reconfigurationParameters.friendlyQuality + 1.0) / 6.0
+                            )
+                  )
+            );
+            scaleAvailabilityMap(availMap, factor);
+        }
 
         // For Pirate forces, assume fewer rounds per bin at lower quality levels, minimum 20%. If fill ratio is
         // already set, leave it.

--- a/megamek/src/megamek/client/generator/TeamLoadOutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadOutGenerator.java
@@ -742,6 +742,71 @@ public class TeamLoadOutGenerator {
     }
 
     /**
+     * Create an availability map with all munition bin counts set to "Unlimited", that is, Integer.MAX_VALUE
+     *
+     * @return HashMap  Availability map set to expected values
+     */
+    public static HashMap<String, Object> createUnlimitedAllMunitionsMap() {
+        return createAllMunitionsMap(Integer.MAX_VALUE);
+    }
+
+    /**
+     * Create a map with all munitions set to a specific value, not restricted by faction/year/tech level
+     * @param count     Count of bins to assign to each munition entry
+     *
+     * @return HashMap  containing per-weapon entries, that contain per-munition entries of "bin counts"
+     */
+    public static HashMap<String, Object> createAllMunitionsMap(int count) {
+        List<EquipmentType> types = EquipmentType.allTypes();
+        HashMap<String, Object> allMunitions = new HashMap<>();
+
+        for (String weaponName : TYPE_LIST) {
+            HashMap<String, Integer> newEntry = new HashMap<>();
+
+            // Grab all AmmoTypes that contain the weapon type name but are not Small Weapon AmmoType
+            List<AmmoType> ammoTypes = types.stream()
+                  .filter(AmmoType.class::isInstance)
+                  .filter(eq -> eq.getName().contains(weaponName) && !(eq instanceof SmallWeaponAmmoType))
+                  .map(AmmoType.class::cast)
+                  .toList();
+
+            // "Standard" munitions usually don't include "Standard" in the name but we know they _are_ the base
+            // ammo type because they don't have a `base` ammo type set!
+            AmmoType standard = ammoTypes.stream()
+                  .filter(munition -> munition.getBaseAmmo() == null)
+                  .findFirst()
+                  .orElse(null);
+            if (standard != null) {
+                newEntry.put("Standard", count);
+            }
+
+            // Munitions must be named in one of the TYPE_MAP sub-maps to be utilized!
+            for (String munitionName: TYPE_MAP.get(weaponName)) {
+                // Get the first munition that matches; tube count or barrel size shouldn't matter for validity checks
+                // Munitions without a base ammo _are_ the base munition and will be marked as "Standard"
+                AmmoType exemplar = ammoTypes.stream()
+                      .filter(munition -> munition.matchesName(munitionName))
+                      .findFirst()
+                      .orElse(null);
+
+                if (exemplar != null) {
+                    // If we found a matching munition in the AmmoTypes, set to passed-in count value
+                    newEntry.put(munitionName, count);
+                }
+            }
+
+            // Ensure "Standard" ammo is set to count if not already set
+            if (newEntry.get("Standard") != count) {
+                newEntry.put("Standard", count);
+            }
+
+            allMunitions.put(weaponName, newEntry);
+        }
+
+        return allMunitions;
+    }
+
+    /**
      * Creates a lookup table of weapon system type -> munition type -> available bins, for the average force
      *
      * @param types       The set of all equipment types within which to search for AmmoTypes

--- a/megamek/src/megamek/client/ui/dialogs/customMek/CustomMekDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/customMek/CustomMekDialog.java
@@ -384,10 +384,12 @@ public class CustomMekDialog extends AbstractButtonDialog
             }
 
             // Hide EI Implant group when neural interface rules are Off
-            if (group.getKey().equalsIgnoreCase(PilotOptions.EI_ADVANTAGES) &&
-                  OptionsConstants.NEURAL_INTERFACE_MODE_OFF.equals(
-                        gameOptions().stringOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE))) {
-                continue;
+            if (group.getKey().equalsIgnoreCase(PilotOptions.EI_ADVANTAGES)) {
+                IOption aniOption = gameOptions().getOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE);
+                String aniMode = (aniOption == null) ? OptionsConstants.NEURAL_INTERFACE_MODE_OFF : aniOption.toString();
+                if (OptionsConstants.NEURAL_INTERFACE_MODE_OFF.equals(aniMode)) {
+                    continue;
+                }
             }
 
             addGroup(group, gridBagLayout, c);

--- a/megamek/src/megamek/client/ui/dialogs/customMek/CustomMekDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/customMek/CustomMekDialog.java
@@ -386,7 +386,7 @@ public class CustomMekDialog extends AbstractButtonDialog
             // Hide EI Implant group when neural interface rules are Off
             if (group.getKey().equalsIgnoreCase(PilotOptions.EI_ADVANTAGES)) {
                 IOption aniOption = gameOptions().getOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE);
-                String aniMode = (aniOption == null) ? OptionsConstants.NEURAL_INTERFACE_MODE_OFF : aniOption.toString();
+                String aniMode = (aniOption == null) ? OptionsConstants.NEURAL_INTERFACE_MODE_OFF : aniOption.stringValue();
                 if (OptionsConstants.NEURAL_INTERFACE_MODE_OFF.equals(aniMode)) {
                     continue;
                 }

--- a/megamek/src/megamek/client/ui/dialogs/customMek/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/customMek/EquipChoicePanel.java
@@ -301,7 +301,7 @@ public class EquipChoicePanel extends JPanel {
         // Only show in Full Tracking mode (hardware + pilot required)
         // DNI is Inner Sphere tech (E/X-X-E-F) - not available for pure Clan units
         IOption aniOption = game.getOptions().getOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE);
-        String aniMode = (aniOption == null) ? OptionsConstants.NEURAL_INTERFACE_MODE_OFF : aniOption.toString();
+        String aniMode = (aniOption == null) ? OptionsConstants.NEURAL_INTERFACE_MODE_OFF : aniOption.stringValue();
 
         boolean isFullTracking = OptionsConstants.NEURAL_INTERFACE_MODE_FULL_TRACKING.equals(aniMode);
 
@@ -940,7 +940,7 @@ public class EquipChoicePanel extends JPanel {
 
         // update DNI Cockpit Modification setting (IO p.83) - only in Full Tracking mode
         IOption aniOption = game.getOptions().getOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE);
-        String aniMode = (aniOption == null) ? OptionsConstants.NEURAL_INTERFACE_MODE_OFF : aniOption.toString();
+        String aniMode = (aniOption == null) ? OptionsConstants.NEURAL_INTERFACE_MODE_OFF : aniOption.stringValue();
 
         boolean isFullTrackingMode = OptionsConstants.NEURAL_INTERFACE_MODE_FULL_TRACKING.equals(aniMode);
         if (isFullTrackingMode) {
@@ -1066,7 +1066,7 @@ public class EquipChoicePanel extends JPanel {
     public void refreshNeuralInterfaceCheckboxes() {
         Game game = (clientgui == null) ? client.getGame() : clientgui.getClient().getGame();
         IOption aniOption = game.getOptions().getOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE);
-        String aniMode = (aniOption == null) ? OptionsConstants.NEURAL_INTERFACE_MODE_OFF : aniOption.toString();
+        String aniMode = (aniOption == null) ? OptionsConstants.NEURAL_INTERFACE_MODE_OFF : aniOption.stringValue();
 
         if (!OptionsConstants.NEURAL_INTERFACE_MODE_FULL_TRACKING.equals(aniMode)) {
             return;

--- a/megamek/src/megamek/client/ui/dialogs/customMek/EquipChoicePanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/customMek/EquipChoicePanel.java
@@ -73,6 +73,7 @@ import megamek.common.equipment.enums.AmmoTypeFlag;
 import megamek.common.equipment.enums.MiscTypeFlag;
 import megamek.common.game.Game;
 import megamek.common.options.IGameOptions;
+import megamek.common.options.IOption;
 import megamek.common.options.OptionsConstants;
 import megamek.common.units.Aero;
 import megamek.common.units.AeroSpaceFighter;
@@ -299,8 +300,11 @@ public class EquipChoicePanel extends JPanel {
         // Set up DNI Cockpit Modification (IO p.83)
         // Only show in Full Tracking mode (hardware + pilot required)
         // DNI is Inner Sphere tech (E/X-X-E-F) - not available for pure Clan units
-        boolean isFullTracking = OptionsConstants.NEURAL_INTERFACE_MODE_FULL_TRACKING.equals(
-              game.getOptions().stringOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE));
+        IOption aniOption = game.getOptions().getOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE);
+        String aniMode = (aniOption == null) ? OptionsConstants.NEURAL_INTERFACE_MODE_OFF : aniOption.toString();
+
+        boolean isFullTracking = OptionsConstants.NEURAL_INTERFACE_MODE_FULL_TRACKING.equals(aniMode);
+
         if (isFullTracking) {
             // DNI cockpit mod is available for Meks, Tanks, Fighters, BA, and Support Vehicles
             // Must be IS, Mixed IS, or Mixed Clan (not pure Clan)
@@ -935,8 +939,10 @@ public class EquipChoicePanel extends JPanel {
         }
 
         // update DNI Cockpit Modification setting (IO p.83) - only in Full Tracking mode
-        boolean isFullTrackingMode = OptionsConstants.NEURAL_INTERFACE_MODE_FULL_TRACKING.equals(
-              game.getOptions().stringOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE));
+        IOption aniOption = game.getOptions().getOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE);
+        String aniMode = (aniOption == null) ? OptionsConstants.NEURAL_INTERFACE_MODE_OFF : aniOption.toString();
+
+        boolean isFullTrackingMode = OptionsConstants.NEURAL_INTERFACE_MODE_FULL_TRACKING.equals(aniMode);
         if (isFullTrackingMode) {
             boolean wantsDNI = chDNICockpitMod.isSelected();
             boolean hasDNI = entity.hasDNICockpitMod();
@@ -1059,8 +1065,10 @@ public class EquipChoicePanel extends JPanel {
      */
     public void refreshNeuralInterfaceCheckboxes() {
         Game game = (clientgui == null) ? client.getGame() : clientgui.getClient().getGame();
-        if (!OptionsConstants.NEURAL_INTERFACE_MODE_FULL_TRACKING.equals(
-              game.getOptions().stringOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE))) {
+        IOption aniOption = game.getOptions().getOption(OptionsConstants.ADVANCED_NEURAL_INTERFACE_MODE);
+        String aniMode = (aniOption == null) ? OptionsConstants.NEURAL_INTERFACE_MODE_OFF : aniOption.toString();
+
+        if (!OptionsConstants.NEURAL_INTERFACE_MODE_FULL_TRACKING.equals(aniMode)) {
             return;
         }
 

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/LobbyErrors.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/LobbyErrors.java
@@ -68,6 +68,7 @@ public final class LobbyErrors {
           "A converted force must conform to the rules given in Interstellar Operations. Conversion " +
           "will typically work with companies created in the Force Generator.";
     private static final String NO_DUAL_TOW = "Both units must have an open appropriate tow hitch.";
+    private static final String ADF_READ_ERROR = "Error reading ADF file: ";
 
     public static void showOnlyOwnBot(JFrame owner) {
         JOptionPane.showMessageDialog(owner, ONLY_OWN_BOT);
@@ -171,6 +172,10 @@ public final class LobbyErrors {
 
     public static void showCannotDisconnectMasterUnit(JFrame owner) {
         JOptionPane.showMessageDialog(owner, Messages.getString("LobbyErrors.cannotDisconnectMaster"));
+    }
+
+    public static void showADFReadError(JFrame owner, String message) {
+        JOptionPane.showMessageDialog(owner, ADF_READ_ERROR + message);
     }
 
     private LobbyErrors() {}

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/LobbyErrors.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/LobbyErrors.java
@@ -68,7 +68,6 @@ public final class LobbyErrors {
           "A converted force must conform to the rules given in Interstellar Operations. Conversion " +
           "will typically work with companies created in the Force Generator.";
     private static final String NO_DUAL_TOW = "Both units must have an open appropriate tow hitch.";
-    private static final String ADF_READ_ERROR = "Error reading ADF file: ";
 
     public static void showOnlyOwnBot(JFrame owner) {
         JOptionPane.showMessageDialog(owner, ONLY_OWN_BOT);
@@ -175,7 +174,7 @@ public final class LobbyErrors {
     }
 
     public static void showADFReadError(JFrame owner, String message) {
-        JOptionPane.showMessageDialog(owner, ADF_READ_ERROR + message);
+        JOptionPane.showMessageDialog(owner, message);
     }
 
     private LobbyErrors() {}

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/LobbyMekPopupActions.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/LobbyMekPopupActions.java
@@ -41,10 +41,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
 import javax.swing.JFileChooser;
+import javax.swing.JFrame;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
 import megamek.MMConstants;
@@ -557,8 +557,14 @@ public record LobbyMekPopupActions(ChatLounge lobby) implements ActionListener {
             return null;
         }
 
-        String file = jFileChooser.getSelectedFile().getAbsolutePath();
-        munitionTree = new MunitionTree(file);
+        try {
+            String file = jFileChooser.getSelectedFile().getAbsolutePath();
+            munitionTree = new MunitionTree(file);
+        } catch (IllegalArgumentException e) {
+            LobbyErrors.showADFReadError(frame(), e.getMessage());
+
+            return null;
+        }
         return munitionTree;
     }
 
@@ -573,5 +579,9 @@ public record LobbyMekPopupActions(ChatLounge lobby) implements ActionListener {
                 lobby.lobbyActions.tow(entity, info);
                 break;
         }
+    }
+
+    private JFrame frame() {
+        return lobby.getClientGUI().getFrame();
     }
 }

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/LobbyMekPopupActions.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/LobbyMekPopupActions.java
@@ -38,8 +38,10 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
 import javax.swing.JFileChooser;
@@ -482,9 +484,12 @@ public record LobbyMekPopupActions(ChatLounge lobby) implements ActionListener {
             case LMP_APPLY_CONFIG:
                 munitionTree = loadLoadout();
                 if (null != munitionTree) {
-                    // Apply to entities
+                    // Apply existing loadout to selected entities.
+                    // Use the unlimited availability map (all munitions allowed in any amount)
                     resetBombChoices(clientGUI, lobby.game(), entityArrayList);
-                    tlg.reconfigureEntities(entityArrayList, faction, munitionTree, reconfigurationParameters, null);
+                    HashMap<String, Object> availMap = TeamLoadOutGenerator.createUnlimitedAllMunitionsMap();
+                    tlg.reconfigureEntities(entityArrayList, faction, munitionTree, reconfigurationParameters,
+                          availMap);
                     reconfigured = true;
                 }
                 break;

--- a/megamek/src/megamek/common/containers/LoadNode.java
+++ b/megamek/src/megamek/common/containers/LoadNode.java
@@ -299,8 +299,8 @@ class LoadNode {
         StringBuilder sb = new StringBuilder();
         if (keys.length == 3) {
             // Create prefix of 3 keys
-            String chassis = (keys[0].isEmpty()) ? "any" : keys[0];
-            String variant = (keys[1].isEmpty()) ? "any" : keys[1];
+            String chassis = (keys[0] == null || keys[0].isEmpty()) ? "any" : keys[0];
+            String variant = (keys[1] == null || keys[1].isEmpty()) ? "any" : keys[1];
             String pilot = "any";
             sb.append(chassis).append(":").append(variant).append(":").append(pilot);
             // Combine all imperatives in one line.

--- a/megamek/src/megamek/common/containers/LoadNode.java
+++ b/megamek/src/megamek/common/containers/LoadNode.java
@@ -292,12 +292,17 @@ class LoadNode {
      * imperatives in "ammoType:munition1[:munition2[...]]::ammoType2..." format. 2. This is a node. 1~2 keys have been
      * passed in; pass these to leaves. 3. This is the root. Iterate over all child keys and pass them to the children.
      *
+     * If case 1 but a key value is blank, replace with "any".
+     * Always use "any" for pilot when dumping imperatives.
      */
     public StringBuilder dumpTextFormat(String... keys) {
         StringBuilder sb = new StringBuilder();
         if (keys.length == 3) {
             // Create prefix of 3 keys
-            sb.append(keys[0]).append(":").append(keys[1]).append(":").append(keys[2]);
+            String chassis = (keys[0].isEmpty()) ? "any" : keys[0];
+            String variant = (keys[1].isEmpty()) ? "any" : keys[1];
+            String pilot = "any";
+            sb.append(chassis).append(":").append(variant).append(":").append(pilot);
             // Combine all imperatives in one line.
             for (Map.Entry<String, String> entry : imperatives.entrySet()) {
                 sb.append("::").append(entry.getKey()).append(":").append(entry.getValue());

--- a/megamek/src/megamek/common/containers/MunitionTree.java
+++ b/megamek/src/megamek/common/containers/MunitionTree.java
@@ -226,7 +226,8 @@ public class MunitionTree {
                 String[] parts = line.split("::");
                 String[] keys = parts[0].split(":");
                 if (keys.length != 3) {
-                    throw new IllegalArgumentException("Malformed entry key[s]: " + parts[0]);
+                    // Record the whole line, to avoid a bunch of messy processing
+                    throw new IllegalArgumentException("Malformed entry: \n" + line);
                 }
                 HashMap<String, String> imperatives = new HashMap<>();
                 String imperative;

--- a/megamek/src/megamek/common/containers/MunitionTree.java
+++ b/megamek/src/megamek/common/containers/MunitionTree.java
@@ -225,6 +225,9 @@ public class MunitionTree {
             try {
                 String[] parts = line.split("::");
                 String[] keys = parts[0].split(":");
+                if (keys.length != 3) {
+                    throw new IllegalArgumentException("Malformed entry key[s]: " + parts[0]);
+                }
                 HashMap<String, String> imperatives = new HashMap<>();
                 String imperative;
 

--- a/megamek/unittests/megamek/client/generator/MunitionTreeTest.java
+++ b/megamek/unittests/megamek/client/generator/MunitionTreeTest.java
@@ -185,8 +185,10 @@ class MunitionTreeTest {
                 assertTrue(line.toLowerCase().contains(
                       "any:any:any::AC:Standard:Precision::LRM:Standard:Heat-Seeking:Semi-Guided".toLowerCase()));
             } else if (line.startsWith("Mauler:")) {
+                // When dumping imperatives to an adf file, we now replace all pilot names with "any" for ease
+                // of application to other units of the same chassis and variant.
                 assertTrue(line.toLowerCase()
-                      .contains("Mauler:MAL-5X:Tsubaki Yonjuro::AC/5:Precision:Tracer:".toLowerCase()));
+                      .contains("Mauler:MAL-5X:any::AC/5:Precision:Tracer:".toLowerCase()));
             } else if (line.startsWith("Shadow Hawk:")) {
                 assertTrue(line.toLowerCase().contains("Shadow Hawk:SHD-2D:any::".toLowerCase()));
             }

--- a/megamek/unittests/megamek/client/generator/TeamLoadOutGeneratorTest.java
+++ b/megamek/unittests/megamek/client/generator/TeamLoadOutGeneratorTest.java
@@ -999,6 +999,22 @@ class TeamLoadOutGeneratorTest {
         }
     }
 
+    @Test
+    void testCreateUnlimitedAllMunitionsMap() {
+        // This method creates an availability map where all entries are set to "unlimited", that is, Integer.MAX_VALUE.
+        // Primary usage is for applying an existing loadout file to a set of other units; we don't wish to apply any
+        // limits to any of the specified munitions as we assume the player already knows whether they are valid or not.
+        HashMap<String, Object> availMap = TeamLoadOutGenerator.createUnlimitedAllMunitionsMap();
+        for (String weaponName: TeamLoadOutGenerator.TYPE_LIST) {
+            HashMap<String, Integer> entries = (HashMap<String, Integer>) availMap.getOrDefault(weaponName, null);
+            assertNotEquals(null, entries);
+            assertFalse(entries.isEmpty());
+            for (Map.Entry<String, Integer> entry: entries.entrySet()) {
+                assertTrue(entry.getValue() == Integer.MAX_VALUE);
+            }
+        }
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {"IS", "CC", "CF", "CP", "CS", "DC", "EI", "FC", "FR", "FS", "FW", "LC",
     "MC", "MH", "OA", "TA", "TC", "TH", "RD", "RS", "RA", "RW", "WB", "MERC", "PER",


### PR DESCRIPTION
Fixes a few issues with the option to apply one unit's config to one or more other units:

- Units without a variant type (such as the AC/2 Carrier in this case) would result in a malformed ADF file entry.
- The new availability calculation system was being applied to loaded ADF files, meaning even when the apply worked, the subject units might only get 1 or 2 bins of the specified ammo.
- ADF file lines, by default, were tied to a specific unit type, variant, _and_ pilot, and required manual editing to be applied to other units with different pilots (QOL fix)

Now the loadout reconfig code will use an availMap where every munition is "unlimited", so the units getting the new loadout should receive exactly as many bins of each munition type as specified in the ADF file.
When saving a specific unit's loadout, the created ADF file entry will apply to "any" pilot by default.
Further, units without variant types will produce valid ADF file entries (the variant field will be set to "any").

Also adds:
- An function to create an availMap with all munition types' availability set to an arbitrary number (this will help with special missions that provide specific ammo to enemy units)
- A few more fixes for the missing Neural Interface Mode option could cause NPEs when loading older games (this is a must for repros using older 0.50.12 saves)

Testing:
1. Added new unit test for the availMap creator
2. Ran all existing unit tests for all projects
3. Ran tests with the original save game from #8176 

Fix #8176 