### PR TITLE
Add FrankenMek filter to advanced search Unit Type tab

### DIFF
--- a/megamek/resources/megamek/client/messages.properties
+++ b/megamek/resources/megamek/client/messages.properties
@@ -2423,6 +2423,7 @@ MekSelectorDialog.Search.LAM=Land Air Mek
 MekSelectorDialog.Search.Tripod=Tripod
 MekSelectorDialog.Search.Quad=Quad
 MekSelectorDialog.Search.QuadVee=Quad VEE
+MekSelectorDialog.Search.FrankenMek=FrankenMek
 MekSelectorDialog.Search.FixedWingSupport=Fixed Wing Support
 MekSelectorDialog.Search.ConvFighter=Conventional Fighter
 MekSelectorDialog.Search.SmallCraft=Small Craft

--- a/megamek/src/megamek/client/ui/dialogs/advancedsearch/AdvSearchState.java
+++ b/megamek/src/megamek/client/ui/dialogs/advancedsearch/AdvSearchState.java
@@ -32,18 +32,18 @@
  */
 package megamek.client.ui.dialogs.advancedsearch;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import megamek.common.alphaStrike.ASDamage;
-import megamek.common.alphaStrike.ASUnitType;
-import megamek.common.alphaStrike.BattleForceSUA;
-import megamek.common.units.UnitRole;
+import static com.formdev.flatlaf.extras.components.FlatTriStateCheckBox.State;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.formdev.flatlaf.extras.components.FlatTriStateCheckBox.State;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import megamek.common.alphaStrike.ASDamage;
+import megamek.common.alphaStrike.ASUnitType;
+import megamek.common.alphaStrike.BattleForceSUA;
+import megamek.common.units.UnitRole;
 
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 class AdvSearchState {
@@ -90,6 +90,7 @@ class AdvSearchState {
         public State tripod = State.UNSELECTED;
         public State quad = State.UNSELECTED;
         public State quadVee = State.UNSELECTED;
+        public State frankenMek = State.UNSELECTED;
         public State aero = State.UNSELECTED;
         public State fixedWingSupport = State.UNSELECTED;
         public State convFighter = State.UNSELECTED;

--- a/megamek/src/megamek/client/ui/dialogs/advancedsearch/MekSearchFilter.java
+++ b/megamek/src/megamek/client/ui/dialogs/advancedsearch/MekSearchFilter.java
@@ -206,6 +206,7 @@ public class MekSearchFilter {
     public int filterTripod;
     public int filterQuad;
     public int filterQuadVee;
+    public int iFrankenMek;
     public int filterAero;
     public int filterFixedWingSupport;
     public int filterConvFighter;
@@ -455,6 +456,10 @@ public class MekSearchFilter {
         }
 
         if (!isMatch(f.iIndustrial, mek.isIndustrialMek())) {
+            return false;
+        }
+
+        if (!isMatch(f.iFrankenMek, mek.isFrankenMek())) {
             return false;
         }
 

--- a/megamek/src/megamek/client/ui/dialogs/advancedsearch/MekSearchFilter.java
+++ b/megamek/src/megamek/client/ui/dialogs/advancedsearch/MekSearchFilter.java
@@ -71,6 +71,7 @@ public class MekSearchFilter {
     public int iOmni;
     public int iMilitary;
     public int iIndustrial;
+    public int iFrankenMek;
     public int iMountedInfantry;
     public int iWaterOnly;
     public int iDoomedOnGround;
@@ -206,7 +207,6 @@ public class MekSearchFilter {
     public int filterTripod;
     public int filterQuad;
     public int filterQuadVee;
-    public int iFrankenMek;
     public int filterAero;
     public int filterFixedWingSupport;
     public int filterConvFighter;

--- a/megamek/src/megamek/client/ui/dialogs/advancedsearch/TWAdvancedSearchPanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/advancedsearch/TWAdvancedSearchPanel.java
@@ -284,6 +284,7 @@ public class TWAdvancedSearchPanel extends JTabbedPane {
         mekFilter.filterTripod = getValue(unitTypePanel.btnFilterTripod);
         mekFilter.filterQuad = getValue(unitTypePanel.btnFilterQuad);
         mekFilter.filterQuadVee = getValue(unitTypePanel.btnFilterQuadVee);
+        mekFilter.iFrankenMek = getValue(unitTypePanel.btnFilterFrankenMek);
         mekFilter.filterAero = getValue(unitTypePanel.btnFilterAero);
         mekFilter.filterFixedWingSupport = getValue(unitTypePanel.btnFilterFixedWingSupport);
         mekFilter.filterConvFighter = getValue(unitTypePanel.btnFilterConvFighter);

--- a/megamek/src/megamek/client/ui/dialogs/advancedsearch/UnitTypeSearchTab.java
+++ b/megamek/src/megamek/client/ui/dialogs/advancedsearch/UnitTypeSearchTab.java
@@ -64,6 +64,8 @@ class UnitTypeSearchTab extends JPanel {
           "MekSelectorDialog.Search.Quad"));
     final FlatTriStateCheckBox btnFilterQuadVee = new SearchTriStateCheckBox(Messages.getString(
           "MekSelectorDialog.Search.QuadVee"));
+    final FlatTriStateCheckBox btnFilterFrankenMek = new SearchTriStateCheckBox(Messages.getString(
+          "MekSelectorDialog.Search.FrankenMek"));
     final FlatTriStateCheckBox btnFilterAero = new SearchTriStateCheckBox(Messages.getString(
           "MekSelectorDialog.Search.Aero"));
     final FlatTriStateCheckBox btnFilterAerospaceFighter = new SearchTriStateCheckBox(Messages.getString(
@@ -151,8 +153,11 @@ class UnitTypeSearchTab extends JPanel {
         gbc.gridy++;
         gbc.gridx = 1;
         add(btnFilterTripod, gbc);
+        gbc.gridx = 2;
+        add(btnFilterFrankenMek, gbc);
 
         gbc.gridy++;
+        gbc.gridx = 1;
         add(btnFilterQuad, gbc);
         gbc.gridx = 2;
         add(btnFilterQuadVee, gbc);
@@ -273,6 +278,7 @@ class UnitTypeSearchTab extends JPanel {
         btnFilterTripod.setState(state.tripod);
         btnFilterQuad.setState(state.quad);
         btnFilterQuadVee.setState(state.quadVee);
+        btnFilterFrankenMek.setState(state.frankenMek);
         btnFilterAero.setState(state.aero);
         btnFilterFixedWingSupport.setState(state.fixedWingSupport);
         btnFilterConvFighter.setState(state.convFighter);
@@ -313,6 +319,7 @@ class UnitTypeSearchTab extends JPanel {
         state.tripod = btnFilterTripod.getState();
         state.quad = btnFilterQuad.getState();
         state.quadVee = btnFilterQuadVee.getState();
+        state.frankenMek = btnFilterFrankenMek.getState();
         state.aero = btnFilterAero.getState();
         state.fixedWingSupport = btnFilterFixedWingSupport.getState();
         state.convFighter = btnFilterConvFighter.getState();

--- a/megamek/src/megamek/common/loaders/MekSummary.java
+++ b/megamek/src/megamek/common/loaders/MekSummary.java
@@ -119,6 +119,7 @@ public class MekSummary implements Serializable, ASCardDisplayable {
     private String extinctRange;
     private boolean canon;
     private boolean patchwork;
+    private boolean frankenMek;
     private boolean doomedOnGround;
     private boolean doomedInAtmosphere;
     private boolean doomedInSpace;
@@ -272,6 +273,10 @@ public class MekSummary implements Serializable, ASCardDisplayable {
 
     public boolean isPatchwork() {
         return patchwork;
+    }
+
+    public boolean isFrankenMek() {
+        return frankenMek;
     }
 
     public boolean isDoomedOnGround() {
@@ -995,6 +1000,10 @@ public class MekSummary implements Serializable, ASCardDisplayable {
 
     public void setPatchwork(boolean patchwork) {
         this.patchwork = patchwork;
+    }
+
+    public void setFrankenMek(boolean frankenMek) {
+        this.frankenMek = frankenMek;
     }
 
     public void setDoomedOnGround(boolean doomedOnGround) {

--- a/megamek/src/megamek/common/loaders/MekSummaryCache.java
+++ b/megamek/src/megamek/common/loaders/MekSummaryCache.java
@@ -748,6 +748,7 @@ public class MekSummaryCache {
         // Check to see if this entity has a cockpit, and if so, set its type
         if ((e instanceof Mek)) {
             ms.setCockpitType(((Mek) e).getCockpitType());
+            ms.setFrankenMek(((Mek) e).isFrankenMek());
         } else if ((e instanceof Aero)) {
             ms.setCockpitType(((Aero) e).getCockpitType());
         } else {

--- a/megamek/testresources/searches/FrankenMeks.json
+++ b/megamek/testresources/searches/FrankenMeks.json
@@ -1,0 +1,27 @@
+{
+  "content": "ADVANCED_SEARCH_STATE",
+  "name": "FrankenMeks",
+  "twState": {
+    "unitTypeState": {
+      "mek": "SELECTED",
+      "frankenMek": "SELECTED"
+    },
+    "transportsState": {},
+    "quirksState": {
+      "chassisQuirks": {},
+      "weaponQuirks": {}
+    },
+    "miscState": {
+      "cockpitType": {},
+      "armorType": {},
+      "internalsType": {},
+      "engineType": {},
+      "gyroType": {},
+      "techLevel": {},
+      "techBase": {},
+      "moveMode": {}
+    },
+    "equipmentState": {}
+  },
+  "asState": {}
+}

--- a/megamek/unittests/megamek/client/ui/dialogs/advancedsearch/MekSearchFilterTest.java
+++ b/megamek/unittests/megamek/client/ui/dialogs/advancedsearch/MekSearchFilterTest.java
@@ -36,10 +36,85 @@ package megamek.client.ui.dialogs.advancedsearch;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Field;
+
 import megamek.common.loaders.MekSummary;
+import megamek.common.units.Entity;
 import org.junit.jupiter.api.Test;
 
 class MekSearchFilterTest {
+
+    /** Tri-state filter value for "must have the trait". */
+    private static final int INCLUDE = 1;
+    /** Tri-state filter value for "must not have the trait". */
+    private static final int EXCLUDE = 2;
+
+    /**
+     * Builds an enabled filter with no active criteria so that a single tri-state field can be tested in isolation.
+     * Every range bound is set to an empty string because {@link MekSearchFilter#isMatch(MekSummary, MekSearchFilter)}
+     * dereferences them unconditionally and they are otherwise null on a fresh filter.
+     */
+    private static MekSearchFilter passThroughFilter() throws IllegalAccessException {
+        MekSearchFilter filter = new MekSearchFilter();
+        filter.isDisabled = false;
+        for (Field field : MekSearchFilter.class.getDeclaredFields()) {
+            if ((field.getType() == String.class) && (field.get(filter) == null)) {
+                field.set(filter, "");
+            }
+        }
+        return filter;
+    }
+
+    /** A summary that reaches the end of the match logic without tripping an unrelated criterion. */
+    private static MekSummary frankenMekSummary(boolean frankenMek) {
+        MekSummary mek = new MekSummary();
+        mek.setFrankenMek(frankenMek);
+        // getEngineName() is dereferenced unconditionally by isMatch, so it must be non-null.
+        mek.setEngineName("");
+        // getEntityType() is auto-unboxed to a primitive by isMatch, so it must be set.
+        mek.setEntityType(Entity.ETYPE_MEK | Entity.ETYPE_BIPED_MEK);
+        return mek;
+    }
+
+    @Test
+    void frankenMekIncludeAcceptsFrankenMek() throws IllegalAccessException {
+        MekSearchFilter filter = passThroughFilter();
+        filter.iFrankenMek = INCLUDE;
+
+        assertTrue(MekSearchFilter.isMatch(frankenMekSummary(true), filter));
+    }
+
+    @Test
+    void frankenMekIncludeRejectsNonFrankenMek() throws IllegalAccessException {
+        MekSearchFilter filter = passThroughFilter();
+        filter.iFrankenMek = INCLUDE;
+
+        assertFalse(MekSearchFilter.isMatch(frankenMekSummary(false), filter));
+    }
+
+    @Test
+    void frankenMekExcludeRejectsFrankenMek() throws IllegalAccessException {
+        MekSearchFilter filter = passThroughFilter();
+        filter.iFrankenMek = EXCLUDE;
+
+        assertFalse(MekSearchFilter.isMatch(frankenMekSummary(true), filter));
+    }
+
+    @Test
+    void frankenMekExcludeAcceptsNonFrankenMek() throws IllegalAccessException {
+        MekSearchFilter filter = passThroughFilter();
+        filter.iFrankenMek = EXCLUDE;
+
+        assertTrue(MekSearchFilter.isMatch(frankenMekSummary(false), filter));
+    }
+
+    @Test
+    void frankenMekIgnoreAcceptsBoth() throws IllegalAccessException {
+        MekSearchFilter filter = passThroughFilter();
+
+        assertTrue(MekSearchFilter.isMatch(frankenMekSummary(true), filter));
+        assertTrue(MekSearchFilter.isMatch(frankenMekSummary(false), filter));
+    }
 
     @Test
     void matchesSourceFilterMatchesSource() {


### PR DESCRIPTION
 ## Summary
  Adds a tri-state "FrankenMek" filter to the Unit Type tab of the (TW) advanced search, letting users include only FrankenMeks, exclude them, or ignore the trait. Surfaces the FrankenMek support added in #8275.

  ## Changes
  1. Track the FrankenMek flag on `MekSummary` and populate it during unit cache build.
  2. Add a `frankenMek` tri-state to the advanced search state, UI tab, and filter logic.
  3. New message string for the checkbox label.

  ## Implementation Notes
  - FrankenMek is a boolean trait (`Mek.isFrankenMek()`), not an `Entity.ETYPE_*` value, so the filter follows the boolean-property pattern (Omni/Industrial/ Patchwork) rather than the entity-type bitmask used by Biped/Tripod/Quad.
  - The search runs against cached `MekSummary` objects, so the flag is threaded into `MekSummary` and set in `MekSummaryCache` during cache build.
  - `MekSummary` has no `serialVersionUID`, so the added field invalidates old serialized caches. The cache reader already catches this and regenerates a graceful one-time rebuild on first run; no migration handling needed.
  - The new search-state field is `@JsonInclude(NON_DEFAULT)`, so existing saved searches remain valid (absent = unselected)