### PR TITLE
Fix wreck sprites drawn above unit layer (Fixes #8253)

### DIFF
--- a/megamek/src/megamek/client/ui/clientGUI/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/BoardView.java
@@ -2082,21 +2082,15 @@ public final class BoardView extends AbstractBoardView
                     if (hex != null) {
                         drawHex(coords, graphics2D, saveBoardImage);
                         drawOrthograph(coords, graphics2D);
+                        // Wrecks must be drawn before behind-terrain sprites so that the iso entity sprite paints
+                        // on top of them; otherwise a unit standing on a wrecked hex appears beneath the wreck.
+                        if (!saveBoardImage && GUIP.getShowWrecks()) {
+                            drawIsometricWreckSpritesForHex(coords, graphics2D, isometricWreckSprites);
+                        }
                         drawHexSpritesForHex(coords, graphics2D, behindTerrainHexSprites);
                         drawDeployment(graphics2D, coords);
                         drawOrthograph(coords, graphics2D);
                         drawHexText(coords, hex, board, graphics2D);
-                    }
-                }
-            }
-
-            for (int x = 0; x < drawWidth; x++) {
-                Coords coords = new Coords(x + drawX, y + drawY);
-                if (board.getHex(coords) != null) {
-                    if (!saveBoardImage) {
-                        if (GUIP.getShowWrecks()) {
-                            drawIsometricWreckSpritesForHex(coords, graphics2D, isometricWreckSprites);
-                        }
                     }
                 }
             }

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/BoardView.java
@@ -77,6 +77,7 @@ import megamek.client.ui.clientGUI.boardview.sprite.isometric.IsometricWreckSpri
 import megamek.client.ui.clientGUI.boardview.toolTip.BoardViewTooltipProvider;
 import megamek.client.ui.dialogs.phaseDisplay.EntityChoiceDialog;
 import megamek.client.ui.tileset.TilesetManager;
+import megamek.client.ui.util.EntityWreckHelper;
 import megamek.client.ui.util.FontHandler;
 import megamek.client.ui.util.ImageCache;
 import megamek.client.ui.util.KeyBindReceiver;
@@ -1442,20 +1443,22 @@ public final class BoardView extends AbstractBoardView
     }
 
     /**
-     * Draws the wreck sprites for the given hex. This function is used by the isometric rendering process so that
-     * sprites are drawn in the order that hills are rendered to create the appearance that the sprite is behind the
-     * hill.
+     * Draws the wreck sprites for the given hex, optionally filtered by whether the wrecked entity was on a bridge.
+     * Splitting the pass by bridge state lets callers draw under-bridge wrecks beneath the bridge orthograph and
+     * on-bridge wrecks above it.
      *
      * @param coords          The Coordinates of the hex that the sprites should be drawn for.
      * @param graphics2D      The Graphics object for this board.
-     * @param spriteArrayList The complete list of all IsometricSprite on the board.
+     * @param spriteArrayList The complete list of all IsometricWreckSprite on the board.
+     * @param onBridge        When true, only draw wrecks of entities on a bridge; when false, only draw the rest.
      */
     private synchronized void drawIsometricWreckSpritesForHex(Coords coords, Graphics2D graphics2D,
-          ArrayList<IsometricWreckSprite> spriteArrayList) {
+          ArrayList<IsometricWreckSprite> spriteArrayList, boolean onBridge) {
         Rectangle view = graphics2D.getClipBounds();
         for (IsometricWreckSprite sprite : spriteArrayList) {
             Coords spritePosition = sprite.getPosition();
-            if (spritePosition.equals(coords) && view.intersects(sprite.getBounds()) && !sprite.isHidden()) {
+            if (spritePosition.equals(coords) && view.intersects(sprite.getBounds()) && !sprite.isHidden()
+                  && EntityWreckHelper.entityOnBridge(sprite.getEntity()) == onBridge) {
                 if (!sprite.isReady()) {
                     sprite.prepare();
                 }
@@ -2082,14 +2085,18 @@ public final class BoardView extends AbstractBoardView
                     if (hex != null) {
                         drawHex(coords, graphics2D, saveBoardImage);
                         drawOrthograph(coords, graphics2D);
-                        // Wrecks must be drawn before behind-terrain sprites so that the iso entity sprite paints
-                        // on top of them; otherwise a unit standing on a wrecked hex appears beneath the wreck.
+                        // Under-bridge / no-bridge wrecks: drawn before the iso entity sprite (so a unit on the
+                        // wreck paints on top) and before the second drawOrthograph (so a bridge deck paints over).
                         if (!saveBoardImage && GUIP.getShowWrecks()) {
-                            drawIsometricWreckSpritesForHex(coords, graphics2D, isometricWreckSprites);
+                            drawIsometricWreckSpritesForHex(coords, graphics2D, isometricWreckSprites, false);
                         }
                         drawHexSpritesForHex(coords, graphics2D, behindTerrainHexSprites);
                         drawDeployment(graphics2D, coords);
                         drawOrthograph(coords, graphics2D);
+                        // On-bridge wrecks: drawn after the bridge orthograph so they sit on the deck.
+                        if (!saveBoardImage && GUIP.getShowWrecks()) {
+                            drawIsometricWreckSpritesForHex(coords, graphics2D, isometricWreckSprites, true);
+                        }
                         drawHexText(coords, hex, board, graphics2D);
                     }
                 }


### PR DESCRIPTION
## Summary

Wreck sprites rendered above active unit sprites when a unit shared a hex with a wreck. Reordering the wreck draw call inside `drawHexes()` restores correct layering. The same change also resolves a latent iso-mode glitch with identical root cause.

## Bug Fixed

- **Wreck z-order in `BoardView.drawHexes()`**: PR #7891 unified the iso/non-iso draw paths and stripped opaque unit-body rendering from `EntitySprite`. The only opaque entity render is now `IsometricSprite` during the per-row behind-terrain pass — which ran *before* the post-row wreck pass. The 35%-alpha iso translucent pass was the only entity render above the wreck, so wrecks visually dominated.

Fix #8253

## Changes

1. **BoardView.java** — Moved `drawIsometricWreckSpritesForHex` from a post-row loop into the per-hex inner loop, between `drawOrthograph` and `drawHexSpritesForHex(...behindTerrainHexSprites)`. `!saveBoardImage` and `GUIP.getShowWrecks()` guards preserved.

## Files Changed

- `megamek/src/megamek/client/ui/clientGUI/boardview/BoardView.java` — Reordered wreck draw inside `drawHexes()`

## Testing

- Compile: `./gradlew :megamek:compileJava` → BUILD SUCCESSFUL
- Manual:
  - Non-iso: unit on wreck → unit visible opaque, wreck below
  - Iso: same scenario → correct layering (also fixes latent iso glitch)
  - Wreck-only hex → renders normally
  - Show Wrecks toggled off → no wrecks
  - Save board image (`ignoreUnits`) → wrecks still skipped