### PR TITLE
Fix MegaMek/mekhq#6833: OPFOR ammo ignores campaign year

### DIFF
--- a/megamek/src/megamek/client/generator/TeamLoadOutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadOutGenerator.java
@@ -959,7 +959,7 @@ public class TeamLoadOutGenerator {
             enemyEntities.clear();
         }
 
-        return generateParameters(ownEntities,
+        ReconfigurationParameters rp = generateParameters(ownEntities,
               enemyEntities,
               friendlyFaction,
               enemyFactions,
@@ -969,6 +969,9 @@ public class TeamLoadOutGenerator {
               spaceEnvironment,
               rating,
               fillRatio);
+        // Propagate the game's allowed year so munition selection respects campaign era
+        rp.allowedYear = gOpts.intOption(OptionsConstants.ALLOWED_YEAR);
+        return rp;
     }
 
     public static ReconfigurationParameters generateParameters(ArrayList<Entity> ownTeamEntities,

--- a/megamek/unittests/megamek/client/generator/TeamLoadOutGeneratorTest.java
+++ b/megamek/unittests/megamek/client/generator/TeamLoadOutGeneratorTest.java
@@ -140,6 +140,34 @@ class TeamLoadOutGeneratorTest {
     void generateParameters() {
     }
 
+    /**
+     * Regression test for MekHQ #6833: the static {@code generateParameters} overload that takes
+     * {@link GameOptions} must propagate {@link OptionsConstants#ALLOWED_YEAR} onto the returned
+     * {@link ReconfigurationParameters}. Without this, the munition selection logic always behaves
+     * as if it were 3151, allowing post-Clan-Invasion ammo (e.g. Tandem-Charge SRMs) to appear
+     * on units in early-era campaigns.
+     */
+    @Test
+    void generateParametersPropagatesAllowedYearFromGameOptions() {
+        when(mockGameOptions.intOption(OptionsConstants.ALLOWED_YEAR)).thenReturn(3014);
+
+        ArrayList<Entity> ownEntities = new ArrayList<>();
+        ownEntities.add(createMek("Atlas", "AS7-D", "Pilot"));
+
+        ReconfigurationParameters rp = TeamLoadOutGenerator.generateParameters(
+              game,
+              mockGameOptions,
+              ownEntities,
+              "FS",
+              new ArrayList<>(),
+              new ArrayList<>(),
+              ForceDescriptor.RATING_5,
+              1.0f);
+
+        assertEquals(3014, rp.allowedYear,
+              "generateParameters must propagate GameOptions ALLOWED_YEAR to ReconfigurationParameters.allowedYear");
+    }
+
     @Test
     void generateMunitionTree() {
     }


### PR DESCRIPTION
Fix MegaMek/mekhq#6833: OPFOR ammo ignores campaign year

## Summary

`TeamLoadOutGenerator.generateParameters(Game, GameOptions, ...)` returned a `ReconfigurationParameters` with `allowedYear` left at its default of **3151**, regardless of the actual game year.

`ReconfigurationParameters.allowedYear` is consumed by the munition weighting logic, so the wrong value silently allowed anachronistic munitions through.

## Fix

Set `rp.allowedYear = gOpts.intOption(OptionsConstants.ALLOWED_YEAR)` in the chokepoint static overload of `generateParameters`. All other overloads funnel through it, so every `ReconfigurationParameters` returned now carries
the correct year without any caller-side change.

## Scope

Munition selection only. Unit generation, BV, equipment legality on chassis, etc. are handled through other code paths that already pass the campaign year correctly.

Fixes MegaMek/mekhq#6833