### PR TITLE
Allow indirect fire for conventional infantry mortars

### DIFF
--- a/megamek/src/megamek/common/equipment/EquipmentTypeLookup.java
+++ b/megamek/src/megamek/common/equipment/EquipmentTypeLookup.java
@@ -224,6 +224,14 @@ public class EquipmentTypeLookup {
     @EquipmentName
     public static final String INFANTRY_TAG = "InfantryTAG";
     @EquipmentName
+    public static final String INFANTRY_MORTAR_LIGHT = "InfantryLightMortar";
+    @EquipmentName
+    public static final String INFANTRY_MORTAR_HEAVY = "InfantryHeavyMortar";
+    @EquipmentName
+    public static final String INFANTRY_MORTAR_LIGHT_INFERNO = "InfantryLightMortarInferno";
+    @EquipmentName
+    public static final String INFANTRY_MORTAR_HEAVY_INFERNO = "InfantryHeavyMortarInferno";
+    @EquipmentName
     public static final String VIBRO_SHOVEL = "Vibro-Shovel";
     @EquipmentName
     public static final String DEMOLITION_CHARGE = "Demolition Charge";

--- a/megamek/src/megamek/common/weapons/infantry/support/mortar/InfantrySupportMortarHeavyInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mortar/InfantrySupportMortarHeavyInfernoWeapon.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2004,2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2010-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2010-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -44,6 +44,7 @@ import megamek.common.enums.AvailabilityValue;
 import megamek.common.enums.TechBase;
 import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
+import megamek.common.equipment.EquipmentTypeLookup;
 import megamek.common.options.IGameOptions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.infantry.InfantryWeapon;
@@ -63,14 +64,14 @@ public class InfantrySupportMortarHeavyInfernoWeapon extends InfantryWeapon {
         super();
 
         name = "Mortar (Heavy) - Inferno";
-        setInternalName("InfantryHeavyMortarInferno");
+        setInternalName(EquipmentTypeLookup.INFANTRY_MORTAR_HEAVY_INFERNO);
         addLookupName(name);
         addLookupName("Infantry Heavy Inferno Mortar");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 5000;
         bv = 2.44;
         tonnage = .220;
-        flags = flags.or(F_INFERNO).or(F_BALLISTIC).or(F_INF_SUPPORT);
+        flags = flags.or(F_INFERNO).or(F_BALLISTIC).or(F_INF_SUPPORT).or(F_MORTAR_TYPE_INDIRECT);
         String[] modeStrings = { "Damage", "Heat" };
         setModes(modeStrings);
         infantryDamage = 0.34;
@@ -106,5 +107,19 @@ public class InfantrySupportMortarHeavyInfernoWeapon extends InfantryWeapon {
                 addMode(MODE_INDIRECT_HEAT);
             }
         }
+    }
+
+    @Override
+    public boolean hasIndirectFire() {
+        // TO:AUE - conventional infantry whose Light/Heavy Mortar defines their final range value may
+        // use indirect fire like Mek Mortars. The F_MORTAR_TYPE_INDIRECT flag is only consulted on the
+        // platoon's range-defining weapon, so this capability applies only when the mortar sets the range.
+        return true;
+    }
+
+    @Override
+    public boolean isAlphaStrikeIndirectFire() {
+        // Conventional infantry do not gain the AlphaStrike IF ability from a carried mortar.
+        return false;
     }
 }

--- a/megamek/src/megamek/common/weapons/infantry/support/mortar/InfantrySupportMortarHeavyWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mortar/InfantrySupportMortarHeavyWeapon.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2004,2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2007-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2007-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -44,6 +44,7 @@ import megamek.common.enums.AvailabilityValue;
 import megamek.common.enums.TechBase;
 import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
+import megamek.common.equipment.EquipmentTypeLookup;
 import megamek.common.options.IGameOptions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.infantry.InfantryWeapon;
