### PR TITLE
FrankenMek leg-mismatch fix

### DIFF
--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -115,6 +115,7 @@ public class MtfFile implements IMekLoader {
     private final String[] armorValues = new String[12];
     private final Map<Integer, String> frankenMekStructureValues = new HashMap<>();
     private final Map<Integer, String> frankenMekLocationSources = new HashMap<>();
+    private final Map<Integer, String> frankenMekLocationSourceMetadata = new HashMap<>();
     private boolean mismatchedFrankenMekLegs = false;
 
     private final String[][] critData;
@@ -200,6 +201,7 @@ public class MtfFile implements IMekLoader {
     public static final String OMNI_POD = "(OMNIPOD)";
     public static final String NO_CRIT = "nocrit:";
     public static final String LOCATION_DONOR = "donor:";
+    public static final String LOCATION_DONOR_METADATA = "donor metadata:";
     public static final String SIZE = ":SIZE:";
     public static final String MUL_ID = "mul id:";
     public static final String QUIRK = "quirk:";
@@ -531,7 +533,8 @@ public class MtfFile implements IMekLoader {
 
             if (mek.isFrankenMek()) {
                 for (Map.Entry<Integer, String> entry : frankenMekLocationSources.entrySet()) {
-                    mek.linkFrankenMekLocationToSource(entry.getKey(), entry.getValue());
+                    mek.linkFrankenMekLocationToSource(entry.getKey(), entry.getValue(),
+                          frankenMekLocationSourceMetadata.get(entry.getKey()));
                 }
             }
 
@@ -757,6 +760,13 @@ public class MtfFile implements IMekLoader {
 
             if ((loc >= 0) && (loc < critData.length) && line.toLowerCase().startsWith(LOCATION_DONOR)) {
                 frankenMekLocationSources.put(loc, line.substring(LOCATION_DONOR.length()).trim());
+                continue;
+            }
+
+            if ((loc >= 0) && (loc < critData.length)
+                  && line.toLowerCase().startsWith(LOCATION_DONOR_METADATA)) {
+                frankenMekLocationSourceMetadata.put(loc,
+                      line.substring(LOCATION_DONOR_METADATA.length()).trim());
                 continue;
             }
 

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -116,7 +116,6 @@ public class MtfFile implements IMekLoader {
     private final Map<Integer, String> frankenMekStructureValues = new HashMap<>();
     private final Map<Integer, String> frankenMekLocationSources = new HashMap<>();
     private final Map<Integer, String> frankenMekLocationSourceTypes = new HashMap<>();
-    private boolean mismatchedFrankenMekLegs = false;
 
     private final String[][] critData;
     private final List<String> noCritEquipment = new ArrayList<>();
@@ -163,7 +162,6 @@ public class MtfFile implements IMekLoader {
     public static final String MASS = "mass:";
     public static final String ENGINE = "engine:";
     public static final String STRUCTURE = "structure:";
-    public static final String MISMATCHED_LEGS = "mismatched legs:";
     public static final String MYOMER = "myomer:";
     public static final String LAM = "lam:";
     public static final String CONFIG = "config:";
@@ -667,7 +665,6 @@ public class MtfFile implements IMekLoader {
                       parseFrankenMekStructureTonnage(mek, entry.getKey(), structureValue));
             }
         }
-        mek.setMismatchedFrankenMekLegs(mismatchedFrankenMekLegs);
     }
 
     private int parseFrankenMekStructureTonnage(Mek mek, int location, String tonnageValue)
@@ -1644,11 +1641,6 @@ public class MtfFile implements IMekLoader {
             return true;
         }
 
-        if (lineLower.startsWith(MISMATCHED_LEGS)) {
-            String value = line.substring(line.indexOf(':') + 1).trim();
-            mismatchedFrankenMekLegs = value.isBlank() || Boolean.parseBoolean(value);
-            return true;
-        }
 
         if (lineLower.startsWith(MYOMER)) {
             return true;

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -201,7 +201,7 @@ public class MtfFile implements IMekLoader {
     public static final String OMNI_POD = "(OMNIPOD)";
     public static final String NO_CRIT = "nocrit:";
     public static final String LOCATION_DONOR = "donor:";
-    public static final String LOCATION_DONOR_METADATA = "donor metadata:";
+    public static final String LOCATION_DONOR_TYPE = "donor type:";
     public static final String SIZE = ":SIZE:";
     public static final String MUL_ID = "mul id:";
     public static final String QUIRK = "quirk:";

--- a/megamek/src/megamek/common/loaders/MtfFile.java
+++ b/megamek/src/megamek/common/loaders/MtfFile.java
@@ -115,7 +115,7 @@ public class MtfFile implements IMekLoader {
     private final String[] armorValues = new String[12];
     private final Map<Integer, String> frankenMekStructureValues = new HashMap<>();
     private final Map<Integer, String> frankenMekLocationSources = new HashMap<>();
-    private final Map<Integer, String> frankenMekLocationSourceMetadata = new HashMap<>();
+    private final Map<Integer, String> frankenMekLocationSourceTypes = new HashMap<>();
     private boolean mismatchedFrankenMekLegs = false;
 
     private final String[][] critData;
@@ -534,7 +534,7 @@ public class MtfFile implements IMekLoader {
             if (mek.isFrankenMek()) {
                 for (Map.Entry<Integer, String> entry : frankenMekLocationSources.entrySet()) {
                     mek.linkFrankenMekLocationToSource(entry.getKey(), entry.getValue(),
-                          frankenMekLocationSourceMetadata.get(entry.getKey()));
+                          frankenMekLocationSourceTypes.get(entry.getKey()));
                 }
             }
 
@@ -764,9 +764,9 @@ public class MtfFile implements IMekLoader {
             }
 
             if ((loc >= 0) && (loc < critData.length)
-                  && line.toLowerCase().startsWith(LOCATION_DONOR_METADATA)) {
-                frankenMekLocationSourceMetadata.put(loc,
-                      line.substring(LOCATION_DONOR_METADATA.length()).trim());
+                  && line.toLowerCase().startsWith(LOCATION_DONOR_TYPE)) {
+                frankenMekLocationSourceTypes.put(loc,
+                      line.substring(LOCATION_DONOR_TYPE.length()).trim());
                 continue;
             }
 

--- a/megamek/src/megamek/common/ui/EnhancedTabbedPane.java
+++ b/megamek/src/megamek/common/ui/EnhancedTabbedPane.java
@@ -1206,6 +1206,70 @@ public class EnhancedTabbedPane extends JTabbedPane {
     }
 
     /**
+     * Checks if a component is currently hosted by this pane, including detached tab windows.
+     *
+     * @param component The component to find
+     * @return true if the component is attached or detached from this pane
+     */
+    public boolean containsTab(Component component) {
+        return (component != null) && ((indexOfComponent(component) >= 0) || (getDetachedTabWindow(component) != null));
+    }
+
+    /**
+     * Removes a component from this pane, closing its floating window if the tab is currently detached.
+     *
+     * @param component The component to remove
+     * @return true if the component was found and removed
+     */
+    public boolean removeTab(Component component) {
+        if (component == null) {
+            return false;
+        }
+        int tabIndex = indexOfComponent(component);
+        if (tabIndex >= 0) {
+            remove(tabIndex);
+            return true;
+        }
+
+        Component detachedWindow = getDetachedTabWindow(component);
+        if (detachedWindow == null) {
+            return false;
+        }
+        DetachedTabInfo tabInfo = detachedTabs.remove(detachedWindow);
+        removeDetachedTabWindow(detachedWindow, tabInfo);
+        return true;
+    }
+
+    private Component getDetachedTabWindow(Component component) {
+        for (Map.Entry<Component, DetachedTabInfo> detachedTab : detachedTabs.entrySet()) {
+            DetachedTabInfo tabInfo = detachedTab.getValue();
+            if ((tabInfo != null) && (tabInfo.component == component)) {
+                return detachedTab.getKey();
+            }
+        }
+        return null;
+    }
+
+    private void removeDetachedTabWindow(Component detachedWindow, DetachedTabInfo tabInfo) {
+        if (tabInfo == null) {
+            return;
+        }
+        if (detachedWindow instanceof JFrame frame) {
+            frame.getContentPane().remove(tabInfo.component);
+            frame.dispose();
+        } else if (detachedWindow instanceof JDialog dialog) {
+            dialog.getContentPane().remove(tabInfo.component);
+            dialog.dispose();
+        } else if (detachedWindow instanceof Window window) {
+            window.dispose();
+        }
+        tabInfo.sourcePane = null;
+        tabInfo.wrapperComponent = null;
+        updateNoTabsMessageVisibility();
+        fireTabRemoved(tabInfo.originalIndex, tabInfo.component);
+    }
+
+    /**
      * Updates the title of a detached tab window containing the given editor
      *
      * @param frame The editor to find in detached windows

--- a/megamek/src/megamek/common/units/Mek.java
+++ b/megamek/src/megamek/common/units/Mek.java
@@ -87,6 +87,7 @@ public abstract class Mek extends Entity {
         private static final long serialVersionUID = 2955102329477149771L;
 
         private String displayName;
+        private String metadata;
         private int structureTonnage;
         private int structureType = EquipmentType.T_STRUCTURE_UNKNOWN;
         private int structureTechLevel = TechConstants.T_TECH_UNKNOWN;
@@ -95,13 +96,18 @@ public abstract class Mek extends Entity {
             return Objects.toString(displayName, "");
         }
 
+        private String getMetadata() {
+            return Objects.toString(metadata, "");
+        }
+
         private boolean isLinked() {
             return (displayName != null) && !displayName.isBlank();
         }
 
-        private void capture(String newDisplayName, int newStructureTonnage, int newStructureType,
-              int newStructureTechLevel) {
+        private void capture(String newDisplayName, String newMetadata, int newStructureTonnage,
+              int newStructureType, int newStructureTechLevel) {
             displayName = newDisplayName;
+            metadata = newMetadata;
             structureTonnage = newStructureTonnage;
             structureType = newStructureType;
             structureTechLevel = newStructureTechLevel;
@@ -115,6 +121,7 @@ public abstract class Mek extends Entity {
 
         private void clear() {
             displayName = null;
+            metadata = null;
             structureTonnage = 0;
             structureType = EquipmentType.T_STRUCTURE_UNKNOWN;
             structureTechLevel = TechConstants.T_TECH_UNKNOWN;
@@ -829,7 +836,18 @@ public abstract class Mek extends Entity {
         return getFrankenMekLocationSourceSnapshot(location).getDisplayName();
     }
 
+    public String getFrankenMekLocationSourceMetadata(int location) {
+        if (!hasFrankenMekStructureLocation(location)) {
+            return "";
+        }
+        return getFrankenMekLocationSourceSnapshot(location).getMetadata();
+    }
+
     public void linkFrankenMekLocationToSource(int location, String sourceDisplayName) {
+        linkFrankenMekLocationToSource(location, sourceDisplayName, "");
+    }
+
+    public void linkFrankenMekLocationToSource(int location, String sourceDisplayName, String sourceMetadata) {
         if (!hasFrankenMekStructureLocation(location)) {
             return;
         }
@@ -837,7 +855,7 @@ public abstract class Mek extends Entity {
             clearFrankenMekLocationSource(location);
             return;
         }
-        captureFrankenMekLocationSourceSnapshot(location, sourceDisplayName);
+        captureFrankenMekLocationSourceSnapshot(location, sourceDisplayName, sourceMetadata);
     }
 
     public void clearFrankenMekLocationSource(int location) {
@@ -882,8 +900,9 @@ public abstract class Mek extends Entity {
         }
     }
 
-    private void captureFrankenMekLocationSourceSnapshot(int location, String sourceDisplayName) {
-        getFrankenMekLocationSourceSnapshot(location).capture(sourceDisplayName,
+    private void captureFrankenMekLocationSourceSnapshot(int location, String sourceDisplayName,
+          String sourceMetadata) {
+        getFrankenMekLocationSourceSnapshot(location).capture(sourceDisplayName, Objects.toString(sourceMetadata, ""),
               getFrankenMekStructureTonnage(location), getFrankenMekStructureType(location),
               getFrankenMekStructureTechLevel(location));
     }
@@ -5244,7 +5263,12 @@ public abstract class Mek extends Entity {
                 }
             }
             if (isFrankenMek() && !getFrankenMekLocationSourceDisplayName(l).isBlank()) {
-                sb.append(MtfFile.LOCATION_DONOR).append(" ").append(getFrankenMekLocationSourceDisplayName(l)).append(newLine);
+                sb.append(MtfFile.LOCATION_DONOR).append(" ")
+                      .append(getFrankenMekLocationSourceDisplayName(l)).append(newLine);
+                if (!getFrankenMekLocationSourceMetadata(l).isBlank()) {
+                    sb.append(MtfFile.LOCATION_DONOR_METADATA).append(" ")
+                          .append(getFrankenMekLocationSourceMetadata(l)).append(newLine);
+                }
             }
             sb.append(newLine);
         }

--- a/megamek/src/megamek/common/units/Mek.java
+++ b/megamek/src/megamek/common/units/Mek.java
@@ -5266,7 +5266,7 @@ public abstract class Mek extends Entity {
                 sb.append(MtfFile.LOCATION_DONOR).append(" ")
                       .append(getFrankenMekLocationSourceDisplayName(l)).append(newLine);
                 if (!getFrankenMekLocationSourceType(l).isBlank()) {
-                    sb.append(MtfFile.LOCATION_DONOR_METADATA).append(" ")
+                    sb.append(MtfFile.LOCATION_DONOR_TYPE).append(" ")
                           .append(getFrankenMekLocationSourceType(l)).append(newLine);
                 }
             }

--- a/megamek/src/megamek/common/units/Mek.java
+++ b/megamek/src/megamek/common/units/Mek.java
@@ -87,7 +87,7 @@ public abstract class Mek extends Entity {
         private static final long serialVersionUID = 2955102329477149771L;
 
         private String displayName;
-        private String metadata;
+        private String type;
         private int structureTonnage;
         private int structureType = EquipmentType.T_STRUCTURE_UNKNOWN;
         private int structureTechLevel = TechConstants.T_TECH_UNKNOWN;
@@ -96,18 +96,18 @@ public abstract class Mek extends Entity {
             return Objects.toString(displayName, "");
         }
 
-        private String getMetadata() {
-            return Objects.toString(metadata, "");
+        private String getType() {
+            return Objects.toString(type, "");
         }
 
         private boolean isLinked() {
             return (displayName != null) && !displayName.isBlank();
         }
 
-        private void capture(String newDisplayName, String newMetadata, int newStructureTonnage,
+        private void capture(String newDisplayName, String newType, int newStructureTonnage,
               int newStructureType, int newStructureTechLevel) {
             displayName = newDisplayName;
-            metadata = newMetadata;
+            type = newType;
             structureTonnage = newStructureTonnage;
             structureType = newStructureType;
             structureTechLevel = newStructureTechLevel;
@@ -121,7 +121,7 @@ public abstract class Mek extends Entity {
 
         private void clear() {
             displayName = null;
-            metadata = null;
+            type = null;
             structureTonnage = 0;
             structureType = EquipmentType.T_STRUCTURE_UNKNOWN;
             structureTechLevel = TechConstants.T_TECH_UNKNOWN;
@@ -836,11 +836,11 @@ public abstract class Mek extends Entity {
         return getFrankenMekLocationSourceSnapshot(location).getDisplayName();
     }
 
-    public String getFrankenMekLocationSourceMetadata(int location) {
+    public String getFrankenMekLocationSourceType(int location) {
         if (!hasFrankenMekStructureLocation(location)) {
             return "";
         }
-        return getFrankenMekLocationSourceSnapshot(location).getMetadata();
+        return getFrankenMekLocationSourceSnapshot(location).getType();
     }
 
     public void linkFrankenMekLocationToSource(int location, String sourceDisplayName) {
@@ -5265,9 +5265,9 @@ public abstract class Mek extends Entity {
             if (isFrankenMek() && !getFrankenMekLocationSourceDisplayName(l).isBlank()) {
                 sb.append(MtfFile.LOCATION_DONOR).append(" ")
                       .append(getFrankenMekLocationSourceDisplayName(l)).append(newLine);
-                if (!getFrankenMekLocationSourceMetadata(l).isBlank()) {
+                if (!getFrankenMekLocationSourceType(l).isBlank()) {
                     sb.append(MtfFile.LOCATION_DONOR_METADATA).append(" ")
-                          .append(getFrankenMekLocationSourceMetadata(l)).append(newLine);
+                          .append(getFrankenMekLocationSourceType(l)).append(newLine);
                 }
             }
             sb.append(newLine);

--- a/megamek/src/megamek/common/units/Mek.java
+++ b/megamek/src/megamek/common/units/Mek.java
@@ -847,7 +847,7 @@ public abstract class Mek extends Entity {
         linkFrankenMekLocationToSource(location, sourceDisplayName, "");
     }
 
-    public void linkFrankenMekLocationToSource(int location, String sourceDisplayName, String sourceMetadata) {
+    public void linkFrankenMekLocationToSource(int location, String sourceDisplayName, String sourceType) {
         if (!hasFrankenMekStructureLocation(location)) {
             return;
         }
@@ -855,7 +855,7 @@ public abstract class Mek extends Entity {
             clearFrankenMekLocationSource(location);
             return;
         }
-        captureFrankenMekLocationSourceSnapshot(location, sourceDisplayName, sourceMetadata);
+        captureFrankenMekLocationSourceSnapshot(location, sourceDisplayName, sourceType);
     }
 
     public void clearFrankenMekLocationSource(int location) {
@@ -901,8 +901,8 @@ public abstract class Mek extends Entity {
     }
 
     private void captureFrankenMekLocationSourceSnapshot(int location, String sourceDisplayName,
-          String sourceMetadata) {
-        getFrankenMekLocationSourceSnapshot(location).capture(sourceDisplayName, Objects.toString(sourceMetadata, ""),
+          String sourceType) {
+        getFrankenMekLocationSourceSnapshot(location).capture(sourceDisplayName, Objects.toString(sourceType, ""),
               getFrankenMekStructureTonnage(location), getFrankenMekStructureType(location),
               getFrankenMekStructureTechLevel(location));
     }

--- a/megamek/src/megamek/common/units/Mek.java
+++ b/megamek/src/megamek/common/units/Mek.java
@@ -337,7 +337,7 @@ public abstract class Mek extends Entity {
 
     private FrankenMekLocationSourceSnapshot[] frankenMekLocationSources = null;
 
-    private boolean frankenMekMismatchedLegs = false;
+    private boolean frankenMekStructureInitialized = false;
 
     private boolean riscHeatSinkKit = false;
 
@@ -573,7 +573,6 @@ public abstract class Mek extends Entity {
             applyFrankenMekInternalStructure();
         } else {
             clearAllFrankenMekLocationSources();
-            frankenMekMismatchedLegs = false;
             autoSetInternal();
         }
         recalculateTechAdvancement();
@@ -586,14 +585,22 @@ public abstract class Mek extends Entity {
 
     public void initializeFrankenMekStructure() {
         int locations = locations();
-        boolean needsNewArrays = (frankenMekStructureTonnage == null)
+        boolean needsNewTonnage = (frankenMekStructureTonnage == null)
               || (frankenMekStructureTonnage.length != locations);
-        boolean needsNewSourceSnapshots = needsNewArrays
-              || (frankenMekLocationSources == null)
+        boolean needsNewStructureType = (frankenMekStructureType == null)
+              || (frankenMekStructureType.length != locations);
+        boolean needsNewStructureTechLevel = (frankenMekStructureTechLevel == null)
+              || (frankenMekStructureTechLevel.length != locations);
+        boolean needsNewSourceSnapshots = (frankenMekLocationSources == null)
               || (frankenMekLocationSources.length != locations);
-        int[] newTonnage = needsNewArrays ? new int[locations] : frankenMekStructureTonnage;
-        int[] newStructureType = needsNewArrays ? new int[locations] : frankenMekStructureType;
-        int[] newStructureTechLevel = needsNewArrays ? new int[locations] : frankenMekStructureTechLevel;
+        if (frankenMekStructureInitialized && !needsNewTonnage && !needsNewStructureType
+            && !needsNewStructureTechLevel && !needsNewSourceSnapshots) {
+            return;
+        }
+
+        int[] newTonnage = needsNewTonnage ? new int[locations] : frankenMekStructureTonnage;
+        int[] newStructureType = needsNewStructureType ? new int[locations] : frankenMekStructureType;
+        int[] newStructureTechLevel = needsNewStructureTechLevel ? new int[locations] : frankenMekStructureTechLevel;
         FrankenMekLocationSourceSnapshot[] newLocationSources = needsNewSourceSnapshots
               ? new FrankenMekLocationSourceSnapshot[locations]
               : frankenMekLocationSources;
@@ -602,10 +609,16 @@ public abstract class Mek extends Entity {
         int defaultStructureTechLevel = getStructureTechLevel() == TechConstants.T_TECH_UNKNOWN
               ? getTechLevel() : getStructureTechLevel();
 
-        if (needsNewArrays && (frankenMekStructureTonnage != null)) {
+        if (needsNewTonnage && (frankenMekStructureTonnage != null)) {
             int copyLength = Math.min(frankenMekStructureTonnage.length, locations);
             java.lang.System.arraycopy(frankenMekStructureTonnage, 0, newTonnage, 0, copyLength);
+        }
+        if (needsNewStructureType && (frankenMekStructureType != null)) {
+            int copyLength = Math.min(frankenMekStructureType.length, locations);
             java.lang.System.arraycopy(frankenMekStructureType, 0, newStructureType, 0, copyLength);
+        }
+        if (needsNewStructureTechLevel && (frankenMekStructureTechLevel != null)) {
+            int copyLength = Math.min(frankenMekStructureTechLevel.length, locations);
             java.lang.System.arraycopy(frankenMekStructureTechLevel, 0, newStructureTechLevel, 0, copyLength);
         }
         if (needsNewSourceSnapshots && (frankenMekLocationSources != null)) {
@@ -614,13 +627,13 @@ public abstract class Mek extends Entity {
         }
 
         for (int loc = 0; loc < locations; loc++) {
-            if (needsNewArrays || (newTonnage[loc] <= 0)) {
+            if (needsNewTonnage || (newTonnage[loc] <= 0)) {
                 newTonnage[loc] = getDefaultFrankenMekStructureTonnage();
             }
-            if (needsNewArrays || (newStructureType[loc] == EquipmentType.T_STRUCTURE_UNKNOWN)) {
+            if (needsNewStructureType || (newStructureType[loc] == EquipmentType.T_STRUCTURE_UNKNOWN)) {
                 newStructureType[loc] = defaultStructureType;
             }
-            if (needsNewArrays || (newStructureTechLevel[loc] == TechConstants.T_TECH_UNKNOWN)) {
+            if (needsNewStructureTechLevel || (newStructureTechLevel[loc] == TechConstants.T_TECH_UNKNOWN)) {
                 newStructureTechLevel[loc] = defaultStructureTechLevel;
             }
             if (needsNewSourceSnapshots || (newLocationSources[loc] == null)) {
@@ -631,6 +644,7 @@ public abstract class Mek extends Entity {
         frankenMekStructureType = newStructureType;
         frankenMekStructureTechLevel = newStructureTechLevel;
         frankenMekLocationSources = newLocationSources;
+        frankenMekStructureInitialized = true;
     }
 
     private int getDefaultFrankenMekStructureTonnage() {
@@ -988,7 +1002,38 @@ public abstract class Mek extends Entity {
     }
 
     public boolean hasMismatchedFrankenMekLegs() {
-        return isFrankenMek() && frankenMekMismatchedLegs;
+        if (!isFrankenMek()) {
+            return false;
+        }
+        initializeFrankenMekStructure();
+        int firstLeg = LOC_NONE;
+        for (int location = 0; location < locations(); location++) {
+            if (!locationIsLeg(location)) {
+                continue;
+            }
+            if (firstLeg == LOC_NONE) {
+                firstLeg = location;
+            } else if (!frankenMekLegsMatch(firstLeg, location)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean frankenMekLegsMatch(int firstLeg, int otherLeg) {
+        FrankenMekLocationSourceSnapshot firstLegSource = frankenMekLocationSources[firstLeg];
+        FrankenMekLocationSourceSnapshot otherLegSource = frankenMekLocationSources[otherLeg];
+        return (frankenMekStructureTonnage[firstLeg] == frankenMekStructureTonnage[otherLeg])
+              && (frankenMekStructureType[firstLeg] == frankenMekStructureType[otherLeg])
+              && (frankenMekStructureTechLevel[firstLeg] == frankenMekStructureTechLevel[otherLeg])
+              && sanitizeFrankenMekSourceValue(firstLegSource.getDisplayName()).equals(
+                    sanitizeFrankenMekSourceValue(otherLegSource.getDisplayName()))
+              && sanitizeFrankenMekSourceValue(firstLegSource.getType()).equals(
+                    sanitizeFrankenMekSourceValue(otherLegSource.getType()));
+    }
+
+    private static String sanitizeFrankenMekSourceValue(String value) {
+        return Objects.toString(value, "").trim();
     }
 
     public boolean hasMismatchedTonnageFrankenMekLegs() {
@@ -996,10 +1041,6 @@ public abstract class Mek extends Entity {
             return false;
         }
         return (getFrankenMekStructureTonnage(Mek.LOC_RIGHT_LEG) != getFrankenMekStructureTonnage(Mek.LOC_LEFT_LEG));
-    }
-
-    public void setMismatchedFrankenMekLegs(boolean mismatchedLegs) {
-        frankenMekMismatchedLegs = mismatchedLegs && isFrankenMek();
     }
 
     public double getFrankenMekStructureWeightFraction(int location) {
@@ -5111,9 +5152,6 @@ public abstract class Mek extends Entity {
                     sb.append(getFrankenMekStructureName(location)).append(":");
                 }
                 sb.append(getFrankenMekStructureTonnage(location)).append(newLine);
-            }
-            if (hasMismatchedFrankenMekLegs()) {
-                sb.append(MtfFile.MISMATCHED_LEGS).append("true").append(newLine);
             }
         }
 

--- a/megamek/unittests/megamek/common/loaders/MtfFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/MtfFileTest.java
@@ -351,6 +351,27 @@ class MtfFileTest {
     }
 
     @Test
+    void frankenMekDonorMetadataRoundTrip() throws Exception {
+        Mek mek = new BipedMek();
+        mek.setTechLevel(TechConstants.T_IS_EXPERIMENTAL);
+        mek.setWeight(25.0);
+        mek.setEngine(new Engine(100, Engine.NORMAL_ENGINE, 0));
+        mek.setFrankenMek(true);
+        mek.linkFrankenMekLocationToSource(Mek.LOC_RIGHT_LEG, "Atlas", "BattleMek");
+
+        String mtf = mek.getMtf();
+        assertTrue(mtf.contains("donor: Atlas\n"));
+        assertTrue(mtf.contains("donor metadata: BattleMek\n"));
+        assertFalse(mtf.contains("donor: Atlas AS7-D\n"));
+
+        MtfFile loader = toMtfFile(mtf);
+        Mek loaded = (Mek) loader.getEntity();
+
+        assertEquals("Atlas", loaded.getFrankenMekLocationSourceDisplayName(Mek.LOC_RIGHT_LEG));
+        assertEquals("BattleMek", loaded.getFrankenMekLocationSourceMetadata(Mek.LOC_RIGHT_LEG));
+    }
+
+    @Test
     void frankenMekStructureRejectsInvalidTonnage() throws Exception {
         Mek mek = new BipedMek();
         mek.setTechLevel(TechConstants.T_IS_EXPERIMENTAL);

--- a/megamek/unittests/megamek/common/loaders/MtfFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/MtfFileTest.java
@@ -351,7 +351,7 @@ class MtfFileTest {
     }
 
     @Test
-    void frankenMekDonorMetadataRoundTrip() throws Exception {
+    void frankenMekDonorRoundTrip() throws Exception {
         Mek mek = new BipedMek();
         mek.setTechLevel(TechConstants.T_IS_EXPERIMENTAL);
         mek.setWeight(25.0);

--- a/megamek/unittests/megamek/common/loaders/MtfFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/MtfFileTest.java
@@ -82,18 +82,6 @@ class MtfFileTest {
         }
     }
 
-    private static void assertFrankenMekStructureCrits(Mek mek, int head, int centerTorso, int sideTorso, int arm,
-          int leg) {
-        assertEquals(head, mek.getFrankenMekStructureCriticalSlots(Mek.LOC_HEAD));
-        assertEquals(centerTorso, mek.getFrankenMekStructureCriticalSlots(Mek.LOC_CENTER_TORSO));
-        assertEquals(sideTorso, mek.getFrankenMekStructureCriticalSlots(Mek.LOC_RIGHT_TORSO));
-        assertEquals(sideTorso, mek.getFrankenMekStructureCriticalSlots(Mek.LOC_LEFT_TORSO));
-        assertEquals(arm, mek.getFrankenMekStructureCriticalSlots(Mek.LOC_RIGHT_ARM));
-        assertEquals(arm, mek.getFrankenMekStructureCriticalSlots(Mek.LOC_LEFT_ARM));
-        assertEquals(leg, mek.getFrankenMekStructureCriticalSlots(Mek.LOC_RIGHT_LEG));
-        assertEquals(leg, mek.getFrankenMekStructureCriticalSlots(Mek.LOC_LEFT_LEG));
-    }
-
     private static String getMekVerifierReport(Mek mek) {
         EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
               "testresources/data/mekfiles/UnitVerifierOptions.xml"));
@@ -294,18 +282,6 @@ class MtfFileTest {
     }
 
     @Test
-    void frankenMekVerifierRejectsOmniMek() {
-        Mek mek = new BipedMek();
-        mek.setWeight(60.0);
-        mek.setEngine(new Engine(240, Engine.NORMAL_ENGINE, 0));
-        mek.setTechLevel(TechConstants.T_IS_EXPERIMENTAL);
-        mek.setOmni(true);
-        mek.setFrankenMek(true);
-
-        assertTrue(getMekVerifierReport(mek).contains("FrankenMeks cannot be OmniMeks"));
-    }
-
-    @Test
     void frankenMekVerifierRejectsLegStructureBelowCenterTorso() throws Exception {
         Mek mek = new BipedMek();
         mek.setWeight(60.0);
@@ -331,13 +307,11 @@ class MtfFileTest {
         mek.setFrankenMekStructureTonnage(Mek.LOC_RIGHT_ARM, 20);
         mek.setFrankenMekStructureTonnage(Mek.LOC_LEFT_LEG, 35);
         mek.setFrankenMekStructureTonnage(Mek.LOC_RIGHT_LEG, 35);
-        mek.setMismatchedFrankenMekLegs(true);
 
         String mtf = mek.getMtf();
         assertTrue(mtf.contains("structure:Standard\n"));
         assertTrue(mtf.contains("RA structure:20\n"));
         assertTrue(mtf.contains("LL structure:35\n"));
-        assertTrue(mtf.contains("mismatched legs:true\n"));
 
         MtfFile loader = toMtfFile(mtf);
         Mek loaded = (Mek) loader.getEntity();
@@ -347,7 +321,6 @@ class MtfFileTest {
         assertEquals(20, loaded.getFrankenMekStructureTonnage(Mek.LOC_RIGHT_ARM));
         assertEquals(35, loaded.getFrankenMekStructureTonnage(Mek.LOC_LEFT_LEG));
         assertEquals(25, loaded.getFrankenMekStructureTonnage(Mek.LOC_CENTER_TORSO));
-        assertTrue(loaded.hasMismatchedFrankenMekLegs());
     }
 
     @Test
@@ -358,17 +331,19 @@ class MtfFileTest {
         mek.setEngine(new Engine(100, Engine.NORMAL_ENGINE, 0));
         mek.setFrankenMek(true);
         mek.linkFrankenMekLocationToSource(Mek.LOC_RIGHT_LEG, "Atlas", "BattleMek");
+        mek.linkFrankenMekLocationToSource(Mek.LOC_LEFT_LEG, "Crab", "BattleMek");
 
         String mtf = mek.getMtf();
         assertTrue(mtf.contains("donor: Atlas\n"));
+        assertTrue(mtf.contains("donor: Crab\n"));
         assertTrue(mtf.contains("donor type: BattleMek\n"));
-        assertFalse(mtf.contains("donor: Atlas AS7-D\n"));
 
         MtfFile loader = toMtfFile(mtf);
         Mek loaded = (Mek) loader.getEntity();
 
         assertEquals("Atlas", loaded.getFrankenMekLocationSourceDisplayName(Mek.LOC_RIGHT_LEG));
         assertEquals("BattleMek", loaded.getFrankenMekLocationSourceType(Mek.LOC_RIGHT_LEG));
+        assertEquals("Crab", loaded.getFrankenMekLocationSourceDisplayName(Mek.LOC_LEFT_LEG));
     }
 
     @Test
@@ -388,51 +363,6 @@ class MtfFileTest {
         assertEquals(EntityLoadingException.class, exception.getCause().getClass());
         assertTrue(exception.getCause().getMessage().contains("Invalid FrankenMek structure tonnage"));
         assertTrue(exception.getCause().getMessage().contains("not-a-number"));
-    }
-
-    @Test
-    void frankenMekStandardSelectionClearsHybridStructure() {
-        Mek mek = new BipedMek();
-        mek.setTechLevel(TechConstants.T_IS_EXPERIMENTAL);
-        mek.setWeight(25.0);
-        mek.setEngine(new Engine(100, Engine.NORMAL_ENGINE, 0));
-        mek.setFrankenMek(true);
-
-        mek.setFrankenMekStructureType(Mek.LOC_HEAD,
-              EquipmentType.get(EquipmentType.getStructureTypeName(EquipmentType.T_STRUCTURE_ENDO_STEEL, false)));
-        assertTrue(mek.hasHybridFrankenMekStructure());
-
-        mek.setFrankenMekStructureType(Mek.LOC_HEAD,
-              EquipmentType.get(EquipmentType.getStructureTypeName(EquipmentType.T_STRUCTURE_STANDARD)));
-
-        assertFalse(mek.hasHybridFrankenMekStructure());
-        assertEquals(EquipmentType.getStructureTypeName(EquipmentType.T_STRUCTURE_STANDARD),
-              mek.getFrankenMekStructureDisplayName());
-    }
-
-    @Test
-    void frankenMekStructureCriticalSlotsUseLocationDistributionTable() {
-        Mek mek = new BipedMek();
-        mek.setTechLevel(TechConstants.T_IS_EXPERIMENTAL);
-        mek.setWeight(25.0);
-        mek.setEngine(new Engine(100, Engine.NORMAL_ENGINE, 0));
-        mek.setFrankenMek(true);
-
-        setAllFrankenMekStructures(mek,
-              EquipmentType.get(EquipmentType.getStructureTypeName(EquipmentType.T_STRUCTURE_ENDO_STEEL, false)));
-        assertFrankenMekStructureCrits(mek, 1, 1, 3, 2, 1);
-
-        setAllFrankenMekStructures(mek,
-              EquipmentType.get(EquipmentType.getStructureTypeName(EquipmentType.T_STRUCTURE_ENDO_STEEL, true)));
-        assertFrankenMekStructureCrits(mek, 0, 1, 1, 1, 1);
-
-        setAllFrankenMekStructures(mek,
-              EquipmentType.get(EquipmentType.getStructureTypeName(EquipmentType.T_STRUCTURE_ENDO_COMPOSITE, false)));
-        assertFrankenMekStructureCrits(mek, 0, 1, 1, 1, 1);
-
-        setAllFrankenMekStructures(mek,
-              EquipmentType.get(EquipmentType.getStructureTypeName(EquipmentType.T_STRUCTURE_ENDO_COMPOSITE, true)));
-        assertFrankenMekStructureCrits(mek, 0, 1, 1, 1, 1);
     }
 
     @Test
@@ -497,7 +427,6 @@ class MtfFileTest {
         assertTrue(mtf.contains("structure:Hybrid\n"));
         assertTrue(mtf.contains("RA structure:Standard:20\n"));
         assertTrue(mtf.contains("CT structure:Clan Endo Steel:25\n"));
-        assertFalse(mtf.contains("mismatched legs:true\n"));
 
         MtfFile loader = toMtfFile(mtf);
         Mek loaded = (Mek) loader.getEntity();
@@ -506,7 +435,6 @@ class MtfFileTest {
         assertTrue(loaded.hasHybridFrankenMekStructure());
         assertEquals(EquipmentType.T_STRUCTURE_ENDO_STEEL, loaded.getFrankenMekStructureType(Mek.LOC_CENTER_TORSO));
         assertEquals(20, loaded.getFrankenMekStructureTonnage(Mek.LOC_RIGHT_ARM));
-        assertFalse(loaded.hasMismatchedFrankenMekLegs());
     }
 
     /**

--- a/megamek/unittests/megamek/common/loaders/MtfFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/MtfFileTest.java
@@ -361,14 +361,14 @@ class MtfFileTest {
 
         String mtf = mek.getMtf();
         assertTrue(mtf.contains("donor: Atlas\n"));
-        assertTrue(mtf.contains("donor metadata: BattleMek\n"));
+        assertTrue(mtf.contains("donor type: BattleMek\n"));
         assertFalse(mtf.contains("donor: Atlas AS7-D\n"));
 
         MtfFile loader = toMtfFile(mtf);
         Mek loaded = (Mek) loader.getEntity();
 
         assertEquals("Atlas", loaded.getFrankenMekLocationSourceDisplayName(Mek.LOC_RIGHT_LEG));
-        assertEquals("BattleMek", loaded.getFrankenMekLocationSourceMetadata(Mek.LOC_RIGHT_LEG));
+        assertEquals("BattleMek", loaded.getFrankenMekLocationSourceType(Mek.LOC_RIGHT_LEG));
     }
 
     @Test

--- a/megamek/unittests/megamek/common/units/FrankenMekTest.java
+++ b/megamek/unittests/megamek/common/units/FrankenMekTest.java
@@ -36,8 +36,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
+
 import megamek.common.TechConstants;
+import megamek.common.equipment.Engine;
 import megamek.common.equipment.EquipmentType;
+import megamek.common.verifier.EntityVerifier;
+import megamek.common.verifier.TestMek;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -45,6 +50,142 @@ class FrankenMekTest {
     @BeforeAll
     static void beforeAll() {
         EquipmentType.initializeTypes();
+    }
+
+    private static Mek newFrankenMek() {
+        Mek mek = new BipedMek();
+        mek.setTechLevel(TechConstants.T_IS_EXPERIMENTAL);
+        mek.setWeight(25.0);
+        mek.setFrankenMek(true);
+        return mek;
+    }
+
+    private static void setAllFrankenMekStructures(Mek mek, EquipmentType structure) {
+        for (int location = 0; location < mek.locations(); location++) {
+            mek.setFrankenMekStructureType(location, structure);
+        }
+    }
+
+    private static void assertFrankenMekStructureCrits(Mek mek, int head, int centerTorso, int sideTorso, int arm,
+          int leg) {
+        assertEquals(head, mek.getFrankenMekStructureCriticalSlots(Mek.LOC_HEAD));
+        assertEquals(centerTorso, mek.getFrankenMekStructureCriticalSlots(Mek.LOC_CENTER_TORSO));
+        assertEquals(sideTorso, mek.getFrankenMekStructureCriticalSlots(Mek.LOC_RIGHT_TORSO));
+        assertEquals(sideTorso, mek.getFrankenMekStructureCriticalSlots(Mek.LOC_LEFT_TORSO));
+        assertEquals(arm, mek.getFrankenMekStructureCriticalSlots(Mek.LOC_RIGHT_ARM));
+        assertEquals(arm, mek.getFrankenMekStructureCriticalSlots(Mek.LOC_LEFT_ARM));
+        assertEquals(leg, mek.getFrankenMekStructureCriticalSlots(Mek.LOC_RIGHT_LEG));
+        assertEquals(leg, mek.getFrankenMekStructureCriticalSlots(Mek.LOC_LEFT_LEG));
+    }
+
+    private static String getMekVerifierReport(Mek mek) {
+        EntityVerifier entityVerifier = EntityVerifier.getInstance(new File(
+              "testresources/data/mekfiles/UnitVerifierOptions.xml"));
+        StringBuffer report = new StringBuffer();
+        new TestMek(mek, entityVerifier.mekOption, null).correctEntity(report, mek.getTechLevel());
+        return report.toString();
+    }
+
+    @Test
+    void verifierRejectsOmniMek() {
+        Mek mek = new BipedMek();
+        mek.setWeight(60.0);
+        mek.setEngine(new Engine(240, Engine.NORMAL_ENGINE, 0));
+        mek.setTechLevel(TechConstants.T_IS_EXPERIMENTAL);
+        mek.setOmni(true);
+        mek.setFrankenMek(true);
+
+        assertTrue(getMekVerifierReport(mek).contains("FrankenMeks cannot be OmniMeks"));
+    }
+
+    @Test
+    void standardSelectionClearsHybridStructure() {
+        Mek mek = newFrankenMek();
+
+        mek.setFrankenMekStructureType(Mek.LOC_HEAD,
+              EquipmentType.get(EquipmentType.getStructureTypeName(EquipmentType.T_STRUCTURE_ENDO_STEEL, false)));
+        assertTrue(mek.hasHybridFrankenMekStructure());
+
+        mek.setFrankenMekStructureType(Mek.LOC_HEAD,
+              EquipmentType.get(EquipmentType.getStructureTypeName(EquipmentType.T_STRUCTURE_STANDARD)));
+
+        assertFalse(mek.hasHybridFrankenMekStructure());
+        assertEquals(EquipmentType.getStructureTypeName(EquipmentType.T_STRUCTURE_STANDARD),
+              mek.getFrankenMekStructureDisplayName());
+    }
+
+    @Test
+    void structureCriticalSlotsUseLocationDistributionTable() {
+        Mek mek = newFrankenMek();
+
+        setAllFrankenMekStructures(mek,
+              EquipmentType.get(EquipmentType.getStructureTypeName(EquipmentType.T_STRUCTURE_ENDO_STEEL, false)));
+        assertFrankenMekStructureCrits(mek, 1, 1, 3, 2, 1);
+
+        setAllFrankenMekStructures(mek,
+              EquipmentType.get(EquipmentType.getStructureTypeName(EquipmentType.T_STRUCTURE_ENDO_STEEL, true)));
+        assertFrankenMekStructureCrits(mek, 0, 1, 1, 1, 1);
+
+        setAllFrankenMekStructures(mek,
+              EquipmentType.get(EquipmentType.getStructureTypeName(EquipmentType.T_STRUCTURE_ENDO_COMPOSITE, false)));
+        assertFrankenMekStructureCrits(mek, 0, 1, 1, 1, 1);
+
+        setAllFrankenMekStructures(mek,
+              EquipmentType.get(EquipmentType.getStructureTypeName(EquipmentType.T_STRUCTURE_ENDO_COMPOSITE, true)));
+        assertFrankenMekStructureCrits(mek, 0, 1, 1, 1, 1);
+    }
+
+    @Test
+    void legMismatchDetectsStructureTonnage() {
+        Mek mek = newFrankenMek();
+
+        assertFalse(mek.hasMismatchedFrankenMekLegs());
+
+        mek.setFrankenMekStructureTonnage(Mek.LOC_LEFT_LEG, 30);
+
+        assertTrue(mek.hasMismatchedFrankenMekLegs());
+
+        mek.setFrankenMekStructureTonnage(Mek.LOC_RIGHT_LEG, 30);
+
+        assertFalse(mek.hasMismatchedFrankenMekLegs());
+    }
+
+    @Test
+    void legMismatchDetectsStructureType() {
+        Mek mek = newFrankenMek();
+        EquipmentType endoSteel = EquipmentType.get(
+              EquipmentType.getStructureTypeName(EquipmentType.T_STRUCTURE_ENDO_STEEL, false));
+
+        assertFalse(mek.hasMismatchedFrankenMekLegs());
+
+        mek.setFrankenMekStructureType(Mek.LOC_LEFT_LEG, endoSteel);
+
+        assertTrue(mek.hasMismatchedFrankenMekLegs());
+
+        mek.setFrankenMekStructureType(Mek.LOC_RIGHT_LEG, endoSteel);
+
+        assertFalse(mek.hasMismatchedFrankenMekLegs());
+    }
+
+    @Test
+    void legMismatchDetectsDonor() {
+        Mek mek = newFrankenMek();
+        mek.linkFrankenMekLocationToSource(Mek.LOC_LEFT_LEG, "Atlas", "BattleMek");
+        mek.linkFrankenMekLocationToSource(Mek.LOC_RIGHT_LEG, "Atlas", "BattleMek");
+
+        assertFalse(mek.hasMismatchedFrankenMekLegs());
+
+        mek.linkFrankenMekLocationToSource(Mek.LOC_RIGHT_LEG, "Crab", "BattleMek");
+
+        assertTrue(mek.hasMismatchedFrankenMekLegs());
+
+        mek.linkFrankenMekLocationToSource(Mek.LOC_LEFT_LEG, "Crab", "BattleMek");
+
+        assertFalse(mek.hasMismatchedFrankenMekLegs());
+
+        mek.linkFrankenMekLocationToSource(Mek.LOC_RIGHT_LEG, "Crab", "OmniMek");
+
+        assertTrue(mek.hasMismatchedFrankenMekLegs());
     }
 
     @Test


### PR DESCRIPTION
This PR drops the use of the `model` to identify mismatching legs.
Now we do it using: chassis/tonnage/structure/omni/BM-IM

This is simplified by:
`donor:` property now stores only the chassis + clanname
`donor type:` IndustrialMek/BattleMek/OmniMek

tonnage/structure is derived directly by the location itself.