### PR TITLE
Fix: add mek mortar ammo to 'no aim' list (6636)

### DIFF
--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -7267,6 +7267,7 @@ public class Compute {
                          TBOLT_15,
                          TBOLT_20,
                          HAG,
+                         MEK_MORTAR,
                          ROCKET_LAUNCHER -> {
                         return false;
                     }


### PR DESCRIPTION
What it says on the description. Fixes #6636.