### PR TITLE
Fix #8293: Fix infantry jumping into positions that're higher than possible

### DIFF
--- a/megamek/src/megamek/common/moves/MovePath.java
+++ b/megamek/src/megamek/common/moves/MovePath.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2003-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2003-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -508,6 +508,19 @@ public class MovePath implements Cloneable, Serializable {
                     step.setMovementType(EntityMovementType.MOVE_ILLEGAL);
                     return;
                 }
+            }
+        }
+
+        // Check if jumping infantry exceeds their maximum reachable elevation
+        if (isJumping() && (entity instanceof Infantry)) {
+            Hex destHex = game.getBoard(step.getBoardId()).getHex(step.getPosition());
+            int maxElevation = (entity.getJumpMP() +
+                  entity.getElevation() +
+                  game.getBoard(entity.getBoardId()).getHex(entity.getPosition()).getLevel()) -
+                  destHex.getLevel();
+            if (step.getElevation() > maxElevation) {
+                step.setMovementType(EntityMovementType.MOVE_ILLEGAL);
+                return;
             }
         }
 

--- a/megamek/unittests/megamek/common/moves/BattleArmorTest.java
+++ b/megamek/unittests/megamek/common/moves/BattleArmorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -49,6 +49,114 @@ import org.junit.jupiter.api.Test;
  * @author Luana Coppio
  */
 public class BattleArmorTest extends GameBoardTestCase {
+
+    /**
+     * Tests for {@link BattleArmor} jumping into each floor of a 4-story building.
+     * <p>
+     * Setup: the BA is two hexes away from the building (one empty hex between them) and has a jump MP of 3. DOWN and
+     * UP steps after the horizontal movement select the target floor.
+     *
+     * @see MovePath#isMoveLegal()
+     */
+    @Nested
+    class JumpingIntoBuildingFloors {
+        static {
+            initializeBoard("BA_JUMP_4_STORY_BUILDING", """
+                  size 1 3
+                  hex 0101 0 "" ""
+                  hex 0102 0 "" ""
+                  hex 0103 0 "bldg_elev:4;building:2:8;bldg_cf:100" ""
+                  end""");
+        }
+
+        private BattleArmor ba() {
+            BattleArmor ba = new BattleArmor();
+            ba.setOriginalJumpMP(3);
+            return ba;
+        }
+
+        @Test
+        void jumpToElevation4() {
+            // arrange
+            setBoard("BA_JUMP_4_STORY_BUILDING");
+            // act
+            MovePath movePath = getMovePathFor(ba(),
+                  EntityMovementMode.INF_LEG,
+                  MoveStepType.START_JUMP,
+                  MoveStepType.FORWARDS,
+                  MoveStepType.FORWARDS,
+                  MoveStepType.UP
+            );
+            // assert
+            assertFalse(movePath.isMoveLegal());
+        }
+
+        @Test
+        void jumpToElevation3() {
+            // arrange
+            setBoard("BA_JUMP_4_STORY_BUILDING");
+            // act
+            MovePath movePath = getMovePathFor(ba(),
+                  EntityMovementMode.INF_LEG,
+                  MoveStepType.START_JUMP,
+                  MoveStepType.FORWARDS,
+                  MoveStepType.FORWARDS
+            );
+            // assert
+            assertTrue(movePath.isMoveLegal());
+        }
+
+        @Test
+        void jumpToElevation2() {
+            // arrange
+            setBoard("BA_JUMP_4_STORY_BUILDING");
+            // act
+            MovePath movePath = getMovePathFor(ba(),
+                  EntityMovementMode.INF_LEG,
+                  MoveStepType.START_JUMP,
+                  MoveStepType.FORWARDS,
+                  MoveStepType.FORWARDS,
+                  MoveStepType.DOWN
+            );
+            // assert
+            assertTrue(movePath.isMoveLegal());
+        }
+
+        @Test
+        void jumpToElevation1() {
+            // arrange
+            setBoard("BA_JUMP_4_STORY_BUILDING");
+            // act
+            MovePath movePath = getMovePathFor(ba(),
+                  EntityMovementMode.INF_LEG,
+                  MoveStepType.START_JUMP,
+                  MoveStepType.FORWARDS,
+                  MoveStepType.FORWARDS,
+                  MoveStepType.DOWN,
+                  MoveStepType.DOWN
+            );
+            // assert
+            assertTrue(movePath.isMoveLegal());
+        }
+
+        @Test
+        void jumpToElevation0() {
+            // arrange
+            setBoard("BA_JUMP_4_STORY_BUILDING");
+            // act
+            MovePath movePath = getMovePathFor(ba(),
+                  EntityMovementMode.INF_LEG,
+                  MoveStepType.START_JUMP,
+                  MoveStepType.FORWARDS,
+                  MoveStepType.FORWARDS,
+                  MoveStepType.DOWN,
+                  MoveStepType.DOWN,
+                  MoveStepType.DOWN
+            );
+            // assert
+            assertFalse(movePath.isMoveLegal());
+        }
+    }
 
     @Nested
     class AntiMekSkillRollNag {


### PR DESCRIPTION
Fixes #8293 

Elevation check for infantry jumping to declare moves that go higher than possible are marked illegal.