### PR TITLE
Fix #7873: Fix units receiving reduced damage when not actually inside buildings

### DIFF
--- a/megamek/src/megamek/common/weapons/handlers/AttackHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/AttackHandler.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2004, 2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2007-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2007-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/src/megamek/common/weapons/handlers/AttackHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/AttackHandler.java
@@ -40,6 +40,7 @@ import megamek.common.Report;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.enums.GamePhase;
 import megamek.common.units.Entity;
+import megamek.common.units.IBuilding;
 
 /**
  * Describes a set of methods a class can use to represent an attack from some weapon.
@@ -99,4 +100,25 @@ public interface AttackHandler {
 
     void setStrafingFirstShot(boolean isFirstShotStrafing);
 
+
+    /**
+     * Scale the {@code nDamage} based on if the unit is inside a building, partially sticking out of it, or not.
+     *
+     * @param entityTarget
+     * @param bldg
+     * @param targetStickingOutOfBuilding
+     * @param nDamage
+     *
+     * @return adjusted {@code nDamage}
+     */
+    default int getBuildingDamageAdjustment(Entity entityTarget, IBuilding bldg,
+          boolean targetStickingOutOfBuilding,
+          int nDamage) {
+        // some buildings scale remaining damage that is not absorbed
+        // TODO: this isn't quite right for castles brian
+        if ((null != bldg) && !targetStickingOutOfBuilding && (entityTarget.isInBuilding())) {
+            nDamage = (int) Math.floor(bldg.getDamageToScale() * nDamage);
+        }
+        return nDamage;
+    }
 }

