### PR TITLE
Adjusted Default Bomb Load Out Sizes to Account for Player Feedback

### DIFF
--- a/megamek/mmconf/munitionLoadoutSettings.yaml
+++ b/megamek/mmconf/munitionLoadoutSettings.yaml
@@ -5,10 +5,10 @@
 ### Prohibitions apply equally to all factions and all munition types.
 ### E.g. adding "  - Smoke" would prevent SRM, LRM, and various Artillery bins from being loaded with Smoke ammo.
 Prohibited:
-  # Prohibited ammo will never be used by any faction.  Entries are indented one level and start with a hyphen:
-  # - Tandem-Charge
-  # - AlamoMissile Ammo
-  # - Davey Crockett-M
+# Prohibited ammo will never be used by any faction.  Entries are indented one level and start with a hyphen:
+# - Tandem-Charge
+# - AlamoMissile Ammo
+# - Davey Crockett-M
 
 ### This section defines override weights, which are applied after all other calculations but before supply checks.
 ### To create an override,
@@ -505,8 +505,8 @@ Defaults:
     pirateAntiBombLoad_LAA: 30
     pirateAntiBombLoad_AAA: 10
     # Sets the minimum + (0 ~ N) range of bomber units in a force that will be equipped.
-    percentBombersToEquipMin: 40
-    percentBombersToEquipRange: 60
+    percentBombersToEquipMin: 10
+    percentBombersToEquipRange: 20
     # For each Aerospace unit, if 1d6 is equal or below threshold, equip for CAP
     fightersLoadForCAPRollTargetThreshold: 1
     bomberMinUnarmedSafeThrustValue: 2

--- a/megamek/src/megamek/client/generator/TeamLoadOutGenerator.java
+++ b/megamek/src/megamek/client/generator/TeamLoadOutGenerator.java
@@ -1973,9 +1973,9 @@ public class TeamLoadOutGenerator {
 
         // Some bombers may not be loaded; calculate percentage of total to equip
         int maxBombers = Math.min((int) Math.ceil(((castPropertyInt(
-              "Defaults.Bombs.percentBombersToEquipMin", 40) +
+              "Defaults.Bombs.percentBombersToEquipMin", 10) +
               Compute.randomInt(castPropertyInt("Defaults.Bombs.percentBombersToEquipRange",
-                    60))) / 100.0) * bomberList.size()), bomberList.size());
+                    20))) / 100.0) * bomberList.size()), bomberList.size());
         int numBombers = 0;
 
         Map<Integer, BombLoadout> bombsByCarrier = new HashMap<>();


### PR DESCRIPTION
This PR just adjusts the autoAmmo config to have a lower bomb loud out preference. This PR is based in **extensive** player feedback. While, yes, players could adjust these values it appears most players either don't know they can, or don't have the confidence to adjust the config file. Instead, players opt to just remove the bombs in the lobby.