### PR TITLE
Fix #8010: successful attempts to brush off iNarc pods do nothing

### DIFF
--- a/megamek/src/megamek/client/ui/clientGUI/MapMenu.java
+++ b/megamek/src/megamek/client/ui/clientGUI/MapMenu.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005 - Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2008-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2008-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -1251,6 +1251,16 @@ public class MapMenu extends JPopupMenu {
                 }
             }
 
+            // Populate brush-off targets
+            // BAs / Infantry should be handled normally by selecting them as a target, we just
+            // don't have a good GUI way to do that for iNarc pods.
+            List<Targetable> inarcs = PhysicalDisplay.getINarcPods(myEntity, coords);
+            if (!inarcs.isEmpty()) {
+                for (Targetable brushTarget : inarcs) {
+                    menu.add(createBrushOffJMenuItem(brushTarget));
+                }
+            }
+
             ToHitData grappleAttackActionToHitData = GrappleAttackAction.toHit(client.getGame(),
                   myEntity.getId(),
                   myTarget);
@@ -1888,6 +1898,26 @@ public class MapMenu extends JPopupMenu {
         item.addActionListener(evt -> {
             try {
                 ((PhysicalDisplay) currentPanel).doGrapple();
+            } catch (Exception ex) {
+                logger.error(ex, "");
+            }
+        });
+        return item;
+    }
+
+    /**
+     * Create a menu entry for sweeping off a specific target (currently only supports iNarc pods)
+     * Each valid iNarc pod should get one entry with the target's name, which will create the
+     * BrushOffAttackAction to try to clear that target only.
+     * @param brushTarget   Targetable iNarc pod instance
+     * @return              JMenuItem that will launch the physical attack selection dialog
+     */
+    private JMenuItem createBrushOffJMenuItem(Targetable brushTarget) {
+        JMenuItem item = new JMenuItem(String.format("Brush Off [%s]", brushTarget.getDisplayName()));
+
+        item.addActionListener(evt -> {
+            try {
+                ((PhysicalDisplay) currentPanel).doBrush(brushTarget);
             } catch (Exception ex) {
                 logger.error(ex, "");
             }

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/PhysicalDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/PhysicalDisplay.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2004 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2002-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2002-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -1401,6 +1401,11 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
         }
     }
 
+    public void doBrush(Targetable brushTarget) {
+        target(brushTarget);
+        brush();
+    }
+
     /**
      * Sweep off the target with the arms that the player selects.
      */
@@ -1885,13 +1890,7 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
         }
 
         // Add any iNarc pods attached to the entity if the attacker is targeting its own hex
-        if (attacker.getPosition().equals(pos)) {
-            Iterator<INarcPod> pods = attacker.getINarcPodsAttached();
-            while (pods.hasNext()) {
-                Targetable choice = pods.next();
-                targets.add(choice);
-            }
-        }
+        targets.addAll(getINarcPods(attacker, pos));
 
         if (targets.size() == 1) {
             // Return the single choice
@@ -2247,5 +2246,26 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
             aimingAt = icb.getIndex();
             updateTarget();
         }
+    }
+
+    /**
+     * Helper method that allows us to get the list of iNarc pods in a given attacker's Coords,
+     * used by PhysicalDisplay and the MapMenu right-click menu.
+     *
+     * @param attacker  Should be the current entity for whom we're building attack data.
+     * @param pos       Coords of the hex to check; may not be the same as attacker.getPosition()
+     * @return          List of Targetables containing co-located iNarc pods
+     */
+    public static List<Targetable> getINarcPods(Entity attacker, Coords pos) {
+        List<Targetable> targets = new ArrayList<>();
+        // Add any iNarc pods attached to the entity if the attacker is targeting its own hex
+        if (attacker.getPosition().equals(pos)) {
+            Iterator<INarcPod> pods = attacker.getINarcPodsAttached();
+            while (pods.hasNext()) {
+                Targetable choice = pods.next();
+                targets.add(choice);
+            }
+        }
+        return targets;
     }
 }

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -12755,11 +12755,12 @@ public class TWGameManager extends AbstractGameManager {
             return;
         }
 
-        if (te != null) {
-            // Different target types get different handling.
-            switch (target.getTargetType()) {
-                case Targetable.TYPE_ENTITY:
-                    // Handle Entity targets.
+        // Different target types get different handling.
+        switch (target.getTargetType()) {
+            // Only applicable to infantry/BAs and iNarc pods
+            case Targetable.TYPE_ENTITY:
+                // Handle Entity targets.
+                if (te != null) {
                     HitData hit = te.rollHitLocation(toHit.getHitTable(), toHit.getSideTable());
                     hit.setGeneralDamageType(HitData.DAMAGE_PHYSICAL);
                     r = new Report(4045);
@@ -12777,19 +12778,18 @@ public class TWGameManager extends AbstractGameManager {
                     r.subject = ae.getId();
                     r.add(te.getDisplayName());
                     addReport(r);
-                    break;
-                case Targetable.TYPE_I_NARC_POD:
-                    // Handle iNarc pod targets.
-                    // TODO : check the return code and handle false appropriately.
-                    ae.removeINarcPod((INarcPod) target);
-                    // TODO : confirm that we don't need to update the attacker.
-                    r = new Report(4105);
-                    r.subject = ae.getId();
-                    r.add(target.getDisplayName());
-                    addReport(r);
-                    break;
-                // TODO : add a default: case and handle it appropriately.
-            }
+                }
+                break;
+            case Targetable.TYPE_I_NARC_POD:
+                // Handle iNarc pod targets.
+                // We don't need to update the attacker here because we will update all entities soon-ish
+                // TODO : check the return code and handle false appropriately.
+                ae.removeINarcPod((INarcPod) target);
+                r = new Report(4105);
+                r.subject = ae.getId();
+                r.add(target.getDisplayName());
+                addReport(r);
+                break;
         }
     }
 


### PR DESCRIPTION
Found that we had disabled iNarc pod brush-off attack actions by adding an overzealous safety check sometime last year.
BAAs against swarming infantry still worked as they had Entity targets, but iNarc pods were getting skipped completely.

This PR fixes that issue, as well as adding a new entry to the Physicals menu that shows which iNarc pods are valid Brush-Off Attack targets for the currently selected unit.
Previously the only ways to select iNarc pods for Brush-Off attacks were:
1. click on the selected unit's hex and spot that the "Brush Off" button became enabled;
2. use the <- / -> keys until the "Brush Off" button became enabled.

<img width="790" height="473" alt="image" src="https://github.com/user-attachments/assets/913f481d-f632-44d7-9a02-b73f5620d095" />

Testing:
- Ran all 3 projects' unit tests
- Set up mp games and confirmed all aspects of iNarc pod attacks, effects, and brushing off are now functional.

Close #8010 