### PR TITLE
Fix 8195: Add null WAA safety checks to assignAMS()

### DIFF
--- a/megamek/src/megamek/common/units/Entity.java
+++ b/megamek/src/megamek/common/units/Entity.java
@@ -7671,7 +7671,10 @@ public abstract class Entity extends TurnOrdered
             } else if (ams.getType().hasFlag(WeaponType.F_PD_BAY)) {
                 // Point defense bays are assigned to the attack with the greatest threat Unlike single AMS, PD bays
                 // can gang up on 1 attack
-                Compute.getHighestExpectedDamage(getGame(), attacksInArc, true).addCounterEquipment(ams);
+                final WeaponAttackAction waa = Compute.getHighestExpectedDamage(getGame(), attacksInArc, true);
+                if (waa != null) {
+                    waa.addCounterEquipment(ams);
+                }
             } else if (gameOptions().booleanOption(OptionsConstants.PLAYTEST_3)) {
                 // PLAYTEST3 AMS shoots twice handling
                 // Assuming AMS has not been used at all yet, so both shots are available.

--- a/megamek/src/megamek/common/units/Entity.java
+++ b/megamek/src/megamek/common/units/Entity.java
@@ -7676,22 +7676,28 @@ public abstract class Entity extends TurnOrdered
                 // PLAYTEST3 AMS shoots twice handling
                 // Assuming AMS has not been used at all yet, so both shots are available.
                 final WeaponAttackAction waa = Compute.getHighestExpectedDamage(getGame(), attacksInArc, true);
-                waa.addCounterEquipment(ams);
-                targets.add(waa);
-                if (attacksInArc.size() > 1) {
-                    final WeaponAttackAction secondWaa = Compute.getSecondHighestExpectedDamage(getGame(), attacksInArc,
-                          true);
-                    if (secondWaa != null) {
-                        secondWaa.addCounterEquipment(ams);
-                        targets.add(secondWaa);
+                if (waa != null) {
+                    waa.addCounterEquipment(ams);
+                    targets.add(waa);
+                    if (attacksInArc.size() > 1) {
+                        final WeaponAttackAction secondWaa = Compute.getSecondHighestExpectedDamage(getGame(),
+                              attacksInArc,
+                              true);
+                        if (secondWaa != null) {
+                            secondWaa.addCounterEquipment(ams);
+                            targets.add(secondWaa);
+                        }
                     }
                 }
             } else {
                 // Otherwise, find the most dangerous salvo by expected damage and target it this ensures that only 1
                 // AMS targets the strike. Use for non-bays.
                 final WeaponAttackAction waa = Compute.getHighestExpectedDamage(getGame(), attacksInArc, true);
-                waa.addCounterEquipment(ams);
-                targets.add(waa);
+                // Null waa indicates no threat detected, as in Copperhead munition with no tagged targets
+                if (waa != null) {
+                    waa.addCounterEquipment(ams);
+                    targets.add(waa);
+                }
             }
         });
     }


### PR DESCRIPTION
Prevent NPEs when a unit with AMS tries to assign AMS to counter attacks with negative expected damage values.

The underlying issue is that, in the interest of speed and efficiency, we check **all** incoming attacks for expected damage in order to assign AMS targets by order of importance (even weapons that cannot be countered by AMS) prior to the incoming attacks being handled.
Then, during handling, we only allocate AMS shots to weapons that _can_ be countered, using polymorphism to ensure that non-counterable attacks skip this check.

This approach keeps the number of conditionals and checks down and ensures that e.g. multiple AMSes will be allocated in a rational way if one unit has more than one, or multiple units with AMS occupy the same hex.
The only drawback is that A) we do a lot of processing of attacks that don't matter, and B) in cases where the projected damage of an attack is less than the threshold of -1.0 (for whatever reason) we get a null value back from the check.

Unfortunately it looks like filtering out non-counterable weapon attack actions prior to passing them to `assignAMS()` would be nontrivial.
This is some of the oldest code in MegaMek, dating back to 2002 in some cases, and seems to work well enough, so I'm loathe to add additional complexity in order to filter out non-missile attacks prior to the expected damage calculations that happen for every attack.
But if someone were interested in adding a belt to these suspenders, implementing that filtering somewhere in `TWGameManager.java` or `Entity.java` would probably be worth exploring.

Testing:
- Ran OP's save game with and without fix to show NPE no longer results.
- Ran all 3 projects' unit tests

Fix #8195 