@@ -63,14 +64,14 @@ public class InfantrySupportMortarHeavyWeapon extends InfantryWeapon {
         super();
 
         name = "Mortar (Heavy)";
-        setInternalName("InfantryHeavyMortar");
+        setInternalName(EquipmentTypeLookup.INFANTRY_MORTAR_HEAVY);
         addLookupName(name);
         addLookupName("Infantry Heavy Mortar");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 5000;
         bv = 4.09;
         tonnage = .220;
-        flags = flags.or(F_NO_FIRES).or(F_BALLISTIC).or(F_INF_SUPPORT);
+        flags = flags.or(F_NO_FIRES).or(F_BALLISTIC).or(F_INF_SUPPORT).or(F_MORTAR_TYPE_INDIRECT);
         infantryDamage = 0.57;
         infantryRange = 3;
         crew = 3;
@@ -98,5 +99,19 @@ public class InfantrySupportMortarHeavyWeapon extends InfantryWeapon {
             removeMode("");
             removeMode("Indirect");
         }
+    }
+
+    @Override
+    public boolean hasIndirectFire() {
+        // TO:AUE - conventional infantry whose Light/Heavy Mortar defines their final range value may
+        // use indirect fire like Mek Mortars. The F_MORTAR_TYPE_INDIRECT flag is only consulted on the
+        // platoon's range-defining weapon, so this capability applies only when the mortar sets the range.
+        return true;
+    }
+
+    @Override
+    public boolean isAlphaStrikeIndirectFire() {
+        // Conventional infantry do not gain the AlphaStrike IF ability from a carried mortar.
+        return false;
     }
 }

--- a/megamek/src/megamek/common/weapons/infantry/support/mortar/InfantrySupportMortarLightInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mortar/InfantrySupportMortarLightInfernoWeapon.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2004,2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2010-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2010-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -44,6 +44,7 @@ import megamek.common.enums.AvailabilityValue;
 import megamek.common.enums.TechBase;
 import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
+import megamek.common.equipment.EquipmentTypeLookup;
 import megamek.common.options.IGameOptions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.infantry.InfantryWeapon;
@@ -63,14 +64,14 @@ public class InfantrySupportMortarLightInfernoWeapon extends InfantryWeapon {
         super();
 
         name = "Mortar (Light) - Inferno";
-        setInternalName("InfantryLightMortarInferno");
+        setInternalName(EquipmentTypeLookup.INFANTRY_MORTAR_LIGHT_INFERNO);
         addLookupName(name);
         addLookupName("Infantry Light Mortar Inferno");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 1400;
         bv = 0.79;
         tonnage = .050;
-        flags = flags.or(F_INFERNO).or(F_BALLISTIC).or(F_INF_SUPPORT);
+        flags = flags.or(F_INFERNO).or(F_BALLISTIC).or(F_INF_SUPPORT).or(F_MORTAR_TYPE_INDIRECT);
         String[] modeStrings = { "Damage", "Heat" };
         setModes(modeStrings);
         infantryDamage = 0.26;
@@ -100,5 +101,19 @@ public class InfantrySupportMortarLightInfernoWeapon extends InfantryWeapon {
             removeMode(MODE_MISSILE_INDIRECT);
             removeMode(MODE_INDIRECT_HEAT);
         }
+    }
+
+    @Override
+    public boolean hasIndirectFire() {
+        // TO:AUE - conventional infantry whose Light/Heavy Mortar defines their final range value may
+        // use indirect fire like Mek Mortars. The F_MORTAR_TYPE_INDIRECT flag is only consulted on the
+        // platoon's range-defining weapon, so this capability applies only when the mortar sets the range.
+        return true;
+    }
+
+    @Override
+    public boolean isAlphaStrikeIndirectFire() {
+        // Conventional infantry do not gain the AlphaStrike IF ability from a carried mortar.
+        return false;
     }
 }

--- a/megamek/src/megamek/common/weapons/infantry/support/mortar/InfantrySupportMortarLightWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mortar/InfantrySupportMortarLightWeapon.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2004,2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2007-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2007-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -44,6 +44,7 @@ import megamek.common.enums.AvailabilityValue;
 import megamek.common.enums.TechBase;
 import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
+import megamek.common.equipment.EquipmentTypeLookup;
 import megamek.common.options.IGameOptions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.infantry.InfantryWeapon;
