### PR TITLE
Stored GBV in MekSummary to Improve Ease of Access

### DIFF
--- a/megamek/src/megamek/common/loaders/MekSummary.java
+++ b/megamek/src/megamek/common/loaders/MekSummary.java
@@ -104,6 +104,7 @@ public class MekSummary implements Serializable, ASCardDisplayable {
     private double tons;
     private int weightClass;
     private int bv;
+    private int genericBattleValue;
 
     /** The full cost of the unit (including ammo). */
     private long cost;
@@ -555,6 +556,10 @@ public class MekSummary implements Serializable, ASCardDisplayable {
         return bv;
     }
 
+    public int getGenericBattleValue() {
+        return genericBattleValue;
+    }
+
     public long getCost() {
         return cost;
     }
@@ -962,6 +967,10 @@ public class MekSummary implements Serializable, ASCardDisplayable {
 
     public void setBV(int nBV) {
         this.bv = nBV;
+    }
+
+    public void setGenericBattleValue(int genericBattleValue) {
+        this.genericBattleValue = genericBattleValue;
     }
 
     public void setModified(long lModified) {

--- a/megamek/src/megamek/common/loaders/MekSummaryCache.java
+++ b/megamek/src/megamek/common/loaders/MekSummaryCache.java
@@ -55,7 +55,15 @@ import megamek.common.equipment.DockingCollar;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.equipment.Transporter;
 import megamek.common.preference.PreferenceManager;
-import megamek.common.units.*;
+import megamek.common.units.Aero;
+import megamek.common.units.ConvInfantry;
+import megamek.common.units.DropShuttleBay;
+import megamek.common.units.Entity;
+import megamek.common.units.EntityWeightClass;
+import megamek.common.units.Mek;
+import megamek.common.units.NavalRepairFacility;
+import megamek.common.units.Tank;
+import megamek.common.units.UnitType;
 import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.common.verifier.TestEntity;
 import megamek.logging.MMLogger;
@@ -680,6 +688,7 @@ public class MekSummaryCache {
         }
 
         ms.setBV(e.calculateBattleValue(true, true));
+        ms.setGenericBattleValue(e.getGenericBattleValue());
         ms.setLevel(TechConstants.T_SIMPLE_LEVEL[e.getTechLevel()]);
         ms.setAdvancedYear(e.getProductionDate(e.isClan()));
         ms.setStandardYear(e.getCommonDate(e.isClan()));


### PR DESCRIPTION
We access GBV a _lot_ in MekHQ, most relevant when calculating the estimated difficulty of a contract. In fact, on my profiler, creating new contracts when a month cycles over (with an empty campaign) adds about 23 seconds (not a typo) to new day time. In an attempt to mitigate this we're now going to calculate GBV once and then store it in the MekSummary. Meaning we no longer need to instantiate the unit's Entity if we want its GBV.