### PR TITLE
Fix #8268: Fixed Missing Trooper Count in TRO Infantry Readout

### DIFF
--- a/megamek/src/megamek/client/ui/entityreadout/InfantryReadout.java
+++ b/megamek/src/megamek/client/ui/entityreadout/InfantryReadout.java
@@ -296,11 +296,14 @@ class InfantryReadout extends GeneralEntityReadout {
     protected List<ViewElement> createArmorElements() {
         List<ViewElement> result = new ArrayList<>();
 
-        ViewElement troopers = new PlainElement(infantry.getShootingStrength());
-        if (infantry.getShootingStrength() == 0) {
+        int activeTroopersCount = infantry.getActiveTroopers();
+        int originalTrooperCount = infantry.getOriginalTrooperCount();
+
+        ViewElement troopers = new PlainElement(activeTroopersCount);
+        if (activeTroopersCount == 0) {
             troopers = new DestroyedElement(0);
-        } else if (infantry.getShootingStrength() < infantry.getOriginalTrooperCount()) {
-            troopers = new DamagedElement(infantry.getShootingStrength());
+        } else if (activeTroopersCount < originalTrooperCount) {
+            troopers = new DamagedElement(activeTroopersCount);
         }
         result.add(new LabeledLine(Messages.getString("MekView.Men"), troopers));
 

--- a/megamek/src/megamek/common/units/Infantry.java
+++ b/megamek/src/megamek/common/units/Infantry.java
@@ -1007,6 +1007,10 @@ public class Infantry extends Entity {
         troopersShooting = activeTroopers;
     }
 
+    public int getActiveTroopers() {
+        return activeTroopers;
+    }
+
     /**
      * Marks field guns and artillery as hit according to their crew requirement when losing troopers. Having them
      * destroyed requires a later call of {@link #applyDamage()}. This method does not restore FG/FA when damage is


### PR DESCRIPTION
Close #8268

TRO Infantry Readout was using 'shooting strength', which is a cached value that is updated only when damage is dealt. This caused issues with MekHQ, as it wouldn't be updated when crews change.

Now the TRO uses active trooper count, which is updated more dynamically across both mm and mhq.