--- a/megamek/src/megamek/common/weapons/handlers/MGAWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/MGAWeaponHandler.java
@@ -231,11 +231,7 @@ public class MGAWeaponHandler extends MGHandler {
 
         nDamage = checkTerrain(nDamage, entityTarget, vPhaseReport);
 
-        // some buildings scale remaining damage that is not absorbed
-        // TODO: this isn't quite right for castles brian
-        if ((null != bldg) && !targetStickingOutOfBuilding) {
-            nDamage = (int) Math.floor(bldg.getDamageToScale() * nDamage);
-        }
+        nDamage = getBuildingDamageAdjustment(entityTarget, bldg, targetStickingOutOfBuilding, nDamage);
 
         // A building may absorb the entire shot.
         if (nDamage == 0) {

--- a/megamek/src/megamek/common/weapons/handlers/MGAWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/MGAWeaponHandler.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2004 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2007-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2007-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/src/megamek/common/weapons/handlers/RifleWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/RifleWeaponHandler.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2010-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2010-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/src/megamek/common/weapons/handlers/RifleWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/RifleWeaponHandler.java
@@ -175,11 +175,7 @@ public class RifleWeaponHandler extends AmmoWeaponHandler {
 
         nDamage = checkTerrain(nDamage, entityTarget, vPhaseReport);
 
-        // some buildings scale remaining damage that is not absorbed
-        // TODO: this isn't quite right for castles brian
-        if ((null != bldg) && !targetStickingOutOfBuilding) {
-            nDamage = (int) Math.floor(bldg.getDamageToScale() * nDamage);
-        }
+        nDamage = getBuildingDamageAdjustment(entityTarget, bldg, targetStickingOutOfBuilding, nDamage);
 
         // A building may absorb the entire shot.
         if (nDamage == 0) {

--- a/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
@@ -1606,11 +1606,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
         nDamage = checkTerrain(nDamage, entityTarget, vPhaseReport);
         nDamage = checkLI(nDamage, entityTarget, vPhaseReport);
 
-        // some buildings scale remaining damage that is not absorbed
-        // TODO: this isn't quite right for castles brian
-        if ((null != bldg) && !targetStickingOutOfBuilding) {
-            nDamage = (int) Math.floor(bldg.getDamageToScale() * nDamage);
-        }
+        nDamage = getBuildingDamageAdjustment(entityTarget, bldg, targetStickingOutOfBuilding, nDamage);
 
         // A building may absorb the entire shot.
         if (nDamage == 0) {

--- a/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2004-2005 - Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2007-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2007-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/src/megamek/common/weapons/handlers/ac/ACAPHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/ac/ACAPHandler.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2004, 2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2007-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2007-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/src/megamek/common/weapons/handlers/ac/ACAPHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/ac/ACAPHandler.java
@@ -115,11 +115,7 @@ public class ACAPHandler extends ACWeaponHandler {
 
         nDamage = checkTerrain(nDamage, entityTarget, vPhaseReport);
 
-        // some buildings scale remaining damage that is not absorbed
-        // TODO : this isn't quite right for castles brian
-        if ((null != bldg) && !targetStickingOutOfBuilding) {
-            nDamage = (int) Math.floor(bldg.getDamageToScale() * nDamage);
-        }
+        nDamage = getBuildingDamageAdjustment(entityTarget, bldg, targetStickingOutOfBuilding, nDamage);
 
         // A building may absorb the entire shot.
         if (nDamage == 0) {

--- a/megamek/src/megamek/common/weapons/handlers/srm/SRMTandemChargeHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/srm/SRMTandemChargeHandler.java
@@ -118,11 +118,7 @@ public class SRMTandemChargeHandler extends SRMHandler {
 
         nDamage = checkTerrain(nDamage, entityTarget, vPhaseReport);
 
-        // some buildings scale remaining damage that is not absorbed
-        // TODO: this isn't quite right for castles brian
-        if ((null != bldg) && !targetStickingOutOfBuilding) {
-            nDamage = (int) Math.floor(bldg.getDamageToScale() * nDamage);
-        }
+        nDamage = getBuildingDamageAdjustment(entityTarget, bldg, targetStickingOutOfBuilding, nDamage);
 
         // A building may absorb the entire shot.
         if (nDamage == 0) {

--- a/megamek/src/megamek/common/weapons/handlers/srm/SRMTandemChargeHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/srm/SRMTandemChargeHandler.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2008-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2008-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/src/megamek/common/weapons/infantry/InfantryHeatWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryHeatWeaponHandler.java
@@ -114,9 +114,7 @@ public class InfantryHeatWeaponHandler extends InfantryWeaponHandler {
                   vPhaseReport, bldg, targetStickingOutOfBuilding);
             nDamage = checkTerrain(nDamage, entityTarget, vPhaseReport);
             nDamage = checkLI(nDamage, entityTarget, vPhaseReport);
-            if ((bldg != null) && !targetStickingOutOfBuilding) {
-                nDamage = (int) Math.floor(bldg.getDamageToScale() * nDamage);
-            }
+            nDamage = getBuildingDamageAdjustment(entityTarget, bldg, targetStickingOutOfBuilding, nDamage);
 
             // If using BMM heat option, do damage as well as heat
             if (game.getOptions().booleanOption(OptionsConstants.BASE_INFANTRY_DAMAGE_HEAT)) {

--- a/megamek/src/megamek/common/weapons/infantry/InfantryHeatWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryHeatWeaponHandler.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2004,2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2012-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2012-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/unittests/megamek/common/ComputeTest.java
+++ b/megamek/unittests/megamek/common/ComputeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/unittests/megamek/common/ComputeTest.java
+++ b/megamek/unittests/megamek/common/ComputeTest.java
@@ -958,4 +958,76 @@ class ComputeTest {
         assertEquals(1, reports.size(), "Report size");
         assertTrue(reports.getFirst().text().contains("in building"));
     }
+
+    /**
+     * Tests for {@link Compute#isInBuilding(Game, Entity)}
+     */
+    @Nested
+    @DisplayName("isInBuilding Tests")
+    class ComputeTestIsInBuilding extends GameBoardTestCase {
+
+        static {
+            initializeBoard("01_BY_02_WITH_BUILDING", """
+                  size 1 2
+                  hex 0101 0 "" ""
+                  hex 0102 0 "bldg_elev:2;building:2:8;bldg_cf:100" ""
+                  end""");
+        }
+
+        @BeforeEach
+        void beforeEach() {
+            setBoard("01_BY_02_WITH_BUILDING");
+        }
+
+        @Test
+        @DisplayName("Mek at ground floor of a building is inside the building")
+        void mekAtGroundFloorIsInBuilding() {
+            Mek mek = createMek("Atlas", "AS7-D", "Alice");
+            mek.setPosition(new Coords(0, 1));
+            mek.setElevation(0);
+
+            assertTrue(Compute.isInBuilding(getGame(), mek));
+        }
+
+        @Test
+        @DisplayName("Mek at upper floor of a building is inside the building")
+        void mekAtUpperFloorIsInBuilding() {
+            Mek mek = createMek("Atlas", "AS7-D", "Alice");
+            mek.setPosition(new Coords(0, 1));
+            mek.setElevation(1);
+
+            assertTrue(Compute.isInBuilding(getGame(), mek));
+        }
+
+        @Test
+        @DisplayName("Mek standing on building roof is not inside the building")
+        void mekOnBuildingRoofIsNotInBuilding() {
+            Mek mek = createMek("Atlas", "AS7-D", "Alice");
+            mek.setPosition(new Coords(0, 1));
+            mek.setElevation(2);
+
+            assertFalse(Compute.isInBuilding(getGame(), mek));
+        }
+
+        @Test
+        @DisplayName("Prone Mek on building roof is not inside the building")
+        void proneMekOnBuildingRoofIsNotInBuilding() {
+            Mek mek = createMek("Atlas", "AS7-D", "Alice");
+            mek.setPosition(new Coords(0, 1));
+            mek.setElevation(2);
+            mek.setProne(true);
+
+            assertFalse(Compute.isInBuilding(getGame(), mek));
+        }
+
+        @Test
+        @DisplayName("Mek in a hex with no building is not inside a building")
+        void mekInNonBuildingHexIsNotInBuilding() {
+            Mek mek = createMek("Atlas", "AS7-D", "Alice");
+            mek.setPosition(new Coords(0, 0));
+            mek.setElevation(0);
+
+            assertFalse(Compute.isInBuilding(getGame(), mek));
+        }
+    }
 }

--- a/megamek/unittests/megamek/common/weapons/handlers/MGAWeaponHandlerTest.java
+++ b/megamek/unittests/megamek/common/weapons/handlers/MGAWeaponHandlerTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.weapons.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Field;
+import java.util.Vector;
+
+import megamek.common.CalledShot;
+import megamek.common.Hex;
+import megamek.common.HitData;
+import megamek.common.Report;
+import megamek.common.ToHitData;
+import megamek.common.actions.WeaponAttackAction;
+import megamek.common.board.Board;
+import megamek.common.board.Coords;
+import megamek.common.enums.AimingMode;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.WeaponMounted;
+import megamek.common.equipment.WeaponType;
+import megamek.common.game.Game;
+import megamek.common.options.GameOptions;
+import megamek.common.units.BipedMek;
+import megamek.common.units.IBuilding;
+import megamek.common.units.Mek;
+import megamek.common.units.Targetable;
+import megamek.common.weapons.DamageType;
+import megamek.server.totalWarfare.TWGameManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class MGAWeaponHandlerTest {
+
+    private BipedMek mockAttacker;
+    private BipedMek mockEntityTarget;
+    private Game mockGame;
+    private TWGameManager mockGameManager;
+    private ToHitData mockToHit;
+    private WeaponAttackAction mockAction;
+    private WeaponMounted mockWeapon;
+    private WeaponType mockWeaponType;
+    private Board mockBoard;
+    private Hex mockHex;
+    private IBuilding mockBuilding;
+    private MGAWeaponHandler handler;
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockAttacker = mock(BipedMek.class);
+        mockEntityTarget = mock(BipedMek.class);
+        mockGame = mock(Game.class);
+        mockGameManager = mock(TWGameManager.class);
+        mockToHit = mock(ToHitData.class);
+        mockAction = mock(WeaponAttackAction.class);
+        mockWeapon = mock(WeaponMounted.class);
+        mockWeaponType = mock(WeaponType.class);
+        mockBoard = mock(Board.class);
+        mockHex = mock(Hex.class);
+        mockBuilding = mock(IBuilding.class);
+
+        GameOptions mockOptions = mock(GameOptions.class);
+        doReturn(false).when(mockOptions).booleanOption(any(String.class));
+        doReturn(mockOptions).when(mockGame).getOptions();
+        doReturn(mockBoard).when(mockGame).getBoard();
+        doReturn(mockHex).when(mockGame).getHexOf(any(BipedMek.class));
+        doReturn(false).when(mockHex).containsTerrain(anyInt());
+
+        Coords attackerCoords = new Coords(0, 0);
+        Coords targetCoords = new Coords(1, 0);
+        doReturn(1).when(mockAttacker).getId();
+        doReturn(mockAttacker).when(mockGame).getEntity(1);
+        doReturn(mockAttacker).when(mockAttacker).getAttackingEntity();
+        doReturn(attackerCoords).when(mockAttacker).getPosition();
+        doReturn(-1).when(mockAttacker).getSwarmTargetId();
+        doReturn(mockAttacker).when(mockGame).getEntity(1);
+
+        doReturn(2).when(mockEntityTarget).getId();
+        doReturn(targetCoords).when(mockEntityTarget).getPosition();
+        doReturn(Targetable.TYPE_ENTITY).when(mockEntityTarget).getTargetType();
+        doReturn(mockEntityTarget).when(mockGame).getTarget(Targetable.TYPE_ENTITY, 2);
+
+        HitData hitData = new HitData(Mek.LOC_CENTER_TORSO, false);
+        doReturn(hitData).when(mockEntityTarget).rollHitLocation(anyInt(), anyInt(), anyInt(), any(AimingMode.class), anyInt());
+        doReturn("CT").when(mockEntityTarget).getLocationAbbr(any(HitData.class));
+        doReturn(false).when(mockEntityTarget).removePartialCoverHits(anyInt(), anyInt(), anyInt());
+
+        CalledShot mockCalledShot = mock(CalledShot.class);
+        doReturn(CalledShot.CALLED_NONE).when(mockCalledShot).getCall();
+        doReturn(mockCalledShot).when(mockWeapon).getCalledShot();
+        doReturn(mockWeaponType).when(mockWeapon).getType();
+        doReturn("MGAWeapon").when(mockWeaponType).getInternalName();
+        doReturn(mockWeapon).when(mockAttacker).getEquipment(0);
+
+        doReturn(1).when(mockAction).getEntityId();
+        doReturn(0).when(mockAction).getWeaponId();
+        doReturn(Targetable.TYPE_ENTITY).when(mockAction).getTargetType();
+        doReturn(2).when(mockAction).getTargetId();
+        doReturn(Mek.LOC_NONE).when(mockAction).getAimedLocation();
+        doReturn(AimingMode.NONE).when(mockAction).getAimingMode();
+
+        doReturn(new Vector<Report>()).when(mockGameManager).damageEntity(
+              any(), any(), anyInt(), anyBoolean(), any(DamageType.class),
+              anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+
+        doReturn(0.5).when(mockBuilding).getDamageToScale();
+
+        handler = new MGAWeaponHandler(mockToHit, mockAction, mockGame, mockGameManager);
+        setField(handler, "nDamPerHit", 10);
+    }
+
+    private static void setField(Object obj, String name, Object value) throws Exception {
+        Class<?> cls = obj.getClass();
+        while (cls != null) {
+            try {
+                Field f = cls.getDeclaredField(name);
+                f.setAccessible(true);
+                f.set(obj, value);
+                return;
+            } catch (NoSuchFieldException e) {
+                cls = cls.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name + " not found in hierarchy of " + obj.getClass().getName());
+    }
+
+    /**
+     * Tests for {@link MGAWeaponHandler#handleEntityDamage}
+     */
+    @Nested
+    @DisplayName("handleEntityDamage")
+    class HandleEntityDamage {
+
+        @Test
+        @DisplayName("damage is scaled when entity is inside a building")
+        void damageIsScaledForEntityInsideBuilding() {
+            doReturn(true).when(mockEntityTarget).isInBuilding();
+
+            handler.handleEntityDamage(mockEntityTarget, new Vector<>(), mockBuilding, 1, 1, 0);
+
+            ArgumentCaptor<Integer> damageCaptor = ArgumentCaptor.forClass(Integer.class);
+            verify(mockGameManager).damageEntity(
+                  any(), any(), damageCaptor.capture(),
+                  anyBoolean(), any(DamageType.class), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+            assertEquals(5, damageCaptor.getValue(), "Damage should be halved (floor(0.5 * 10)) when entity is inside the building");
+        }
+
+        @Test
+        @DisplayName("damage is not scaled when entity is not inside the building")
+        void damageIsNotScaledForEntityOutsideBuilding() {
+            doReturn(false).when(mockEntityTarget).isInBuilding();
+
+            handler.handleEntityDamage(mockEntityTarget, new Vector<>(), mockBuilding, 1, 1, 0);
+
+            ArgumentCaptor<Integer> damageCaptor = ArgumentCaptor.forClass(Integer.class);
+            verify(mockGameManager).damageEntity(
+                  any(), any(), damageCaptor.capture(),
+                  anyBoolean(), any(DamageType.class), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+            assertEquals(10, damageCaptor.getValue(), "Damage should be unmodified when entity is not inside the building");
+        }
+
+        @Test
+        @DisplayName("damage is not scaled when there is no building")
+        void damageIsNotScaledWithNullBuilding() {
+            handler.handleEntityDamage(mockEntityTarget, new Vector<>(), null, 1, 1, 0);
+
+            ArgumentCaptor<Integer> damageCaptor = ArgumentCaptor.forClass(Integer.class);
+            verify(mockGameManager).damageEntity(
+                  any(), any(), damageCaptor.capture(),
+                  anyBoolean(), any(DamageType.class), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+            assertEquals(10, damageCaptor.getValue(), "Damage should be unmodified when there is no building");
+        }
+    }
+}

--- a/megamek/unittests/megamek/common/weapons/handlers/RifleWeaponHandlerTest.java
+++ b/megamek/unittests/megamek/common/weapons/handlers/RifleWeaponHandlerTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.weapons.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Field;
+import java.util.Vector;
+
+import megamek.common.CalledShot;
+import megamek.common.Hex;
+import megamek.common.HitData;
+import megamek.common.Report;
+import megamek.common.ToHitData;
+import megamek.common.actions.WeaponAttackAction;
+import megamek.common.board.Board;
+import megamek.common.board.Coords;
+import megamek.common.enums.AimingMode;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.WeaponMounted;
+import megamek.common.equipment.WeaponType;
+import megamek.common.game.Game;
+import megamek.common.options.GameOptions;
+import megamek.common.rolls.Roll;
+import megamek.common.units.BipedMek;
+import megamek.common.units.IBuilding;
+import megamek.common.units.Mek;
+import megamek.common.units.Targetable;
+import megamek.common.weapons.DamageType;
+import megamek.server.totalWarfare.TWGameManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class RifleWeaponHandlerTest {
+
+    private BipedMek mockAttacker;
+    private BipedMek mockEntityTarget;
+    private Game mockGame;
+    private TWGameManager mockGameManager;
+    private ToHitData mockToHit;
+    private WeaponAttackAction mockAction;
+    private WeaponMounted mockWeapon;
+    private WeaponType mockWeaponType;
+    private Board mockBoard;
+    private Hex mockHex;
+    private IBuilding mockBuilding;
+    private RifleWeaponHandler handler;
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockAttacker = mock(BipedMek.class);
+        mockEntityTarget = mock(BipedMek.class);
+        mockGame = mock(Game.class);
+        mockGameManager = mock(TWGameManager.class);
+        mockToHit = mock(ToHitData.class);
+        mockAction = mock(WeaponAttackAction.class);
+        mockWeapon = mock(WeaponMounted.class);
+        mockWeaponType = mock(WeaponType.class);
+        mockBoard = mock(Board.class);
+        mockHex = mock(Hex.class);
+        mockBuilding = mock(IBuilding.class);
+
+        GameOptions mockOptions = mock(GameOptions.class);
+        doReturn(false).when(mockOptions).booleanOption(any(String.class));
+        doReturn(mockOptions).when(mockGame).getOptions();
+        doReturn(mockBoard).when(mockGame).getBoard();
+        doReturn(mockHex).when(mockGame).getHexOf(any(BipedMek.class));
+        doReturn(false).when(mockHex).containsTerrain(anyInt());
+
+        Coords attackerCoords = new Coords(0, 0);
+        Coords targetCoords = new Coords(1, 0);
+        doReturn(1).when(mockAttacker).getId();
+        doReturn(mockAttacker).when(mockGame).getEntity(1);
+        doReturn(mockAttacker).when(mockAttacker).getAttackingEntity();
+        doReturn(attackerCoords).when(mockAttacker).getPosition();
+        doReturn(-1).when(mockAttacker).getSwarmTargetId();
+
+        doReturn(2).when(mockEntityTarget).getId();
+        doReturn(targetCoords).when(mockEntityTarget).getPosition();
+        doReturn(Targetable.TYPE_ENTITY).when(mockEntityTarget).getTargetType();
+        doReturn(mockEntityTarget).when(mockGame).getTarget(Targetable.TYPE_ENTITY, 2);
+
+        doReturn("CT").when(mockEntityTarget).getLocationAbbr(any(HitData.class));
+        doReturn(false).when(mockEntityTarget).removePartialCoverHits(anyInt(), anyInt(), anyInt());
+
+        CalledShot mockCalledShot = mock(CalledShot.class);
+        doReturn(CalledShot.CALLED_NONE).when(mockCalledShot).getCall();
+        doReturn(mockCalledShot).when(mockWeapon).getCalledShot();
+        doReturn(mockWeaponType).when(mockWeapon).getType();
+        doReturn("RifleWeapon").when(mockWeaponType).getInternalName();
+        doReturn(mockWeapon).when(mockAttacker).getEquipment(0);
+
+        doReturn(1).when(mockAction).getEntityId();
+        doReturn(0).when(mockAction).getWeaponId();
+        doReturn(Targetable.TYPE_ENTITY).when(mockAction).getTargetType();
+        doReturn(2).when(mockAction).getTargetId();
+        doReturn(Mek.LOC_NONE).when(mockAction).getAimedLocation();
+        doReturn(AimingMode.NONE).when(mockAction).getAimingMode();
+
+        doReturn(new Vector<Report>()).when(mockGameManager).damageEntity(
+              any(), any(), anyInt(), anyBoolean(), any(DamageType.class),
+              anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+
+        doReturn(0.5).when(mockBuilding).getDamageToScale();
+
+        handler = new RifleWeaponHandler(mockToHit, mockAction, mockGame, mockGameManager);
+
+        // RifleWeaponHandler sets its private `hit` field in calcDamagePerHit(); inject directly
+        HitData hitData = new HitData(Mek.LOC_CENTER_TORSO, false);
+        setField(handler, "hit", hitData);
+        setField(handler, "nDamPerHit", 10);
+
+        // RifleWeaponHandler.handleEntityDamage reads roll.getIntValue() for box-cars check
+        Roll mockRoll = mock(Roll.class);
+        doReturn(6).when(mockRoll).getIntValue();
+        handler.roll = mockRoll;
+    }
+
+    private static void setField(Object obj, String name, Object value) throws Exception {
+        Class<?> cls = obj.getClass();
+        while (cls != null) {
+            try {
+                Field f = cls.getDeclaredField(name);
+                f.setAccessible(true);
+                f.set(obj, value);
+                return;
+            } catch (NoSuchFieldException e) {
+                cls = cls.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name + " not found in hierarchy of " + obj.getClass().getName());
+    }
+
+    /**
+     * Tests for {@link RifleWeaponHandler#handleEntityDamage}
+     */
+    @Nested
+    @DisplayName("handleEntityDamage")
+    class HandleEntityDamage {
+
+        @Test
+        @DisplayName("damage is scaled when entity is inside a building")
+        void damageIsScaledForEntityInsideBuilding() {
+            doReturn(true).when(mockEntityTarget).isInBuilding();
+
+            handler.handleEntityDamage(mockEntityTarget, new Vector<>(), mockBuilding, 1, 1, 0);
+
+            ArgumentCaptor<Integer> damageCaptor = ArgumentCaptor.forClass(Integer.class);
+            verify(mockGameManager).damageEntity(
+                  any(), any(), damageCaptor.capture(),
+                  anyBoolean(), any(DamageType.class), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+            assertEquals(5, damageCaptor.getValue(), "Damage should be halved (floor(0.5 * 10)) when entity is inside the building");
+        }
+
+        @Test
+        @DisplayName("damage is not scaled when entity is not inside the building")
+        void damageIsNotScaledForEntityOutsideBuilding() {
+            doReturn(false).when(mockEntityTarget).isInBuilding();
+
+            handler.handleEntityDamage(mockEntityTarget, new Vector<>(), mockBuilding, 1, 1, 0);
+
+            ArgumentCaptor<Integer> damageCaptor = ArgumentCaptor.forClass(Integer.class);
+            verify(mockGameManager).damageEntity(
+                  any(), any(), damageCaptor.capture(),
+                  anyBoolean(), any(DamageType.class), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+            assertEquals(10, damageCaptor.getValue(), "Damage should be unmodified when entity is not inside the building");
+        }
+
+        @Test
+        @DisplayName("damage is not scaled when there is no building")
+        void damageIsNotScaledWithNullBuilding() {
+            handler.handleEntityDamage(mockEntityTarget, new Vector<>(), null, 1, 1, 0);
+
+            ArgumentCaptor<Integer> damageCaptor = ArgumentCaptor.forClass(Integer.class);
+            verify(mockGameManager).damageEntity(
+                  any(), any(), damageCaptor.capture(),
+                  anyBoolean(), any(DamageType.class), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+            assertEquals(10, damageCaptor.getValue(), "Damage should be unmodified when there is no building");
+        }
+    }
+}

--- a/megamek/unittests/megamek/common/weapons/handlers/ac/ACAPHandlerTest.java
+++ b/megamek/unittests/megamek/common/weapons/handlers/ac/ACAPHandlerTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.weapons.handlers.ac;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Field;
+import java.util.Vector;
+
+import megamek.common.CalledShot;
+import megamek.common.Hex;
+import megamek.common.HitData;
+import megamek.common.Report;
+import megamek.common.ToHitData;
+import megamek.common.actions.WeaponAttackAction;
+import megamek.common.board.Board;
+import megamek.common.board.Coords;
+import megamek.common.enums.AimingMode;
+import megamek.common.equipment.AmmoType;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.Mounted;
+import megamek.common.equipment.WeaponMounted;
+import megamek.common.equipment.WeaponType;
+import megamek.common.game.Game;
+import megamek.common.options.GameOptions;
+import megamek.common.units.BipedMek;
+import megamek.common.units.IBuilding;
+import megamek.common.units.Mek;
+import megamek.common.units.Targetable;
+import megamek.common.weapons.DamageType;
+import megamek.server.totalWarfare.TWGameManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ACAPHandlerTest {
+
+    private BipedMek mockAttacker;
+    private BipedMek mockEntityTarget;
+    private Game mockGame;
+    private TWGameManager mockGameManager;
+    private ToHitData mockToHit;
+    private WeaponAttackAction mockAction;
+    private WeaponMounted mockWeapon;
+    private WeaponType mockWeaponType;
+    private Board mockBoard;
+    private Hex mockHex;
+    private IBuilding mockBuilding;
+    private ACAPHandler handler;
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockAttacker = mock(BipedMek.class);
+        mockEntityTarget = mock(BipedMek.class);
+        mockGame = mock(Game.class);
+        mockGameManager = mock(TWGameManager.class);
+        mockToHit = mock(ToHitData.class);
+        mockAction = mock(WeaponAttackAction.class);
+        mockWeapon = mock(WeaponMounted.class);
+        mockWeaponType = mock(WeaponType.class);
+        mockBoard = mock(Board.class);
+        mockHex = mock(Hex.class);
+        mockBuilding = mock(IBuilding.class);
+
+        GameOptions mockOptions = mock(GameOptions.class);
+        doReturn(false).when(mockOptions).booleanOption(any(String.class));
+        doReturn(mockOptions).when(mockGame).getOptions();
+        doReturn(mockBoard).when(mockGame).getBoard();
+        doReturn(mockHex).when(mockGame).getHexOf(any(BipedMek.class));
+        doReturn(false).when(mockHex).containsTerrain(anyInt());
+
+        Coords attackerCoords = new Coords(0, 0);
+        Coords targetCoords = new Coords(1, 0);
+        doReturn(1).when(mockAttacker).getId();
+        doReturn(mockAttacker).when(mockGame).getEntity(1);
+        doReturn(mockAttacker).when(mockAttacker).getAttackingEntity();
+        doReturn(attackerCoords).when(mockAttacker).getPosition();
+        doReturn(-1).when(mockAttacker).getSwarmTargetId();
+
+        doReturn(2).when(mockEntityTarget).getId();
+        doReturn(targetCoords).when(mockEntityTarget).getPosition();
+        doReturn(Targetable.TYPE_ENTITY).when(mockEntityTarget).getTargetType();
+        doReturn(mockEntityTarget).when(mockGame).getTarget(Targetable.TYPE_ENTITY, 2);
+
+        HitData hitData = new HitData(Mek.LOC_CENTER_TORSO, false);
+        doReturn(hitData).when(mockEntityTarget).rollHitLocation(anyInt(), anyInt(), anyInt(), any(AimingMode.class), anyInt());
+        doReturn("CT").when(mockEntityTarget).getLocationAbbr(any(HitData.class));
+        doReturn(false).when(mockEntityTarget).removePartialCoverHits(anyInt(), anyInt(), anyInt());
+
+        // ACAPHandler casts weapon.getLinked().getType() to AmmoType in handleEntityDamage
+        Mounted<?> mockLinked = mock(Mounted.class);
+        AmmoType mockAmmoType = mock(AmmoType.class);
+        doReturn(mockAmmoType).when(mockLinked).getType();
+        doReturn(mockLinked).when(mockWeapon).getLinked();
+
+        CalledShot mockCalledShot = mock(CalledShot.class);
+        doReturn(CalledShot.CALLED_NONE).when(mockCalledShot).getCall();
+        doReturn(mockCalledShot).when(mockWeapon).getCalledShot();
+        doReturn(mockWeaponType).when(mockWeapon).getType();
+        doReturn("ACAPWeapon").when(mockWeaponType).getInternalName();
+        doReturn(mockWeapon).when(mockAttacker).getEquipment(0);
+
+        doReturn(1).when(mockAction).getEntityId();
+        doReturn(0).when(mockAction).getWeaponId();
+        doReturn(Targetable.TYPE_ENTITY).when(mockAction).getTargetType();
+        doReturn(2).when(mockAction).getTargetId();
+        doReturn(Mek.LOC_NONE).when(mockAction).getAimedLocation();
+        doReturn(AimingMode.NONE).when(mockAction).getAimingMode();
+
+        doReturn(new Vector<Report>()).when(mockGameManager).damageEntity(
+              any(), any(), anyInt(), anyBoolean(), any(DamageType.class),
+              anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+
+        doReturn(0.5).when(mockBuilding).getDamageToScale();
+
+        handler = new ACAPHandler(mockToHit, mockAction, mockGame, mockGameManager);
+        setField(handler, "nDamPerHit", 10);
+    }
+
+    private static void setField(Object obj, String name, Object value) throws Exception {
+        Class<?> cls = obj.getClass();
+        while (cls != null) {
+            try {
+                Field f = cls.getDeclaredField(name);
+                f.setAccessible(true);
+                f.set(obj, value);
+                return;
+            } catch (NoSuchFieldException e) {
+                cls = cls.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name + " not found in hierarchy of " + obj.getClass().getName());
+    }
+
+    /**
+     * Tests for {@link ACAPHandler#handleEntityDamage}
+     */
+    @Nested
+    @DisplayName("handleEntityDamage")
+    class HandleEntityDamage {
+
+        @Test
+        @DisplayName("damage is scaled when entity is inside a building")
+        void damageIsScaledForEntityInsideBuilding() {
+            doReturn(true).when(mockEntityTarget).isInBuilding();
+
+            handler.handleEntityDamage(mockEntityTarget, new Vector<>(), mockBuilding, 1, 1, 0);
+
+            ArgumentCaptor<Integer> damageCaptor = ArgumentCaptor.forClass(Integer.class);
+            verify(mockGameManager).damageEntity(
+                  any(), any(), damageCaptor.capture(),
+                  anyBoolean(), any(DamageType.class), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+            assertEquals(5, damageCaptor.getValue(), "Damage should be halved (floor(0.5 * 10)) when entity is inside the building");
+        }
+
+        @Test
+        @DisplayName("damage is not scaled when entity is not inside the building")
+        void damageIsNotScaledForEntityOutsideBuilding() {
+            doReturn(false).when(mockEntityTarget).isInBuilding();
+
+            handler.handleEntityDamage(mockEntityTarget, new Vector<>(), mockBuilding, 1, 1, 0);
+
+            ArgumentCaptor<Integer> damageCaptor = ArgumentCaptor.forClass(Integer.class);
+            verify(mockGameManager).damageEntity(
+                  any(), any(), damageCaptor.capture(),
+                  anyBoolean(), any(DamageType.class), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+            assertEquals(10, damageCaptor.getValue(), "Damage should be unmodified when entity is not inside the building");
+        }
+
+        @Test
+        @DisplayName("damage is not scaled when there is no building")
+        void damageIsNotScaledWithNullBuilding() {
+            handler.handleEntityDamage(mockEntityTarget, new Vector<>(), null, 1, 1, 0);
+
+            ArgumentCaptor<Integer> damageCaptor = ArgumentCaptor.forClass(Integer.class);
+            verify(mockGameManager).damageEntity(
+                  any(), any(), damageCaptor.capture(),
+                  anyBoolean(), any(DamageType.class), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+            assertEquals(10, damageCaptor.getValue(), "Damage should be unmodified when there is no building");
+        }
+    }
+}

--- a/megamek/unittests/megamek/common/weapons/handlers/srm/SRMTandemChargeHandlerTest.java
+++ b/megamek/unittests/megamek/common/weapons/handlers/srm/SRMTandemChargeHandlerTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek Organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.weapons.handlers.srm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Field;
+import java.util.Vector;
+
+import megamek.common.CalledShot;
+import megamek.common.Hex;
+import megamek.common.HitData;
+import megamek.common.Report;
+import megamek.common.ToHitData;
+import megamek.common.actions.WeaponAttackAction;
+import megamek.common.board.Board;
+import megamek.common.board.Coords;
+import megamek.common.enums.AimingMode;
+import megamek.common.equipment.AmmoType;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.Mounted;
+import megamek.common.equipment.WeaponMounted;
+import megamek.common.equipment.WeaponType;
+import megamek.common.game.Game;
+import megamek.common.options.GameOptions;
+import megamek.common.units.BipedMek;
+import megamek.common.units.IBuilding;
+import megamek.common.units.Mek;
+import megamek.common.units.Targetable;
+import megamek.common.weapons.DamageType;
+import megamek.server.totalWarfare.TWGameManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class SRMTandemChargeHandlerTest {
+
+    private BipedMek mockAttacker;
+    private BipedMek mockEntityTarget;
+    private Game mockGame;
+    private TWGameManager mockGameManager;
+    private ToHitData mockToHit;
+    private WeaponAttackAction mockAction;
+    private WeaponMounted mockWeapon;
+    private WeaponType mockWeaponType;
+    private Board mockBoard;
+    private Hex mockHex;
+    private IBuilding mockBuilding;
+    private SRMTandemChargeHandler handler;
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockAttacker = mock(BipedMek.class);
+        mockEntityTarget = mock(BipedMek.class);
+        mockGame = mock(Game.class);
+        mockGameManager = mock(TWGameManager.class);
+        mockToHit = mock(ToHitData.class);
+        mockAction = mock(WeaponAttackAction.class);
+        mockWeapon = mock(WeaponMounted.class);
+        mockWeaponType = mock(WeaponType.class);
+        mockBoard = mock(Board.class);
+        mockHex = mock(Hex.class);
+        mockBuilding = mock(IBuilding.class);
+
+        GameOptions mockOptions = mock(GameOptions.class);
+        doReturn(false).when(mockOptions).booleanOption(any(String.class));
+        doReturn(mockOptions).when(mockGame).getOptions();
+        doReturn(mockBoard).when(mockGame).getBoard();
+        doReturn(mockHex).when(mockGame).getHexOf(any(BipedMek.class));
+        doReturn(false).when(mockHex).containsTerrain(anyInt());
+
+        Coords attackerCoords = new Coords(0, 0);
+        Coords targetCoords = new Coords(1, 0);
+        doReturn(1).when(mockAttacker).getId();
+        doReturn(mockAttacker).when(mockGame).getEntity(1);
+        doReturn(mockAttacker).when(mockAttacker).getAttackingEntity();
+        doReturn(attackerCoords).when(mockAttacker).getPosition();
+        doReturn(-1).when(mockAttacker).getSwarmTargetId();
+
+        doReturn(2).when(mockEntityTarget).getId();
+        doReturn(targetCoords).when(mockEntityTarget).getPosition();
+        doReturn(Targetable.TYPE_ENTITY).when(mockEntityTarget).getTargetType();
+        doReturn(mockEntityTarget).when(mockGame).getTarget(Targetable.TYPE_ENTITY, 2);
+
+        HitData hitData = new HitData(Mek.LOC_CENTER_TORSO, false);
+        doReturn(hitData).when(mockEntityTarget)
+              .rollHitLocation(anyInt(), anyInt(), anyInt(), any(AimingMode.class), anyInt());
+        doReturn("CT").when(mockEntityTarget).getLocationAbbr(any(HitData.class));
+        doReturn(false).when(mockEntityTarget).removePartialCoverHits(anyInt(), anyInt(), anyInt());
+
+        // SRMTandemChargeHandler casts weapon.getLinked().getType() to AmmoType in handleEntityDamage
+        Mounted<?> mockLinked = mock(Mounted.class);
+        AmmoType mockAmmoType = mock(AmmoType.class);
+        doReturn(mockAmmoType).when(mockLinked).getType();
+        doReturn(mockLinked).when(mockWeapon).getLinked();
+
+        CalledShot mockCalledShot = mock(CalledShot.class);
+        doReturn(CalledShot.CALLED_NONE).when(mockCalledShot).getCall();
+        doReturn(mockCalledShot).when(mockWeapon).getCalledShot();
+        doReturn(mockWeaponType).when(mockWeapon).getType();
+        doReturn("SRMTandemCharge").when(mockWeaponType).getInternalName();
+        doReturn(mockWeapon).when(mockAttacker).getEquipment(0);
+
+        doReturn(1).when(mockAction).getEntityId();
+        doReturn(0).when(mockAction).getWeaponId();
+        doReturn(Targetable.TYPE_ENTITY).when(mockAction).getTargetType();
+        doReturn(2).when(mockAction).getTargetId();
+        doReturn(Mek.LOC_NONE).when(mockAction).getAimedLocation();
+        doReturn(AimingMode.NONE).when(mockAction).getAimingMode();
+
+        doReturn(new Vector<Report>()).when(mockGameManager).damageEntity(
+              any(), any(), anyInt(), anyBoolean(), any(DamageType.class),
+              anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+
+        doReturn(0.5).when(mockBuilding).getDamageToScale();
+
+        handler = new SRMTandemChargeHandler(mockToHit, mockAction, mockGame, mockGameManager);
+        setField(handler, "nDamPerHit", 10);
+    }
+
+    private static void setField(Object obj, String name, Object value) throws Exception {
+        Class<?> cls = obj.getClass();
+        while (cls != null) {
+            try {
+                Field f = cls.getDeclaredField(name);
+                f.setAccessible(true);
+                f.set(obj, value);
+                return;
+            } catch (NoSuchFieldException e) {
+                cls = cls.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name + " not found in hierarchy of " + obj.getClass().getName());
+    }
+
+    /**
+     * Tests for {@link SRMTandemChargeHandler#handleEntityDamage}
+     */
+    @Nested
+    @DisplayName("handleEntityDamage")
+    class HandleEntityDamage {
+
+        @Test
+        @DisplayName("damage is scaled when entity is inside a building")
+        void damageIsScaledForEntityInsideBuilding() {
+            doReturn(true).when(mockEntityTarget).isInBuilding();
+
+            handler.handleEntityDamage(mockEntityTarget, new Vector<>(), mockBuilding, 1, 1, 0);
+
+            ArgumentCaptor<Integer> damageCaptor = ArgumentCaptor.forClass(Integer.class);
+            verify(mockGameManager).damageEntity(
+                  any(), any(), damageCaptor.capture(),
+                  anyBoolean(), any(DamageType.class), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+            assertEquals(5,
+                  damageCaptor.getValue(),
+                  "Damage should be halved (floor(0.5 * 10)) when entity is inside the building");
+        }
+
+        @Test
+        @DisplayName("damage is not scaled when entity is not inside the building")
+        void damageIsNotScaledForEntityOutsideBuilding() {
+            doReturn(false).when(mockEntityTarget).isInBuilding();
+
+            handler.handleEntityDamage(mockEntityTarget, new Vector<>(), mockBuilding, 1, 1, 0);
+
+            ArgumentCaptor<Integer> damageCaptor = ArgumentCaptor.forClass(Integer.class);
+            verify(mockGameManager).damageEntity(
+                  any(), any(), damageCaptor.capture(),
+                  anyBoolean(), any(DamageType.class), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+            assertEquals(10,
+                  damageCaptor.getValue(),
+                  "Damage should be unmodified when entity is not inside the building");
+        }
+
+        @Test
+        @DisplayName("damage is not scaled when there is no building")
+        void damageIsNotScaledWithNullBuilding() {
+            handler.handleEntityDamage(mockEntityTarget, new Vector<>(), null, 1, 1, 0);
+
+            ArgumentCaptor<Integer> damageCaptor = ArgumentCaptor.forClass(Integer.class);
+            verify(mockGameManager).damageEntity(
+                  any(), any(), damageCaptor.capture(),
+                  anyBoolean(), any(DamageType.class), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+            assertEquals(10, damageCaptor.getValue(), "Damage should be unmodified when there is no building");
+        }
+    }
+}

--- a/megamek/unittests/megamek/common/weapons/infantry/InfantryHeatWeaponHandlerTest.java
+++ b/megamek/unittests/megamek/common/weapons/infantry/InfantryHeatWeaponHandlerTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.weapons.infantry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Field;
+import java.util.Vector;
+
+import megamek.common.CalledShot;
+import megamek.common.Hex;
+import megamek.common.HitData;
+import megamek.common.Report;
+import megamek.common.ToHitData;
+import megamek.common.actions.WeaponAttackAction;
+import megamek.common.board.Board;
+import megamek.common.board.Coords;
+import megamek.common.enums.AimingMode;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.WeaponMounted;
+import megamek.common.equipment.WeaponType;
+import megamek.common.game.Game;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
+import megamek.common.units.BipedMek;
+import megamek.common.units.IBuilding;
+import megamek.common.units.Mek;
+import megamek.common.units.Targetable;
+import megamek.common.weapons.DamageType;
+import megamek.server.totalWarfare.TWGameManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class InfantryHeatWeaponHandlerTest {
+
+    private BipedMek mockAttacker;
+    private BipedMek mockEntityTarget;
+    private Game mockGame;
+    private TWGameManager mockGameManager;
+    private ToHitData mockToHit;
+    private WeaponAttackAction mockAction;
+    private WeaponMounted mockWeapon;
+    private WeaponType mockWeaponType;
+    private Board mockBoard;
+    private Hex mockHex;
+    private IBuilding mockBuilding;
+    private InfantryHeatWeaponHandler handler;
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockAttacker = mock(BipedMek.class);
+        mockEntityTarget = mock(BipedMek.class);
+        mockGame = mock(Game.class);
+        mockGameManager = mock(TWGameManager.class);
+        mockToHit = mock(ToHitData.class);
+        mockAction = mock(WeaponAttackAction.class);
+        mockWeapon = mock(WeaponMounted.class);
+        mockWeaponType = mock(WeaponType.class);
+        mockBoard = mock(Board.class);
+        mockHex = mock(Hex.class);
+        mockBuilding = mock(IBuilding.class);
+
+        GameOptions mockOptions = mock(GameOptions.class);
+        doReturn(false).when(mockOptions).booleanOption(any(String.class));
+        // Enables damage-as-well-as-heat so damageEntity is called for verification
+        doReturn(true).when(mockOptions).booleanOption(OptionsConstants.BASE_INFANTRY_DAMAGE_HEAT);
+        doReturn(mockOptions).when(mockGame).getOptions();
+        doReturn(mockBoard).when(mockGame).getBoard();
+        doReturn(mockHex).when(mockGame).getHexOf(any(BipedMek.class));
+        doReturn(false).when(mockHex).containsTerrain(anyInt());
+
+        Coords attackerCoords = new Coords(0, 0);
+        Coords targetCoords = new Coords(1, 0);
+        doReturn(1).when(mockAttacker).getId();
+        doReturn(mockAttacker).when(mockGame).getEntity(1);
+        doReturn(mockAttacker).when(mockAttacker).getAttackingEntity();
+        doReturn(attackerCoords).when(mockAttacker).getPosition();
+        doReturn(-1).when(mockAttacker).getSwarmTargetId();
+
+        doReturn(2).when(mockEntityTarget).getId();
+        doReturn(targetCoords).when(mockEntityTarget).getPosition();
+        doReturn(Targetable.TYPE_ENTITY).when(mockEntityTarget).getTargetType();
+        doReturn(mockEntityTarget).when(mockGame).getTarget(Targetable.TYPE_ENTITY, 2);
+
+        // tracksHeat() must be true so handleEntityDamage takes the heat-damage branch
+        doReturn(true).when(mockEntityTarget).tracksHeat();
+
+        HitData hitData = new HitData(Mek.LOC_CENTER_TORSO, false);
+        doReturn(hitData).when(mockEntityTarget).rollHitLocation(anyInt(), anyInt(), anyInt(), any(AimingMode.class), anyInt());
+        doReturn("CT").when(mockEntityTarget).getLocationAbbr(any(HitData.class));
+        doReturn(false).when(mockEntityTarget).removePartialCoverHits(anyInt(), anyInt(), anyInt());
+
+        CalledShot mockCalledShot = mock(CalledShot.class);
+        doReturn(CalledShot.CALLED_NONE).when(mockCalledShot).getCall();
+        doReturn(mockCalledShot).when(mockWeapon).getCalledShot();
+        doReturn(false).when(mockWeapon).hasModes();
+        doReturn(mockWeaponType).when(mockWeapon).getType();
+        doReturn("InfantryHeatWeapon").when(mockWeaponType).getInternalName();
+        doReturn(mockWeapon).when(mockAttacker).getEquipment(0);
+
+        doReturn(1).when(mockAction).getEntityId();
+        doReturn(0).when(mockAction).getWeaponId();
+        doReturn(Targetable.TYPE_ENTITY).when(mockAction).getTargetType();
+        doReturn(2).when(mockAction).getTargetId();
+        doReturn(Mek.LOC_NONE).when(mockAction).getAimedLocation();
+        doReturn(AimingMode.NONE).when(mockAction).getAimingMode();
+
+        doReturn(new Vector<Report>()).when(mockGameManager).damageEntity(
+              any(), any(), anyInt(), anyBoolean(), any(DamageType.class),
+              anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+
+        doReturn(0.5).when(mockBuilding).getDamageToScale();
+
+        handler = new InfantryHeatWeaponHandler(mockToHit, mockAction, mockGame, mockGameManager);
+        setField(handler, "nDamPerHit", 10);
+    }
+
+    private static void setField(Object obj, String name, Object value) throws Exception {
+        Class<?> cls = obj.getClass();
+        while (cls != null) {
+            try {
+                Field f = cls.getDeclaredField(name);
+                f.setAccessible(true);
+                f.set(obj, value);
+                return;
+            } catch (NoSuchFieldException e) {
+                cls = cls.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name + " not found in hierarchy of " + obj.getClass().getName());
+    }
+
+    /**
+     * Tests for {@link InfantryHeatWeaponHandler#handleEntityDamage}
+     */
+    @Nested
+    @DisplayName("handleEntityDamage")
+    class HandleEntityDamage {
+
+        @Test
+        @DisplayName("damage is scaled when entity is inside a building")
+        void damageIsScaledForEntityInsideBuilding() {
+            doReturn(true).when(mockEntityTarget).isInBuilding();
+
+            handler.handleEntityDamage(mockEntityTarget, new Vector<>(), mockBuilding, 1, 1, 0);
+
+            ArgumentCaptor<Integer> damageCaptor = ArgumentCaptor.forClass(Integer.class);
+            verify(mockGameManager).damageEntity(
+                  any(), any(), damageCaptor.capture(),
+                  anyBoolean(), any(DamageType.class), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+            assertEquals(5, damageCaptor.getValue(), "Damage should be halved (floor(0.5 * 10)) when entity is inside the building");
+        }
+
+        @Test
+        @DisplayName("damage is not scaled when entity is not inside the building")
+        void damageIsNotScaledForEntityOutsideBuilding() {
+            doReturn(false).when(mockEntityTarget).isInBuilding();
+
+            handler.handleEntityDamage(mockEntityTarget, new Vector<>(), mockBuilding, 1, 1, 0);
+
+            ArgumentCaptor<Integer> damageCaptor = ArgumentCaptor.forClass(Integer.class);
+            verify(mockGameManager).damageEntity(
+                  any(), any(), damageCaptor.capture(),
+                  anyBoolean(), any(DamageType.class), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+            assertEquals(10, damageCaptor.getValue(), "Damage should be unmodified when entity is not inside the building");
+        }
+
+        @Test
+        @DisplayName("damage is not scaled when there is no building")
+        void damageIsNotScaledWithNullBuilding() {
+            handler.handleEntityDamage(mockEntityTarget, new Vector<>(), null, 1, 1, 0);
+
+            ArgumentCaptor<Integer> damageCaptor = ArgumentCaptor.forClass(Integer.class);
+            verify(mockGameManager).damageEntity(
+                  any(), any(), damageCaptor.capture(),
+                  anyBoolean(), any(DamageType.class), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+            assertEquals(10, damageCaptor.getValue(), "Damage should be unmodified when there is no building");
+        }
+    }
+}

--- a/megamek/unittests/megamek/common/weapons/infantry/InfantryHeatWeaponHandlerTest.java
+++ b/megamek/unittests/megamek/common/weapons/infantry/InfantryHeatWeaponHandlerTest.java
@@ -39,6 +39,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 import java.util.Vector;
@@ -144,7 +145,9 @@ class InfantryHeatWeaponHandlerTest {
         doReturn(mockWeapon).when(mockAttacker).getEquipment(0);
 
         doReturn(1).when(mockAction).getEntityId();
+        doReturn(mockAttacker).when(mockAction).getEntity(mockGame);
         doReturn(0).when(mockAction).getWeaponId();
+        when(mockAttacker.getWeapon(mockAction.getWeaponId())).thenReturn(mockWeapon);
         doReturn(Targetable.TYPE_ENTITY).when(mockAction).getTargetType();
         doReturn(2).when(mockAction).getTargetId();
         doReturn(Mek.LOC_NONE).when(mockAction).getAimedLocation();


### PR DESCRIPTION
Fixes #7873 
Fixes #4425, I guess, I couldn't replicate it but I feel between the change and the additional unit tests that this bug is fixed.

We were not properly checking if a unit was inside a building. This adds a final check before doing building-damage-adjustment to make sure we're actually inside a building. 

This also adds unit tests.