### PR TITLE
Adding NLRT and ammo

### DIFF
--- a/megamek/src/megamek/common/actions/compute/ComputeToHitIsImpossible.java
+++ b/megamek/src/megamek/common/actions/compute/ComputeToHitIsImpossible.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -541,17 +541,15 @@ class ComputeToHitIsImpossible {
         }
 
         // Torpedoes must remain in the water over their whole path to the target
-        if ((ammoType != null) &&
-              ((ammoType.getAmmoType() == LRM_TORPEDO) ||
-                    (ammoType.getAmmoType() == SRM_TORPEDO) ||
-                    (((ammoType.getAmmoType() == SRM) ||
-                          (ammoType.getAmmoType() == SRM_IMP) ||
-                          (ammoType.getAmmoType() == MRM) ||
-                          (ammoType.getAmmoType() == LRM) ||
-                          (ammoType.getAmmoType() == LRM_IMP) ||
-                          (ammoType.getAmmoType() == MML)) &&
-                          (ammoType.getMunitionType().contains(AmmoType.Munitions.M_TORPEDO)))) &&
-              (los.getMinimumWaterDepth() < 1)) {
+        if ((ammoType != null) && (ammoType.getAmmoType().isTorpedo()
+              || (((ammoType.getAmmoType() == SRM)
+              || (ammoType.getAmmoType() == SRM_IMP)
+              || (ammoType.getAmmoType() == MRM)
+              || (ammoType.getAmmoType() == LRM)
+              || (ammoType.getAmmoType() == LRM_IMP)
+              || (ammoType.getAmmoType() == MML))
+              && (ammoType.getMunitionType().contains(AmmoType.Munitions.M_TORPEDO))))
+              && (los.getMinimumWaterDepth() < 1)) {
             return Messages.getString("WeaponAttackAction.TorpOutOfWater");
         }
 

--- a/megamek/src/megamek/common/actions/compute/ComputeToHitIsImpossible.java
+++ b/megamek/src/megamek/common/actions/compute/ComputeToHitIsImpossible.java
@@ -541,7 +541,7 @@ class ComputeToHitIsImpossible {
         }
 
         // Torpedoes must remain in the water over their whole path to the target
-        if ((ammoType != null) && (ammoType.getAmmoType().isTorpedo()
+        if ((ammoType != null) && (ammoType.getAmmoType() != null && ammoType.getAmmoType().isTorpedo()
               || (((ammoType.getAmmoType() == SRM)
               || (ammoType.getAmmoType() == SRM_IMP)
               || (ammoType.getAmmoType() == MRM)
@@ -550,6 +550,7 @@ class ComputeToHitIsImpossible {
               || (ammoType.getAmmoType() == MML))
               && (ammoType.getMunitionType().contains(AmmoType.Munitions.M_TORPEDO))))
               && (los.getMinimumWaterDepth() < 1)) {
+
             return Messages.getString("WeaponAttackAction.TorpOutOfWater");
         }
 

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -1463,8 +1463,7 @@ public class Compute {
             }
         } else if (targetUnderwater) {
             return new ToHitData(TargetRoll.IMPOSSIBLE, "Target underwater, but not weapon.");
-        } else if ((weaponType.getAmmoType() == AmmoTypeEnum.LRM_TORPEDO)
-              || (weaponType.getAmmoType() == AmmoTypeEnum.SRM_TORPEDO)) {
+        } else if (weaponType.getAmmoType() != null && weaponType.getAmmoType().isTorpedo()) {
             // Torpedoes only fire underwater.
             return new ToHitData(TargetRoll.IMPOSSIBLE, "Weapon can only fire underwater.");
         }

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2002-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2002-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -1411,8 +1411,7 @@ public class Compute {
 
         // allow naval units to target underwater units,
         // torpedo tubes are mounted underwater
-        if ((targetUnderwater || (weaponType.getAmmoType() == AmmoTypeEnum.LRM_TORPEDO) ||
-              (weaponType.getAmmoType() == AmmoTypeEnum.SRM_TORPEDO))
+        if ((targetUnderwater || weaponType.getAmmoType().isTorpedo())
               && (attackingEntity.getUnitType() == UnitType.NAVAL)) {
             weaponUnderwater = true;
             weaponRanges = weaponType.getWRanges();
@@ -7225,7 +7224,7 @@ public class Compute {
                 switch (ammoType.getAmmoType()) {
                     case SRM_STREAK, LRM_STREAK, LRM, LRM_IMP, LRM_TORPEDO, SRM, SRM_IMP, SRM_TORPEDO, MRM, NARC,
                          INARC, AMS, ARROW_IV, LONG_TOM, SNIPER, THUMPER, SRM_ADVANCED, LRM_TORPEDO_COMBO, ATM, IATM,
-                         MML, EXLRM, NLRM, TBOLT_5, TBOLT_10, TBOLT_15, TBOLT_20, HAG, ROCKET_LAUNCHER -> {
+                         MML, EXLRM, NLRM, NLRM_TORPEDO, TBOLT_5, TBOLT_10, TBOLT_15, TBOLT_20, HAG, ROCKET_LAUNCHER -> {
                         return false;
                     }
                     default -> {

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -1411,7 +1411,7 @@ public class Compute {
 
         // allow naval units to target underwater units,
         // torpedo tubes are mounted underwater
-        if ((targetUnderwater || weaponType.getAmmoType().isTorpedo())
+        if ((targetUnderwater || (weaponType.getAmmoType() != null && weaponType.getAmmoType().isTorpedo()))
               && (attackingEntity.getUnitType() == UnitType.NAVAL)) {
             weaponUnderwater = true;
             weaponRanges = weaponType.getWRanges();

--- a/megamek/src/megamek/common/equipment/AmmoType.java
+++ b/megamek/src/megamek/common/equipment/AmmoType.java
@@ -258,6 +258,7 @@ public class AmmoType extends EquipmentType {
                                                                   AmmoTypeEnum.MRM, AmmoTypeEnum.ROCKET_LAUNCHER,
                                                                   AmmoTypeEnum.EXLRM, AmmoTypeEnum.MML,
                                                                   AmmoTypeEnum.NLRM,
+                                                                  AmmoTypeEnum.NLRM_TORPEDO,
                                                                   AmmoTypeEnum.MG, AmmoTypeEnum.MG_LIGHT,
                                                                   AmmoTypeEnum.MG_HEAVY,
                                                                   AmmoTypeEnum.NAIL_RIVET_GUN, AmmoTypeEnum.ATM,

--- a/megamek/src/megamek/common/equipment/AmmoType.java
+++ b/megamek/src/megamek/common/equipment/AmmoType.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2004, 2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2018-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -191,7 +191,8 @@ public class AmmoType extends EquipmentType {
         KILLER_WHALE_T(110, "Killer Whale-T", AmmoCategory.Missile),
         WHITE_SHARK_T(111, "White Shark-T", AmmoCategory.Missile),
         BARRACUDA_T(112, "Barracuda-T", AmmoCategory.Missile),
-        INFANTRY(113, "Infantry", AmmoCategory.Special);
+        INFANTRY(113, "Infantry", AmmoCategory.Special),
+        NLRM_TORPEDO(114, "NLRM Torpedo", AmmoCategory.Missile);
 
         private static final Map<Integer, AmmoTypeEnum> INDEX_LOOKUP = new HashMap<>();
 
@@ -239,6 +240,10 @@ public class AmmoType extends EquipmentType {
          */
         public boolean isAnyOf(AmmoTypeEnum type, AmmoTypeEnum... otherTypes) {
             return (this == type) || Arrays.stream(otherTypes).anyMatch(t -> this == t);
+        }
+
+        public boolean isTorpedo() {
+            return this == LRM_TORPEDO || this == SRM_TORPEDO || this == NLRM_TORPEDO;
         }
     }
 
@@ -2623,6 +2628,7 @@ public class AmmoType extends EquipmentType {
         ArrayList<AmmoType> mortarAmmos = new ArrayList<>(4);
         ArrayList<AmmoType> clanMortarAmmos = new ArrayList<>(4);
         ArrayList<AmmoType> lrtAmmos = new ArrayList<>(26);
+        ArrayList<AmmoType> enhancedLrtAmmos = new ArrayList<>(26);
         ArrayList<AmmoType> clanLrtAmmos = new ArrayList<>();
         ArrayList<AmmoType> srtAmmos = new ArrayList<>(26);
         ArrayList<AmmoType> clanSrtAmmos = new ArrayList<>();
@@ -3352,6 +3358,19 @@ public class AmmoType extends EquipmentType {
         EquipmentType.addType(AmmoType.createISLRT15Ammo());
         EquipmentType.addType(AmmoType.createISLRT20Ammo());
 
+        base = AmmoType.createISEnhancedLRT5Ammo();
+        enhancedLrtAmmos.add(base);
+        EquipmentType.addType(base);
+        base = AmmoType.createISEnhancedLRT10Ammo();
+        enhancedLrtAmmos.add(base);
+        EquipmentType.addType(base);
+        base = AmmoType.createISEnhancedLRT15Ammo();
+        enhancedLrtAmmos.add(base);
+        EquipmentType.addType(base);
+        base = AmmoType.createISEnhancedLRT20Ammo();
+        enhancedLrtAmmos.add(base);
+        EquipmentType.addType(base);
+
         base = AmmoType.createISSRT2Ammo();
         srtAmmos.add(base);
         base = AmmoType.createISSRT4Ammo();
@@ -3695,6 +3714,7 @@ public class AmmoType extends EquipmentType {
         munitions.add(ARTEMIS_CAPABLE_MUNITION_MUTATOR);
         AmmoType.createMunitions(srtAmmos, munitions);
         AmmoType.createMunitions(lrtAmmos, munitions);
+        AmmoType.createMunitions(enhancedLrtAmmos, munitions);
 
         // Create the munition types for Clan SRT launchers.
         munitions.clear();
@@ -7896,6 +7916,113 @@ public class AmmoType extends EquipmentType {
         ammo.damagePerShot = 1;
         ammo.rackSize = 20;
         ammo.ammoType = AmmoTypeEnum.NLRM;
+        ammo.shots = 6;
+        ammo.flags = ammo.flags.or(F_HOTLOAD);
+        ammo.setModes("", "HotLoad");
+        ammo.bv = 26;
+        ammo.cost = 31000;
+        ammo.rulesRefs = "138, TO:AUE";
+        // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
+        ammo.techAdvancement.setTechBase(TechBase.IS)
+              .setTechRating(TechRating.E)
+              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.F, AvailabilityValue.E)
+              .setISAdvancement(3058, DATE_NONE, 3082, DATE_NONE, DATE_NONE)
+              .setPrototypeFactions(Faction.FS)
+              .setProductionFactions(Faction.FS)
+              .setStaticTechLevel(SimpleTechLevel.STANDARD);
+        return ammo;
+    }
+
+    // Enhanced LRTs
+
+    private static AmmoType createISEnhancedLRT5Ammo() {
+        AmmoType ammo = new AmmoType();
+
+        ammo.name = "Enhanced LRT 5 Ammo";
+        ammo.shortName = "NLRT 5";
+        ammo.setInternalName("ISEnhancedLRT5 Ammo");
+        ammo.damagePerShot = 1;
+        ammo.rackSize = 5;
+        ammo.ammoType = AmmoTypeEnum.NLRM_TORPEDO;
+        ammo.shots = 24;
+        ammo.flags = ammo.flags.or(F_HOTLOAD);
+        ammo.setModes("", "HotLoad");
+        ammo.bv = 7;
+        ammo.cost = 31000;
+        ammo.rulesRefs = "138, TO:AUE";
+        // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
+        ammo.techAdvancement.setTechBase(TechBase.IS)
+              .setTechRating(TechRating.E)
+              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.F, AvailabilityValue.E)
+              .setISAdvancement(3058, DATE_NONE, 3082, DATE_NONE, DATE_NONE)
+              .setPrototypeFactions(Faction.FS)
+              .setProductionFactions(Faction.FS)
+              .setStaticTechLevel(SimpleTechLevel.STANDARD);
+
+        return ammo;
+    }
+
+    private static AmmoType createISEnhancedLRT10Ammo() {
+        AmmoType ammo = new AmmoType();
+
+        ammo.name = "Enhanced LRT 10 Ammo";
+        ammo.shortName = "NLRT 10";
+        ammo.setInternalName("ISEnhancedLRT10 Ammo");
+        ammo.damagePerShot = 1;
+        ammo.rackSize = 10;
+        ammo.ammoType = AmmoTypeEnum.NLRM_TORPEDO;
+        ammo.shots = 12;
+        ammo.flags = ammo.flags.or(F_HOTLOAD);
+        ammo.setModes("", "HotLoad");
+        ammo.bv = 13;
+        ammo.cost = 31000;
+        ammo.rulesRefs = "138, TO:AUE";
+        // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
+        ammo.techAdvancement.setTechBase(TechBase.IS)
+              .setTechRating(TechRating.E)
+              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.F, AvailabilityValue.E)
+              .setISAdvancement(3058, DATE_NONE, 3082, DATE_NONE, DATE_NONE)
+              .setPrototypeFactions(Faction.FS)
+              .setProductionFactions(Faction.FS)
+              .setStaticTechLevel(SimpleTechLevel.STANDARD);
+        return ammo;
+    }
+
+    private static AmmoType createISEnhancedLRT15Ammo() {
+        AmmoType ammo = new AmmoType();
+
+        ammo.name = "Enhanced LRT 15 Ammo";
+        ammo.shortName = "NLRT 15";
+        ammo.setInternalName("ISEnhancedLRT15 Ammo");
+        ammo.damagePerShot = 1;
+        ammo.rackSize = 15;
+        ammo.ammoType = AmmoTypeEnum.NLRM_TORPEDO;
+        ammo.shots = 8;
+        ammo.flags = ammo.flags.or(F_HOTLOAD);
+        ammo.setModes("", "HotLoad");
+        ammo.bv = 20;
+        ammo.cost = 31000;
+        ammo.rulesRefs = "138, TO:AUE";
+        // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
+        ammo.techAdvancement.setTechBase(TechBase.IS)
+              .setTechRating(TechRating.E)
+              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.F, AvailabilityValue.E)
+              .setISAdvancement(3058, DATE_NONE, 3082, DATE_NONE, DATE_NONE)
+              .setPrototypeFactions(Faction.FS)
+              .setProductionFactions(Faction.FS)
+              .setStaticTechLevel(SimpleTechLevel.STANDARD);
+        return ammo;
+    }
+
+    private static AmmoType createISEnhancedLRT20Ammo() {
+        AmmoType ammo = new AmmoType();
+
+        ammo.name = "Enhanced LRT 20 Ammo";
+        ammo.shortName = "NLRT 20";
+        ammo.setInternalName("ISEnhancedLRT20 Ammo");
+        ammo.damagePerShot = 1;
+        ammo.rackSize = 20;
+        ammo.ammoType = AmmoTypeEnum.NLRM_TORPEDO;
         ammo.shots = 6;
         ammo.flags = ammo.flags.or(F_HOTLOAD);
         ammo.setModes("", "HotLoad");
@@ -16047,6 +16174,7 @@ public class AmmoType extends EquipmentType {
                 case NLRM:
                 case SRM_TORPEDO:
                 case LRM_TORPEDO:
+                case NLRM_TORPEDO:
                     // Add the munition name to the end of some ammo names.
                     nameBuf = new StringBuilder(" ");
                     nameBuf.append(name);

--- a/megamek/src/megamek/common/equipment/EquipmentTypeLookup.java
+++ b/megamek/src/megamek/common/equipment/EquipmentTypeLookup.java
@@ -377,4 +377,13 @@ public class EquipmentTypeLookup {
 
     @EquipmentName
     public static final String SV_EXTERNAL_HARDPOINT = "External Stores Hardpoint";
+
+    @EquipmentName
+    public static final String NLRT5 = "ISNLRT05";
+    @EquipmentName
+    public static final String NLRT10 = "ISNLRT10";
+    @EquipmentName
+    public static final String NLRT15 = "ISNLRT15";
+    @EquipmentName
+    public static final String NLRT20 = "ISNLRT20";
 }

--- a/megamek/src/megamek/common/equipment/WeaponType.java
+++ b/megamek/src/megamek/common/equipment/WeaponType.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2002-2007 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2002-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2002-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -309,6 +309,10 @@ import megamek.common.weapons.lrms.innerSphere.oneShot.ISLRM20IOS;
 import megamek.common.weapons.lrms.innerSphere.oneShot.ISLRM20OS;
 import megamek.common.weapons.lrms.innerSphere.oneShot.ISLRM5IOS;
 import megamek.common.weapons.lrms.innerSphere.oneShot.ISLRM5OS;
+import megamek.common.weapons.lrms.innerSphere.torpedo.ISEnhancedLRT10;
+import megamek.common.weapons.lrms.innerSphere.torpedo.ISEnhancedLRT15;
+import megamek.common.weapons.lrms.innerSphere.torpedo.ISEnhancedLRT20;
+import megamek.common.weapons.lrms.innerSphere.torpedo.ISEnhancedLRT5;
 import megamek.common.weapons.lrms.innerSphere.torpedo.ISLRT10;
 import megamek.common.weapons.lrms.innerSphere.torpedo.ISLRT15;
 import megamek.common.weapons.lrms.innerSphere.torpedo.ISLRT20;
@@ -1548,6 +1552,10 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new ISLRM10Primitive());
         EquipmentType.addType(new ISLRM15Primitive());
         EquipmentType.addType(new ISLRM20Primitive());
+        EquipmentType.addType(new ISEnhancedLRT5());
+        EquipmentType.addType(new ISEnhancedLRT10());
+        EquipmentType.addType(new ISEnhancedLRT15());
+        EquipmentType.addType(new ISEnhancedLRT20());
 
         // LRTs
         EquipmentType.addType(new ISLRT5());

--- a/megamek/src/megamek/common/weapons/lrms/EnhancedLRTWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/EnhancedLRTWeapon.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.weapons.lrms;
+
+import megamek.common.SimpleTechLevel;
+import megamek.common.enums.AvailabilityValue;
+import megamek.common.enums.Faction;
+import megamek.common.enums.TechBase;
+import megamek.common.enums.TechRating;
+import megamek.common.equipment.AmmoType;
+
+public abstract class EnhancedLRTWeapon extends LRTWeapon {
+
+    public EnhancedLRTWeapon() {
+        minimumRange = 3;
+        waterShortRange = 7;
+        waterMediumRange = 14;
+        waterLongRange = 21;
+        waterExtremeRange = 28;
+        maxRange = RANGE_LONG;
+        ammoType = AmmoType.AmmoTypeEnum.NLRM_TORPEDO;
+        rulesRefs = "138, TO:AUE";
+        //Tech Progression taken from NLRMs
+        techAdvancement.setTechBase(TechBase.IS).setTechRating(TechRating.E)
+              .setAvailability(AvailabilityValue.C, AvailabilityValue.F, AvailabilityValue.E, AvailabilityValue.D)
+              .setISAdvancement(3058, DATE_NONE, 3082).setPrototypeFactions(Faction.FS)
+              .setProductionFactions(Faction.FS).setStaticTechLevel(SimpleTechLevel.STANDARD);
+    }
+
+    @Override
+    public String getSortingName() {
+        return "Enhanced LRT " + ((rackSize < 10) ? "0" + rackSize : rackSize);
+    }
+}

--- a/megamek/src/megamek/common/weapons/lrms/innerSphere/torpedo/ISEnhancedLRT10.java
+++ b/megamek/src/megamek/common/weapons/lrms/innerSphere/torpedo/ISEnhancedLRT10.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.weapons.lrms.innerSphere.torpedo;
+
+import megamek.common.SimpleTechLevel;
+import megamek.common.enums.AvailabilityValue;
+import megamek.common.enums.Faction;
+import megamek.common.enums.TechBase;
+import megamek.common.enums.TechRating;
+import megamek.common.equipment.EquipmentTypeLookup;
+import megamek.common.weapons.lrms.EnhancedLRTWeapon;
+
+public class ISEnhancedLRT10 extends EnhancedLRTWeapon {
+
+    public ISEnhancedLRT10() {
+        name = "Enhanced LRT 10";
+        setInternalName(EquipmentTypeLookup.NLRT10);
+        heat = 4;
+        rackSize = 10;
+        tonnage = 6.0;
+        criticalSlots = 4;
+        bv = 104;
+        cost = 125000;
+        shortAV = 6;
+        medAV = 6;
+        longAV = 6;
+    }
+}

--- a/megamek/src/megamek/common/weapons/lrms/innerSphere/torpedo/ISEnhancedLRT10.java
+++ b/megamek/src/megamek/common/weapons/lrms/innerSphere/torpedo/ISEnhancedLRT10.java
@@ -33,11 +33,6 @@
 
 package megamek.common.weapons.lrms.innerSphere.torpedo;
 
-import megamek.common.SimpleTechLevel;
-import megamek.common.enums.AvailabilityValue;
-import megamek.common.enums.Faction;
-import megamek.common.enums.TechBase;
-import megamek.common.enums.TechRating;
 import megamek.common.equipment.EquipmentTypeLookup;
 import megamek.common.weapons.lrms.EnhancedLRTWeapon;
 

--- a/megamek/src/megamek/common/weapons/lrms/innerSphere/torpedo/ISEnhancedLRT15.java
+++ b/megamek/src/megamek/common/weapons/lrms/innerSphere/torpedo/ISEnhancedLRT15.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.weapons.lrms.innerSphere.torpedo;
+
+import megamek.common.equipment.EquipmentTypeLookup;
+import megamek.common.weapons.lrms.EnhancedLRTWeapon;
+
+public class ISEnhancedLRT15 extends EnhancedLRTWeapon {
+
+    public ISEnhancedLRT15() {
+        name = "Enhanced LRT 15";
+        setInternalName(EquipmentTypeLookup.NLRT15);
+        heat = 5;
+        rackSize = 15;
+        tonnage = 9.0;
+        criticalSlots = 6;
+        bv = 157;
+        cost = 218750;
+        shortAV = 9;
+        medAV = 9;
+        longAV = 9;
+    }
+}

--- a/megamek/src/megamek/common/weapons/lrms/innerSphere/torpedo/ISEnhancedLRT20.java
+++ b/megamek/src/megamek/common/weapons/lrms/innerSphere/torpedo/ISEnhancedLRT20.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.weapons.lrms.innerSphere.torpedo;
+
+import megamek.common.equipment.EquipmentTypeLookup;
+import megamek.common.weapons.lrms.EnhancedLRTWeapon;
+
+public class ISEnhancedLRT20 extends EnhancedLRTWeapon {
+
+    public ISEnhancedLRT20() {
+        name = "Enhanced LRT 20";
+        setInternalName(EquipmentTypeLookup.NLRT20);
+        heat = 6;
+        rackSize = 20;
+        tonnage = 12.0;
+        criticalSlots = 9;
+        bv = 210;
+        cost = 312500;
+        shortAV = 12;
+        medAV = 12;
+        longAV = 12;
+    }
+}

--- a/megamek/src/megamek/common/weapons/lrms/innerSphere/torpedo/ISEnhancedLRT5.java
+++ b/megamek/src/megamek/common/weapons/lrms/innerSphere/torpedo/ISEnhancedLRT5.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.weapons.lrms.innerSphere.torpedo;
+
+import megamek.common.equipment.EquipmentTypeLookup;
+import megamek.common.weapons.lrms.EnhancedLRTWeapon;
+
+public class ISEnhancedLRT5 extends EnhancedLRTWeapon {
+
+    public ISEnhancedLRT5() {
+        name = "Enhanced LRT 5";
+        setInternalName(EquipmentTypeLookup.NLRT5);
+        heat = 2;
+        rackSize = 5;
+        tonnage = 3.0;
+        criticalSlots = 2;
+        bv = 52;
+        cost = 37500;
+        shortAV = 3;
+        medAV = 3;
+        longAV = 3;
+    }
+}

--- a/megamek/unittests/megamek/common/WeaponTypeTest.java
+++ b/megamek/unittests/megamek/common/WeaponTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -65,15 +65,16 @@ class WeaponTypeTest {
                 AmmoTypeEnum ammoType = weaponType.getAmmoType();
 
                 assertEquals(equipmentType.hasFlag(WeaponType.F_ARTEMIS_COMPATIBLE),
-                      (ammoType == AmmoType.AmmoTypeEnum.LRM)
-                            || (ammoType == AmmoType.AmmoTypeEnum.LRM_IMP)
-                            || (ammoType == AmmoType.AmmoTypeEnum.MML)
-                            || (ammoType == AmmoType.AmmoTypeEnum.SRM)
-                            || (ammoType == AmmoType.AmmoTypeEnum.SRM_IMP)
-                            || (ammoType == AmmoType.AmmoTypeEnum.NLRM)
-                            || (ammoType == AmmoType.AmmoTypeEnum.LRM_TORPEDO)
-                            || (ammoType == AmmoType.AmmoTypeEnum.SRM_TORPEDO)
-                            || (ammoType == AmmoType.AmmoTypeEnum.LRM_TORPEDO_COMBO));
+                      (ammoType == AmmoTypeEnum.LRM)
+                            || (ammoType == AmmoTypeEnum.LRM_IMP)
+                            || (ammoType == AmmoTypeEnum.MML)
+                            || (ammoType == AmmoTypeEnum.SRM)
+                            || (ammoType == AmmoTypeEnum.SRM_IMP)
+                            || (ammoType == AmmoTypeEnum.NLRM)
+                            || (ammoType == AmmoTypeEnum.LRM_TORPEDO)
+                            || (ammoType == AmmoTypeEnum.SRM_TORPEDO)
+                            || (ammoType == AmmoTypeEnum.NLRM_TORPEDO)
+                            || (ammoType == AmmoTypeEnum.LRM_TORPEDO_COMBO));
             }
         }
     }

--- a/megamek/unittests/megamek/common/actions/WeaponAttackActionToHitTest.java
+++ b/megamek/unittests/megamek/common/actions/WeaponAttackActionToHitTest.java
@@ -53,6 +53,7 @@ import megamek.common.Hex;
 import megamek.common.LosEffects;
 import megamek.common.Player;
 import megamek.common.ToHitData;
+import megamek.common.WoodsClearingTracker;
 import megamek.common.board.Board;
 import megamek.common.board.Coords;
 import megamek.common.compute.Compute;
@@ -682,6 +683,8 @@ public class WeaponAttackActionToHitTest {
             GamePhase mockGamePhase = mock(GamePhase.class);
             when(mockGame.getPhase()).thenReturn(mockGamePhase);
             when(mockGamePhase.isLounge()).thenReturn(true);
+            WoodsClearingTracker mockWoodsClearingTracker = new WoodsClearingTracker();
+            when(mockGame.getWoodsClearingTracker()).thenReturn(mockWoodsClearingTracker);
 
             TWGameManager gameManager = new TWGameManager();
             gameManager.setGame(mockGame);


### PR DESCRIPTION
Fixes Megamek/megameklab#1879
There is a parallel MML PR that should be merged with or after this one.

Adds Enhanced LRTs per TO:AUE p.139. No OS versions, ammo only standard and artemis in line with NLRMs.

first in-game test, first shot...
<img width="1794" height="759" alt="image" src="https://github.com/user-attachments/assets/28ce6166-05ac-461d-a553-58b7899a652d" />
