### PR TITLE
Fixing #8325 Fixing ProtoMek ammo costs for Missile Launchers

### DIFF
--- a/megamek/src/megamek/common/weapons/lrms/clan/CLLRM1.java
+++ b/megamek/src/megamek/common/weapons/lrms/clan/CLLRM1.java
@@ -64,6 +64,7 @@ public class CLLRM1 extends LRMWeapon {
         // But LRM Tech Base and Avail Ratings.
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
+        cost = 10000;
         rulesRefs = "231, TM";
         techAdvancement.setTechBase(TechBase.CLAN)
               .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/lrms/clan/CLLRM11.java
+++ b/megamek/src/megamek/common/weapons/lrms/clan/CLLRM11.java
@@ -64,6 +64,7 @@ public class CLLRM11 extends LRMWeapon {
         // But LRM Tech Base and Avail Ratings.
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
+        cost = 110000;
         rulesRefs = "231, TM";
         techAdvancement.setTechBase(TechBase.CLAN)
               .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/lrms/clan/CLLRM12.java
+++ b/megamek/src/megamek/common/weapons/lrms/clan/CLLRM12.java
@@ -64,6 +64,7 @@ public class CLLRM12 extends LRMWeapon {
         // But LRM Tech Base and Avail Ratings.
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
+        cost = 120000;
         rulesRefs = "231, TM";
         techAdvancement.setTechBase(TechBase.CLAN)
               .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/lrms/clan/CLLRM13.java
+++ b/megamek/src/megamek/common/weapons/lrms/clan/CLLRM13.java
@@ -64,6 +64,7 @@ public class CLLRM13 extends LRMWeapon {
         // But LRM Tech Base and Avail Ratings.
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
+        cost = 130000;
         rulesRefs = "231, TM";
         techAdvancement.setTechBase(TechBase.CLAN)
               .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/lrms/clan/CLLRM14.java
+++ b/megamek/src/megamek/common/weapons/lrms/clan/CLLRM14.java
@@ -62,6 +62,7 @@ public class CLLRM14 extends LRMWeapon {
         bv = 163;
         // Per Herb all ProtoMek launcher use the ProtoMek Chassis progression.
         // But LRM Tech Base and Avail Ratings.
+        cost = 140000;
         rulesRefs = "231, TM";
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);

--- a/megamek/src/megamek/common/weapons/lrms/clan/CLLRM16.java
+++ b/megamek/src/megamek/common/weapons/lrms/clan/CLLRM16.java
@@ -62,6 +62,7 @@ public class CLLRM16 extends LRMWeapon {
         bv = 214;
         // Per Herb all ProtoMek launcher use the ProtoMek Chassis progression.
         // But LRM Tech Base and Avail Ratings.
+        cost = 160000;
         rulesRefs = "231, TM";
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);

--- a/megamek/src/megamek/common/weapons/lrms/clan/CLLRM17.java
+++ b/megamek/src/megamek/common/weapons/lrms/clan/CLLRM17.java
@@ -62,6 +62,7 @@ public class CLLRM17 extends LRMWeapon {
         bv = 215;
         // Per Herb all ProtoMek launcher use the ProtoMek Chassis progression.
         // But LRM Tech Base and Avail Ratings.
+        cost = 170000;
         rulesRefs = "231, TM";
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);

--- a/megamek/src/megamek/common/weapons/lrms/clan/CLLRM18.java
+++ b/megamek/src/megamek/common/weapons/lrms/clan/CLLRM18.java
@@ -62,6 +62,7 @@ public class CLLRM18 extends LRMWeapon {
         bv = 217;
         // Per Herb all ProtoMek launcher use the ProtoMek Chassis progression.
         // But LRM Tech Base and Avail Ratings.
+        cost = 180000;
         rulesRefs = "231, TM";
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);

--- a/megamek/src/megamek/common/weapons/lrms/clan/CLLRM19.java
+++ b/megamek/src/megamek/common/weapons/lrms/clan/CLLRM19.java
@@ -62,6 +62,7 @@ public class CLLRM19 extends LRMWeapon {
         bv = 218;
         // Per Herb all ProtoMek launcher use the ProtoMek Chassis progression.
         // But LRM Tech Base and Avail Ratings.
+        cost = 190000;
         rulesRefs = "231, TM";
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);

--- a/megamek/src/megamek/common/weapons/lrms/clan/CLLRM2.java
+++ b/megamek/src/megamek/common/weapons/lrms/clan/CLLRM2.java
@@ -64,6 +64,7 @@ public class CLLRM2 extends LRMWeapon {
         // But LRM Tech Base and Avail Ratings.
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
+        cost = 20000;
         rulesRefs = "231, TM";
         techAdvancement.setTechBase(TechBase.CLAN)
               .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/lrms/clan/CLLRM3.java
+++ b/megamek/src/megamek/common/weapons/lrms/clan/CLLRM3.java
@@ -64,6 +64,7 @@ public class CLLRM3 extends LRMWeapon {
         // But LRM Tech Base and Avail Ratings.
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
+        cost = 30000;
         rulesRefs = "231, TM";
         techAdvancement.setTechBase(TechBase.CLAN)
               .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/lrms/clan/CLLRM4.java
+++ b/megamek/src/megamek/common/weapons/lrms/clan/CLLRM4.java
@@ -64,6 +64,7 @@ public class CLLRM4 extends LRMWeapon {
         // But LRM Tech Base and Avail Ratings.
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
+        cost = 40000;
         rulesRefs = "231, TM";
         techAdvancement.setTechBase(TechBase.CLAN)
               .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/lrms/clan/CLLRM6.java
+++ b/megamek/src/megamek/common/weapons/lrms/clan/CLLRM6.java
@@ -64,6 +64,7 @@ public class CLLRM6 extends LRMWeapon {
         // But LRM Tech Base and Avail Ratings.
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
+        cost = 60000;
         rulesRefs = "231, TM";
         techAdvancement.setTechBase(TechBase.CLAN)
               .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/lrms/clan/CLLRM7.java
+++ b/megamek/src/megamek/common/weapons/lrms/clan/CLLRM7.java
@@ -62,6 +62,7 @@ public class CLLRM7 extends LRMWeapon {
         bv = 82;
         // Per Herb all ProtoMek launcher use the ProtoMek Chassis progression.
         // But LRM Tech Base and Avail Ratings.
+        cost = 70000;
         rulesRefs = "231, TM";
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);

--- a/megamek/src/megamek/common/weapons/lrms/clan/CLLRM8.java
+++ b/megamek/src/megamek/common/weapons/lrms/clan/CLLRM8.java
@@ -62,6 +62,7 @@ public class CLLRM8 extends LRMWeapon {
         bv = 93;
         // Per Herb all ProtoMek launcher use the ProtoMek Chassis progression.
         // But LRM Tech Base and Avail Ratings.
+        cost = 80000;
         rulesRefs = "231, TM";
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);

--- a/megamek/src/megamek/common/weapons/lrms/clan/CLLRM9.java
+++ b/megamek/src/megamek/common/weapons/lrms/clan/CLLRM9.java
@@ -66,8 +66,6 @@ public class CLLRM9 extends LRMWeapon {
         // But LRM Tech Base and Avail Ratings.
         cost = 90000;
         rulesRefs = "231, TM";
-        flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
-              .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
         techAdvancement.setTechBase(TechBase.CLAN)
               .setIntroLevel(false)
               .setUnofficial(false)

--- a/megamek/src/megamek/common/weapons/lrms/clan/CLLRM9.java
+++ b/megamek/src/megamek/common/weapons/lrms/clan/CLLRM9.java
@@ -64,6 +64,7 @@ public class CLLRM9 extends LRMWeapon {
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
         // Per Herb all ProtoMek launcher use the ProtoMek Chassis progression.
         // But LRM Tech Base and Avail Ratings.
+        cost = 90000;
         rulesRefs = "231, TM";
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);

--- a/megamek/src/megamek/common/weapons/srms/clan/CLSRM1.java
+++ b/megamek/src/megamek/common/weapons/srms/clan/CLSRM1.java
@@ -71,7 +71,7 @@ public class CLSRM1 extends SRMWeapon {
         bv = 15;
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
-        cost = 80000;
+        cost = 10000;
         // Per Herb all ProtoMek launcher use the ProtoMek Chassis progression.
         //But LRM Tech Base and Avail Ratings.
         rulesRefs = "231, TM";

--- a/megamek/src/megamek/common/weapons/srms/clan/CLSRM1.java
+++ b/megamek/src/megamek/common/weapons/srms/clan/CLSRM1.java
@@ -73,7 +73,7 @@ public class CLSRM1 extends SRMWeapon {
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
         cost = 10000;
         // Per Herb all ProtoMek launcher use the ProtoMek Chassis progression.
-        //But LRM Tech Base and Avail Ratings.
+        // But SRM Tech Base and Avail Ratings.
         rulesRefs = "231, TM";
         techAdvancement.setTechBase(TechBase.CLAN)
               .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/srms/clan/CLSRM3.java
+++ b/megamek/src/megamek/common/weapons/srms/clan/CLSRM3.java
@@ -73,7 +73,7 @@ public class CLSRM3 extends SRMWeapon {
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
         cost = 30000;
         // Per Herb all ProtoMek launcher use the ProtoMek Chassis progression.
-        //But LRM Tech Base and Avail Ratings.
+        // But SRM Tech Base and Avail Ratings.
         rulesRefs = "231, TM";
         techAdvancement.setTechBase(TechBase.CLAN)
               .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/srms/clan/CLSRM3.java
+++ b/megamek/src/megamek/common/weapons/srms/clan/CLSRM3.java
@@ -71,7 +71,7 @@ public class CLSRM3 extends SRMWeapon {
         bv = 30;
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
-        cost = 80000;
+        cost = 30000;
         // Per Herb all ProtoMek launcher use the ProtoMek Chassis progression.
         //But LRM Tech Base and Avail Ratings.
         rulesRefs = "231, TM";

--- a/megamek/src/megamek/common/weapons/srms/clan/CLSRM5.java
+++ b/megamek/src/megamek/common/weapons/srms/clan/CLSRM5.java
@@ -71,7 +71,7 @@ public class CLSRM5 extends SRMWeapon {
         bv = 47;
         flags = flags.or(F_NO_FIRES).andNot(F_AERO_WEAPON).andNot(F_BA_WEAPON)
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
-        cost = 80000;
+        cost = 50000;
         // Per Herb all ProtoMek launcher use the ProtoMek Chassis progression.
         //But LRM Tech Base and Avail Ratings.
         rulesRefs = "231, TM";

--- a/megamek/src/megamek/common/weapons/srms/clan/CLSRM5.java
+++ b/megamek/src/megamek/common/weapons/srms/clan/CLSRM5.java
@@ -73,7 +73,7 @@ public class CLSRM5 extends SRMWeapon {
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
         cost = 50000;
         // Per Herb all ProtoMek launcher use the ProtoMek Chassis progression.
-        //But LRM Tech Base and Avail Ratings.
+        // But SRM Tech Base and Avail Ratings.
         rulesRefs = "231, TM";
         techAdvancement.setTechBase(TechBase.CLAN)
               .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/srms/clan/streak/CLStreakSRM1.java
+++ b/megamek/src/megamek/common/weapons/srms/clan/streak/CLStreakSRM1.java
@@ -72,6 +72,7 @@ public class CLStreakSRM1 extends StreakSRMWeapon {
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
         // Per Herb all ProtoMek launcher use the ProtoMek Chassis progression.
         //But SRM Tech Base and Avail Ratings.
+        cost = 15000;
         rulesRefs = "230, TM";
         techAdvancement.setTechBase(TechBase.CLAN)
               .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/srms/clan/streak/CLStreakSRM3.java
+++ b/megamek/src/megamek/common/weapons/srms/clan/streak/CLStreakSRM3.java
@@ -72,6 +72,7 @@ public class CLStreakSRM3 extends StreakSRMWeapon {
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
         // Per Herb all ProtoMek launcher use the ProtoMek Chassis progression.
         //But SRM Tech Base and Avail Ratings.
+        cost = 45000;
         rulesRefs = "230, TM";
         techAdvancement.setTechBase(TechBase.CLAN)
               .setIntroLevel(false)

--- a/megamek/src/megamek/common/weapons/srms/clan/streak/CLStreakSRM5.java
+++ b/megamek/src/megamek/common/weapons/srms/clan/streak/CLStreakSRM5.java
@@ -72,6 +72,7 @@ public class CLStreakSRM5 extends StreakSRMWeapon {
               .andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
         // Per Herb all ProtoMek launcher use the ProtoMek Chassis progression.
         //But SRM Tech Base and Avail Ratings.
+        cost = 75000;
         rulesRefs = "230, TM";
         techAdvancement.setTechBase(TechBase.CLAN)
               .setIntroLevel(false)

--- a/megamek/unittests/megamek/common/weapons/ProtoMekMissileLauncherCostTest.java
+++ b/megamek/unittests/megamek/common/weapons/ProtoMekMissileLauncherCostTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.weapons;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import megamek.common.equipment.EquipmentType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for ProtoMek missile launcher costs (issue #8325).
+ *
+ * <p>Per TechManual (p. 291), ProtoMek-specific launchers are priced per tube (per missile in the rack):
+ * LRM and SRM launchers cost 10,000 C-Bills per tube, and Streak SRM launchers cost 15,000 C-Bills per tube. These are
+ * the dedicated ProtoMek launcher classes (the ones that strip the Mek/Tank/BA/Aero flags), which previously had a flat
+ * 80,000 cost (SRM) or an unset cost of 0 (LRM and Streak SRM).</p>
+ */
+public class ProtoMekMissileLauncherCostTest {
+
+    private static final double PROTOMEK_LRM_COST_PER_TUBE = 10_000;
+    private static final double PROTOMEK_SRM_COST_PER_TUBE = 10_000;
+    private static final double PROTOMEK_STREAK_SRM_COST_PER_TUBE = 15_000;
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    private static void assertCostByTube(String internalName, int rackSize, double costPerTube) {
+        EquipmentType equipmentType = EquipmentType.get(internalName);
+        assertNotNull(equipmentType, internalName + " should be a registered equipment type");
+        assertEquals(rackSize * costPerTube, equipmentType.getRawCost(),
+              internalName + " should cost " + costPerTube + " per tube");
+    }
+
+    @Nested
+    @DisplayName("ProtoMek SRM launchers cost 10,000 per tube")
+    class ProtoMekSrmCosts {
+
+        @Test
+        void srm1Costs10000() {
+            assertCostByTube("CLSRM1", 1, PROTOMEK_SRM_COST_PER_TUBE);
+        }
+
+        @Test
+        void srm3Costs30000() {
+            assertCostByTube("CLSRM3", 3, PROTOMEK_SRM_COST_PER_TUBE);
+        }
+
+        @Test
+        void srm5Costs50000() {
+            assertCostByTube("CLSRM5", 5, PROTOMEK_SRM_COST_PER_TUBE);
+        }
+    }
+
+    @Nested
+    @DisplayName("ProtoMek Streak SRM launchers cost 15,000 per tube")
+    class ProtoMekStreakSrmCosts {
+
+        @Test
+        void streakSrm1Costs15000() {
+            assertCostByTube("CLStreakSRM1", 1, PROTOMEK_STREAK_SRM_COST_PER_TUBE);
+        }
+
+        @Test
+        void streakSrm3Costs45000() {
+            assertCostByTube("CLStreakSRM3", 3, PROTOMEK_STREAK_SRM_COST_PER_TUBE);
+        }
+
+        @Test
+        void streakSrm5Costs75000() {
+            assertCostByTube("CLStreakSRM5", 5, PROTOMEK_STREAK_SRM_COST_PER_TUBE);
+        }
+    }
+
+    @Nested
+    @DisplayName("ProtoMek LRM launchers cost 10,000 per tube")
+    class ProtoMekLrmCosts {
+
+        @Test
+        void allProtoMekLrmLaunchersCostPerTube() {
+            int[] rackSizes = { 1, 2, 3, 4, 6, 7, 8, 9, 11, 12, 13, 14, 16, 17, 18, 19 };
+            for (int rackSize : rackSizes) {
+                assertCostByTube("CLLRM" + rackSize, rackSize, PROTOMEK_LRM_COST_PER_TUBE);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Protomek launchers have the wrong costing or lack of costing this PR fixes that.

Fixes #8325 