### PR TITLE
Constructor removal for Packet

### DIFF
--- a/megamek/src/megamek/common/net/packets/Packet.java
+++ b/megamek/src/megamek/common/net/packets/Packet.java
@@ -96,14 +96,6 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
     public Packet {
     }
 
-    public Packet(PacketCommand command, List<Object> listData) {
-        this(command, new Object[listData.size()]);
-        
-        for (int i = 0; i < listData.size(); i++) {
-            this.data[i] = listData.get(i);
-        }
-    }
-
     /**
      * @return the command associated.
      */

--- a/megamek/src/megamek/common/net/packets/Packet.java
+++ b/megamek/src/megamek/common/net/packets/Packet.java
@@ -96,6 +96,14 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
     public Packet {
     }
 
+    public Packet(PacketCommand command, List<Object> listData) {
+        this(command, new Object[listData.size()]);
+
+        for (int i = 0; i < listData.size(); i++) {
+            this.data[i] = listData.get(i);
+        }
+    }
+
     /**
      * @return the command associated.
      */

--- a/megamek/src/megamek/common/net/packets/Packet.java
+++ b/megamek/src/megamek/common/net/packets/Packet.java
@@ -96,14 +96,6 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
     public Packet {
     }
 
-    public Packet(PacketCommand command, List<Object> listData) {
-        this(command, new Object[listData.size()]);
-
-        for (int i = 0; i < listData.size(); i++) {
-            this.data[i] = listData.get(i);
-        }
-    }
-
     /**
      * @return the command associated.
      */


### PR DESCRIPTION
Removing a type specific constructor for Packet. MM is not ready for it just yet and is causing issues found in J21 Update code.

My bad.