### PR TITLE
Make Princess sprint-aware: fix damage estimates and avoid sprinting into enemy weapon range

### DIFF
--- a/megamek/mmconf/log4j2.xml
+++ b/megamek/mmconf/log4j2.xml
@@ -84,19 +84,21 @@
           </Logger>
         -->
         <!--
-          Princess movement-decision loggers. Candidate-path data with scoring columns
-          (isSprinting, sprintExposurePenalty, sprintThreatEnemyId, ...) is always written as
-          TSV to logs/bot_path_ranker.log by the BotLogger above. The loggers below add the
-          per-unit sprint decision summary (debug, PathRanker) and the full per-path scoring
-          formula with sprint threat detail (trace, BasicPathRanker) to logs/megamek.log.
-          Set both levels to "error" to silence them again.
+          Princess movement-decision loggers, silent by default (parent "megamek.client.bot"
+          logger at error). Candidate-path data with scoring columns (isSprinting,
+          sprintExposurePenalty, sprintThreatEnemyId, ...) is always written as TSV to
+          logs/bot_path_ranker.log by the BotLogger above. To also log the per-unit sprint
+          decision summary (debug, PathRanker) and the per-path scoring detail (debug,
+          BasicPathRanker) to logs/megamek.log, uncomment the loggers below. Avoid trace on
+          BasicPathRanker during full games: per-hex hazard logging is extremely verbose.
+
+          <Logger name="megamek.client.bot.princess.PathRanker" level="debug" additivity="false">
+              <AppenderRef ref="MegaMekLog" />
+          </Logger>
+          <Logger name="megamek.client.bot.princess.BasicPathRanker" level="debug" additivity="false">
+              <AppenderRef ref="MegaMekLog" />
+          </Logger>
         -->
-        <Logger name="megamek.client.bot.princess.PathRanker" level="debug" additivity="false">
-            <AppenderRef ref="MegaMekLog" />
-        </Logger>
-        <Logger name="megamek.client.bot.princess.BasicPathRanker" level="debug" additivity="false">
-            <AppenderRef ref="MegaMekLog" />
-        </Logger>
         <Logger name="megamek" level="info" additivity="false">
             <AppenderRef ref="${env:mm.profile:-null}" />
             <AppenderRef ref="UnifiedLog" />

--- a/megamek/mmconf/log4j2.xml
+++ b/megamek/mmconf/log4j2.xml
@@ -88,14 +88,15 @@
           logger at error). Candidate-path data with scoring columns (isSprinting,
           sprintExposurePenalty, sprintThreatEnemyId, ...) is always written as TSV to
           logs/bot_path_ranker.log by the BotLogger above. To also log the per-unit sprint
-          decision summary (debug, PathRanker) and the per-path scoring detail (debug,
-          BasicPathRanker) to logs/megamek.log, uncomment the loggers below. Avoid trace on
-          BasicPathRanker during full games: per-hex hazard logging is extremely verbose.
+          decision summary to logs/megamek.log, uncomment the PathRanker logger below. The
+          BasicPathRanker logger additionally emits the full per-path scoring formula with
+          sprint threat detail, but only at trace level, which also logs per-hex hazard
+          checks and is extremely verbose - use it for short test games only.
 
           <Logger name="megamek.client.bot.princess.PathRanker" level="debug" additivity="false">
               <AppenderRef ref="MegaMekLog" />
           </Logger>
-          <Logger name="megamek.client.bot.princess.BasicPathRanker" level="debug" additivity="false">
+          <Logger name="megamek.client.bot.princess.BasicPathRanker" level="trace" additivity="false">
               <AppenderRef ref="MegaMekLog" />
           </Logger>
         -->

--- a/megamek/mmconf/log4j2.xml
+++ b/megamek/mmconf/log4j2.xml
@@ -83,6 +83,20 @@
               <AppenderRef ref="MegaMekLog" />
           </Logger>
         -->
+        <!--
+          Princess movement-decision loggers. Candidate-path data with scoring columns
+          (isSprinting, sprintExposurePenalty, sprintThreatEnemyId, ...) is always written as
+          TSV to logs/bot_path_ranker.log by the BotLogger above. The loggers below add the
+          per-unit sprint decision summary (debug, PathRanker) and the full per-path scoring
+          formula with sprint threat detail (trace, BasicPathRanker) to logs/megamek.log.
+          Set both levels to "error" to silence them again.
+        -->
+        <Logger name="megamek.client.bot.princess.PathRanker" level="debug" additivity="false">
+            <AppenderRef ref="MegaMekLog" />
+        </Logger>
+        <Logger name="megamek.client.bot.princess.BasicPathRanker" level="debug" additivity="false">
+            <AppenderRef ref="MegaMekLog" />
+        </Logger>
         <Logger name="megamek" level="info" additivity="false">
             <AppenderRef ref="${env:mm.profile:-null}" />
             <AppenderRef ref="UnifiedLog" />

--- a/megamek/src/megamek/ai/dataset/EntityDataSerializer.java
+++ b/megamek/src/megamek/ai/dataset/EntityDataSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 
 import megamek.common.enums.AimingMode;
 import megamek.common.enums.GamePhase;
