### PR TITLE
Mine deployment UX fixes (tooltip, density default, sizing, labels)

### DIFF
--- a/megamek/resources/megamek/client/messages.properties
+++ b/megamek/resources/megamek/client/messages.properties
@@ -1882,9 +1882,9 @@ DeployMinefieldDisplay.waitingForDeployMinefieldPhase=Waiting to begin Deploy mi
 DeployMinefieldDisplay.deployCarriable=Cargo({0})
 DeployMinefieldDisplay.deployCarriableDialogHeader=Deploy Ground Object
 DeployMinefieldDisplay.undeployedTitle=Undeployed Items
-DeployMinefieldDisplay.undeployedMines=You have {0} undeployed mine(s). Undeployed mines will be lost. Continue anyway?
+DeployMinefieldDisplay.undeployedMines=You have {0} undeployed minefield(s). Undeployed minefields will be lost. Continue anyway?
 DeployMinefieldDisplay.undeployedCarryables=You have {0} undeployed ground object(s). Undeployed items will be lost. Continue anyway?
-DeployMinefieldDisplay.undeployedBoth=You have {0} undeployed mine(s) and {1} undeployed ground object(s). Undeployed items will be lost. Continue anyway?
+DeployMinefieldDisplay.undeployedBoth=You have {0} undeployed minefield(s) and {1} undeployed ground object(s). Undeployed items will be lost. Continue anyway?
 #Expand Map Dialog
 ExpandMapDialog.title=Expand map settings
 ExpandMapDialog.labelNorth=North

--- a/megamek/src/megamek/client/ui/dialogs/phaseDisplay/MineDensityDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/phaseDisplay/MineDensityDialog.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2003-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2003-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -47,6 +47,7 @@ import javax.swing.JLabel;
 import javax.swing.SwingConstants;
 
 import megamek.client.ui.Messages;
