### PR TITLE
Fix validation of endoslots in head of frankenmeks

### DIFF
--- a/megamek/src/megamek/common/verifier/TestMek.java
+++ b/megamek/src/megamek/common/verifier/TestMek.java
@@ -589,7 +589,7 @@ public class TestMek extends TestEntity {
         for (int location = 0; location < mek.locations(); location++) {
             EquipmentType structure = mek.getFrankenMekStructureEquipment(location);
             // does this structure type even take up slots in the first place
-            boolean structureUsesSlots = structure.getNumCriticalSlots(mek) > 0;
+            boolean structureUsesSlots = structure != null && structure.getNumCriticalSlots(mek) > 0;
 
             int actualStructureCrits = countInternalStructureCriticalSlots(mek, location);
             int actualMatchingStructureCrits = structure == null ? 0 : mek.getNumberOfCriticalSlots(structure, location);

--- a/megamek/src/megamek/common/verifier/TestMek.java
+++ b/megamek/src/megamek/common/verifier/TestMek.java
@@ -588,13 +588,16 @@ public class TestMek extends TestEntity {
         boolean illegal = false;
         for (int location = 0; location < mek.locations(); location++) {
             EquipmentType structure = mek.getFrankenMekStructureEquipment(location);
-            int fallbackStructureCrits = mek.getFrankenMekStructureCriticalSlots(location);
+            // does this structure type even take up slots in the first place
+            boolean structureUsesSlots = structure.getNumCriticalSlots(mek) > 0;
+
             int actualStructureCrits = countInternalStructureCriticalSlots(mek, location);
             int actualMatchingStructureCrits = structure == null ? 0 : mek.getNumberOfCriticalSlots(structure, location);
             boolean hasOnlyMatchingStructureCrits = actualStructureCrits == actualMatchingStructureCrits;
-            boolean validStructureCrits = fallbackStructureCrits == 0
-                  ? actualStructureCrits == 0
-                  : hasOnlyMatchingStructureCrits;
+
+            boolean validStructureCrits = structureUsesSlots
+                  ? hasOnlyMatchingStructureCrits
+                  : actualStructureCrits == 0;
             if (!validStructureCrits) {
                 buff.append("The FrankenMek internal structure of ")
                       .append(mek.getLocationName(location))


### PR DESCRIPTION
Currently validation doesn't believe there can be clan endosteel slots in the head of a frankenmek, even with the appropriate structure type, which isn't true.