### PR TITLE
Quiet Board.collapseBuilding "no building" error log (Fixes #8229)

### DIFF
--- a/megamek/src/megamek/common/board/Board.java
+++ b/megamek/src/megamek/common/board/Board.java
@@ -1479,7 +1479,12 @@ public class Board implements Serializable {
         // Remove the building from the building map.
         IBuilding bldg = bldgByCoords.get(coords);
         if (bldg == null) {
-            logger.error("No building found at {}", coords);
+            // Expected during multi-hex collapses: the per-coord loop in collapseBuilding(IBuilding) re-enters this
+            // method for each hex of the same building, but bldgByCoords.remove() below clears the entry on the first
+            // pass, so subsequent hexes of the same building land here. Also reached when a caller hands us coords for
+            // a hex with no building (e.g. a fall-through into an adjacent non-building hex). Logging at debug avoids
+            // polluting megamek.log during normal play while preserving the trail for diagnostics.
+            logger.debug("No building found at {}", coords);
             return;
         }
         bldg.removeHex(coords);

--- a/megamek/src/megamek/common/board/Board.java
+++ b/megamek/src/megamek/common/board/Board.java
@@ -1479,10 +1479,10 @@ public class Board implements Serializable {
         // Remove the building from the building map.
         IBuilding bldg = bldgByCoords.get(coords);
         if (bldg == null) {
-            // Expected during multi-hex collapses: the per-coord loop in collapseBuilding(IBuilding) re-enters this
-            // method for each hex of the same building, but bldgByCoords.remove() below clears the entry on the first
-            // pass, so subsequent hexes of the same building land here. Also reached when a caller hands us coords for
-            // a hex with no building (e.g. a fall-through into an adjacent non-building hex). Logging at debug avoids
+            // Reaching this guard is expected when callers hand us coords that do not currently map to a building,
+            // such as a non-building hex, a duplicate collapse request for the same hex, or a coord that was already
+            // processed earlier in the collapse flow. Since bldgByCoords is maintained per hex, removing one coord
+            // below does not by itself clear the other hexes of a multi-hex building. Logging at debug avoids
             // polluting megamek.log during normal play while preserving the trail for diagnostics.
             logger.debug("No building found at {}", coords);
             return;


### PR DESCRIPTION
 ## Summary

  `Board.collapseBuilding(Coords)` logged ERROR every time its null-guard fired, even though the guard catches two expected paths in normal play.  Drops the log to DEBUG and documents both triggers above the call.

 ## Bug Fixed

  - **megamek.log noise**: `collapseBuilding(IBuilding)` iterates a building's hexes and re-enters `collapseBuilding(Coords)` per hex, but `bldgByCoords.remove()` clears the entry on the first pass, so every subsequent hex of a multi-hex building lands in the null-guard. Adjacent non-building hexes from fall-through also reach it. Neither is a fault.
  
  Fixes #8229

  ## Changes

  ### Lower null-guard log level (Board.java)

  - Demote `logger.error` to `logger.debug` at `Board.java:1482`
  - Add a comment above the guard explaining the two expected triggers so future readers don't re-escalate the level

  ## Files Changed

  - `megamek/src/megamek/common/board/Board.java` - log level + explanatory comment

  ## Testing

  - Compile: `./gradlew :megamek:compileJava` clean
  - Manual: ran a Movement Phase scenario where a Mek collapses a building
    and falls into an adjacent hex - megamek.log no longer shows the
    recurring `No building found at Coords (...)` ERROR line