@@ -63,14 +64,14 @@ public class InfantrySupportMortarLightWeapon extends InfantryWeapon {
         super();
 
         name = "Mortar (Light)";
-        setInternalName("InfantryLightMortar");
+        setInternalName(EquipmentTypeLookup.INFANTRY_MORTAR_LIGHT);
         addLookupName(name);
         addLookupName("Infantry Light Mortar");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 1400;
         bv = 1.62;
         tonnage = .050;
-        flags = flags.or(F_NO_FIRES).or(F_BALLISTIC).or(F_INF_SUPPORT);
+        flags = flags.or(F_NO_FIRES).or(F_BALLISTIC).or(F_INF_SUPPORT).or(F_MORTAR_TYPE_INDIRECT);
         infantryDamage = 0.53;
         infantryRange = 1;
         crew = 2;
@@ -98,5 +99,19 @@ public class InfantrySupportMortarLightWeapon extends InfantryWeapon {
             removeMode("");
             removeMode("Indirect");
         }
+    }
+
+    @Override
+    public boolean hasIndirectFire() {
+        // TO:AUE - conventional infantry whose Light/Heavy Mortar defines their final range value may
+        // use indirect fire like Mek Mortars. The F_MORTAR_TYPE_INDIRECT flag is only consulted on the
+        // platoon's range-defining weapon, so this capability applies only when the mortar sets the range.
+        return true;
+    }
+
+    @Override
+    public boolean isAlphaStrikeIndirectFire() {
+        // Conventional infantry do not gain the AlphaStrike IF ability from a carried mortar.
+        return false;
     }
 }

