### PR TITLE
Ruler diagram: match the active LOS rule (Fixes #8256)

### DIFF
--- a/megamek/src/megamek/client/ui/clientGUI/boardview/LOSDiagramData.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/LOSDiagramData.java
@@ -53,6 +53,10 @@ import megamek.common.board.Coords;
  * @param targetIsHullDown   whether the target is hull-down (reduces LOS profile by 1 TW level)
  * @param attackerName       display name of the attacker entity, or empty if none
  * @param targetName         display name of the target entity, or empty if none
+ * @param losRuleMode        the active LOS rule set; the panel uses this to pick the correct line shape
+ *                           (step-function for {@link LosRuleMode#STANDARD} and {@link LosRuleMode#DEAD_ZONE},
+ *                           smooth interp for {@link LosRuleMode#DIAGRAMMED}) and to overlay the dead-zone shadow
+ *                           when applicable
  */
 record LOSDiagramData(
       List<HexRow> hexPath,
@@ -68,7 +72,8 @@ record LOSDiagramData(
       boolean attackerAtAltitude,
       boolean targetAtAltitude,
       String attackerName,
-      String targetName
+      String targetName,
+      LosRuleMode losRuleMode
 ) {
 
     /**

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/LOSDiagramDataBuilder.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/LOSDiagramDataBuilder.java
@@ -74,7 +74,8 @@ final class LOSDiagramDataBuilder {
           boolean attackerIsHullDown, boolean targetIsHullDown,
           DiagramUnitType attackerUnitType, DiagramUnitType targetUnitType,
           boolean attackerAtAltitude, boolean targetAtAltitude,
-          String attackerName, String targetName) {
+          String attackerName, String targetName,
+          LosRuleMode losRuleMode) {
         LosEffects losEffects = LosEffects.calculateLos(game, attackInfo);
         boolean losBlocked = !losEffects.canSee();
 
@@ -82,20 +83,24 @@ final class LOSDiagramDataBuilder {
               attackerIsHullDown, targetIsHullDown,
               attackerUnitType, targetUnitType,
               attackerAtAltitude, targetAtAltitude,
-              attackerName, targetName);
+              attackerName, targetName,
+              losRuleMode);
     }
 
     /**
      * Builds diagram data with a pre-computed LOS blocked result. Use this when the LOS calculation was already
      * performed via the entity-based path (fire phase code), so the diagram doesn't re-compute with the manual
-     * AttackInfo (which may produce different results).
+     * AttackInfo (which may produce different results). {@code losRuleMode} controls the per-hex comparison level
+     * the diagram uses to draw the line and flag blockers; pick it from the active game options via
+     * {@link LosRuleMode#fromGameOptions(Game)}.
      */
     public static LOSDiagramData buildWithLosResult(Game game, LosEffects.AttackInfo attackInfo,
           boolean losBlocked,
           boolean attackerIsHullDown, boolean targetIsHullDown,
           DiagramUnitType attackerUnitType, DiagramUnitType targetUnitType,
           boolean attackerAtAltitude, boolean targetAtAltitude,
-          String attackerName, String targetName) {
+          String attackerName, String targetName,
+          LosRuleMode losRuleMode) {
         Board board = game.getBoard();
         Coords attackPos = attackInfo.attackPos;
         Coords targetPos = attackInfo.targetPos;
@@ -136,13 +141,16 @@ final class LOSDiagramDataBuilder {
             boolean hasFields = hex.containsTerrain(Terrains.FIELDS);
             boolean hasFire = hex.containsTerrain(Terrains.FIRE);
 
-            // Calculate the interpolated LOS line elevation at this hex
+            // The LOS line elevation at this hex is the level the engine compares hex tops against,
+            // expressed in BMM LOS-level units (= silhouette top = hex + twHeight). Standard and Dead Zone
+            // use the BMM adjacency rule (step function); Diagrammed uses a smooth linear interpolation.
             double losLineElevation = calculateLosLineElevation(
-                  attackInfo, coords, attackPos, targetPos);
+                  attackInfo, coords, attackPos, targetPos, losRuleMode);
 
-            // Determine if this hex's solid terrain (ground + building) blocks LOS.
-            // Woods, smoke, and other soft terrain add modifiers but don't block
-            // by elevation alone - only accumulated intervening counts block.
+            // Solid terrain (ground + building) blocks LOS when its top reaches the line. The >=
+            // matches BMM ("equal to or higher than") for Standard/Dead Zone and the engine's >=
+            // against (1 + interp(absHeight)) for Diagrammed. Attacker and target hexes never count
+            // as intervening terrain.
             int solidTerrainHeight = groundElevation + buildingHeight;
             boolean blocksLos = solidTerrainHeight >= losLineElevation
                   && !coords.equals(attackPos)
@@ -182,8 +190,9 @@ final class LOSDiagramDataBuilder {
             ));
         }
 
-        // The + 1 converts from code's 0-indexed heights to TW unit heights,
-        // matching the LosEffects interpolation formula (LosEffects line 1332)
+        // attackerAbsHeight / targetAbsHeight stored on the data are the BMM LOS levels (= hex + twHeight),
+        // which is also the silhouette top in y-coords. The engine's internal absHeight is one less; the +1
+        // converts back to BMM units for the diagram.
         return new LOSDiagramData(
               List.copyOf(hexPath),
               attackInfo.attackAbsHeight + 1,
@@ -198,44 +207,63 @@ final class LOSDiagramDataBuilder {
               attackerAtAltitude,
               targetAtAltitude,
               attackerName,
-              targetName
+              targetName,
+              losRuleMode
         );
     }
 
     /**
-     * Calculates the interpolated LOS line elevation at a given hex position. Uses the same weighted average formula as
-     * {@link LosEffects}, including the {@code + 1} correction that converts from the code's 0-indexed unit heights to
-     * TW's unit heights (e.g., Mek = hex level + 2, Vehicle = hex level + 1).
-     *
-     * @param attackInfo the attack info with absolute heights
-     * @param coords     the hex to calculate for
-     * @param attackPos  the attacker position
-     * @param targetPos  the target position
-     *
-     * @return the interpolated LOS elevation at the given hex
+     * Returns the LOS line's reference level at a given hex, in BMM LOS-level units (= hex + twHeight). Standard
+     * and Dead Zone use the BMM adjacency rule, which is a step function: the comparison level is the
+     * attacker-adjacent unit's LOS for hexes adjacent to the attacker, the target-adjacent unit's LOS for hexes
+     * adjacent to the target, the lower of the two for hexes adjacent to both (only possible at distance 2), and
+     * the higher of the two for non-adjacent intermediate hexes. Diagrammed uses a smooth linear interpolation
+     * matching {@code LosEffects.losElevation = 1 + interp(absHeight)} at line 1404.
      */
     private static double calculateLosLineElevation(LosEffects.AttackInfo attackInfo,
-          Coords coords, Coords attackPos, Coords targetPos) {
+          Coords coords, Coords attackPos, Coords targetPos, LosRuleMode mode) {
+        double attLos = attackInfo.attackAbsHeight + 1;
+        double tgtLos = attackInfo.targetAbsHeight + 1;
+
         if (coords.equals(attackPos)) {
-            return attackInfo.attackAbsHeight + 1;
+            return attLos;
         }
         if (coords.equals(targetPos)) {
-            return attackInfo.targetAbsHeight + 1;
+            return tgtLos;
         }
 
-        double distanceFromAttacker = attackPos.distance(coords);
-        double distanceFromTarget = targetPos.distance(coords);
-        double totalDistance = distanceFromAttacker + distanceFromTarget;
+        int distFromAttacker = attackPos.distance(coords);
+        int distFromTarget = targetPos.distance(coords);
+        int totalDistance = distFromAttacker + distFromTarget;
 
         if (totalDistance == 0) {
-            return attackInfo.attackAbsHeight + 1;
+            return attLos;
         }
 
-        // Weighted height interpolation matching LosEffects formula (line 1332)
-        // The + 1 corrects from code's 0-indexed heights to TW unit heights
-        double weightedHeight = (attackInfo.targetAbsHeight * distanceFromAttacker)
-              + (attackInfo.attackAbsHeight * distanceFromTarget);
-        return 1 + weightedHeight / totalDistance;
+        if (mode == LosRuleMode.DIAGRAMMED) {
+            // TacOps Diagrammed LOS: linear interp between LOS levels at the unit positions.
+            // weightedHeight is the engine's (absHeight*distFromOpposite) form; +1 of total/totalDistance
+            // shifts the result into BMM LOS-level units to match attLos / tgtLos endpoints.
+            double weightedHeight = (attackInfo.targetAbsHeight * distFromAttacker)
+                  + (attackInfo.attackAbsHeight * distFromTarget);
+            return 1 + weightedHeight / totalDistance;
+        }
+
+        // STANDARD or DEAD_ZONE: BMM adjacency rule.
+        boolean adjAttacker = distFromAttacker == 1;
+        boolean adjTarget = distFromTarget == 1;
+        if (adjAttacker && adjTarget) {
+            // Distance-2 case: hex is adjacent to both ends. BMM says it intervenes if it reaches either
+            // unit's LOS level, so the lower level is the binding threshold.
+            return Math.min(attLos, tgtLos);
+        }
+        if (adjAttacker) {
+            return attLos;
+        }
+        if (adjTarget) {
+            return tgtLos;
+        }
+        return Math.max(attLos, tgtLos);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/LOSElevationDiagramPanel.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/LOSElevationDiagramPanel.java
@@ -115,6 +115,7 @@ class LOSElevationDiagramPanel extends JPanel {
           2.0f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 10.0f, LOS_DASH_PATTERN, 0.0f);
     private static final Stroke STROKE_GRID = new BasicStroke(0.5f);
     private static final Stroke STROKE_DEFAULT = new BasicStroke(1.0f);
+    private static final Stroke STROKE_BLOCKER_OUTLINE = new BasicStroke(2.5f);
     private static final float[] DASH_PATTERN = { 6.0f, 4.0f };
     private static final Stroke STROKE_SPLIT = new BasicStroke(
           1.0f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 10.0f, DASH_PATTERN, 0.0f);
@@ -563,6 +564,23 @@ class LOSElevationDiagramPanel extends JPanel {
                 g2d.setStroke(STROKE_SPLIT);
                 g2d.drawRect(xLeft + 1, metrics.topMargin + 1,
                       columnWidth - 2, metrics.drawAreaHeight - 2);
+                g2d.setStroke(STROKE_DEFAULT);
+            }
+
+            // Highlight the hex bar in red when this hex's solid terrain blocks LOS so the offender pops
+            // visually. Outline runs from the hex's effective top (ground + buildings) down to ground level.
+            if (hex.blocksLOS()) {
+                int blockerTopElevation = hex.groundElevation() + hex.buildingHeight();
+                int yBlockerTop = metrics.levelToY(blockerTopElevation);
+                int blockerHeight = yGround - yBlockerTop;
+                if (blockerHeight <= 0) {
+                    // No building above ground: outline the ground bar itself
+                    yBlockerTop = yGround;
+                    blockerHeight = Math.max(yBottom - yGround, 1);
+                }
+                g2d.setColor(COLOR_LOS_BLOCKED);
+                g2d.setStroke(STROKE_BLOCKER_OUTLINE);
+                g2d.drawRect(xLeft, yBlockerTop, columnWidth, blockerHeight);
                 g2d.setStroke(STROKE_DEFAULT);
             }
         }
@@ -2094,11 +2112,36 @@ class LOSElevationDiagramPanel extends JPanel {
             return;
         }
 
+        g2d.setStroke(STROKE_LOS);
+        g2d.setColor(diagramData.losBlocked() ? COLOR_LOS_BLOCKED : COLOR_LOS_CLEAR);
+
+        // Diagrammed LOS uses a smooth interpolation in the engine; draw a single straight line.
+        // Standard / Dead Zone use BMM's adjacency rule, which is a step function on per-hex comparison
+        // levels - draw horizontal segments at each hex with vertical risers between hexes whose levels
+        // change. Altitude endpoints fall back to the straight-line form (the per-hex levels aren't
+        // meaningful when one end is hundreds of levels above the diagram).
+        boolean useStep = diagramData.losRuleMode() != LosRuleMode.DIAGRAMMED
+              && !metrics.attackerIsAltitude
+              && !metrics.targetIsAltitude;
+        if (useStep) {
+            drawStepLosLine(g2d, metrics, hexPath);
+        } else {
+            drawSmoothLosLine(g2d, metrics, hexPath);
+        }
+
+        g2d.setStroke(STROKE_DEFAULT);
+    }
+
+    /**
+     * Draws the LOS line as a single straight segment from attacker silhouette top to target silhouette top.
+     * Used for Diagrammed LOS (smooth interp matches the engine's {@code losElevation = 1 + interp(absHeight)})
+     * and for any case with an altitude endpoint.
+     */
+    private void drawSmoothLosLine(Graphics2D g2d, DiagramMetrics metrics, List<HexRow> hexPath) {
         int xStart = metrics.leftMargin + (metrics.hexColumnWidth / 2);
         int xEnd = metrics.leftMargin + ((hexPath.size() - 1) * metrics.hexColumnWidth)
               + (metrics.hexColumnWidth / 2);
 
-        // For altitude units, the LOS line originates from above the break indicator
         int yStart;
         if (metrics.attackerIsAltitude) {
             yStart = metrics.topMargin - UIUtil.scaleForGUI(ALTITUDE_SILHOUETTE_HEIGHT / 2);
@@ -2114,7 +2157,6 @@ class LOSElevationDiagramPanel extends JPanel {
 
         // Clip the LOS line to the visible drawing area so it spans the full diagram width
         // even when endpoints are far outside the visible elevation range (e.g., aerospace at altitude 1000).
-        // Without clipping, the line would only be visible in the small region where it crosses the panel.
         int yMin = metrics.topMargin;
         int yMax = metrics.topMargin + metrics.drawAreaHeight;
 
@@ -2123,7 +2165,6 @@ class LOSElevationDiagramPanel extends JPanel {
         int clippedXEnd = xEnd;
         int clippedYEnd = yEnd;
 
-        // Cohen-Sutherland-style clipping against top and bottom edges
         if (yStart != yEnd) {
             if (yStart < yMin) {
                 clippedXStart = xStart + (int) ((long) (xEnd - xStart) * (yMin - yStart) / (yEnd - yStart));
@@ -2141,10 +2182,47 @@ class LOSElevationDiagramPanel extends JPanel {
             }
         }
 
-        g2d.setStroke(STROKE_LOS);
-        g2d.setColor(diagramData.losBlocked() ? COLOR_LOS_BLOCKED : COLOR_LOS_CLEAR);
         g2d.drawLine(clippedXStart, clippedYStart, clippedXEnd, clippedYEnd);
-        g2d.setStroke(STROKE_DEFAULT);
+    }
+
+    /**
+     * Draws the LOS line as a step function for Standard / Dead Zone modes. Each hex contributes a horizontal
+     * segment at its per-hex {@code losLineElevation} (BMM's "comparison level" given adjacency), and adjacent
+     * hexes whose levels differ get a vertical riser at their shared boundary. The resulting staircase makes the
+     * BMM rule visible: terrain reaching the segment over its hex is exactly what intervenes.
+     */
+    private void drawStepLosLine(Graphics2D g2d, DiagramMetrics metrics, List<HexRow> hexPath) {
+        int yMin = metrics.topMargin;
+        int yMax = metrics.topMargin + metrics.drawAreaHeight;
+        int prevY = -1;
+        int prevXRight = -1;
+        for (int i = 0; i < hexPath.size(); i++) {
+            HexRow hex = hexPath.get(i);
+            int xLeft = metrics.leftMargin + (i * metrics.hexColumnWidth);
+            int xRight = xLeft + metrics.hexColumnWidth;
+            int y = clampToPanel(metrics.levelToY(hex.losLineElevation()), yMin, yMax);
+
+            // Horizontal segment across this hex at its comparison level
+            g2d.drawLine(xLeft, y, xRight, y);
+
+            // Vertical riser at the boundary with the previous hex when the level changed
+            if (i > 0 && y != prevY) {
+                g2d.drawLine(prevXRight, prevY, prevXRight, y);
+            }
+
+            prevY = y;
+            prevXRight = xRight;
+        }
+    }
+
+    private static int clampToPanel(int y, int yMin, int yMax) {
+        if (y < yMin) {
+            return yMin;
+        }
+        if (y > yMax) {
+            return yMax;
+        }
+        return y;
     }
 
     /**

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/LosRuleMode.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/LosRuleMode.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.ui.clientGUI.boardview;
+
+import megamek.common.game.Game;
+import megamek.common.options.OptionsConstants;
+
+/**
+ * The three line-of-sight rule sets the engine implements. The Ruler tool reads the active rule from game options and
+ * draws the LOS line shape that matches.
+ *
+ * <ul>
+ *   <li>{@link #STANDARD} — BattleMech Manual default. A hex's terrain intervenes if its top is at or above the
+ *       attacker's LOS level (when attacker-adjacent), the target's LOS level (when target-adjacent), or the higher
+ *       of the two LOS levels (when non-adjacent). The diagram draws a step-function line at those reference levels.
+ *   </li>
+ *   <li>{@link #DIAGRAMMED} — TacOps p.20 (game option {@code TAC_OPS_LOS1}). The LOS reference is a linear
+ *       interpolation between attacker and target LOS levels, evaluated at each hex's position along the path. The
+ *       diagram draws a straight slope.</li>
+ *   <li>{@link #DEAD_ZONE} — TacOps optional rule (game option {@code TAC_OPS_DEAD_ZONES}). Adds a geometric "shadow"
+ *       check on top of Standard: if the tallest intervening hill projects a shadow that the lower unit sits inside,
+ *       LOS is blocked. The diagram uses the same step-function line as Standard, plus a shadow overlay.</li>
+ * </ul>
+ */
+enum LosRuleMode {
+    STANDARD,
+    DIAGRAMMED,
+    DEAD_ZONE;
+
+    /**
+     * Selects the active rule based on which TacOps options the game has enabled. Diagrammed and Dead Zone are
+     * mutually exclusive in the comparison table and treated the same way here.
+     */
+    static LosRuleMode fromGameOptions(Game game) {
+        if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_LOS1)) {
+            return DIAGRAMMED;
+        }
+        if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_DEAD_ZONES)) {
+            return DEAD_ZONE;
+        }
+        return STANDARD;
+    }
+}

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/RulerDialog.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/RulerDialog.java
@@ -63,6 +63,7 @@ import megamek.client.ui.util.UIUtil;
 import megamek.common.Hex;
 import megamek.common.LosEffects;
 import megamek.common.Player;
+import megamek.common.board.Board;
 import megamek.common.board.Coords;
 import megamek.common.game.Game;
 import megamek.common.options.OptionsConstants;
@@ -959,6 +960,10 @@ public class RulerDialog extends JDialog implements BoardViewListener {
         int h1 = (int) height1.getValue();
         int h2 = (int) height2.getValue();
 
+        // Refresh the title each turn so the LOS rule and board name in the title bar follow the
+        // current game state (TacOps option toggles, multi-board games).
+        setTitle(getRulerTitle(game));
+
         if (!game.getBoard().contains(start) || !game.getBoard().contains(end)) {
             return;
         }
@@ -1140,19 +1145,22 @@ public class RulerDialog extends JDialog implements BoardViewListener {
         boolean attackerIsAlt = flip ? atAltitude1 : atAltitude2;
         boolean targetIsAlt = flip ? atAltitude2 : atAltitude1;
 
+        // Pass the active LOS rule through to the diagram so it can pick the matching line shape and overlays.
+        LosRuleMode losRuleMode = LosRuleMode.fromGameOptions(game);
+
         LOSDiagramData diagramData;
         if (entityLosBlocked != null) {
             // Use pre-computed entity-based LOS result (matches fire phase)
             diagramData = LOSDiagramDataBuilder.buildWithLosResult(game, attackInfo,
                   entityLosBlocked, attackerHullDown, targetHullDown,
                   attackerType, targetType, attackerIsAlt, targetIsAlt,
-                  attackerName, targetName);
+                  attackerName, targetName, losRuleMode);
         } else {
             // Use manual AttackInfo-based LOS (scenario testing)
             diagramData = LOSDiagramDataBuilder.build(game, attackInfo,
                   attackerHullDown, targetHullDown, attackerType, targetType,
                   attackerIsAlt, targetIsAlt,
-                  attackerName, targetName);
+                  attackerName, targetName, losRuleMode);
         }
 
         diagramPanel.setData(diagramData);
@@ -1342,16 +1350,26 @@ public class RulerDialog extends JDialog implements BoardViewListener {
     }
 
     /**
-     * Returns the ruler dialog title based on which optional LOS rules are active.
+     * Returns the ruler dialog title with the active LOS rule set and the current board name. The board name
+     * is appended in brackets so screenshots include the map identity, which speeds up triage of player LOS
+     * questions.
      */
     private static String getRulerTitle(Game game) {
-        if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_LOS1)) {
-            return Messages.getString("Ruler.titleDiagrammedLOS");
+        String modeTitle;
+        switch (LosRuleMode.fromGameOptions(game)) {
+            case DIAGRAMMED -> modeTitle = Messages.getString("Ruler.titleDiagrammedLOS");
+            case DEAD_ZONE -> modeTitle = Messages.getString("Ruler.titleDeadZone");
+            default -> modeTitle = Messages.getString("Ruler.title");
         }
-        if (game.getOptions().booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_DEAD_ZONES)) {
-            return Messages.getString("Ruler.titleDeadZone");
+        Board board = game.getBoard();
+        if (board == null) {
+            return modeTitle;
         }
-        return Messages.getString("Ruler.title");
+        String boardName = board.getBoardName();
+        if (boardName == null || boardName.isBlank()) {
+            return modeTitle;
+        }
+        return modeTitle + " [" + boardName + "]";
     }
 
     @Override


### PR DESCRIPTION
## Summary

The ruler tool's elevation diagram drew the LOS line as a smooth slope between unit silhouette tops in every mode. That matches TacOps Diagrammed LOS, not BMM Standard. The smooth slope lifted the line above attacker-adjacent ridges that BMM correctly intervenes against, so the picture said "clear" while the engine said "blocked." A player reported the engine as bugged; the engine was right. This makes the diagram match whichever rule the engine is actually applying.

`LosEffects` is **not** modified.

## Bug Fixed

- **Diagram only drew one shape regardless of LOS rule.** BMM Standard uses an adjacency-aware step function: comparison level is the attacker's LOS level over attacker-adjacent hexes, the target's over target-adjacent, and `max(attacker, target)` over non-adjacent. The diagram now picks the matching shape per active rule.
- **No visible blocker.** The hex that actually broke LOS got no special rendering, so players had to cross-reference the path against terrain mentally. Blockers now get a red hex-bar outline.

## Changes

1. **LosRuleMode.java** (NEW) — three-value enum (`STANDARD`, `DIAGRAMMED`, `DEAD_ZONE`). `fromGameOptions(Game)` reads `TAC_OPS_LOS1` and `TAC_OPS_DEAD_ZONES`.
2. **LOSDiagramData.java** — carries the active `LosRuleMode` to the panel.
3. **LOSDiagramDataBuilder.java** — `calculateLosLineElevation` picks the BMM adjacency rule for Standard/Dead Zone (step function on `attLOS` / `max(att,tgt)` / `tgtLOS`) and the engine's `1 + interp(absHeight)` for Diagrammed. Per-hex `blocksLos` uses `>=` against the per-hex line, matching BMM's "equal to or higher than" rule.
4. **LOSElevationDiagramPanel.java** — `drawLosLine` splits into `drawSmoothLosLine` (Diagrammed, altitude endpoints) and `drawStepLosLine` (Standard, Dead Zone). `drawTerrain` adds a thick red outline on hex bars whose `blocksLos` flag is set.
5. **RulerDialog.java** — passes `LosRuleMode.fromGameOptions(game)` to the builder. Title bar reads `Ruler [Map Name]` (or `Ruler - Diagrammed LOS [Map Name]`, etc.) so screenshots include the map. `setText()` refreshes the title each turn so option toggles take effect immediately.

## Files Changed

- `megamek/src/megamek/client/ui/clientGUI/boardview/LosRuleMode.java` — NEW: three-value LOS rule enum.
- `megamek/src/megamek/client/ui/clientGUI/boardview/LOSDiagramData.java` — `losRuleMode` field on the data record.
- `megamek/src/megamek/client/ui/clientGUI/boardview/LOSDiagramDataBuilder.java` — mode-aware per-hex line elevation.
- `megamek/src/megamek/client/ui/clientGUI/boardview/LOSElevationDiagramPanel.java` — step-function line and blocker outline.
- `megamek/src/megamek/client/ui/clientGUI/boardview/RulerDialog.java` — plumb mode, title with map name.

## Testing

- Unit tests: `LOSHeightCalculationTest` and `LOSModifierCalculatorTest` pass.
- Compile: `./gradlew :megamek:compileJava` clean.
- Manual on the #8256 scenario: vehicle on a level-2 hex, Mek on a level-5 hex with a 2-level building, distance 5, level-3 ridge attacker-adjacent.
  - Standard: line is flat at level 3 across attacker and the adjacent ridge, jumps to level 7 across the rest. Ridge hex bar gets a red outline. Picture matches engine result "blocked."
  - Diagrammed: line is the original smooth slope from 3 to 7. No red outlines. Engine result "clear."
  - Dead Zone: same step-function line as Standard. Engine result "blocked." Geometric shadow overlay deferred.

## Out of scope (follow-up)

Dead Zone shadow rendering — the geometric shadow region behind the tallest intervening hill that the engine's `isDeadZone` check evaluates. Adding a translucent shaded region between the shadow-casting hill and the lower unit's hex would explain *why* a Dead Zone block fires when the Standard rule alone wouldn't have. Filed separately because it needs its own design pass on visualization.