### PR TITLE
Fix Entity.NONE id assignment in Game.addEntity

### DIFF
--- a/megamek/src/megamek/common/game/Game.java
+++ b/megamek/src/megamek/common/game/Game.java
@@ -1401,7 +1401,7 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
         }
         // Add this Entity, ensuring that its id is unique
         int id = entity.getId();
-        if (isIdUsed(id)) {
+        if ((id == Entity.NONE) || isIdUsed(id)) {
             id = getNextEntityId();
             entity.setId(id);
         }

--- a/megamek/unittests/megamek/common/GameTest.java
+++ b/megamek/unittests/megamek/common/GameTest.java
@@ -33,14 +33,43 @@
 package megamek.common;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
 
 import megamek.common.game.Game;
+import megamek.common.units.Entity;
 import megamek.server.victory.VictoryResult;
 import org.junit.jupiter.api.Test;
 
 class GameTest {
+
+    @Test
+    void testAddEntityAssignsIdWhenEntityIdIsNone() {
+        Game game = new Game();
+        Entity entity = mock(Entity.class);
+        int[] entityId = { Entity.NONE };
+        when(entity.getId()).thenAnswer(invocation -> entityId[0]);
+        doAnswer(invocation -> {
+            entityId[0] = invocation.getArgument(0);
+            return null;
+        }).when(entity).setId(anyInt());
+        when(entity.getC3UUIDAsString()).thenReturn("test");
+        when(entity.getOccupiedCoords()).thenReturn(new HashSet<>());
+
+        game.addEntity(entity, false);
+
+        assertNotEquals(Entity.NONE, entity.getId());
+        assertSame(entity, game.getEntity(entity.getId()));
+        assertNull(game.getEntity(Entity.NONE));
+    }
 
     @Test
     void testCancelVictory() {


### PR DESCRIPTION
## Summary

Fixes `Game.addEntity` so entities whose id is still `Entity.NONE` are assigned a real game id before being inserted into the in-game object map.

A unit added under `Entity.NONE` can collide with other sentinel-based lookups. In the reported failure, a newly constructed mek was stored under `-1`; later `Entity.getElevation()` resolved `getTransportId() == Entity.NONE` back to that same entity and recursed until `StackOverflowError`.

This also adds a focused regression test that verifies `Game.addEntity` does not leave an entity registered under `Entity.NONE`.

## Alternative Considered

The narrower test-only fix would be to assign an id in `TWGameManagerTest.testCriticalEntityAllReactiveSlots()` before calling `game.addEntity(mek)`, for example:

```java
mek.setId(game.getNextEntityId());
game.addEntity(mek);
```

That would fix the failing test, but it would still allow other callers to add a default-id entity under the `Entity.NONE` sentinel. The production fix prevents the sentinel collision at the source.

## Testing

- `./gradlew test --rerun-tasks --tests megamek.common.GameTest --tests megamek.server.totalWarfare.TWGameManagerTest.testCriticalEntityAllReactiveSlots -x jacocoTestReport`
- `./gradlew :megamek:checkstyleTest --rerun-tasks`