### PR TITLE
Fix BotClient.toggleStealth NPE on null-position enemies (Fixes #8166)

### DIFF
--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -1271,7 +1271,11 @@ public abstract class BotClient extends Client {
                                     for (Entity test_ent : game.getEntitiesVector()) {
                                         if (check_ent.isEnemyOf(test_ent)) {
                                             total_bv += test_ent.calculateBattleValue();
-                                            if (test_ent.isVisibleToEnemy()) {
+                                            // Skip enemies without a position (off-board, not yet deployed, in
+                                            // transport, etc.) - we can't measure distance to them, and including
+                                            // them in the count/BV would skew the (known_range / known_count)
+                                            // average. Mirrors the check_ent null-position guard above.
+                                            if (test_ent.isVisibleToEnemy() && (test_ent.getPosition() != null)) {
                                                 known_count++;
                                                 known_bv += test_ent.calculateBattleValue();
                                                 known_range += Compute.effectiveDistance(game, check_ent, test_ent);

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -1275,7 +1275,7 @@ public abstract class BotClient extends Client {
                                             // transport, etc.) - we can't measure distance to them, and including
                                             // them in the count/BV would skew the (known_range / known_count)
                                             // average. Mirrors the check_ent null-position guard above.
-                                            if (test_ent.isVisibleToEnemy() && (test_ent.getPosition() != null)) {
+                                            if ((test_ent.getPosition() != null) && test_ent.isVisibleToEnemy()) {
                                                 known_count++;
                                                 known_bv += test_ent.calculateBattleValue();
                                                 known_range += Compute.effectiveDistance(game, check_ent, test_ent);


### PR DESCRIPTION
 ## Summary

  `BotClient.toggleStealth()` iterated all enemies and called `Compute.effectiveDistance(check_ent, test_ent)` for any enemy that was `isVisibleToEnemy()`, with no guard against the enemy having no position (off-board, undeployed, in transport). `effectiveDistance` ultimately walks `Coords.nextHex(destination)` which NPEs on null, aborting the bot's `changePhase` and hanging the game on the bot's turn.

  ## Bug Fixed

  - **NPE in BotClient.toggleStealth** when a stealth-equipped bot encounters an enemy with `getPosition() == null` (e.g., units carried inside a DropShip, reinforcements not yet deployed, or units in the pre-deployment phase). The throw aborts the bot's phase change; the game then stalls forever waiting on the bot to complete its turn. Reproducible "by round 1" per the issue. The reporter's `megamek.log` shows the throw at `BotClient.toggleStealth → Compute.effectiveDistance → Coords.nextHex(null)`. Subsequent NPEs in the log collapse to the bare exception line because the JVM's `OmitStackTraceInFastThrow` kicks in on the repeat throws.

Fixes #8166

  ## Changes

  ### Skip null-position enemies in stealth toggle (BotClient.java)

  - Add `(test_ent.getPosition() != null)` to the inner visibility guard so enemies without a position are excluded from the count/BV/range triple that drives the stealth-on/stealth-off decision
  - Mirrors the existing `check_ent.getPosition() == null` guard a few lines above; comment explains why the entire block (not just the range add) is skipped: excluding only the range entry would skew the `(known_range / known_count)` average

  ## Files Changed

  - `megamek/src/megamek/client/bot/BotClient.java` - one extra null-check on the inner visibility guard plus an explanatory comment

  ## Testing

  - Compile: `./gradlew :megamek:compileJava` clean
  - Manual: ran a fresh 0.51.0 game with a Princess bot owning aerospace units across Round 0 -> Round 1 phase transitions; bot processed all phases cleanly, no NPE in `megamek.log`, normal shutdown. Note: the fixture didn't carry F_STEALTH, so the patched inner loop wasn't exercised on the buggy path - but the change is a single defensive null-check mirroring the existing guard at line 1253, and the log evidence in #8166 unambiguously identifies the throw site