--- a/megamek/unittests/megamek/common/weapons/infantry/support/mortar/InfantryMortarIndirectFireTest.java
+++ b/megamek/unittests/megamek/common/weapons/infantry/support/mortar/InfantryMortarIndirectFireTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.weapons.infantry.support.mortar;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import megamek.common.LosEffects;
+import megamek.common.compute.Compute;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.EquipmentTypeLookup;
+import megamek.common.equipment.InfantryWeaponMounted;
+import megamek.common.equipment.WeaponType;
+import megamek.common.game.Game;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
+import megamek.common.units.ConvInfantry;
+import megamek.common.units.Targetable;
+import megamek.common.weapons.infantry.InfantryWeapon;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Verifies the TO:AUE rule that conventional infantry whose Light or Heavy Mortar defines their final range value may
+ * use indirect fire like Mek Mortars (which Battle Armor mortars already do).
+ *
+ * <p>The capability is granted by the {@link WeaponType#F_MORTAR_TYPE_INDIRECT} flag plus
+ * {@link WeaponType#hasIndirectFire()}. The to-hit logic only consults these on the weapon returned by
+ * {@code weapon.getType()}, which for a conventional platoon is the range-defining weapon (the first constructor
+ * argument of {@link InfantryWeaponMounted}). That dispatch is what restricts the capability to platoons "for whom
+ * Light or Heavy Mortars define the final range value".
+ */
+class InfantryMortarIndirectFireTest {
+
+    @BeforeAll
+    static void setup() {
+        EquipmentType.initializeTypes();
+    }
+
+    private static InfantryWeapon infantryWeapon(String internalName) {
+        return (InfantryWeapon) EquipmentType.get(internalName);
+    }
+
+    private static void assertSupportsMortarIndirectFire(String internalName) {
+        InfantryWeapon mortar = infantryWeapon(internalName);
+        assertTrue(mortar.hasIndirectFire(),
+              internalName + " should report indirect fire capability");
+        assertTrue(mortar.hasFlag(WeaponType.F_MORTAR_TYPE_INDIRECT),
+              internalName + " should carry the mortar indirect flag");
+        // Conventional infantry must not gain the AlphaStrike IF ability from the mortar.
+        assertFalse(mortar.isAlphaStrikeIndirectFire(),
+              internalName + " should not contribute the AlphaStrike IF ability");
+    }
+
+    @Test
+    void lightMortarSupportsMortarIndirectFire() {
+        assertSupportsMortarIndirectFire(EquipmentTypeLookup.INFANTRY_MORTAR_LIGHT);
+    }
+
+    @Test
+    void heavyMortarSupportsMortarIndirectFire() {
+        assertSupportsMortarIndirectFire(EquipmentTypeLookup.INFANTRY_MORTAR_HEAVY);
+    }
+
+    @Test
+    void lightInfernoMortarSupportsMortarIndirectFire() {
+        assertSupportsMortarIndirectFire(EquipmentTypeLookup.INFANTRY_MORTAR_LIGHT_INFERNO);
+    }
+
+    @Test
+    void heavyInfernoMortarSupportsMortarIndirectFire() {
+        assertSupportsMortarIndirectFire(EquipmentTypeLookup.INFANTRY_MORTAR_HEAVY_INFERNO);
+    }
+
+    @Test
+    void standardInfantryWeaponDoesNotSupportMortarIndirectFire() {
+        InfantryWeapon rifle = infantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+        assertFalse(rifle.hasIndirectFire(),
+              "A non-mortar infantry weapon should not report indirect fire capability");
+        assertFalse(rifle.hasFlag(WeaponType.F_MORTAR_TYPE_INDIRECT),
+              "A non-mortar infantry weapon should not carry the mortar indirect flag");
+    }
+
+    /**
+     * The indirect-fire gates check the flag on the platoon's range-defining weapon (the InfantryWeaponMounted's type).
+     * The mortar therefore enables mortar-style indirect fire only when it is the range-defining weapon.
+     */
+    @Test
+    void mortarEnablesIndirectOnlyWhenItDefinesRange() {
+        ConvInfantry platoon = new ConvInfantry();
+        InfantryWeapon mortar = infantryWeapon(EquipmentTypeLookup.INFANTRY_MORTAR_LIGHT);
+        InfantryWeapon rifle = infantryWeapon(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE);
+
+        // Mortar is the range-defining weapon (first constructor argument): capability is honored.
+        InfantryWeaponMounted mortarDefinesRange = new InfantryWeaponMounted(platoon, mortar, rifle);
+        assertTrue(mortarDefinesRange.getType().hasFlag(WeaponType.F_MORTAR_TYPE_INDIRECT),
+              "Mortar defining the platoon range should expose the indirect flag to the to-hit logic");
+
+        // Mortar is the secondary, non-range-defining weapon: capability is not honored.
+        InfantryWeaponMounted rifleDefinesRange = new InfantryWeaponMounted(platoon, rifle, mortar);
+        assertFalse(rifleDefinesRange.getType().hasFlag(WeaponType.F_MORTAR_TYPE_INDIRECT),
+              "A mortar that does not define the platoon range should not expose the indirect flag");
+    }
+
+    /**
+     * The "do not require a completely blocked line of sight" clause: with the Indirect Fire option on and a clear LOS
+     * to the target, {@link Compute#indirectAttackImpossible} must return {@code false} for a mortar (attack is still
+     * allowed) but {@code true} for an ordinary infantry weapon (blocked, like an indirect LRM with LOS). This
+     * exercises the real gate that consumes {@link WeaponType#F_MORTAR_TYPE_INDIRECT}, so it catches a regression in
+     * either the flag or the gate.
+     */
+    @Test
+    void mortarMayFireIndirectlyEvenWithLineOfSight() {
+        assertFalse(indirectImpossibleWithLineOfSight(EquipmentTypeLookup.INFANTRY_MORTAR_LIGHT),
+              "An infantry mortar should be allowed to fire indirectly even with line of sight to the target");
+    }
+
+    @Test
+    void standardInfantryWeaponBlockedFromIndirectWithLineOfSight() {
+        assertTrue(indirectImpossibleWithLineOfSight(EquipmentTypeLookup.INFANTRY_ASSAULT_RIFLE),
+              "A non-mortar infantry weapon firing indirectly should be blocked when it has line of sight");
+    }
+
+    /**
+     * Runs {@link Compute#indirectAttackImpossible} for the named weapon under: Indirect Fire option on, double-blind
+     * off, "indirect always possible" off, and a clear line of sight to the target. Under these conditions the only
+     * thing that lets the attack proceed is the mortar indirect flag.
+     *
+     * @param weaponInternalName the internal name of the firing weapon
+     *
+     * @return whether the indirect attack is impossible
+     */
+    private static boolean indirectImpossibleWithLineOfSight(String weaponInternalName) {
+        WeaponType weaponType = (WeaponType) EquipmentType.get(weaponInternalName);
+        ConvInfantry attacker = new ConvInfantry();
+        Targetable target = mock(Targetable.class);
+
+        GameOptions options = mock(GameOptions.class);
+        when(options.booleanOption(anyString())).thenReturn(false);
+        when(options.booleanOption(OptionsConstants.BASE_INDIRECT_FIRE)).thenReturn(true);
+
+        Game game = mock(Game.class);
+        when(game.getOptions()).thenReturn(options);
+
+        LosEffects los = mock(LosEffects.class);
+        when(los.canSee()).thenReturn(true);
+
+        try (MockedStatic<LosEffects> mockedLos = mockStatic(LosEffects.class)) {
+            mockedLos.when(() -> LosEffects.calculateLOS(any(), any(), any())).thenReturn(los);
+            return Compute.indirectAttackImpossible(game, attacker, target, weaponType, null);
+        }
+    }
+}


### PR DESCRIPTION
  ## Summary
  Per TO:AUE (the same rule reference as the 'Mech Mortar / BA Mortar indirect-fire rules), conventional
  infantry whose **Light or Heavy Mortar defines the platoon's final range value** may fire indirectly
  like 'Mech Mortars. Battle Armor mortars already had this (PR #4240); this extends the identical
  mechanism to conventional-infantry mortars, which were previously unable to use mortar-style indirect
  fire (they still required a spotter).

  ## Background
  Indirect mortar fire is gated entirely by the `WeaponType.F_MORTAR_TYPE_INDIRECT` flag plus
  `hasIndirectFire()`. The to-hit code only consults these on `weapon.getType()`, which for a conventional
  platoon is the **range-defining** weapon (the first constructor argument of `InfantryWeaponMounted`).
  Flagging the mortar weapon classes therefore enables mortar-style indirect fire **only when the mortar
  defines the platoon's range** — exactly the rule's "for whom Light or Heavy Mortars define the final
  range value" clause — with no new conditional logic. No engine/gating changes were needed; that
  infrastructure already exists from PR #4240.

  ## Changes
  1. Added `F_MORTAR_TYPE_INDIRECT` and overrode `hasIndirectFire()` → `true` on the four conventional infantry mortar weapons (Light, Heavy, Light Inferno, Heavy Inferno), mirroring the BA mortar pattern.
  2. Overrode `isAlphaStrikeIndirectFire()` → `false` on those weapons. `hasIndirectFire()` defaults this to true, but the conventional-infantry AlphaStrike converter computes damage per-trooper and does not grant the IF ability, so this keeps AlphaStrike output unchanged.
  3. Added `EquipmentTypeLookup` constants for the four mortars and switched their `setInternalName(...)` calls to use them (parity with how PR #4240 handled the BA mortars; also gives `@EquipmentName` verification coverage).

  ## Files Changed
  - `megamek/src/megamek/common/weapons/infantry/support/mortar/InfantrySupportMortarLightWeapon.java` - flag + overrides + lookup constant
  - `megamek/src/megamek/common/weapons/infantry/support/mortar/InfantrySupportMortarHeavyWeapon.java` - flag + overrides + lookup constant
  - `megamek/src/megamek/common/weapons/infantry/support/mortar/InfantrySupportMortarLightInfernoWeapon.java` - flag + overrides + lookup constant
  - `megamek/src/megamek/common/weapons/infantry/support/mortar/InfantrySupportMortarHeavyInfernoWeapon.java` - flag + overrides + lookup constant
  - `megamek/src/megamek/common/equipment/EquipmentTypeLookup.java` - four `@EquipmentName` mortar constants
  - `megamek/unittests/megamek/common/weapons/infantry/support/mortar/InfantryMortarIndirectFireTest.java` - new regression/behavior tests

  ## Testing
  - New `InfantryMortarIndirectFireTest`:
    - Capability granted on all four mortars (flag + `hasIndirectFire`), AS-IF stays off; non-mortar control.
    - Range-defining dispatch: the flag is exposed only when the mortar is the platoon's range-defining weapon.
    - Behavioral (real engine gate): `Compute.indirectAttackImpossible` allows a mortar to fire indirectly even with clear LOS, while an ordinary infantry weapon is blocked — proving the flag drives the gate.
  - `EquipmentTypeLookupTest` passes (new constants resolve to real equipment).
  - Manual in-game verification: a mortar-range-defining platoon fires indirectly without a spotter and with LOS; +2 (no spotter) / +3 (direct) modifiers apply; non-mortar platoons still require a spotter.

  ## Notes / Out of scope
  - Does not change the "infantry cannot clear woods" rule or the airborne/submerged firing restriction (the latter is not flag-gated and behaves identically for all mortar types).
