### PR TITLE
Fix geysers not impacting line of sight

### DIFF
--- a/megamek/src/megamek/client/ui/clientGUI/boardview/LOSDiagramData.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/LOSDiagramData.java
@@ -119,6 +119,7 @@ record LOSDiagramData(
      * @param hasScreen        true if a smoke/ECM screen is present
      * @param hasFields        true if planted fields are present
      * @param hasFire          true if the hex is on fire
+     * @param eruptingGeyser   true if an erupting geyser is present (its plume blocks LOS as ultra-heavy woods)
      * @param splitHex         true if this hex was part of a split LOS path (line along hex edge)
      * @param splitAlternate   the alternate hex coordinates if this is a split hex, null otherwise
      * @param blocksLOS        true if this specific hex blocks the LOS line
@@ -137,6 +138,7 @@ record LOSDiagramData(
           boolean hasScreen,
           boolean hasFields,
           boolean hasFire,
+          boolean eruptingGeyser,
           boolean splitHex,
           @Nullable Coords splitAlternate,
           boolean blocksLOS,
@@ -169,7 +171,7 @@ record LOSDiagramData(
          */
         public boolean hasLosModifiers() {
             return hasWoodsOrJungle() || smokeLevel > 0 || hasScreen || hasFields
-                  || hasFire || industrialHeight > 0;
+                  || hasFire || industrialHeight > 0 || eruptingGeyser;
         }
     }
 }

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/LOSDiagramDataBuilder.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/LOSDiagramDataBuilder.java
@@ -141,6 +141,7 @@ final class LOSDiagramDataBuilder {
             boolean hasScreen = hex.containsTerrain(Terrains.SCREEN);
             boolean hasFields = hex.containsTerrain(Terrains.FIELDS);
             boolean hasFire = hex.containsTerrain(Terrains.FIRE);
+            boolean eruptingGeyser = getTerrainLevel(hex, Terrains.GEYSER) == 2;
 
             // The LOS line elevation at this hex is the level the engine compares hex tops against,
             // expressed in BMM LOS-level units (= silhouette top = hex + twHeight). Standard and Dead Zone
@@ -184,6 +185,7 @@ final class LOSDiagramDataBuilder {
                   hasScreen,
                   hasFields,
                   hasFire,
+                  eruptingGeyser,
                   isSplitHex,
                   splitAlternate,
                   blocksLos,

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/LOSDiagramDataBuilder.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/LOSDiagramDataBuilder.java
@@ -141,7 +141,7 @@ final class LOSDiagramDataBuilder {
             boolean hasScreen = hex.containsTerrain(Terrains.SCREEN);
             boolean hasFields = hex.containsTerrain(Terrains.FIELDS);
             boolean hasFire = hex.containsTerrain(Terrains.FIRE);
-            boolean eruptingGeyser = getTerrainLevel(hex, Terrains.GEYSER) == 2;
+            boolean eruptingGeyser = getTerrainLevel(hex, Terrains.GEYSER) == Terrains.GEYSER_LVL_ACTIVE;
 
             // The LOS line elevation at this hex is the level the engine compares hex tops against,
             // expressed in BMM LOS-level units (= silhouette top = hex + twHeight). Standard and Dead Zone

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/LOSElevationDiagramPanel.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/LOSElevationDiagramPanel.java
@@ -32,16 +32,7 @@
  */
 package megamek.client.ui.clientGUI.boardview;
 
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.FontMetrics;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.RenderingHints;
-import java.awt.Shape;
-import java.awt.Stroke;
+import java.awt.*;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionAdapter;
@@ -105,6 +96,8 @@ class LOSElevationDiagramPanel extends JPanel {
     private static final Color COLOR_FIRE = new Color(255, 50, 0, 210);
     private static final Color COLOR_SCREEN = new Color(180, 180, 255, 120);
     private static final Color COLOR_FIELDS = new Color(200, 180, 50, 100);
+    private static final Color COLOR_GEYSER_JET = new Color(150, 200, 235, 175);
+    private static final Color COLOR_GEYSER_SPRAY = new Color(215, 238, 250, 160);
     private static final Color COLOR_LOS_CLEAR = new Color(60, 220, 60);
     private static final Color COLOR_LOS_BLOCKED = new Color(240, 50, 50);
     private static final Color COLOR_SPLIT_MARKER = new Color(255, 165, 0, 120);
@@ -141,6 +134,12 @@ class LOSElevationDiagramPanel extends JPanel {
 
     /** Aspect ratio (height/width) for the larger crown puffs at the plume top. */
     private static final double SMOKE_CROWN_ASPECT_RATIO = 0.65;
+
+    /** Erupting-geyser plume height in TW levels; treated as ultra-heavy woods for LOS (TacOps). */
+    private static final int GEYSER_PLUME_LEVELS = 3;
+
+    /** Width of the geyser water jet as a fraction of the column width. */
+    private static final double GEYSER_JET_WIDTH_FACTOR = 0.28;
 
     private static final String LOS_SILHOUETTE_DIR = "units" + File.separator + "LOS" + File.separator;
 
@@ -978,6 +977,61 @@ class LOSElevationDiagramPanel extends JPanel {
     }
 
     /**
+     * Draws an erupting geyser as a narrow vertical water jet topped by a fountain-like spray crown of droplets.
+     * Deliberately distinct from the wide billowing smoke plume: a thin, fast column of water shooting straight up with
+     * droplets arcing outward at the top.
+     *
+     * @param g2d    the graphics context
+     * @param x      the left edge of the hex column
+     * @param y      the top of the plume (three levels above ground)
+     * @param width  the hex column width
+     * @param height the pixel height of the three-level plume (ground to plume top)
+     */
+    private void drawGeyserJet(Graphics2D g2d, int x, int y, int width, int height) {
+        if (width <= 0 || height <= 0) {
+            return;
+        }
+
+        int centerX = x + width / 2;
+        int jetWidth = Math.max((int) (width * GEYSER_JET_WIDTH_FACTOR), 3);
+
+        // Central rising water jet: a translucent column that tapers slightly toward the top.
+        int[] jetX = {
+              centerX - jetWidth / 2,
+              centerX + jetWidth / 2,
+              centerX + jetWidth / 4,
+              centerX - jetWidth / 4
+        };
+        int[] jetY = { y + height, y + height, y, y };
+        g2d.setColor(COLOR_GEYSER_JET);
+        g2d.fillPolygon(jetX, jetY, 4);
+
+        // Vertical streaks suggesting fast-moving water inside the jet.
+        g2d.setColor(COLOR_GEYSER_SPRAY);
+        g2d.setStroke(STROKE_DEFAULT);
+        for (int streak = 0; streak < 3; streak++) {
+            int streakX = centerX - jetWidth / 3 + streak * jetWidth / 3;
+            g2d.drawLine(streakX, y + height, streakX, y + height / 6);
+        }
+
+        // Spray crown: droplets arcing up and outward from the jet top like a fountain. The arc is a
+        // parabola - highest in the middle of the fan, tailing off toward the edges.
+        int dropSize = Math.max(jetWidth / 2, 3);
+        int fanWidth = width;
+        int drops = 9;
+        for (int drop = 0; drop < drops; drop++) {
+            double fan = (drop / (double) (drops - 1)) * 2.0 - 1.0; // -1.0 .. 1.0
+            int hash = (drop * 13 + 5) % 11;
+            int dropX = centerX + (int) (fan * fanWidth / 2.0);
+            int arc = (int) ((1.0 - fan * fan) * height * 0.5);
+            int dropY = y - arc + (hash % 3) * dropSize / 2;
+            int diameter = dropSize + (hash % 3);
+            g2d.setColor(COLOR_GEYSER_SPRAY);
+            g2d.fillOval(dropX - diameter / 2, dropY, diameter, diameter);
+        }
+    }
+
+    /**
      * Draws overlay indicators for terrain that modifies LOS (smoke, fire, screen, fields).
      */
     private void drawTerrainOverlays(Graphics2D g2d, DiagramMetrics metrics, HexRow hex,
@@ -1010,6 +1064,12 @@ class LOSElevationDiagramPanel extends JPanel {
         if (hex.hasFields()) {
             int yFieldsTop = metrics.levelToY(hex.groundElevation() + 1);
             drawFieldStalks(g2d, xLeft, yFieldsTop, columnWidth, yGround - yFieldsTop);
+        }
+
+        // Erupting geyser: a rising water/steam jet, three levels tall (ultra-heavy woods for LOS)
+        if (hex.eruptingGeyser()) {
+            int yGeyserTop = metrics.levelToY(hex.groundElevation() + GEYSER_PLUME_LEVELS);
+            drawGeyserJet(g2d, xLeft, yGeyserTop, columnWidth, yGround - yGeyserTop);
         }
     }
 
@@ -1058,6 +1118,13 @@ class LOSElevationDiagramPanel extends JPanel {
                 int barMidY = (ySmokeTop + yGround) / 2 + fontHeight / 2;
                 String label = hex.smokeLevel() >= 2 ? "S2" : "S1";
                 drawCenteredLabel(g2d, fontMetrics, label, xCenter, barMidY, getLabelColor());
+            }
+
+            // Erupting geyser label
+            if (hex.eruptingGeyser()) {
+                int yGeyserTop = metrics.levelToY(hex.groundElevation() + GEYSER_PLUME_LEVELS);
+                int barMidY = (yGeyserTop + yGround) / 2 + fontHeight / 2;
+                drawCenteredLabel(g2d, fontMetrics, "G", xCenter, barMidY, getLabelColor());
             }
 
             // Water depth label
@@ -2356,6 +2423,14 @@ class LOSElevationDiagramPanel extends JPanel {
         if (hex.hasFields()) {
             tooltip.append("<br>Planted Fields");
         }
+        if (hex.eruptingGeyser()) {
+            int geyserTopElevation = hex.groundElevation() + GEYSER_PLUME_LEVELS;
+            boolean geyserAffectsLos = geyserTopElevation >= hex.losLineElevation();
+            tooltip.append("<br>Erupting Geyser (top elev ").append(geyserTopElevation).append(")");
+            if (!geyserAffectsLos) {
+                tooltip.append(" - <i>LOS line above geyser</i>");
+            }
+        }
         if (hex.splitHex() && hex.splitAlternate() != null) {
             tooltip.append("<br><i>Split hex (alternate: ")
                   .append(hex.splitAlternate().toFriendlyString())
@@ -2377,6 +2452,9 @@ class LOSElevationDiagramPanel extends JPanel {
             }
             if (hex.hasScreen() || hex.hasFields() || hex.hasFire()) {
                 anyTerrainReachesLos = true;
+            }
+            if (hex.eruptingGeyser()) {
+                anyTerrainReachesLos |= (hex.groundElevation() + GEYSER_PLUME_LEVELS) >= hex.losLineElevation();
             }
             if (anyTerrainReachesLos) {
                 tooltip.append("<br><font color='orange'>Affects LOS (modifier)</font>");

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/LOSElevationDiagramPanel.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/LOSElevationDiagramPanel.java
@@ -54,6 +54,7 @@ import megamek.client.ui.Messages;
 import megamek.client.ui.clientGUI.boardview.LOSDiagramData.HexRow;
 import megamek.client.ui.util.UIUtil;
 import megamek.common.Configuration;
+import megamek.common.LosEffects;
 
 /**
  * A panel that renders a 2D elevation cross-section diagram for a LOS path. Shows ground elevation, terrain features,
@@ -135,8 +136,11 @@ class LOSElevationDiagramPanel extends JPanel {
     /** Aspect ratio (height/width) for the larger crown puffs at the plume top. */
     private static final double SMOKE_CROWN_ASPECT_RATIO = 0.65;
 
-    /** Erupting-geyser plume height in TW levels; treated as ultra-heavy woods for LOS (TacOps). */
-    private static final int GEYSER_PLUME_LEVELS = 3;
+    /**
+     * Erupting-geyser plume height in TW levels; treated as ultra-heavy woods for LOS (TacOps). Derived from the LOS
+     * engine's {@link LosEffects#GEYSER_PLUME_HEIGHT} so the diagram cannot drift out of sync with the rule.
+     */
+    private static final int GEYSER_PLUME_LEVELS = LosEffects.GEYSER_PLUME_HEIGHT;
 
     /** Width of the geyser water jet as a fraction of the column width. */
     private static final double GEYSER_JET_WIDTH_FACTOR = 0.28;

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/LOSModifierCalculator.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/LOSModifierCalculator.java
@@ -480,8 +480,11 @@ final class LOSModifierCalculator {
             }
         }
 
-        // Erupting geyser
-        if (targetHex.terrainLevel(Terrains.GEYSER) == 2) {
+        // Erupting geyser. Per TacOps an erupting geyser blocks LOS as ultra-heavy woods (plume rises
+        // three levels); a target engulfed by the plume is already unreachable (handled by losModifiers).
+        // The +2 modifier only applies to a target raised above the plume that remains visible.
+        boolean isAbovePlume = targetRelHeight + 1 > 3;
+        if ((targetHex.terrainLevel(Terrains.GEYSER) == 2) && isAbovePlume) {
             thd.addModifier(2, "target in erupting geyser");
         }
 

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/LOSModifierCalculator.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/LOSModifierCalculator.java
@@ -483,8 +483,8 @@ final class LOSModifierCalculator {
         // Erupting geyser. Per TacOps an erupting geyser blocks LOS as ultra-heavy woods (plume rises
         // three levels); a target engulfed by the plume is already unreachable (handled by losModifiers).
         // The +2 modifier only applies to a target raised above the plume that remains visible.
-        boolean isAbovePlume = targetRelHeight + 1 > 3;
-        if ((targetHex.terrainLevel(Terrains.GEYSER) == 2) && isAbovePlume) {
+        boolean isAbovePlume = targetRelHeight + 1 > LosEffects.GEYSER_PLUME_HEIGHT;
+        if ((targetHex.terrainLevel(Terrains.GEYSER) == Terrains.GEYSER_LVL_ACTIVE) && isAbovePlume) {
             thd.addModifier(2, "target in erupting geyser");
         }
 

--- a/megamek/src/megamek/common/LosEffects.java
+++ b/megamek/src/megamek/common/LosEffects.java
@@ -140,6 +140,14 @@ public class LosEffects {
     public static final int DAMAGABLE_COVER_DROPSHIP = 0x1;
     public static final int DAMAGABLE_COVER_BUILDING = 0x2;
 
+    /** Terrain level of an erupting (active) geyser; see {@link Terrains#GEYSER}. */
+    private static final int GEYSER_ERUPTING = 2;
+    /**
+     * Height in levels that an erupting geyser's plume rises above its hex. Per TacOps, an erupting geyser blocks line
+     * of sight as ultra-heavy woods, which rises three levels above the hex.
+     */
+    private static final int GEYSER_PLUME_HEIGHT = 3;
+
     boolean blocked = false;
     boolean deadZone = false;
     boolean infProtected = false;
@@ -846,6 +854,11 @@ public class LosEffects {
             finalLoS = LosEffects.losStraight(game, ai, diagramLos, partialCover);
         }
 
+        // TacOps: a unit standing in an erupting geyser cannot be seen into (or out of) its own
+        // hex, treated as ultra-heavy woods. losForCoords() ignores the attacker's and target's
+        // own hexes, so those endpoints are handled here.
+        addEruptingGeyserEndpointBlock(game, ai, finalLoS);
+
         finalLoS.hasLoS = !finalLoS.blocked &&
               (finalLoS.screen < 1) &&
               (finalLoS.plantedFields < 6) &&
@@ -872,6 +885,50 @@ public class LosEffects {
 
         finalLoS.targetLoc = ai.targetPos;
         return finalLoS;
+    }
+
+    /**
+     * Applies the TacOps erupting-geyser line-of-sight block to the attacker's and target's own hexes.
+     *
+     * <p>An erupting geyser is treated as ultra-heavy woods for the purpose of determining line of sight into or
+     * through its hex. {@link #losForCoords} ignores the attacker's and target's own hexes, so a unit standing in an
+     * erupting geyser is handled here: if its absolute height is below the top of the plume, it is engulfed and line of
+     * sight is blocked.</p>
+     *
+     * @param game the current game
+     * @param ai   the attack info describing attacker and target positions and heights
+     * @param los  the line-of-sight effects to update
+     */
+    private static void addEruptingGeyserEndpointBlock(Game game, AttackInfo ai, LosEffects los) {
+        if (ai.underWaterCombat) {
+            return;
+        }
+        if (isEngulfedByEruptingGeyser(game, ai.boardId, ai.attackPos, ai.attackAbsHeight) ||
+              isEngulfedByEruptingGeyser(game, ai.boardId, ai.targetPos, ai.targetAbsHeight)) {
+            los.ultraWoods++;
+        }
+    }
+
+    /**
+     * Determines whether a unit at the given position and absolute height is engulfed by an erupting geyser, treating
+     * the geyser plume as ultra-heavy woods rising {@link #GEYSER_PLUME_HEIGHT} levels above the hex.
+     *
+     * @param game      the current game
+     * @param boardId   the board the position is on
+     * @param pos       the hex to check, or null if the unit has no position
+     * @param absHeight the absolute height of the unit in that hex
+     *
+     * @return true if an erupting geyser occupies the hex and its plume rises above the unit
+     */
+    private static boolean isEngulfedByEruptingGeyser(Game game, int boardId, @Nullable Coords pos, int absHeight) {
+        if ((pos == null) || !game.getBoard(boardId).contains(pos)) {
+            return false;
+        }
+        Hex hex = game.getBoard(boardId).getHex(pos);
+        if (hex.terrainLevel(Terrains.GEYSER) != GEYSER_ERUPTING) {
+            return false;
+        }
+        return (hex.getLevel() + GEYSER_PLUME_HEIGHT) > absHeight;
     }
 
     /**
@@ -1580,6 +1637,23 @@ public class LosEffects {
                     if ((woodsLevel == 3) || (jungleLevel == 3)) {
                         los.ultraWoods++;
                     }
+                }
+            }
+
+            // TacOps: an erupting geyser blocks LOS through its hex, treated as ultra-heavy woods.
+            // The plume rises three levels above the hex level.
+            if (hex.terrainLevel(Terrains.GEYSER) == GEYSER_ERUPTING) {
+                int geyserPlumeEl = hexEl + GEYSER_PLUME_HEIGHT;
+                if (diagramLoS) {
+                    affectsLos = geyserPlumeEl >= losElevation;
+                } else {
+                    affectsLos = (geyserPlumeEl > maxUnitHeight) ||
+                          ((geyserPlumeEl > ai.attackAbsHeight) && attackerAdjacent) ||
+                          ((geyserPlumeEl > ai.targetAbsHeight) && targetAdjacent);
+                }
+                if (affectsLos) {
+                    los.ultraWoods++;
+                    logger.debug("    -> {} counted as ULTRA WOODS (erupting geyser)", coords);
                 }
             }
         }

--- a/megamek/src/megamek/common/LosEffects.java
+++ b/megamek/src/megamek/common/LosEffects.java
@@ -140,13 +140,12 @@ public class LosEffects {
     public static final int DAMAGABLE_COVER_DROPSHIP = 0x1;
     public static final int DAMAGABLE_COVER_BUILDING = 0x2;
 
-    /** Terrain level of an erupting (active) geyser; see {@link Terrains#GEYSER}. */
-    private static final int GEYSER_ERUPTING = 2;
     /**
      * Height in levels that an erupting geyser's plume rises above its hex. Per TacOps, an erupting geyser blocks line
-     * of sight as ultra-heavy woods, which rises three levels above the hex.
+     * of sight as ultra-heavy woods, which rises three levels above the hex. Shared with the LOS Ruler/diagram so the
+     * UI cannot drift out of sync with the rule. The erupting terrain level itself is {@link Terrains#GEYSER_LVL_ACTIVE}.
      */
-    private static final int GEYSER_PLUME_HEIGHT = 3;
+    public static final int GEYSER_PLUME_HEIGHT = 3;
 
     boolean blocked = false;
     boolean deadZone = false;
@@ -925,7 +924,7 @@ public class LosEffects {
             return false;
         }
         Hex hex = game.getBoard(boardId).getHex(pos);
-        if (hex.terrainLevel(Terrains.GEYSER) != GEYSER_ERUPTING) {
+        if (hex.terrainLevel(Terrains.GEYSER) != Terrains.GEYSER_LVL_ACTIVE) {
             return false;
         }
         return (hex.getLevel() + GEYSER_PLUME_HEIGHT) > absHeight;
@@ -1642,7 +1641,7 @@ public class LosEffects {
 
             // TacOps: an erupting geyser blocks LOS through its hex, treated as ultra-heavy woods.
             // The plume rises three levels above the hex level.
-            if (hex.terrainLevel(Terrains.GEYSER) == GEYSER_ERUPTING) {
+            if (hex.terrainLevel(Terrains.GEYSER) == Terrains.GEYSER_LVL_ACTIVE) {
                 int geyserPlumeEl = hexEl + GEYSER_PLUME_HEIGHT;
                 if (diagramLoS) {
                     affectsLos = geyserPlumeEl >= losElevation;

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -3220,6 +3220,9 @@ public class Compute {
             }
         }
         if (hex.terrainLevel(Terrains.GEYSER) == 2) {
+            // Per TacOps an erupting geyser also blocks LOS as ultra-heavy woods (see
+            // LosEffects), so a target engulfed by the plume is already unreachable; this
+            // modifier still applies to a target raised above the plume that remains visible.
             // Always add full geyser modifier
             toHit.addModifier(2, "target in erupting geyser");
             if (eiStatus > 0) {

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -3219,7 +3219,7 @@ public class Compute {
                     break;
             }
         }
-        if (hex.terrainLevel(Terrains.GEYSER) == 2) {
+        if (hex.terrainLevel(Terrains.GEYSER) == Terrains.GEYSER_LVL_ACTIVE) {
             // Per TacOps an erupting geyser also blocks LOS as ultra-heavy woods (see
             // LosEffects), so a target engulfed by the plume is already unreachable; this
             // modifier still applies to a target raised above the plume that remains visible.
@@ -3317,7 +3317,7 @@ public class Compute {
                 break;
         }
 
-        if (hex.terrainLevel(Terrains.GEYSER) == 2) {
+        if (hex.terrainLevel(Terrains.GEYSER) == Terrains.GEYSER_LVL_ACTIVE) {
             // Always add full geyser modifier
             toHit.addModifier(2, "erupting geyser");
             if (eiStatus > 0) {

--- a/megamek/src/megamek/common/units/Terrains.java
+++ b/megamek/src/megamek/common/units/Terrains.java
@@ -97,6 +97,10 @@ public class Terrains implements Serializable {
     public static final int FIRE_LVL_INFERNO_BOMB = 3;
     public static final int FIRE_LVL_INFERNO_IV = 4;
 
+    public static final int GEYSER_LVL_DORMANT = 1;
+    public static final int GEYSER_LVL_ACTIVE = 2;
+    public static final int GEYSER_LVL_MAGMA_VENT = 3;
+
     // Building stuff
     public static final int BUILDING = 22; // 1: light 2: medium 3: heavy 4:
     // hardened [5: wall not implemented]

--- a/megamek/src/megamek/server/GeyserProcessor.java
+++ b/megamek/src/megamek/server/GeyserProcessor.java
@@ -84,15 +84,15 @@ public class GeyserProcessor extends DynamicTerrainProcessor {
                 g.turnsToGo--;
             } else {
                 Hex hex = gameManager.getGame().getHex(g.position, g.boardId);
-                if (hex.terrainLevel(Terrains.GEYSER) == 2) {
+                if (hex.terrainLevel(Terrains.GEYSER) == Terrains.GEYSER_LVL_ACTIVE) {
                     r = new Report(5275, Report.PUBLIC);
                     r.add(g.position.getBoardNum());
                     vPhaseReport.add(r);
                     hex.removeTerrain(Terrains.GEYSER);
-                    hex.addTerrain(new Terrain(Terrains.GEYSER, 1));
+                    hex.addTerrain(new Terrain(Terrains.GEYSER, Terrains.GEYSER_LVL_DORMANT));
                     markHexUpdate(g.position, g.boardId);
                 } else if (Compute.d6() == 1) {
-                    if (hex.terrainLevel(Terrains.GEYSER) == 3) {
+                    if (hex.terrainLevel(Terrains.GEYSER) == Terrains.GEYSER_LVL_MAGMA_VENT) {
                         r = new Report(5285, Report.PUBLIC);
                         r.add(g.position.getBoardNum());
                         vPhaseReport.add(r);
@@ -110,7 +110,7 @@ public class GeyserProcessor extends DynamicTerrainProcessor {
                         vPhaseReport.add(r);
                         eruptionReports.add(r);
                         hex.removeTerrain(Terrains.GEYSER);
-                        hex.addTerrain(new Terrain(Terrains.GEYSER, 2));
+                        hex.addTerrain(new Terrain(Terrains.GEYSER, Terrains.GEYSER_LVL_ACTIVE));
                         markHexUpdate(g.position, g.boardId);
                         g.turnsToGo = Compute.d6() - 1;
                     }

--- a/megamek/src/megamek/server/GeyserProcessor.java
+++ b/megamek/src/megamek/server/GeyserProcessor.java
@@ -74,6 +74,10 @@ public class GeyserProcessor extends DynamicTerrainProcessor {
         }
 
         Report r;
+        // Eruptions are also pushed as a transient "special" report so clients show a toast
+        // notification the instant a geyser (or magma vent) erupts, in addition to the normal
+        // end-phase report entry shown in the report panel.
+        Vector<Report> eruptionReports = new Vector<>();
         for (Iterator<GeyserInfo> gs = geysers.iterator(); gs.hasNext(); ) {
             GeyserInfo g = gs.next();
             if (g.turnsToGo > 0) {
@@ -92,6 +96,7 @@ public class GeyserProcessor extends DynamicTerrainProcessor {
                         r = new Report(5285, Report.PUBLIC);
                         r.add(g.position.getBoardNum());
                         vPhaseReport.add(r);
+                        eruptionReports.add(r);
                         hex.removeAllTerrains();
                         hex.addTerrain(new Terrain(Terrains.MAGMA, 2));
                         markHexUpdate(g.position, g.boardId);
@@ -103,6 +108,7 @@ public class GeyserProcessor extends DynamicTerrainProcessor {
                         r = new Report(5280, Report.PUBLIC);
                         r.add(g.position.getBoardNum());
                         vPhaseReport.add(r);
+                        eruptionReports.add(r);
                         hex.removeTerrain(Terrains.GEYSER);
                         hex.addTerrain(new Terrain(Terrains.GEYSER, 2));
                         markHexUpdate(g.position, g.boardId);
@@ -110,6 +116,11 @@ public class GeyserProcessor extends DynamicTerrainProcessor {
                     }
                 }
             }
+        }
+
+        // Broadcast eruption notifications as a transient special report so clients toast them.
+        if (!eruptionReports.isEmpty()) {
+            gameManager.send(gameManager.createSpecialReportPacket(eruptionReports));
         }
     }
 

--- a/megamek/unittests/megamek/common/LosEffectsTest.java
+++ b/megamek/unittests/megamek/common/LosEffectsTest.java
@@ -174,6 +174,39 @@ public class LosEffectsTest extends GameBoardTestCase {
               hex 0305 0 "" ""
               end"""
         );
+
+        // Board with an erupting geyser (level 2) in the intervening hex 0103
+        initializeBoard("01_BY_05_ERUPTING_GEYSER_INTERVENING", """
+              size 1 5
+              hex 0101 0 "" ""
+              hex 0102 0 "" ""
+              hex 0103 0 "geyser:2" ""
+              hex 0104 0 "" ""
+              hex 0105 0 "" ""
+              end"""
+        );
+
+        // Board with a dormant geyser (level 1) in the intervening hex 0103
+        initializeBoard("01_BY_05_DORMANT_GEYSER_INTERVENING", """
+              size 1 5
+              hex 0101 0 "" ""
+              hex 0102 0 "" ""
+              hex 0103 0 "geyser:1" ""
+              hex 0104 0 "" ""
+              hex 0105 0 "" ""
+              end"""
+        );
+
+        // Board with an erupting geyser (level 2) in the target's own hex 0105
+        initializeBoard("01_BY_05_ERUPTING_GEYSER_AT_TARGET", """
+              size 1 5
+              hex 0101 0 "" ""
+              hex 0102 0 "" ""
+              hex 0103 0 "" ""
+              hex 0104 0 "" ""
+              hex 0105 0 "geyser:2" ""
+              end"""
+        );
     }
 
     @BeforeEach
@@ -731,6 +764,93 @@ public class LosEffectsTest extends GameBoardTestCase {
             assertNotNull(result, "LosEffects should not be null");
             assertFalse(result.blocked, "LOS should not be blocked by level 3 terrain when firing from level 4");
             assertTrue(result.hasLoS, "Should have line of sight");
+        }
+    }
+
+    /**
+     * Tests for the TacOps erupting-geyser rule: an erupting geyser is treated as ultra-heavy woods for the purpose of
+     * determining line of sight into or through its hex.
+     */
+    @Nested
+    @DisplayName("Erupting Geyser LOS Blocking Tests")
+    class EruptingGeyserBlockingTests {
+
+        private LosEffects.AttackInfo buildGroundAttackInfo(Coords attackPos, Coords targetPos,
+              int attackAbsHeight, int targetAbsHeight) {
+            LosEffects.AttackInfo ai = new LosEffects.AttackInfo();
+            ai.attackPos = attackPos;
+            ai.targetPos = targetPos;
+            ai.attackAbsHeight = attackAbsHeight;
+            ai.targetAbsHeight = targetAbsHeight;
+            ai.attOnLand = true;
+            ai.targetOnLand = true;
+            ai.targetEntity = true;
+            return ai;
+        }
+
+        @Test
+        @DisplayName("erupting geyser in an intervening hex blocks LOS (treated as ultra-heavy woods)")
+        void shouldBlockLos_EruptingGeyserIntervening() {
+            setBoard("01_BY_05_ERUPTING_GEYSER_INTERVENING");
+            LosEffects.AttackInfo ai = buildGroundAttackInfo(new Coords(0, 0), new Coords(0, 4), 0, 0);
+
+            LosEffects result = LosEffects.calculateLos(game, ai);
+
+            assertNotNull(result);
+            assertEquals(1, result.ultraWoods, "Erupting geyser should count as 1 ultra woods");
+            assertFalse(result.hasLoS, "hasLoS should be false through an erupting geyser");
+
+            ToHitData thd = result.losModifiers(game);
+            assertEquals(TargetRoll.IMPOSSIBLE, thd.getValue(),
+                  "losModifiers should return IMPOSSIBLE through an erupting geyser");
+        }
+
+        @Test
+        @DisplayName("dormant geyser in an intervening hex does NOT block LOS")
+        void shouldNotBlockLos_DormantGeyserIntervening() {
+            setBoard("01_BY_05_DORMANT_GEYSER_INTERVENING");
+            LosEffects.AttackInfo ai = buildGroundAttackInfo(new Coords(0, 0), new Coords(0, 4), 0, 0);
+
+            LosEffects result = LosEffects.calculateLos(game, ai);
+
+            assertNotNull(result);
+            assertEquals(0, result.ultraWoods, "Dormant geyser should not count as ultra woods");
+            assertTrue(result.hasLoS, "hasLoS should be true through a dormant geyser");
+
+            ToHitData thd = result.losModifiers(game);
+            assertNotEquals(TargetRoll.IMPOSSIBLE, thd.getValue(),
+                  "losModifiers should NOT return IMPOSSIBLE through a dormant geyser");
+        }
+
+        @Test
+        @DisplayName("target standing in an erupting geyser cannot be seen (LOS into the hex blocked)")
+        void shouldBlockLos_TargetInEruptingGeyser() {
+            setBoard("01_BY_05_ERUPTING_GEYSER_AT_TARGET");
+            LosEffects.AttackInfo ai = buildGroundAttackInfo(new Coords(0, 0), new Coords(0, 4), 0, 0);
+
+            LosEffects result = LosEffects.calculateLos(game, ai);
+
+            assertNotNull(result);
+            assertEquals(1, result.ultraWoods, "Target's own erupting geyser should count as 1 ultra woods");
+            assertFalse(result.hasLoS, "hasLoS should be false for a target engulfed by an erupting geyser");
+
+            ToHitData thd = result.losModifiers(game);
+            assertEquals(TargetRoll.IMPOSSIBLE, thd.getValue(),
+                  "losModifiers should return IMPOSSIBLE for a target engulfed by an erupting geyser");
+        }
+
+        @Test
+        @DisplayName("target raised above the geyser plume remains visible")
+        void shouldNotBlockLos_TargetAboveEruptingGeyserPlume() {
+            setBoard("01_BY_05_ERUPTING_GEYSER_AT_TARGET");
+            // Plume rises 3 levels above the hex (level 0), so a unit at absolute height 4 is above it.
+            LosEffects.AttackInfo ai = buildGroundAttackInfo(new Coords(0, 0), new Coords(0, 4), 4, 4);
+
+            LosEffects result = LosEffects.calculateLos(game, ai);
+
+            assertNotNull(result);
+            assertEquals(0, result.ultraWoods, "A target above the plume should not be engulfed");
+            assertTrue(result.hasLoS, "hasLoS should be true for a target raised above the geyser plume");
         }
     }
 }


### PR DESCRIPTION
  A player on Discord reported that geysers weren't impacting line of sight. They weren't — `LosEffects` had no geyser handling at all, so you could shoot straight through (or into) an erupting geyser for just a +2 to-hit penalty.

  Per TacOps, an erupting geyser should be treated as ultra-heavy woods for determining line of sight into or through its hex. This adds that, plus matching support in the LOS Ruler tool and a toast notification when a geyser erupts.

  ## Changes
  - Erupting geysers (GEYSER level 2) now block LOS as ultra-heavy woods — both when intervening and when a unit is standing in one (a unit raised above the plume stays visible).
  - LOS Ruler: the +2 modifier now only applies to a target above the plume, and the elevation diagram draws the geyser as a water/steam jet with a "G" label and tooltip.
  - Added a toast notification that fires whenever a geyser (or magma vent) erupts.

  ## Testing
  - New regression tests in `LosEffectsTest` (intervening block, dormant no-block, target-in-geyser block, target-above-plume visible) — all passing.
  - Full `LosEffectsTest` + `LOSModifierCalculatorTest` pass; compile and checkstyle clean.