### PR TITLE
  Fix hex note tooltips by correcting SHD draw-guard operator (Fixes #8228)

### DIFF
--- a/megamek/src/megamek/client/ui/clientGUI/boardview/toolTip/TWBoardViewTooltip.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/toolTip/TWBoardViewTooltip.java
@@ -337,7 +337,7 @@ public class TWBoardViewTooltip implements BoardViewTooltipProvider {
                 // don't show tooltips for SHDs that aren't drawn. The exception is auto hits.  There will be an icon
                 // for auto hits, so we need to draw a tooltip
                 if (!shd.isObscured(localPlayer)
-                      && (shd.drawNow(game.getPhase(), round, localPlayer, GUIP) && isTypeAutoHit)) {
+                      && (shd.drawNow(game.getPhase(), round, localPlayer, GUIP) || isTypeAutoHit)) {
                     if (shd.getType() == SpecialHexDisplay.Type.PLAYER_NOTE) {
                         if (Objects.equals(localPlayer, shd.getOwner())) {
                             sSpecialHex += "Note: ";


### PR DESCRIPTION
  ## Summary

  `TWBoardViewTooltip` filtered every non-auto-hit SpecialHexDisplay out of the hex tooltip body because the guard used `&&` between the per-SHD `drawNow` check and the auto-hit type check. Notes were silently unreadable in tooltips for everyone, including the placer.

  ## Bug Fixed

  - **PLAYER_NOTE never reached the tooltip body**: the guard at `TWBoardViewTooltip.java:340` was `drawNow && isTypeAutoHit`. Since `isTypeAutoHit` is only true for `ARTILLERY_AUTO_HIT`, every other SHD type was skipped. The comment immediately above states the intent ("The exception is auto hits") - the operator should be `||`. Regression from commit 742714f14a (2025-03-27).
  
  Fixes #8228

  ## Changes

  ### Restore the original guard semantics (TWBoardViewTooltip.java)

  - One-character operator swap: `&&` -> `||` between `drawNow(...)` and `isTypeAutoHit` so the body runs when the SHD wants to draw normally *or* when it's an auto-hit (which always shows an icon)

  ## Files Changed

  - `megamek/src/megamek/client/ui/clientGUI/boardview/toolTip/TWBoardViewTooltip.java`
    - operator fix on the SHD tooltip guard

  ## Testing

  - Compile: `./gradlew :megamek:compileJava` clean
  - Manual: loaded the issue's `notes-test.sav.gz` (version-bumped to 0.51.0) and hovered the noted hex - note text now appears in the tooltip with the expected `Note: ...` / `Note (PlayerName): ...` prefix