### PR TITLE
Apply EMI ECM-range doubling to ground units (display + effect)

### DIFF
--- a/megamek/src/megamek/common/compute/ComputeECM.java
+++ b/megamek/src/megamek/common/compute/ComputeECM.java
@@ -1,7 +1,7 @@
 /*
 
  * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2014-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2014-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -636,7 +636,7 @@ public class ComputeECM {
                 }
             }
         }
-        return bestInfo;
+        return applyEmiRangeBonus(bestInfo, game);
     }
 
     /**
@@ -725,7 +725,26 @@ public class ComputeECM {
                 }
             }
         }
-        return bestInfo;
+        return applyEmiRangeBonus(bestInfo, game);
+    }
+
+    /**
+     * Under EMI planetary conditions, ECM and ECCM systems double their effective range (TO:AR p.59). Single-hex
+     * systems (range 0) are unaffected, since 0 doubled is still 0. This is applied to the range used both for the
+     * board view's ECM shading and for the actual ECM/ECCM effect resolution, keeping the two consistent. The
+     * spaceborne E(C)CM branches already derive their range from {@link Entity#getECMRange()}, which applies this
+     * doubling on its own, so they must not be routed through this method.
+     *
+     * @param ecmInfo the computed E(C)CM info for a ground unit, or null if the unit emits none
+     * @param game    the current game, used to read the active planetary conditions
+     *
+     * @return the same ecmInfo with its range doubled when EMI is active; otherwise the unchanged ecmInfo (or null)
+     */
+    private static @Nullable ECMInfo applyEmiRangeBonus(@Nullable ECMInfo ecmInfo, Game game) {
+        if ((ecmInfo != null) && game.getPlanetaryConditions().getEMI().isEMI()) {
+            ecmInfo.setRange(ecmInfo.getRange() * 2);
+        }
+        return ecmInfo;
     }
 
     private ComputeECM() {}

--- a/megamek/unittests/megamek/common/ComputeECMTest.java
+++ b/megamek/unittests/megamek/common/ComputeECMTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000-2005 - Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2014-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2014-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -61,6 +61,8 @@ import megamek.common.equipment.Mounted;
 import megamek.common.exceptions.LocationFullException;
 import megamek.common.game.Game;
 import megamek.common.options.GameOptions;
+import megamek.common.planetaryConditions.EMI;
+import megamek.common.planetaryConditions.PlanetaryConditions;
 import megamek.common.units.Aero;
 import megamek.common.units.Entity;
 import megamek.common.units.Mek;