+import megamek.client.ui.util.UIUtil;
 import megamek.codeUtilities.MathUtility;
 
 /**
@@ -67,7 +68,7 @@ public class MineDensityDialog extends JDialog implements ActionListener {
         butOk.addActionListener(this);
 
         choDensity.removeAllItems();
-        for (int i = 5; i < 35; i = i + 5) {
+        for (int i = 30; i >= 5; i = i - 5) {
             choDensity.addItem(Integer.toString(i));
         }
         choDensity.setSelectedIndex(0);
@@ -96,6 +97,10 @@ public class MineDensityDialog extends JDialog implements ActionListener {
         gridBagLayout.setConstraints(butOk, gridBagConstraints);
         getContentPane().add(butOk);
         pack();
+        int minWidth = UIUtil.scaleForGUI(250);
+        if (getWidth() < minWidth) {
+            setSize(minWidth, getHeight());
+        }
         setLocation(frame.getLocation().x + frame.getSize().width / 2 - getSize().width / 2,
               frame.getLocation().y + frame.getSize().height / 2 - getSize().height / 2);
     }

--- a/megamek/src/megamek/client/ui/dialogs/phaseDisplay/SeaMineDepthDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/phaseDisplay/SeaMineDepthDialog.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2003-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2003-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -47,6 +47,7 @@ import javax.swing.JLabel;
 import javax.swing.SwingConstants;
 
 import megamek.client.ui.Messages;
+import megamek.client.ui.util.UIUtil;
 import megamek.codeUtilities.MathUtility;
 
 /**
@@ -94,6 +95,10 @@ public class SeaMineDepthDialog extends JDialog implements ActionListener {
         gridBagLayout.setConstraints(butOk, gridBagConstraints);
         getContentPane().add(butOk);
         pack();
+        int minWidth = UIUtil.scaleForGUI(250);
+        if (getWidth() < minWidth) {
+            setSize(minWidth, getHeight());
+        }
         setLocation(p.getLocation().x + p.getSize().width / 2 - getSize().width / 2,
               p.getLocation().y + p.getSize().height / 2 - getSize().height / 2);
     }

--- a/megamek/src/megamek/client/ui/dialogs/phaseDisplay/SeaMineDepthDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/phaseDisplay/SeaMineDepthDialog.java
@@ -58,7 +58,7 @@ public class SeaMineDepthDialog extends JDialog implements ActionListener {
     private static final long serialVersionUID = -7642956136536119067L;
     private final JButton butOk = new JButton(Messages.getString("Okay"));
     private final JComboBox<String> choDepth = new JComboBox<>();
-    private int depth;
+    private int depth = -1;
 
     public SeaMineDepthDialog(JFrame p, int totalDepth) {
         super(p, Messages.getString("MineDensityDialog.title"), true);

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/DeployMinefieldDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/DeployMinefieldDisplay.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
+import java.util.function.Supplier;
 import javax.swing.JOptionPane;
 
 import megamek.client.event.BoardViewEvent;
@@ -332,13 +333,12 @@ public class DeployMinefieldDisplay extends StatusBarPhaseDisplay {
             if (groundObjects.size() > 1) {
                 String title = "Choose Cargo to Place";
                 String body = "Choose the cargo to place:";
-                clientgui.suspendBoardTooltips();
-                try {
-                    toDeploy = (ICarryable) JOptionPane.showInputDialog(clientgui.getFrame(),
-                          body, title, JOptionPane.QUESTION_MESSAGE, null,
-                          groundObjects.toArray(), groundObjects.getFirst());
-                } finally {
-                    clientgui.activateBoardTooltips();
+                toDeploy = runWithSuspendedTooltips(() ->
+                      (ICarryable) JOptionPane.showInputDialog(clientgui.getFrame(),
+                            body, title, JOptionPane.QUESTION_MESSAGE, null,
+                            groundObjects.toArray(), groundObjects.getFirst()));
+                if (toDeploy == null) {
+                    return;
                 }
             }
 
@@ -379,22 +379,15 @@ public class DeployMinefieldDisplay extends StatusBarPhaseDisplay {
                 if (sea) {
                     SeaMineDepthDialog smd = new SeaMineDepthDialog(
                           clientgui.getFrame(), hex.depth());
-                    clientgui.suspendBoardTooltips();
-                    try {
-                        smd.setVisible(true);
-                    } finally {
-                        clientgui.activateBoardTooltips();
-                    }
+                    runWithSuspendedTooltips(() -> smd.setVisible(true));
 
                     depth = smd.getDepth();
+                    if (depth < 0) {
+                        return;
+                    }
                 }
                 MineDensityDialog mfd = new MineDensityDialog(clientgui.getFrame());
-                clientgui.suspendBoardTooltips();
-                try {
-                    mfd.setVisible(true);
-                } finally {
-                    clientgui.activateBoardTooltips();
-                }
+                runWithSuspendedTooltips(() -> mfd.setVisible(true));
 
                 if (mfd.getDensity() > 0) {
                     mf = Minefield.createMinefield(coords, p.getId(),
@@ -408,12 +401,7 @@ public class DeployMinefieldDisplay extends StatusBarPhaseDisplay {
                 }
             } else if (deployingCommandMinefields()) {
                 MineDensityDialog mfd = new MineDensityDialog(clientgui.getFrame());
-                clientgui.suspendBoardTooltips();
-                try {
-                    mfd.setVisible(true);
-                } finally {
-                    clientgui.activateBoardTooltips();
-                }
+                runWithSuspendedTooltips(() -> mfd.setVisible(true));
 
                 if (mfd.getDensity() > 0) {
                     mf = Minefield.createMinefield(coords, p.getId(),
@@ -427,12 +415,7 @@ public class DeployMinefieldDisplay extends StatusBarPhaseDisplay {
                 }
             } else if (deployingActiveMinefields()) {
                 MineDensityDialog mfd = new MineDensityDialog(clientgui.getFrame());
-                clientgui.suspendBoardTooltips();
-                try {
-                    mfd.setVisible(true);
-                } finally {
-                    clientgui.activateBoardTooltips();
-                }
+                runWithSuspendedTooltips(() -> mfd.setVisible(true));
 
                 if (mfd.getDensity() > 0) {
                     mf = Minefield.createMinefield(coords, p.getId(),
@@ -445,12 +428,7 @@ public class DeployMinefieldDisplay extends StatusBarPhaseDisplay {
                 }
             } else if (deployingInfernoMinefields()) {
                 MineDensityDialog mfd = new MineDensityDialog(clientgui.getFrame());
-                clientgui.suspendBoardTooltips();
-                try {
-                    mfd.setVisible(true);
-                } finally {
-                    clientgui.activateBoardTooltips();
-                }
+                runWithSuspendedTooltips(() -> mfd.setVisible(true));
 
                 if (mfd.getDensity() > 0) {
                     mf = Minefield.createMinefield(coords, p.getId(),
@@ -464,21 +442,11 @@ public class DeployMinefieldDisplay extends StatusBarPhaseDisplay {
                 }
             } else if (deployingVibrabombMinefields()) {
                 MineDensityDialog mfd = new MineDensityDialog(clientgui.getFrame());
-                clientgui.suspendBoardTooltips();
-                try {
-                    mfd.setVisible(true);
-                } finally {
-                    clientgui.activateBoardTooltips();
-                }
+                runWithSuspendedTooltips(() -> mfd.setVisible(true));
 
                 VibrabombSettingDialog vsd = new VibrabombSettingDialog(
                       clientgui.getFrame());
-                clientgui.suspendBoardTooltips();
-                try {
-                    vsd.setVisible(true);
-                } finally {
-                    clientgui.activateBoardTooltips();
-                }
+                runWithSuspendedTooltips(() -> vsd.setVisible(true));
 
                 if (mfd.getDensity() > 0) {
                     mf = Minefield.createMinefield(coords, p.getId(),
@@ -499,12 +467,7 @@ public class DeployMinefieldDisplay extends StatusBarPhaseDisplay {
                 }
                 // Get weight threshold setting from dialog
                 EMPMineSettingDialog esd = new EMPMineSettingDialog(clientgui.getFrame());
-                clientgui.suspendBoardTooltips();
-                try {
-                    esd.setVisible(true);
-                } finally {
-                    clientgui.activateBoardTooltips();
-                }
+                runWithSuspendedTooltips(() -> esd.setVisible(true));
 
                 if (esd.getSetting() > 0) {
                     // Fixed density of 5 since EMP mines are one-use
@@ -645,6 +608,34 @@ public class DeployMinefieldDisplay extends StatusBarPhaseDisplay {
         clientgui.getClient().sendDeployGroundObjects(clientgui.getClient().getGame().getGroundObjects());
         clientgui.getClient().sendDeployMinefields(deployedMinefields);
         clientgui.getClient().sendPlayerInfo();
+    }
+
+    /**
+     * Suspends BoardView hex tooltips for the duration of the given action so they cannot draw over a modal dialog, and
+     * re-activates them when the action returns.
+     */
+    private void runWithSuspendedTooltips(Runnable action) {
+        clientgui.suspendBoardTooltips();
+        try {
+            action.run();
+        } finally {
+            clientgui.activateBoardTooltips();
+        }
+    }
+
+    /**
+     * Suspends BoardView hex tooltips for the duration of the given action so they cannot draw over a modal dialog, and
+     * re-activates them when the action returns.
+     *
+     * @return the value supplied by the action
+     */
+    private <T> T runWithSuspendedTooltips(Supplier<T> action) {
+        clientgui.suspendBoardTooltips();
+        try {
+            return action.get();
+        } finally {
+            clientgui.activateBoardTooltips();
+        }
     }
 
     private void setConventionalEnabled(int nbr) {

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/DeployMinefieldDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/DeployMinefieldDisplay.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2003, 2004 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2003-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2003-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -332,9 +332,14 @@ public class DeployMinefieldDisplay extends StatusBarPhaseDisplay {
             if (groundObjects.size() > 1) {
                 String title = "Choose Cargo to Place";
                 String body = "Choose the cargo to place:";
-                toDeploy = (ICarryable) JOptionPane.showInputDialog(clientgui.getFrame(),
-                      body, title, JOptionPane.QUESTION_MESSAGE, null,
-                      groundObjects.toArray(), groundObjects.getFirst());
+                clientgui.suspendBoardTooltips();
+                try {
+                    toDeploy = (ICarryable) JOptionPane.showInputDialog(clientgui.getFrame(),
+                          body, title, JOptionPane.QUESTION_MESSAGE, null,
+                          groundObjects.toArray(), groundObjects.getFirst());
+                } finally {
+                    clientgui.activateBoardTooltips();
+                }
             }
 
             game.placeGroundObject(coords, toDeploy);
@@ -374,12 +379,22 @@ public class DeployMinefieldDisplay extends StatusBarPhaseDisplay {
                 if (sea) {
                     SeaMineDepthDialog smd = new SeaMineDepthDialog(
                           clientgui.getFrame(), hex.depth());
-                    smd.setVisible(true);
+                    clientgui.suspendBoardTooltips();
+                    try {
+                        smd.setVisible(true);
+                    } finally {
+                        clientgui.activateBoardTooltips();
+                    }
 
                     depth = smd.getDepth();
                 }
                 MineDensityDialog mfd = new MineDensityDialog(clientgui.getFrame());
-                mfd.setVisible(true);
+                clientgui.suspendBoardTooltips();
+                try {
+                    mfd.setVisible(true);
+                } finally {
+                    clientgui.activateBoardTooltips();
+                }
 
                 if (mfd.getDensity() > 0) {
                     mf = Minefield.createMinefield(coords, p.getId(),
@@ -393,7 +408,12 @@ public class DeployMinefieldDisplay extends StatusBarPhaseDisplay {
                 }
             } else if (deployingCommandMinefields()) {
                 MineDensityDialog mfd = new MineDensityDialog(clientgui.getFrame());
-                mfd.setVisible(true);
+                clientgui.suspendBoardTooltips();
+                try {
+                    mfd.setVisible(true);
+                } finally {
+                    clientgui.activateBoardTooltips();
+                }
 
                 if (mfd.getDensity() > 0) {
                     mf = Minefield.createMinefield(coords, p.getId(),
@@ -407,7 +427,12 @@ public class DeployMinefieldDisplay extends StatusBarPhaseDisplay {
                 }
             } else if (deployingActiveMinefields()) {
                 MineDensityDialog mfd = new MineDensityDialog(clientgui.getFrame());
-                mfd.setVisible(true);
+                clientgui.suspendBoardTooltips();
+                try {
+                    mfd.setVisible(true);
+                } finally {
+                    clientgui.activateBoardTooltips();
+                }
 
                 if (mfd.getDensity() > 0) {
                     mf = Minefield.createMinefield(coords, p.getId(),
@@ -420,7 +445,12 @@ public class DeployMinefieldDisplay extends StatusBarPhaseDisplay {
                 }
             } else if (deployingInfernoMinefields()) {
                 MineDensityDialog mfd = new MineDensityDialog(clientgui.getFrame());
-                mfd.setVisible(true);
+                clientgui.suspendBoardTooltips();
+                try {
+                    mfd.setVisible(true);
+                } finally {
+                    clientgui.activateBoardTooltips();
+                }
 
                 if (mfd.getDensity() > 0) {
                     mf = Minefield.createMinefield(coords, p.getId(),
@@ -434,11 +464,21 @@ public class DeployMinefieldDisplay extends StatusBarPhaseDisplay {
                 }
             } else if (deployingVibrabombMinefields()) {
                 MineDensityDialog mfd = new MineDensityDialog(clientgui.getFrame());
-                mfd.setVisible(true);
+                clientgui.suspendBoardTooltips();
+                try {
+                    mfd.setVisible(true);
+                } finally {
+                    clientgui.activateBoardTooltips();
+                }
 
                 VibrabombSettingDialog vsd = new VibrabombSettingDialog(
                       clientgui.getFrame());
-                vsd.setVisible(true);
+                clientgui.suspendBoardTooltips();
+                try {
+                    vsd.setVisible(true);
+                } finally {
+                    clientgui.activateBoardTooltips();
+                }
 
                 if (mfd.getDensity() > 0) {
                     mf = Minefield.createMinefield(coords, p.getId(),
@@ -459,7 +499,12 @@ public class DeployMinefieldDisplay extends StatusBarPhaseDisplay {
                 }
                 // Get weight threshold setting from dialog
                 EMPMineSettingDialog esd = new EMPMineSettingDialog(clientgui.getFrame());
-                esd.setVisible(true);
+                clientgui.suspendBoardTooltips();
+                try {
+                    esd.setVisible(true);
+                } finally {
+                    clientgui.activateBoardTooltips();
+                }
 
                 if (esd.getSetting() > 0) {
                     // Fixed density of 5 since EMP mines are one-use


### PR DESCRIPTION
## Summary

  Player feedback on Discord flagged two issues in the minefield deployment phase: the BoardView hex tooltip drawing on
  top of the modal mine-config dialogs (`MineDensityDialog`, `SeaMineDepthDialog`, `VibrabombSettingDialog`,
  `EMPMineSettingDialog`, plus the cargo-choice `JOptionPane`), and the density combo defaulting to the lowest value (5)
  when the typical pick at the table is the highest (30). On large mine allotments — the lobby allows arbitrarily many —
  the combo default forces an extra click on every single placement, which adds up fast.

  Investigating those surfaced two adjacent issues in the same flow: `MineDensityDialog`'s `pack()`-only sizing made the
  title bar clip "Mine Density" to "Mine Den..." (the dialog's content is just a `JLabel` + tiny `JComboBox` + OK button,
   narrower than the title), and the end-of-phase undeployed-items confirm read "You have N undeployed mine(s)" —
  misleading wording, since the lobby allocates *minefields* (each chosen at placement to be density 5–30), not
  individual mines.

## Issues Addressed

  - **Hex tooltip overlaps mine-config dialogs.** Reported on Discord. The BoardView tooltip continues to render while a
  modal `JDialog` is up because the tooltip is a heavyweight popup. Existing infrastructure
  (`ClientGUI.suspendBoardTooltips()` / `activateBoardTooltips()`, used by `SimpleConfirmDialog`) wasn't applied to the
  mine-deployment call sites.

  - **Density defaults to the lowest value.** Reported on Discord. `MineDensityDialog` populated the combo `5..30` and
  called `setSelectedIndex(0)`, so every placement defaulted to density 5 — the weakest minefield. Players consistently
  want max density, so each placement required a manual selection.

  - **"Mine Density" title clipped to "Mine Den..."**. Surfaced during testing of issue #1 above. `MineDensityDialog` and
   `SeaMineDepthDialog` (which reuses the `MineDensityDialog.title` key) call `pack()` with very narrow content, leaving
  the dialog frame too small for the title text on standard L&Fs.

  - **Confirm dialog says "mines" but means "minefields"**. Surfaced while auditing wording.
  `DeployMinefieldDisplay.undeployedMines` / `undeployedBoth` interpolate the count of undeployed *minefields*, not
  individual mines.

## Changes

  ### Suspend BoardView tooltips during mine-config dialogs (DeployMinefieldDisplay.java)

  - Wrap each blocking `setVisible(true)` in `deployMinefield()` with `clientgui.suspendBoardTooltips()` /
  `activateBoardTooltips()` in try/finally, covering `MineDensityDialog` (×5 — conventional, command, active, inferno,
  vibrabomb), `SeaMineDepthDialog`, `VibrabombSettingDialog`, and `EMPMineSettingDialog`
  - Same wrap on the cargo-choice `JOptionPane.showInputDialog` for the multi-cargo case
  - Mirrors the pattern already in `SimpleConfirmDialog.show()` — the dialogs themselves stay simple `JDialog` subclasses
   with no `ClientGUI` dependency; pairing is at the call site so the lifetime is exactly the modal block

  ### Default density combo to maximum and reverse list order (MineDensityDialog.java)

  - Change loop from `for (int i = 5; i < 35; i += 5)` to `for (int i = 30; i >= 5; i -= 5)` so the items render 30, 25,
  20, 15, 10, 5 top-to-bottom
  - Existing `setSelectedIndex(0)` then resolves to `30`, the typical pick — placement becomes click-hex → Enter rather
  than click-hex → open combo → click 30 → Enter

  ### Enforce minimum dialog width to fit title (MineDensityDialog.java, SeaMineDepthDialog.java)

  - After `pack()`, bump the dialog width to `UIUtil.scaleForGUI(250)` if narrower, leaving height as-packed
  - `UIUtil.scaleForGUI` honours the user's GUI scale setting, per the project's GUI scaling rule
  - Applied to `SeaMineDepthDialog` as well — it shares `MineDensityDialog.title` ("Mine Density") and has equally narrow
   content (depth combo + OK button), so it would clip identically when placing a conventional minefield in water

  ### Correct undeployed-items confirm wording (messages.properties)

  - `DeployMinefieldDisplay.undeployedMines`: "You have {0} undeployed mine(s). Undeployed mines will be lost..." → "You
  have {0} undeployed minefield(s). Undeployed minefields will be lost..."
  - `DeployMinefieldDisplay.undeployedBoth`: same `mine(s)` → `minefield(s)` substitution
  - de/es/ru locale files do not override these keys; English fallback covers all locales

  ## Files Changed

  - `megamek/src/megamek/client/ui/panels/phaseDisplay/DeployMinefieldDisplay.java` — six tooltip suspend/activate wraps
  around modal dialogs and one around the cargo `JOptionPane`; copyright year bumped to 2026
  - `megamek/src/megamek/client/ui/dialogs/phaseDisplay/MineDensityDialog.java` — reverse density loop, add `UIUtil`
  import, enforce minimum width after `pack()`; copyright year bumped
  - `megamek/src/megamek/client/ui/dialogs/phaseDisplay/SeaMineDepthDialog.java` — add `UIUtil` import, enforce minimum
  width after `pack()`; copyright year bumped
  - `megamek/resources/megamek/client/messages.properties` — corrected wording in `undeployedMines` and `undeployedBoth`
