### PR TITLE
Fix 8233: NPE during reactive armor crit if any slots were empty

### DIFF
--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -23406,7 +23406,7 @@ public class TWGameManager extends AbstractGameManager {
                             boolean allHittableCritsReactive = true;
                             for (int i = 0; i < en.getNumberOfCriticalSlots(loc); i++) {
                                 CriticalSlot crit = en.getCritical(loc, i);
-                                if (crit.isHittable()) {
+                                if (crit != null && crit.isHittable()) {
                                     allHittableCritsReactive = false;
                                     break;
                                 }

--- a/megamek/unittests/megamek/server/totalWarfare/TWGameManagerTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/TWGameManagerTest.java
@@ -33,6 +33,7 @@
 package megamek.server.totalWarfare;
 
 import static megamek.common.CargoBayTest.createInfantry;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -52,11 +53,16 @@ import megamek.common.board.Board;
 import megamek.common.board.Coords;
 import megamek.common.enums.BasementType;
 import megamek.common.enums.MoveStepType;
+import megamek.common.equipment.ArmorType;
 import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.Mounted;
+import megamek.common.equipment.MountedHelper;
+import megamek.common.exceptions.LocationFullException;
 import megamek.common.game.Game;
 import megamek.common.moves.MovePath;
 import megamek.common.rolls.PilotingRollData;
 import megamek.common.units.*;
+import megamek.common.weapons.DamageType;
 import megamek.server.Server;
 import megamek.utils.ServerFactory;
 import org.junit.jupiter.api.BeforeAll;
@@ -859,7 +865,77 @@ class TWGameManagerTest {
             assertTrue(infantryDamageReported, "Infantry inside building should also take damage");
         }
     }
+
+    @Test
+    void testCriticalEntityAllReactiveSlots() throws LocationFullException {
+        // Verify that reactive armor crit handling in cases with full crit slots is safe.
+        BipedMek mek = new BipedMek();
+
+        // Configure Reactive armor
+        mek.setArmorType(EquipmentType.T_ARMOR_REACTIVE);
+        mek.setArmor(10, Mek.LOC_LEFT_TORSO);
+
+        ArmorType reactiveType = ArmorType.of(ArmorType.T_ARMOR_REACTIVE, false);
+
+
+        // Initialize armor critical slots (normally done by unit loader)
+        for (int i=1; i<=12; i++) {
+            Mounted reactiveMounted = Mounted.createMounted(mek, reactiveType);
+            mek.addEquipment(reactiveMounted, Mek.LOC_LEFT_TORSO, false);
+            //mek.setCritical(Mek.LOC_LEFT_TORSO, i, new CriticalSlot(reactiveMounted));
+        }
+
+        game.addEntity(mek);
+
+        // Apply single armor crit
+        assertDoesNotThrow(() ->
+            gameManager.criticalEntity(
+                  mek,
+                  Mek.LOC_LEFT_TORSO,
+                  false,
+                  0,
+                  false,
+                  false,
+                  1,
+                  DamageType.NONE
+            )
+        );
+    }
+
+    @Test
+    void testCriticalEntityAllButOneReactiveSlots() throws LocationFullException {
+        // Verify that reactive armor crit handling in cases with one empty slot.
+        BipedMek mek = new BipedMek();
+
+        // Configure Reactive armor
+        mek.setArmorType(EquipmentType.T_ARMOR_REACTIVE);
+        mek.setArmor(10, Mek.LOC_LEFT_TORSO);
+
+        ArmorType reactiveType = ArmorType.of(ArmorType.T_ARMOR_REACTIVE, false);
+
+
+        // Initialize armor critical slots (normally done by unit loader)
+        // Note that we leave one slot empty in this case
+        for (int i=1; i<=11; i++) {
+            Mounted reactiveMounted = Mounted.createMounted(mek, reactiveType);
+            mek.addEquipment(reactiveMounted, Mek.LOC_LEFT_TORSO, false);
+            //mek.setCritical(Mek.LOC_LEFT_TORSO, i, new CriticalSlot(reactiveMounted));
+        }
+
+        game.addEntity(mek);
+
+        // Apply single armor crit
+        assertDoesNotThrow(() ->
+              gameManager.criticalEntity(
+                    mek,
+                    Mek.LOC_LEFT_TORSO,
+                    false,
+                    0,
+                    false,
+                    false,
+                    1,
+                    DamageType.NONE
+              )
+        );
+    }
 }
-
-
-

--- a/megamek/unittests/megamek/server/totalWarfare/TWGameManagerTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/TWGameManagerTest.java
@@ -877,12 +877,10 @@ class TWGameManagerTest {
 
         ArmorType reactiveType = ArmorType.of(ArmorType.T_ARMOR_REACTIVE, false);
 
-
         // Initialize armor critical slots (normally done by unit loader)
         for (int i=1; i<=12; i++) {
             Mounted reactiveMounted = Mounted.createMounted(mek, reactiveType);
             mek.addEquipment(reactiveMounted, Mek.LOC_LEFT_TORSO, false);
-            //mek.setCritical(Mek.LOC_LEFT_TORSO, i, new CriticalSlot(reactiveMounted));
         }
 
         game.addEntity(mek);
@@ -913,13 +911,11 @@ class TWGameManagerTest {
 
         ArmorType reactiveType = ArmorType.of(ArmorType.T_ARMOR_REACTIVE, false);
 
-
         // Initialize armor critical slots (normally done by unit loader)
         // Note that we leave one slot empty in this case
         for (int i=1; i<=11; i++) {
             Mounted reactiveMounted = Mounted.createMounted(mek, reactiveType);
             mek.addEquipment(reactiveMounted, Mek.LOC_LEFT_TORSO, false);
-            //mek.setCritical(Mek.LOC_LEFT_TORSO, i, new CriticalSlot(reactiveMounted));
         }
 
         game.addEntity(mek);


### PR DESCRIPTION
Adds recommended safety check from #8233 

Testing:
- Ran all 3 projects' unit tests
- Added 2 unit tests to verify safety of updated conditional

Fix #8233 