### PR TITLE
Fixed Mek Bays Being Able to Load LAM in Air Mek Mode

### DIFF
--- a/megamek/src/megamek/common/bays/MekBay.java
+++ b/megamek/src/megamek/common/bays/MekBay.java
@@ -72,7 +72,7 @@ public final class MekBay extends UnitBay {
     public boolean canLoad(Entity unit) {
         boolean loadableQuadVee = (unit instanceof QuadVee) && (unit.getConversionMode() == QuadVee.CONV_MODE_MEK);
         boolean loadableLAM = (unit instanceof LandAirMek) && (unit.getConversionMode()
-              != LandAirMek.CONV_MODE_FIGHTER);
+              == LandAirMek.CONV_MODE_MEK);
         boolean loadableOtherMek = (unit instanceof Mek) && !(unit instanceof QuadVee) && !(unit instanceof LandAirMek);
         return (getUnused() >= 1) && (doors > loadedThisTurn) && (loadableLAM || loadableQuadVee || loadableOtherMek);
     }


### PR DESCRIPTION
As per https://battletech.com/forums/index.php/topic,69442.msg1845814.html#msg1845814 LAM in Air-Mek mode cannot use MekBays