@@ -107,6 +109,8 @@ class ComputeECMTest {
         when(mockGame.hasBoardLocation(any(BoardLocation.class))).thenReturn(true);
         when(mockGame.getHex(any(Coords.class), anyInt())).thenCallRealMethod();
         when(mockGame.getBoard(any(Targetable.class))).thenReturn(mockBoard);
+        // No EMI by default; a real PlanetaryConditions defaults to EMI_NONE, leaving ECM ranges unchanged
+        when(mockGame.getPlanetaryConditions()).thenReturn(new PlanetaryConditions());
 
         Entity archer = getEntityForUnitTesting("Archer ARC-2R", false);
         assertNotNull(archer, "Archer ARC-2R not found");
@@ -211,6 +215,84 @@ class ComputeECMTest {
         assertEquals(testInfoECM, ecmInfo);
         eccmInfo = archer.getECCMInfo();
         assertEquals(testInfoECCM, eccmInfo);
+    }
+
+    /**
+     * Under EMI planetary conditions, a ground unit's ECM and ECCM bubbles double their effective range (TO:AR p.59).
+     * This verifies the doubling that the board view's ECM shading and the ECM effect resolution both rely on.
+     */
+    @Test
+    void testGetECMInfoDoublesRangeUnderEMI() {
+        // Mock Player
+        Player mockPlayer = mock(Player.class);
+
+        // Mock the board
+        Board mockBoard = mock(Board.class);
+        when(mockBoard.isSpace()).thenReturn(false);
+        when(mockBoard.contains(any(Coords.class))).thenReturn(true);
+        when(mockBoard.contains(anyInt(), anyInt())).thenReturn(true);
+
+        // Mock Options
+        GameOptions mockOptions = mock(GameOptions.class);
+        when(mockOptions.booleanOption(anyString())).thenReturn(false);
+        when(mockOptions.booleanOption("tacops_eccm")).thenReturn(true);
+
+        // EMI is active for this game
+        PlanetaryConditions emiConditions = new PlanetaryConditions();
+        emiConditions.setEMI(EMI.EMI);
+
+        // Mock the game
+        Game mockGame = mock(Game.class);
+        when(mockGame.getBoard()).thenReturn(mockBoard);
+        when(mockGame.getSmokeCloudList()).thenReturn(new ArrayList<>());
+        when(mockGame.getOptions()).thenReturn(mockOptions);
+        when(mockGame.getPlayer(anyInt())).thenReturn(mockPlayer);
+        when(mockGame.getBoard(anyInt())).thenReturn(mockBoard);
+        when(mockGame.hasBoard(0)).thenReturn(true);
+        when(mockGame.hasBoardLocation(any(Coords.class), anyInt())).thenReturn(true);
+        when(mockGame.hasBoardLocation(any(BoardLocation.class))).thenReturn(true);
+        when(mockGame.getHex(any(Coords.class), anyInt())).thenCallRealMethod();
+        when(mockGame.getBoard(any(Targetable.class))).thenReturn(mockBoard);
+        when(mockGame.getPlanetaryConditions()).thenReturn(emiConditions);
+
+        Entity archer = getEntityForUnitTesting("Archer ARC-2R", false);
+        assertNotNull(archer, "Archer ARC-2R not found");
+
+        MiscType.initializeTypes();
+
+        // Add a Guardian ECM Suite (base ground range of 6 hexes)
+        EquipmentType eType = EquipmentType.get("ISGuardianECMSuite");
+        try {
+            archer.addEquipment(eType, Mek.LOC_RIGHT_TORSO);
+        } catch (LocationFullException e) {
+            fail(e.getMessage());
+        }
+
+        Coords pos = new Coords(0, 0);
+        archer.setPosition(pos);
+        archer.setOwner(mockPlayer);
+        archer.setGame(mockGame);
+
+        // Under EMI, the ECM bubble doubles from 6 to 12 hexes
+        ECMInfo ecmInfo = archer.getECMInfo();
+        assertNotNull(ecmInfo);
+        assertEquals(12, ecmInfo.getRange());
+
+        // Switch the suite to ECCM; the ECCM bubble also doubles from 6 to 12 hexes
+        Mounted<?> ecm = null;
+        for (Mounted<?> m : archer.getMisc()) {
+            if (m.getType().equals(eType)) {
+                ecm = m;
+            }
+        }
+        assertNotNull(ecm);
+        assertEquals(1, ecm.setMode("ECCM"));
+        // Need to update the round to make the mode switch happen
+        archer.newRound(1);
+
+        ECMInfo eccmInfo = archer.getECCMInfo();
+        assertNotNull(eccmInfo);
+        assertEquals(12, eccmInfo.getRange());
     }
 
     /**


### PR DESCRIPTION
Per TO:AR, when a battle is fought under Electromagnetic Interference (EMI), ECM systems double their effective range
  (and active probes are rendered useless). MegaMek already encodes the doubling in Entity.getECMRange(), but on ground
  maps that method is only consulted by the space-combat ECM paths and the minimap. The main board view and the actual
  ECM effect resolution never see it.

  As a result, under EMI a ground unit's ECM bubble was both displayed and resolved at its base range (e.g. 6 hexes for
  a Guardian suite) instead of the doubled range the rules call for. The board shading told players the jamming field
  was smaller than it actually should be, and — more importantly — the underlying to-hit/C3/sensor effects were computed
  against the un-doubled range, so the EMI rule simply wasn't being applied on the ground at all.

  The fix targets the single chokepoint both consumers share: ComputeECM.getECMInfo() / getECCMInfo(). A new
  applyEmiRangeBonus() helper doubles the computed ECMInfo range when EMI is active, applied at the ground-branch return
  of both methods. Because BoardView.updateEcmList() (shading) and getECMEffects() (effect) both read
  ECMInfo.getRange(), this one change keeps the visual bubble and the actual jamming field in lockstep — and consistent
  with the minimap, which already doubled. Single-hex ECM (range 0) is unaffected, and the spaceborne branches are
  deliberately left alone since they already double via getECMRange().

  The active-probe half of the rule needed no change (it's already handled in hasBAP()/getBAPRange(), and there's no
  probe overlay to update). Tests live in ComputeECMTest: the existing test was updated to stub planetary conditions
  (defaulting to no-EMI), and a new test asserts a Guardian suite reaches range 12 under EMI in both ECM and ECCM modes.
  Note this corrects a gameplay mechanic, not just a visual — ground ECM now genuinely reaches twice as far under EMI.