### PR TITLE
Fix #8293: Fix terrain elevation not being accounted for when infantry are jumping into a building

### DIFF
--- a/megamek/src/megamek/common/moves/MoveStep.java
+++ b/megamek/src/megamek/common/moves/MoveStep.java
@@ -1737,7 +1737,7 @@ public class MoveStep implements Serializable {
 
         if (isInfantry && isJumping() && stepType == MoveStepType.DOWN) {
             Hex curHex = game.getBoard(boardId).getHex(curPos);
-            if (curHex != null && curHex.containsTerrain(Terrains.BUILDING)) {
+            if (curHex.containsTerrain(Terrains.BUILDING)) {
                 Coords startingPosition = entity.getPosition();
                 Coords adjacentCoords = curPos.translated(curPos.direction(startingPosition));
                 Hex adjacentHex = game.getHex(adjacentCoords, boardId);

--- a/megamek/src/megamek/common/moves/MoveStep.java
+++ b/megamek/src/megamek/common/moves/MoveStep.java
@@ -1737,7 +1737,7 @@ public class MoveStep implements Serializable {
 
         if (isInfantry && isJumping() && stepType == MoveStepType.DOWN) {
             Hex curHex = game.getBoard(boardId).getHex(curPos);
-            if (curHex.containsTerrain(Terrains.BUILDING)) {
+            if (curHex != null && curHex.containsTerrain(Terrains.BUILDING)) {
                 Coords startingPosition = entity.getPosition();
                 Coords adjacentCoords = curPos.translated(curPos.direction(startingPosition));
                 Hex adjacentHex = game.getHex(adjacentCoords, boardId);

--- a/megamek/src/megamek/common/moves/MoveStep.java
+++ b/megamek/src/megamek/common/moves/MoveStep.java
@@ -1736,7 +1736,8 @@ public class MoveStep implements Serializable {
         } // end AERO stuff
 
         if (isInfantry && isJumping() && stepType == MoveStepType.DOWN) {
-            if (game.getBoard(boardId).getHex(curPos).containsTerrain(Terrains.BUILDING)) {
+            Hex curHex = game.getBoard(boardId).getHex(curPos);
+            if (curHex.containsTerrain(Terrains.BUILDING)) {
                 Coords startingPosition = entity.getPosition();
                 Coords adjacentCoords = curPos.translated(curPos.direction(startingPosition));
                 Hex adjacentHex = game.getHex(adjacentCoords, boardId);
@@ -1745,7 +1746,7 @@ public class MoveStep implements Serializable {
                       entity,
                       new FloorTarget(curPos, game.getBoard(boardId), getElevation())).canSee();
 
-                if (adjacentHex.ceiling() >= getElevation() || !hasLOS) {
+                if (adjacentHex.ceiling() >= getElevation() + curHex.getLevel() || !hasLOS) {
                     return; // can't enter the building from this direction
                 } else {
                     // we can enter the building, but we need to roll anti-mek skill

--- a/megamek/unittests/megamek/common/moves/BattleArmorTest.java
+++ b/megamek/unittests/megamek/common/moves/BattleArmorTest.java
@@ -158,6 +158,114 @@ public class BattleArmorTest extends GameBoardTestCase {
         }
     }
 
+    /**
+     * Tests for {@link BattleArmor} jumping into each floor of a 4-story building on terrain at level 1.
+     * <p>
+     * Identical setup to {@link JumpingIntoBuildingFloors} except all hex terrain levels are 1.
+     *
+     * @see MovePath#isMoveLegal()
+     */
+    @Nested
+    class JumpingIntoBuildingFloorsOnElevatedTerrain {
+        static {
+            initializeBoard("BA_JUMP_4_STORY_BUILDING_L1", """
+                  size 1 3
+                  hex 0101 1 "" ""
+                  hex 0102 1 "" ""
+                  hex 0103 1 "bldg_elev:4;building:2:8;bldg_cf:100" ""
+                  end""");
+        }
+
+        private BattleArmor ba() {
+            BattleArmor ba = new BattleArmor();
+            ba.setOriginalJumpMP(3);
+            return ba;
+        }
+
+        @Test
+        void jumpToElevation4() {
+            // arrange
+            setBoard("BA_JUMP_4_STORY_BUILDING_L1");
+            // act
+            MovePath movePath = getMovePathFor(ba(),
+                  EntityMovementMode.INF_LEG,
+                  MoveStepType.START_JUMP,
+                  MoveStepType.FORWARDS,
+                  MoveStepType.FORWARDS,
+                  MoveStepType.UP
+            );
+            // assert
+            assertFalse(movePath.isMoveLegal());
+        }
+
+        @Test
+        void jumpToElevation3() {
+            // arrange
+            setBoard("BA_JUMP_4_STORY_BUILDING_L1");
+            // act
+            MovePath movePath = getMovePathFor(ba(),
+                  EntityMovementMode.INF_LEG,
+                  MoveStepType.START_JUMP,
+                  MoveStepType.FORWARDS,
+                  MoveStepType.FORWARDS
+            );
+            // assert
+            assertTrue(movePath.isMoveLegal());
+        }
+
+        @Test
+        void jumpToElevation2() {
+            // arrange
+            setBoard("BA_JUMP_4_STORY_BUILDING_L1");
+            // act
+            MovePath movePath = getMovePathFor(ba(),
+                  EntityMovementMode.INF_LEG,
+                  MoveStepType.START_JUMP,
+                  MoveStepType.FORWARDS,
+                  MoveStepType.FORWARDS,
+                  MoveStepType.DOWN
+            );
+            // assert
+            assertTrue(movePath.isMoveLegal());
+        }
+
+        @Test
+        void jumpToElevation1() {
+            // arrange
+            setBoard("BA_JUMP_4_STORY_BUILDING_L1");
+            // act
+            MovePath movePath = getMovePathFor(ba(),
+                  EntityMovementMode.INF_LEG,
+                  MoveStepType.START_JUMP,
+                  MoveStepType.FORWARDS,
+                  MoveStepType.FORWARDS,
+                  MoveStepType.DOWN,
+                  MoveStepType.DOWN
+            );
+            // assert
+            assertTrue(movePath.isMoveLegal());
+        }
+
+
+        @Test
+        void jumpToElevation0() {
+            // arrange
+            setBoard("BA_JUMP_4_STORY_BUILDING_L1");
+            // act
+            MovePath movePath = getMovePathFor(ba(),
+                  EntityMovementMode.INF_LEG,
+                  MoveStepType.START_JUMP,
+                  MoveStepType.FORWARDS,
+                  MoveStepType.FORWARDS,
+                  MoveStepType.DOWN,
+                  MoveStepType.DOWN,
+                  MoveStepType.DOWN
+            );
+            // assert
+            assertFalse(movePath.isMoveLegal());
+        }
+    }
+
     @Nested
     class AntiMekSkillRollNag {
         static {


### PR DESCRIPTION
Fixes #8293 - again
There was a second bug described in #8293 where infantry were unable to jump onto the 2nd floor of a 2 story building, but could jump onto the roof. The issue was because the terrain elevation of the final hex was not being considered when comparing it to the height of the adjacent hex - the logic used to make sure we aren't jumping in through an obstructed window. 