+import megamek.common.units.EntityMovementType;
 import megamek.common.units.UnitRole;
 
 /**
@@ -82,6 +83,7 @@ public abstract class EntityDataSerializer<F extends Enum<F>, T extends EntityDa
         DEFAULT_FORMAT_HANDLERS.put(UnitRole.class, value -> ((UnitRole) value).name());
         DEFAULT_FORMAT_HANDLERS.put(GamePhase.class, value -> ((GamePhase) value).name());
         DEFAULT_FORMAT_HANDLERS.put(AimingMode.class, value -> ((AimingMode) value).name());
+        DEFAULT_FORMAT_HANDLERS.put(EntityMovementType.class, value -> ((EntityMovementType) value).name());
 
         // Lists with space-separated values
         DEFAULT_FORMAT_HANDLERS.put(List.class, value -> {

--- a/megamek/src/megamek/ai/dataset/UnitAction.java
+++ b/megamek/src/megamek/ai/dataset/UnitAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -92,7 +92,8 @@ public class UnitAction extends EntityDataMap<UnitAction.Field> {
         ARMOR_RIGHT_P,
         ARMOR_BACK_P,
         ROLE,
-        WEAPON_DMG_FACING_SHORT_MEDIUM_LONG_RANGE
+        WEAPON_DMG_FACING_SHORT_MEDIUM_LONG_RANGE,
+        MOVEMENT_TYPE
     }
 
     /**
@@ -141,6 +142,7 @@ public class UnitAction extends EntityDataMap<UnitAction.Field> {
               .put(Field.MP_USED, movePath.getMpUsed())
               .put(Field.MAX_MP, movePath.getMaxMP())
               .put(Field.MP_P, movePath.getMaxMP() > 0 ? (double) movePath.getMpUsed() / movePath.getMaxMP() : 0.0)
+              .put(Field.MOVEMENT_TYPE, movePath.getLastStepMovementType())
               .put(Field.HEAT_P,
                     entity.getHeatCapacity() > 0 ? entity.getHeat() / (double) entity.getHeatCapacity() : 0.0);
 

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -104,6 +104,10 @@ public class BasicPathRanker extends PathRanker {
     // this is a value used to indicate how much we dis-value the unit being destroyed as a result of what it's doing
     private final int UNIT_DESTRUCTION_FACTOR = 1000;
 
+    // penalty for ending a sprint inside enemy weapon range; a sprinting unit forfeits all of its attacks,
+    // so this must outweigh the aggression/bravery incentives that would otherwise favor closing distance
+    private final int SPRINT_INTO_THREAT_PENALTY = 250;
+
     private final FacingDiffCalculator facingDiffCalculator;
     private final UnitsMedianCoordinateCalculator unitsMedianCoordinateCalculator;
     protected final DecimalFormat LOG_DECIMAL = new DecimalFormat("0.00", new DecimalFormatSymbols(Locale.US));
@@ -233,7 +237,9 @@ public class BasicPathRanker extends PathRanker {
             rightBounds = new HexLine(behind, (myFacing + 5) % 6);
         }
 
-        if (isInMyLoS(enemy, leftBounds, rightBounds)) {
+        // A unit that sprinted may not make any deliberate attacks this turn, so a sprinting
+        // path contributes no damage of mine no matter who ends up in my line of fire.
+        if (!isSprintingPath(path) && isInMyLoS(enemy, leftBounds, rightBounds)) {
             returnResponse.addToMyEstimatedDamage(getMaxDamageAtRange(path.getEntity(),
                   range,
                   useExtremeRange,
@@ -449,15 +455,188 @@ public class BasicPathRanker extends PathRanker {
 
         returnResponse.setEstimatedEnemyDamage(theirDamagePotential);
 
-        // How much damage can I do to them?
-        returnResponse.setMyEstimatedDamage(calculateMyDamagePotential(path, enemy, distance, game));
+        // A unit that sprinted may not make any deliberate attacks this turn, weapon or physical,
+        // so a sprinting path contributes no damage of mine.
+        if (!isSprintingPath(path)) {
+            // How much damage can I do to them?
+            returnResponse.setMyEstimatedDamage(calculateMyDamagePotential(path, enemy, distance, game));
 
-        // How much physical damage can I do to them?
-        if (distance <= 1) {
-            returnResponse.setMyEstimatedPhysicalDamage(calculateMyKickDamagePotential(path, enemy, game));
+            // How much physical damage can I do to them?
+            if (distance <= 1) {
+                returnResponse.setMyEstimatedPhysicalDamage(calculateMyKickDamagePotential(path, enemy, game));
+            }
         }
 
         return returnResponse;
+    }
+
+    /**
+     * Determines whether an enemy can be disregarded when evaluating a move path: it is on another board, is an ejected
+     * crew, is off the board or has no position, or is broken and fleeing the field.
+     *
+     * @param movingUnit the unit whose move path is being evaluated
+     * @param enemy      the enemy to check
+     * @param game       the current {@link Game}
+     *
+     * @return true if the enemy has no bearing on the path evaluation
+     */
+    boolean isIgnorableEnemy(Entity movingUnit, Entity enemy, Game game) {
+        // For now, disregard enemy units that are not on the same board
+        if (!game.onTheSameBoard(movingUnit, enemy)) {
+            return true;
+        }
+
+        // Skip ejected pilots.
+        if (enemy instanceof EjectedCrew) {
+            return true;
+        }
+
+        // Skip units not on the board.
+        if (enemy.isOffBoard() || (enemy.getPosition() == null) || !game.getBoard(enemy)
+              .contains(enemy.getPosition())) {
+            return true;
+        }
+
+        // Skip broken enemies
+        return getOwner().getHonorUtil()
+              .isEnemyBroken(enemy.getId(), enemy.getOwnerId(), getOwner().getForcedWithdrawal());
+    }
+
+    /**
+     * Returns true if the given path ends in sprinting movement. A unit that sprinted may not make any deliberate
+     * attacks or spot for indirect fire that turn (TacOps Sprinting rules).
+     *
+     * @param path the move path to check
+     *
+     * @return true if the path's final movement type is a ground or VTOL sprint
+     */
+    static boolean isSprintingPath(MovePath path) {
+        EntityMovementType movementType = path.getLastStepMovementType();
+        return (EntityMovementType.MOVE_SPRINT == movementType)
+              || (EntityMovementType.MOVE_VTOL_SPRINT == movementType);
+    }
+
+    /**
+     * Describes the enemy that makes ending a sprint at a given position dangerous.
+     *
+     * @param enemy             the threatening enemy
+     * @param firingPosition    the position the enemy can bring weapons to bear from
+     * @param distance          hexes from the path's final position to the firing position
+     * @param maxWeaponRange    the threatening enemy's maximum weapon range
+     * @param positionPredicted true if the firing position is a prediction (the enemy has not moved yet this turn and
+     *                          the position is the closest one it can reach), false if it is where the enemy currently
+     *                          stands
+     */
+    record SprintThreat(Entity enemy, Coords firingPosition, int distance, int maxWeaponRange,
+          boolean positionPredicted) {
+    }
+
+    /**
+     * Finds an enemy that can bring weapons to bear on the given path's final position, if any. For enemies that can
+     * still move this turn, range is measured from the closest position they can reach instead of where they currently
+     * stand. Returns the first threatening enemy found, not necessarily the closest one.
+     *
+     * @param path    the move path to check
+     * @param enemies the known enemy units
+     * @param game    the current {@link Game}
+     *
+     * @return the threat assessment for one enemy in weapon range of the path's final position, or empty if none
+     */
+    Optional<SprintThreat> findSprintThreat(MovePath path, List<Entity> enemies, Game game) {
+        Coords finalCoords = path.getFinalCoords();
+        Entity movingUnit = path.getEntity();
+
+        for (Entity enemy : enemies) {
+            if (isIgnorableEnemy(movingUnit, enemy, game)) {
+                continue;
+            }
+
+            boolean positionPredicted = !evaluateAsMoved(enemy);
+            Coords firingPosition = positionPredicted ? getClosestCoordsTo(enemy.getId(), finalCoords)
+                  : enemy.getPosition();
+            if (firingPosition == null) {
+                // no movable-area data for this enemy; fall back to where it currently stands
+                firingPosition = enemy.getPosition();
+                positionPredicted = false;
+            }
+
+            int distance = finalCoords.distance(firingPosition);
+            int maxWeaponRange = getOwner().getMaxWeaponRange(enemy, movingUnit.isAirborne());
+            if (distance <= maxWeaponRange) {
+                return Optional.of(new SprintThreat(enemy, firingPosition, distance, maxWeaponRange,
+                      positionPredicted));
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    /**
+     * Calculates a penalty for paths that end a sprint inside enemy weapon range. A sprinting unit forfeits all of its
+     * attacks and suffers an additional -1 to-hit modifier against it, so ending a sprint where the enemy can shoot
+     * back gives up firepower for no defensive gain. Units performing a forced withdrawal are exempt: they do not
+     * intend to attack, and the extra movement serves the withdrawal.
+     *
+     * <p>The decision is traced two ways so it can be reconstructed after a battle: the sprint-related entries in
+     * {@code scores} become columns in the {@link megamek.client.bot.BotLogger} TSV output, and {@code sprintFormula}
+     * receives a human-readable explanation that ends up in the ranked path's reason string.</p>
+     *
+     * @param path          the move path to evaluate
+     * @param enemies       the known enemy units
+     * @param game          the current {@link Game}
+     * @param scores        the path's score map; receives {@code isSprinting}, {@code sprintThreatEnemyId},
+     *                      {@code sprintThreatDistance} and {@code sprintThreatRange} entries (-1 where not
+     *                      applicable)
+     * @param sprintFormula receives a human-readable explanation of the decision; left empty for non-sprint paths
+     *
+     * @return {@code SPRINT_INTO_THREAT_PENALTY} if the path sprints into enemy weapon range, otherwise 0
+     */
+    double calculateSprintExposurePenalty(MovePath path, List<Entity> enemies, Game game,
+          Map<String, Double> scores, StringBuilder sprintFormula) {
+        boolean sprinting = isSprintingPath(path);
+        scores.put("isSprinting", sprinting ? 1.0 : 0.0);
+        scores.put("sprintThreatEnemyId", -1.0);
+        scores.put("sprintThreatDistance", -1.0);
+        scores.put("sprintThreatRange", -1.0);
+
+        if (!sprinting) {
+            return 0;
+        }
+
+        Entity movingUnit = path.getEntity();
+        boolean isWithdrawing = BehaviorType.ForcedWithdrawal ==
+              getOwner().getUnitBehaviorTracker().getBehaviorType(movingUnit, getOwner());
+        if (isWithdrawing) {
+            sprintFormula.append("sprintExposurePenalty [0: withdrawing, sprint always allowed]");
+            return 0;
+        }
+
+        Optional<SprintThreat> sprintThreat = findSprintThreat(path, enemies, game);
+        if (sprintThreat.isEmpty()) {
+            sprintFormula.append("sprintExposurePenalty [0: no enemy can reach ")
+                  .append(path.getFinalCoords().toFriendlyString())
+                  .append(" with weapons]");
+            return 0;
+        }
+
+        SprintThreat threat = sprintThreat.get();
+        scores.put("sprintThreatEnemyId", (double) threat.enemy().getId());
+        scores.put("sprintThreatDistance", (double) threat.distance());
+        scores.put("sprintThreatRange", (double) threat.maxWeaponRange());
+        sprintFormula.append("sprintExposurePenalty [")
+              .append(SPRINT_INTO_THREAT_PENALTY)
+              .append(": sprint ends at ")
+              .append(path.getFinalCoords().toFriendlyString())
+              .append(", ")
+              .append(threat.enemy().getDisplayName())
+              .append(threat.positionPredicted() ? " can reach " : " stands at ")
+              .append(threat.firingPosition().toFriendlyString())
+              .append(", distance ")
+              .append(threat.distance())
+              .append(" <= weapon range ")
+              .append(threat.maxWeaponRange())
+              .append("]");
+        return SPRINT_INTO_THREAT_PENALTY;
     }
 
     /**
@@ -760,25 +939,7 @@ public class BasicPathRanker extends PathRanker {
         boolean extremeRange = isExtremeRange(game);
         boolean losRange = isLosRange(game);
         for (Entity enemy : enemies) {
-            // For now, disregard enemy units that are not on the same board
-            if (!game.onTheSameBoard(movingUnit, enemy)) {
-                continue;
-            }
-
-            // Skip ejected pilots.
-            if (enemy instanceof EjectedCrew) {
-                continue;
-            }
-
-            // Skip units not on the board.
-            if (enemy.isOffBoard() || (enemy.getPosition() == null) || !game.getBoard(enemy)
-                  .contains(enemy.getPosition())) {
-                continue;
-            }
-
-            // Skip broken enemies
-            if (getOwner().getHonorUtil()
-                  .isEnemyBroken(enemy.getId(), enemy.getOwnerId(), getOwner().getForcedWithdrawal())) {
+            if (isIgnorableEnemy(movingUnit, enemy, game)) {
                 continue;
             }
 
@@ -904,6 +1065,11 @@ public class BasicPathRanker extends PathRanker {
 
         double selfPreservationMod = calculateSelfPreservationMod(movingUnit, pathCopy, game);
 
+        StringBuilder sprintFormula = new StringBuilder(64);
+        double sprintExposurePenalty = calculateSprintExposurePenalty(pathCopy, enemies, game, scores,
+              sprintFormula);
+        scores.put("sprintExposurePenalty", sprintExposurePenalty);
+
         double offBoardMod = calculateOffBoardMod(pathCopy);
         // if we're an aircraft, we want to devalue paths that will force us off the board on the subsequent turn.
         double utility = -fallMod;
@@ -914,6 +1080,7 @@ public class BasicPathRanker extends PathRanker {
         utility -= crowdingTolerance;
         utility -= facingMod;
         utility -= selfPreservationMod;
+        utility -= sprintExposurePenalty;
         utility -= utility * offBoardMod;
 
         formula.append("Calculation: {fall mod [")
@@ -963,6 +1130,10 @@ public class BasicPathRanker extends PathRanker {
               .append(" * ")
               .append((int) (facingMod / FACING_MOD_MULTIPLIER))
               .append("]");
+
+        if (!sprintFormula.isEmpty()) {
+            formula.append(" - ").append(sprintFormula);
+        }
 
         logger.trace("{}", formula);
 

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -185,7 +185,58 @@ public abstract class PathRanker implements IPathRanker {
             i++;
         }
 
+        logSprintDecisionSummary(returnPaths);
+
         return returnPaths;
+    }
+
+    /**
+     * Logs a one-line, debug-level summary of the sprint decision for a unit's move: whether the best-ranked path
+     * sprints, how many candidate paths end in a sprint, how many of those were penalized for ending inside enemy
+     * weapon range, and the best sprint vs. non-sprint ranks. This makes the bot's sprint reasoning visible without
+     * wading through per-path trace output; the full per-path detail is in the BotLogger TSV columns
+     * ({@code isSprinting}, {@code sprintExposurePenalty}, {@code sprintThreatEnemyId}, {@code sprintThreatDistance},
+     * {@code sprintThreatRange}) and each ranked path's reason string.
+     *
+     * @param rankedPaths the ranked paths for this unit's move, best first
+     */
+    private void logSprintDecisionSummary(TreeSet<RankedPath> rankedPaths) {
+        if (rankedPaths.isEmpty() || !logger.isLevelLessSpecificThan(Level.INFO)) {
+            return;
+        }
+
+        int sprintPathCount = 0;
+        int penalizedPathCount = 0;
+        RankedPath bestSprintPath = null;
+        RankedPath bestNonSprintPath = null;
+
+        for (RankedPath rankedPath : rankedPaths) {
+            if (BasicPathRanker.isSprintingPath(rankedPath.getPath())) {
+                sprintPathCount++;
+                Double sprintExposurePenalty = rankedPath.getScores().get("sprintExposurePenalty");
+                if ((sprintExposurePenalty != null) && (sprintExposurePenalty > 0)) {
+                    penalizedPathCount++;
+                }
+                if (bestSprintPath == null) {
+                    bestSprintPath = rankedPath;
+                }
+            } else if (bestNonSprintPath == null) {
+                bestNonSprintPath = rankedPath;
+            }
+        }
+
+        RankedPath bestPath = rankedPaths.first();
+        logger.debug("Sprint decision for {}: best path {} (rank {}); {} of {} candidate paths sprint, "
+                    + "{} sprint paths penalized for ending in enemy weapon range; "
+                    + "best sprint rank {}, best non-sprint rank {}",
+              bestPath.getPath().getEntity().getDisplayName(),
+              BasicPathRanker.isSprintingPath(bestPath.getPath()) ? "SPRINTS" : "does not sprint",
+              bestPath.getRank(),
+              sprintPathCount,
+              rankedPaths.size(),
+              penalizedPathCount,
+              (bestSprintPath == null) ? "n/a" : bestSprintPath.getRank(),
+              (bestNonSprintPath == null) ? "n/a" : bestNonSprintPath.getRank());
     }
 
     private List<MovePath> validatePaths(List<MovePath> startingPathList, Game game, int maxRange,

--- a/megamek/src/megamek/utilities/ScenarioGameRunner.java
+++ b/megamek/src/megamek/utilities/ScenarioGameRunner.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.utilities;
+
+import static megamek.MMConstants.LOCALHOST_IP;
+
+import java.io.File;
+import java.io.ObjectInputFilter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+import megamek.MMConstants;
+import megamek.client.HeadlessClient;
+import megamek.client.bot.princess.BehaviorSettings;
+import megamek.client.bot.princess.BehaviorSettingsFactory;
+import megamek.client.bot.princess.Princess;
+import megamek.common.Player;
+import megamek.common.enums.GamePhase;
+import megamek.common.event.GameListenerAdapter;
+import megamek.common.event.GamePhaseChangeEvent;
+import megamek.common.game.Game;
+import megamek.common.game.IGame;
+import megamek.common.jacksonAdapters.BotParser;
+import megamek.common.loaders.MekSummaryCache;
+import megamek.common.net.marshalling.SanityInputFilter;
+import megamek.common.preference.PreferenceManager;
+import megamek.common.scenario.Scenario;
+import megamek.common.scenario.ScenarioLoader;
+import megamek.logging.MMLogger;
+import megamek.server.Server;
+import megamek.server.totalWarfare.TWGameManager;
+
+/**
+ * Runs a Scenario file headless as a fully automated bot-vs-bot game, without any GUI or human interaction.
+ *
+ * <p>The first faction in the scenario is claimed by a headless watcher client that automatically acknowledges
+ * report phases; every other faction is played by a Princess bot, using the behavior settings declared in the
+ * scenario's {@code bot:} block when present, or default behavior otherwise. The game runs until victory, the given
+ * round limit, or the timeout, whichever comes first.</p>
+ *
+ * <p>Intended for AI testing and decision-log generation (see {@code docs/issues/princess-work-tracker.md}):
+ * bot decision data is written to the BotLogger TSV and the standard logs while the game runs.</p>
+ *
+ * <p>Usage: {@code ScenarioGameRunner <scenarioFile> [roundsLimit] [timeoutMinutes]}</p>
+ */
+public class ScenarioGameRunner {
+    private static final MMLogger logger = MMLogger.create(ScenarioGameRunner.class);
+
+    private static final int DEFAULT_ROUNDS_LIMIT = 6;
+    private static final int DEFAULT_TIMEOUT_MINUTES = 10;
+    private static final int CONNECT_RETRY_LIMIT = 250;
+    private static final int CONNECT_RETRY_SLEEP_MILLIS = 50;
+
+    static {
+        MekSummaryCache.getInstance();
+        ObjectInputFilter.Config.setSerialFilter(new SanityInputFilter());
+    }
+
+    private final Server server;
+    private final Scenario scenario;
+    private final Game game;
+
+    public ScenarioGameRunner(File scenarioFile) throws Exception {
+        TWGameManager gameManager = new TWGameManager();
+        Random random = new Random();
+        server = new Server(null,
+              random.nextInt(MMConstants.MIN_PORT_FOR_QUICK_GAME, MMConstants.MAX_PORT),
+              gameManager, false, "", null, true);
+
+        ScenarioLoader scenarioLoader = new ScenarioLoader(scenarioFile);
+        scenario = scenarioLoader.load();
+        IGame loadedGame = scenario.createGame();
+        if (!(loadedGame instanceof Game totalWarfareGame)) {
+            throw new IllegalArgumentException("Only Total Warfare scenarios are supported: " + scenarioFile);
+        }
+        game = totalWarfareGame;
+
+        server.setGame(game);
+        scenario.applyDamage(gameManager);
+        gameManager.calculatePlayerInitialCounts();
+    }
+
+    /**
+     * Connects the watcher and bots, then runs the game.
+     *
+     * @param roundsLimit    maximum number of rounds before the game is ended via /victory
+     * @param timeoutMinutes wall-clock limit; the game is abandoned when exceeded
+     *
+     * @return true if the game finished (victory or round limit), false on timeout
+     */
+    private boolean run(int roundsLimit, int timeoutMinutes) throws Exception {
+        List<Player> players = new ArrayList<>(game.getPlayersList());
+        if (players.isEmpty()) {
+            throw new IllegalStateException("Scenario defines no players");
+        }
+        players.sort(Comparator.comparingInt(Player::getId));
+
+        Player watcherSlot = players.getFirst();
+        CountDownLatch roundCounter = new CountDownLatch(roundsLimit);
+
+        HeadlessClient watcher = new HeadlessClient(watcherSlot.getName(), LOCALHOST_IP, server.getPort());
+        watcher.getGame().addGameListener(new GameListenerAdapter() {
+            @Override
+            public void gamePhaseChange(GamePhaseChangeEvent event) {
+                GamePhase newPhase = event.getNewPhase();
+                if (newPhase == GamePhase.END_REPORT) {
+                    roundCounter.countDown();
+                    if (roundCounter.getCount() == 1) {
+                        watcher.sendChat("/victory");
+                    }
+                } else if (newPhase == GamePhase.VICTORY) {
+                    while (roundCounter.getCount() > 0) {
+                        roundCounter.countDown();
+                    }
+                }
+
+                // the watcher has no units; acknowledge every report phase so the game never waits on it
+                if (newPhase.isReport()) {
+                    watcher.sendDone(true);
+                }
+            }
+        });
+
+        watcher.connect();
+        waitForLocalPlayer(watcher.getName(), () -> watcher.getLocalPlayer() != null);
+
+        for (Player botSlot : players.subList(1, players.size())) {
+            Princess princess = Princess.createPrincess(botSlot.getName(),
+                  LOCALHOST_IP,
+                  server.getPort(),
+                  behaviorFor(botSlot.getName()));
+            if (!princess.connect()) {
+                throw new IllegalStateException("Princess failed to connect for player " + botSlot.getName());
+            }
+            waitForLocalPlayer(princess.getName(), () -> princess.getLocalPlayer() != null);
+            princess.sendPlayerInfo();
+            logger.info("Connected Princess for {}", botSlot.getName());
+        }
+
+        logger.info("Running scenario '{}' for up to {} rounds ({} minute timeout)",
+              scenario.getName(), roundsLimit, timeoutMinutes);
+        boolean finished = roundCounter.await(timeoutMinutes, TimeUnit.MINUTES);
+        if (finished) {
+            logger.info("Scenario game completed");
+        } else {
+            logger.error("Scenario game timed out");
+        }
+        return finished;
+    }
+
+    /**
+     * Returns the Princess behavior declared for the named player in the scenario, or default behavior.
+     */
+    private BehaviorSettings behaviorFor(String playerName) {
+        if (scenario.hasBotInfo(playerName)
+              && scenario.getBotInfo(playerName) instanceof BotParser.PrincessRecord(BehaviorSettings settings)) {
+            return settings;
+        }
+        return BehaviorSettingsFactory.getInstance().DEFAULT_BEHAVIOR;
+    }
+
+    private void waitForLocalPlayer(String clientName, BooleanSupplier connected) throws InterruptedException {
+        int retryCount = 0;
+        while (!connected.getAsBoolean() && (retryCount++ < CONNECT_RETRY_LIMIT)) {
+            Thread.sleep(CONNECT_RETRY_SLEEP_MILLIS);
+        }
+        if (!connected.getAsBoolean()) {
+            throw new IllegalStateException("Client " + clientName + " failed to receive its player slot");
+        }
+    }
+
+    public static void main(String[] args) {
+        if (args.length < 1) {
+            System.out.println("Usage: ScenarioGameRunner <scenarioFile> [roundsLimit] [timeoutMinutes]");
+            System.out.println(" - scenarioFile: an MMS scenario; first faction is the headless watcher,");
+            System.out.println("   all other factions are played by Princess bots");
+            System.out.println(" - roundsLimit: stop the game after this many rounds (default "
+                  + DEFAULT_ROUNDS_LIMIT + ")");
+            System.out.println(" - timeoutMinutes: abandon the game after this long (default "
+                  + DEFAULT_TIMEOUT_MINUTES + ")");
+            System.exit(1);
+        }
+
+        File scenarioFile = new File(args[0]);
+        int roundsLimit = (args.length > 1) ? Integer.parseInt(args[1]) : DEFAULT_ROUNDS_LIMIT;
+        int timeoutMinutes = (args.length > 2) ? Integer.parseInt(args[2]) : DEFAULT_TIMEOUT_MINUTES;
+
+        PreferenceManager.getClientPreferences().setAskForVictoryList(false);
+        // stamp gamelog.html and game_actions TSV filenames with date+time so consecutive runs
+        // accumulate instead of overwriting each other
+        PreferenceManager.getClientPreferences().setStampFilenames(true);
+
+        int exitCode = 0;
+        try {
+            ScenarioGameRunner runner = new ScenarioGameRunner(scenarioFile);
+            if (!runner.run(roundsLimit, timeoutMinutes)) {
+                exitCode = 2;
+            }
+        } catch (Exception e) {
+            logger.fatal(e, "Failed to run scenario game");
+            exitCode = 1;
+        }
+        System.exit(exitCode);
+    }
+}

--- a/megamek/src/megamek/utilities/ScenarioGameRunner.java
+++ b/megamek/src/megamek/utilities/ScenarioGameRunner.java
@@ -156,7 +156,9 @@ public class ScenarioGameRunner {
             }
         });
 
-        watcher.connect();
+        if (!watcher.connect()) {
+            throw new IllegalStateException("Watcher client failed to connect to the local server");
+        }
         waitForLocalPlayer(watcher.getName(), () -> watcher.getLocalPlayer() != null);
 
         for (Player botSlot : players.subList(1, players.size())) {
@@ -217,8 +219,21 @@ public class ScenarioGameRunner {
         }
 
         File scenarioFile = new File(args[0]);
-        int roundsLimit = (args.length > 1) ? Integer.parseInt(args[1]) : DEFAULT_ROUNDS_LIMIT;
-        int timeoutMinutes = (args.length > 2) ? Integer.parseInt(args[2]) : DEFAULT_TIMEOUT_MINUTES;
+        int roundsLimit = DEFAULT_ROUNDS_LIMIT;
+        int timeoutMinutes = DEFAULT_TIMEOUT_MINUTES;
+        try {
+            if (args.length > 1) {
+                roundsLimit = Integer.parseInt(args[1]);
+            }
+            if (args.length > 2) {
+                timeoutMinutes = Integer.parseInt(args[2]);
+            }
+        } catch (NumberFormatException e) {
+            System.out.println("roundsLimit and timeoutMinutes must be whole numbers, but got: "
+                  + String.join(" ", args));
+            System.out.println("Usage: ScenarioGameRunner <scenarioFile> [roundsLimit] [timeoutMinutes]");
+            System.exit(1);
+        }
 
         PreferenceManager.getClientPreferences().setAskForVictoryList(false);
         // stamp gamelog.html and game_actions TSV filenames with date+time so consecutive runs

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -34,12 +34,15 @@
 package megamek.client.bot.princess;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
@@ -378,6 +381,210 @@ class BasicPathRankerTest {
         expected.setEstimatedEnemyDamage(15);
         actual = testRanker.evaluateMovedEnemy(mockEnemyMek, mockPath, mockGame);
         assertEntityEvaluationResponseEquals(expected, actual);
+    }
+
+    @Test
+    void testEvaluateUnmovedEnemySprintingPathDoesNoDamage() {
+        final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
+        doReturn(mockPrincess).when(testRanker).getOwner();
+
+        final Coords testCoords = new Coords(10, 10);
+        final Entity mockMyUnit = MockGenerators.generateMockBipedMek(0, 0);
+        when(mockMyUnit.canChangeSecondaryFacing()).thenReturn(true);
+
+        doReturn(10.0).when(testRanker).getMaxDamageAtRange(eq(mockMyUnit), anyInt(), anyBoolean(), anyBoolean());
+
+        // A sprinting unit may not attack, so a sprinting path contributes no damage of mine
+        // even with the enemy in my line of sight.
+        final MovePath mockPath = MockGenerators.generateMockPath(testCoords, mockMyUnit);
+        when(mockPath.getFinalFacing()).thenReturn(3);
+        when(mockPath.getLastStepMovementType()).thenReturn(EntityMovementType.MOVE_SPRINT);
+
+        Coords enemyCoords = new Coords(10, 15);
+        int enemyMekId = 1;
+        Entity mockEnemyMek = MockGenerators.generateMockBipedMek(0, 0);
+        when(mockEnemyMek.getId()).thenReturn(enemyMekId);
+        doReturn(enemyCoords).when(testRanker).getClosestCoordsTo(eq(enemyMekId), eq(testCoords));
+        doReturn(true).when(testRanker).isInMyLoS(eq(mockEnemyMek), any(HexLine.class), any(HexLine.class));
+        doReturn(8.5).when(testRanker).getMaxDamageAtRange(eq(mockEnemyMek), anyInt(), anyBoolean(), anyBoolean());
+        doReturn(false).when(testRanker)
+              .canFlankAndKick(eq(mockEnemyMek), any(Coords.class), any(Coords.class), any(Coords.class), anyInt());
+
+        EntityEvaluationResponse expected = new EntityEvaluationResponse();
+        expected.setEstimatedEnemyDamage(2.125);
+        expected.setMyEstimatedDamage(0.0);
+        expected.setMyEstimatedPhysicalDamage(0.0);
+
+        EntityEvaluationResponse actual = testRanker.evaluateUnmovedEnemy(mockEnemyMek, mockPath, false, false);
+        assertEntityEvaluationResponseEquals(expected, actual);
+    }
+
+    @Test
+    void testEvaluateMovedEnemySprintingPathDoesNoDamage() {
+        final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
+        doReturn(mockPrincess).when(testRanker).getOwner();
+
+        final MovePath mockPath = mock(MovePath.class);
+        final Entity mockMyUnit = mock(BipedMek.class);
+        final Crew mockCrew = mock(Crew.class);
+        final PilotOptions mockOptions = mock(PilotOptions.class);
+
+        when(mockPath.getEntity()).thenReturn(mockMyUnit);
+        when(mockMyUnit.getCrew()).thenReturn(mockCrew);
+        when(mockCrew.getOptions()).thenReturn(mockOptions);
+        when(mockOptions.booleanOption(any(String.class))).thenReturn(false);
+        when(mockPath.getFinalCoords()).thenReturn(new Coords(0, 0));
+        when(mockPath.getLastStepMovementType()).thenReturn(EntityMovementType.MOVE_SPRINT);
+
+        final Game mockGame = mock(Game.class);
+
+        final int mockEnemyMekId = 1;
+        final Entity mockEnemyMek = mock(BipedMek.class);
+        when(mockEnemyMek.getId()).thenReturn(mockEnemyMekId);
+        when(mockEnemyMek.getPosition()).thenReturn(new Coords(1, 0));
+        when(mockEnemyMek.getCrew()).thenReturn(mockCrew);
+
+        doReturn(15.0).when(testRanker)
+              .calculateDamagePotential(eq(mockEnemyMek),
+                    any(EntityState.class),
+                    any(MovePath.class),
+                    any(EntityState.class),
+                    anyInt(),
+                    any(Game.class));
+        doReturn(10.0).when(testRanker)
+              .calculateKickDamagePotential(eq(mockEnemyMek), any(MovePath.class), any(Game.class));
+        doReturn(14.5).when(testRanker)
+              .calculateMyDamagePotential(any(MovePath.class), eq(mockEnemyMek), anyInt(), any(Game.class));
+        doReturn(8.0).when(testRanker)
+              .calculateMyKickDamagePotential(any(MovePath.class), eq(mockEnemyMek), any(Game.class));
+        final Map<Integer, Double> testBestDamageByEnemies = new TreeMap<>();
+        testBestDamageByEnemies.put(mockEnemyMekId, 0.0);
+        doReturn(testBestDamageByEnemies).when(testRanker).getBestDamageByEnemies();
+
+        // The enemy still threatens me, but my sprinting path contributes no weapon or kick damage.
+        final EntityEvaluationResponse expected = new EntityEvaluationResponse();
+        expected.setMyEstimatedDamage(0.0);
+        expected.setMyEstimatedPhysicalDamage(0.0);
+        expected.setEstimatedEnemyDamage(25.0);
+        EntityEvaluationResponse actual = testRanker.evaluateMovedEnemy(mockEnemyMek, mockPath, mockGame);
+        assertEntityEvaluationResponseEquals(expected, actual);
+    }
+
+    @Test
+    void testIsSprintingPath() {
+        final Entity mockMyUnit = MockGenerators.generateMockBipedMek(0, 0);
+        final MovePath mockPath = MockGenerators.generateMockPath(new Coords(0, 0), mockMyUnit);
+
+        when(mockPath.getLastStepMovementType()).thenReturn(EntityMovementType.MOVE_RUN);
+        assertFalse(BasicPathRanker.isSprintingPath(mockPath));
+
+        when(mockPath.getLastStepMovementType()).thenReturn(EntityMovementType.MOVE_SPRINT);
+        assertTrue(BasicPathRanker.isSprintingPath(mockPath));
+
+        when(mockPath.getLastStepMovementType()).thenReturn(EntityMovementType.MOVE_VTOL_SPRINT);
+        assertTrue(BasicPathRanker.isSprintingPath(mockPath));
+    }
+
+    @Test
+    void testFindSprintThreat() {
+        final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
+        doReturn(mockPrincess).when(testRanker).getOwner();
+
+        final Game mockGame = mock(Game.class);
+        final Entity mockMyUnit = MockGenerators.generateMockBipedMek(0, 0);
+        final MovePath mockPath = MockGenerators.generateMockPath(new Coords(10, 10), mockMyUnit);
+
+        final int enemyMekId = 1;
+        final Entity mockEnemyMek = MockGenerators.generateMockBipedMek(0, 0);
+        when(mockEnemyMek.getId()).thenReturn(enemyMekId);
+        doReturn(false).when(testRanker).isIgnorableEnemy(any(Entity.class), any(Entity.class), any(Game.class));
+
+        // An already-moved enemy 10 hexes away with 21 hex weapon range can hit me.
+        doReturn(true).when(testRanker).evaluateAsMoved(mockEnemyMek);
+        when(mockEnemyMek.getPosition()).thenReturn(new Coords(10, 20));
+        Optional<BasicPathRanker.SprintThreat> threat = testRanker.findSprintThreat(mockPath,
+              List.of(mockEnemyMek), mockGame);
+        assertTrue(threat.isPresent());
+        assertEquals(10, threat.get().distance());
+        assertEquals(21, threat.get().maxWeaponRange());
+        assertFalse(threat.get().positionPredicted());
+
+        // The same enemy 30 hexes away cannot.
+        when(mockEnemyMek.getPosition()).thenReturn(new Coords(10, 40));
+        assertTrue(testRanker.findSprintThreat(mockPath, List.of(mockEnemyMek), mockGame).isEmpty());
+
+        // An unmoved enemy currently 30 hexes away is measured from the closest position
+        // it can reach, 15 hexes away, which is back in weapon range.
+        doReturn(false).when(testRanker).evaluateAsMoved(mockEnemyMek);
+        doReturn(new Coords(10, 25)).when(testRanker).getClosestCoordsTo(eq(enemyMekId), any(Coords.class));
+        threat = testRanker.findSprintThreat(mockPath, List.of(mockEnemyMek), mockGame);
+        assertTrue(threat.isPresent());
+        assertEquals(15, threat.get().distance());
+        assertTrue(threat.get().positionPredicted());
+    }
+
+    @Test
+    void testCalculateSprintExposurePenalty() {
+        final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
+        doReturn(mockPrincess).when(testRanker).getOwner();
+
+        final Game mockGame = mock(Game.class);
+        final Entity mockMyUnit = MockGenerators.generateMockBipedMek(0, 0);
+        final MovePath mockPath = MockGenerators.generateMockPath(new Coords(10, 10), mockMyUnit);
+        final List<Entity> enemies = List.of();
+
+        final int enemyMekId = 7;
+        final Entity mockEnemyMek = MockGenerators.generateMockBipedMek(0, 0);
+        when(mockEnemyMek.getId()).thenReturn(enemyMekId);
+        when(mockEnemyMek.getDisplayName()).thenReturn("Test Enemy Mek");
+        final BasicPathRanker.SprintThreat testThreat = new BasicPathRanker.SprintThreat(mockEnemyMek,
+              new Coords(10, 15), 5, 21, false);
+        doReturn(Optional.of(testThreat)).when(testRanker)
+              .findSprintThreat(any(MovePath.class), anyList(), any(Game.class));
+
+        // A non-sprinting path is never penalized and writes no formula entry.
+        Map<String, Double> scores = new HashMap<>();
+        StringBuilder sprintFormula = new StringBuilder();
+        when(mockPath.getLastStepMovementType()).thenReturn(EntityMovementType.MOVE_RUN);
+        assertEquals(0.0,
+              testRanker.calculateSprintExposurePenalty(mockPath, enemies, mockGame, scores, sprintFormula),
+              TOLERANCE);
+        assertEquals(0.0, scores.get("isSprinting"), TOLERANCE);
+        assertTrue(sprintFormula.isEmpty());
+
+        // Sprinting into enemy weapon range is penalized, and the decision detail is traceable.
+        scores = new HashMap<>();
+        sprintFormula = new StringBuilder();
+        when(mockPath.getLastStepMovementType()).thenReturn(EntityMovementType.MOVE_SPRINT);
+        assertTrue(testRanker.calculateSprintExposurePenalty(mockPath, enemies, mockGame, scores, sprintFormula) > 0);
+        assertEquals(1.0, scores.get("isSprinting"), TOLERANCE);
+        assertEquals(enemyMekId, scores.get("sprintThreatEnemyId"), TOLERANCE);
+        assertEquals(5.0, scores.get("sprintThreatDistance"), TOLERANCE);
+        assertEquals(21.0, scores.get("sprintThreatRange"), TOLERANCE);
+        assertFalse(sprintFormula.isEmpty());
+
+        // Sprinting outside enemy weapon range is fine, but still explained.
+        scores = new HashMap<>();
+        sprintFormula = new StringBuilder();
+        doReturn(Optional.empty()).when(testRanker)
+              .findSprintThreat(any(MovePath.class), anyList(), any(Game.class));
+        assertEquals(0.0,
+              testRanker.calculateSprintExposurePenalty(mockPath, enemies, mockGame, scores, sprintFormula),
+              TOLERANCE);
+        assertEquals(-1.0, scores.get("sprintThreatEnemyId"), TOLERANCE);
+        assertFalse(sprintFormula.isEmpty());
+
+        // A withdrawing unit may sprint even inside enemy weapon range.
+        scores = new HashMap<>();
+        sprintFormula = new StringBuilder();
+        doReturn(Optional.of(testThreat)).when(testRanker)
+              .findSprintThreat(any(MovePath.class), anyList(), any(Game.class));
+        when(mockPrincess.getUnitBehaviorTracker().getBehaviorType(any(Entity.class), any(Princess.class)))
+              .thenReturn(BehaviorType.ForcedWithdrawal);
+        assertEquals(0.0,
+              testRanker.calculateSprintExposurePenalty(mockPath, enemies, mockGame, scores, sprintFormula),
+              TOLERANCE);
+        assertFalse(sprintFormula.isEmpty());
     }
 
     private void assertEntityEvaluationResponseEquals(final EntityEvaluationResponse expected,


### PR DESCRIPTION
## Summary
  
   With TacOps Sprinting enabled, Princess sprints during her approach — but not deliberately. Sprint movement only
   ever emerged as a side-effect of her long-range pathfinder, and her path evaluation had two bugs that made her
   sprint recklessly: she credited sprinting paths with weapon and physical attack damage they cannot deal (a sprinting
   unit may not make any deliberate attacks), and nothing in path ranking weighed the downside of ending a sprint
   where the enemy can shoot back (no return fire possible, plus a -1 to-hit modifier in the enemy's favor). The result
   was Princess sprinting right up to enemy units and arriving unable to fire while being easier to hit.
  
  ## Changes
  
 1. Damage estimates fixed (BasicPathRanker): paths that end in a sprint no longer receive weapon-fire or kick damage
  credit during path evaluation, for both moved and not-yet-moved enemies. Previously only one of the two evaluation
  branches accounted for this.
  2. New threat-range check: a sprint path that ends within weapon range of any enemy now takes a heavy ranking
  penalty. For enemies that have not moved yet, range is measured from the closest hex they can reach this turn, not
  where they currently stand. Units performing a forced withdrawal are exempt — they are not giving up attacks they
  intended to make, and the extra distance serves the retreat.
  3. Decision visibility, so sprint behavior can be reviewed after a game:
    - The bot path-ranking TSV (logs/bot_path_ranker.log) gains columns showing whether each candidate path sprints,
  the penalty applied, and which enemy/distance/range triggered it.
    - Each ranked path's reason string now explains the sprint decision in plain text (e.g. which enemy can reach the
  landing hex and from where).
    - A one-line debug summary per unit move states whether the chosen path sprints and how the best sprint path
  ranked against the best non-sprint path.
    - The AI dataset log (game_actions_*.tsv) gains a MOVEMENT_TYPE column (e.g. MOVE_SPRINT, MOVE_RUN, MOVE_JUMP)   on every executed action, appended as the last column so existing parsers are unaffected.
  4. New developer utility ScenarioGameRunner: runs any MMS scenario headless as a fully automated bot-vs-bot game
  (first faction is a watcher that auto-acknowledges report phases; all other factions are played by Princess). Used
  to validate this change; generally useful for AI testing.
 
 ## Files Changed
  
  - megamek/src/megamek/client/bot/princess/BasicPathRanker.java — damage estimate fixes, threat check, penalty,
  decision tracing
  - megamek/src/megamek/client/bot/princess/PathRanker.java — per-unit sprint decision summary logging
  - megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java — five new tests
  - megamek/src/megamek/ai/dataset/UnitAction.java, EntityDataSerializer.java — MOVEMENT_TYPE dataset column
  - megamek/src/megamek/utilities/ScenarioGameRunner.java — new headless scenario runner
  - megamek/mmconf/log4j2.xml — debug loggers for Princess movement decisions (commented guidance included)
 
 ## Testing
 
  Unit tests: Five new tests were added to BasicPathRankerTest covering the new logic: sprint detection on a move
  path, the check for whether a path ends inside an enemy's weapon range, the penalty calculation (including the
  forced-withdrawal exemption), and verification that sprinting paths no longer get credited with weapon or kick
  damage they cannot deal. The full BasicPathRankerTest suite passes, as do the megamek.ai.dataset serializer tests
  that cover the new MOVEMENT_TYPE column.
 
 Live game testing: To verify the behavior in real games (not just unit tests), I ran ten automated
 Princess-vs-Princess games using the new ScenarioGameRunner utility included in this PR. Each game was two lances
 (2x Jenner JR7-D + 1x Wolverine WVR-6R per side) starting about 45 hexes apart on a 50x50 map with TacOps Sprinting
 enabled, played across five different terrain types: open grassland, arid badlands, volcanic terrain with hazards, a
 fortified star fort, and rough badlands.
 
##  Observed results across all ten games:
 - Princess sprints during the approach phase on every map (3-11 sprint moves per game), and stops sprinting once
 units are in combat.
 - When a sprint would have ended within range of an enemy's weapons, the new penalty correctly pushed that path down
 the rankings. This situation came up over 75 times across the test games, and Princess never once chose to sprint
into enemy weapon range out of roughly 100,000 candidate paths she evaluated.
- Movement adapted sensibly to terrain (for example, preferring jumps over sprints on the fortified map).
- One unit declined to sprint because terrain forced its sprint route through a detour that gained less ground than running — confirming sprint is weighed as a trade-off rather than always taken.