### PR TITLE
Fix #8155: error unmarshalling INarcPods from MegaMek save games

### DIFF
--- a/megamek/src/megamek/common/util/SerializationHelper.java
+++ b/megamek/src/megamek/common/util/SerializationHelper.java
@@ -44,6 +44,7 @@ import megamek.common.board.Board;
 import megamek.common.board.BoardLocation;
 import megamek.common.board.Coords;
 import megamek.common.board.CubeCoords;
+import megamek.common.equipment.INarcPod;
 import megamek.common.equipment.Mounted;
 import megamek.common.equipment.NarcPod;
 import megamek.common.equipment.Sensor;
@@ -148,22 +149,29 @@ public class SerializationHelper {
 
         // Necessary because, while Java 17+ supports Record serialization/deserialization, XStream 1.4.x
         // does not (natively).
+        // Supports both Narc and iNarc pods
         xStream.registerConverter(new Converter() {
             @Override
             public boolean canConvert(Class cls) {
-                return (cls == NarcPod.class);
+                return (cls == NarcPod.class || cls == INarcPod.class);
             }
 
             @Override
             public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+                // Shared by NarcPod and INarcPod
                 int team = -1;
                 int location = -1;
+
+                // INarcPod only
+                int type = -1;
+
                 while (reader.hasMoreChildren()) {
                     reader.moveDown();
                     try {
                         switch (reader.getNodeName()) {
                             case "team" -> team = Integer.parseInt(reader.getValue());
                             case "location" -> location = Integer.parseInt(reader.getValue());
+                            case "type" -> type = Integer.parseInt(reader.getValue());
                         }
                         reader.moveUp();
                     } catch (NumberFormatException e) {
@@ -171,7 +179,10 @@ public class SerializationHelper {
                         return null;
                     }
                 }
-                return ((team > -1) && (location > -1)) ? new NarcPod(team, location) : null;
+                if ((team > -1) && (location > -1)) {
+                    return (type > -1) ? new INarcPod(team, type, location) : new NarcPod(team, location);
+                }
+                return null;
             }
 
             @Override


### PR DESCRIPTION
Adds handling for INarcPods to the existing NarcPod unmarshaller; despite no direct inheritance relationship, they are functionally nearly identical.

Testing:
- Ran all 3 projects' existing unit tests
- Loaded OP's failing saves (after some massaging to work with 0.51.0 code)

Close #8155 