### PR TITLE
  Fix BA Disposable Weapon validation to check the actual mount point

### DIFF
--- a/megamek/src/megamek/common/verifier/TestBattleArmor.java
+++ b/megamek/src/megamek/common/verifier/TestBattleArmor.java
@@ -1332,12 +1332,14 @@ public class TestBattleArmor extends TestEntity {
      */
     private static boolean isValidDisposableWeaponMounting(BattleArmor battleArmor, Mounted<?> mount) {
         Mounted<?> attachmentPoint = mount.getLinkedBy();
-        if (attachmentPoint == null) {
+        // The instanceof guard also prevents EquipmentBitSet ordinal collisions: MiscTypeFlags must only ever be
+        // tested against a MiscType (see EquipmentType#hasFlag)
+        if ((attachmentPoint == null) || !(attachmentPoint.getType() instanceof MiscType attachmentType)) {
             return false;
         }
-        boolean inAntiPersonnelWeaponMount = attachmentPoint.getType().hasFlag(MiscType.F_AP_MOUNT)
-              && !attachmentPoint.getType().hasFlag(MiscType.F_ARMORED_GLOVE);
-        boolean carriedByArmoredGlove = attachmentPoint.getType().hasFlag(MiscType.F_ARMORED_GLOVE)
+        boolean inAntiPersonnelWeaponMount = attachmentType.hasFlag(MiscType.F_AP_MOUNT)
+              && !attachmentType.hasFlag(MiscType.F_ARMORED_GLOVE);
+        boolean carriedByArmoredGlove = attachmentType.hasFlag(MiscType.F_ARMORED_GLOVE)
               && (battleArmor.countWorkingMisc(MiscType.F_ARMORED_GLOVE) >= 2);
         return inAntiPersonnelWeaponMount || carriedByArmoredGlove;
     }

--- a/megamek/src/megamek/common/verifier/TestBattleArmor.java
+++ b/megamek/src/megamek/common/verifier/TestBattleArmor.java
@@ -1315,6 +1315,33 @@ public class TestBattleArmor extends TestEntity {
         return totalWeight;
     }
 
+    /**
+     * Determines whether the given Disposable Weapon (TO:AuE p.116, Corrected Sixth Printing) is legally carried by the
+     * suit. Beyond the suit-level eligibility of {@link BattleArmor#canCarryDisposableWeapons()} (an anti-personnel
+     * weapon mount or two armored gloves), the weapon must actually be attached to such a mount point (TM p.262
+     * Modular/Turret Mounts, pp.259-260 Manipulators): either a dedicated anti-personnel weapon mount, or an armored
+     * glove on a suit equipped with two armored gloves. The suit merely owning an AP mount that is occupied by a
+     * different weapon is not sufficient. Note that armored gloves themselves carry the {@code F_AP_MOUNT} flag, so a
+     * dedicated AP mount is identified as an {@code F_AP_MOUNT} item that is not an armored glove.
+     *
+     * @param battleArmor the suit carrying the weapon
+     * @param mount       the Disposable Weapon mount to validate
+     *
+     * @return {@code true} if the weapon is attached to an anti-personnel weapon mount, or to an armored glove on a
+     *       suit with two armored gloves
+     */
+    private static boolean isValidDisposableWeaponMounting(BattleArmor battleArmor, Mounted<?> mount) {
+        Mounted<?> attachmentPoint = mount.getLinkedBy();
+        if (attachmentPoint == null) {
+            return false;
+        }
+        boolean inAntiPersonnelWeaponMount = attachmentPoint.getType().hasFlag(MiscType.F_AP_MOUNT)
+              && !attachmentPoint.getType().hasFlag(MiscType.F_ARMORED_GLOVE);
+        boolean carriedByArmoredGlove = attachmentPoint.getType().hasFlag(MiscType.F_ARMORED_GLOVE)
+              && (battleArmor.countWorkingMisc(MiscType.F_ARMORED_GLOVE) >= 2);
+        return inAntiPersonnelWeaponMount || carriedByArmoredGlove;
+    }
+
     @Override
     public boolean hasIllegalEquipmentCombinations(@Nullable StringBuffer errors) {
         BattleArmor battleArmor = (BattleArmor) getEntity();
@@ -1331,11 +1358,13 @@ public class TestBattleArmor extends TestEntity {
                 }
 
                 // Disposable Weapons (TO:AuE p.116, Corrected Sixth Printing) require an anti-personnel weapon mount
-                // or two armored gloves
-                if (mount.getType().hasFlag(WeaponType.F_INF_DISPOSABLE) && !battleArmor.canCarryDisposableWeapons()) {
+                // or two armored gloves, and must actually be carried by that mount point - a suit whose AP mount is
+                // occupied by a different weapon may not carry a Disposable Weapon on the side
+                if (mount.getType().hasFlag(WeaponType.F_INF_DISPOSABLE)
+                      && !isValidDisposableWeaponMounting(battleArmor, mount)) {
                     currentErrors.add(mount.getName()
-                          + " is a Disposable Weapon, which requires an anti-personnel weapon mount or two armored "
-                          + "gloves");
+                          + " is a Disposable Weapon, which must be mounted in an anti-personnel weapon mount or "
+                          + "carried by an armored glove on a suit with two armored gloves");
                 }
 
             } else if (mount.getType() instanceof MiscType misc) {

--- a/megamek/unittests/megamek/common/battleArmor/BattleArmorDisposableWeaponTest.java
+++ b/megamek/unittests/megamek/common/battleArmor/BattleArmorDisposableWeaponTest.java
@@ -38,11 +38,17 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
 import java.util.List;
 
 import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.EquipmentTypeLookup;
 import megamek.common.equipment.MiscMounted;
 import megamek.common.equipment.MiscType;
+import megamek.common.equipment.Mounted;
+import megamek.common.units.BaConstructionUtil;
+import megamek.common.verifier.EntityVerifier;
+import megamek.common.verifier.TestBattleArmor;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -51,8 +57,20 @@ import org.junit.jupiter.api.Test;
  * Tests Battle Armor eligibility to carry Disposable Weapons (TO:AuE p.116, Corrected Sixth Printing): only suits with
  * an anti-personnel weapon mount or two armored gloves may carry them. Armored gloves themselves carry the
  * {@code F_AP_MOUNT} flag, so the "AP mount" path must exclude them.
+ * <p>
+ * Also tests the construction validation of the actual mounting: the Disposable Weapon must be attached to the
+ * anti-personnel weapon mount or to an armored glove (on a suit with two armored gloves) - a suit whose AP mount is
+ * occupied by a different weapon may not carry a Disposable Weapon on the side.
+ * </p>
  */
 class BattleArmorDisposableWeaponTest {
+
+    private static final String DISPOSABLE_WEAPON = "InfantryGrenade";
+    private static final String OTHER_AP_WEAPON = "Auto-Pistol";
+    // Internal name from MiscType#createBAArmoredGlove (mirrored in BattleArmor.MANIPULATOR_TYPE_STRINGS, which we
+    // cannot reference here: it would class-load BattleArmor before EquipmentType.initializeTypes() has run)
+    private static final String ARMORED_GLOVE = "BAArmoredGlove";
+    private static final String DISPOSABLE_ERROR_MARKER = "is a Disposable Weapon";
 
     @BeforeAll
     static void initialize() {
@@ -103,5 +121,78 @@ class BattleArmorDisposableWeaponTest {
     void noMountIsNotEligible() {
         BattleArmor battleArmor = battleArmorWith(List.of(), 0);
         assertFalse(battleArmor.canCarryDisposableWeapons());
+    }
+
+    private static BattleArmor buildSuit() {
+        BattleArmor battleArmor = new BattleArmor();
+        battleArmor.setChassisType(BattleArmor.CHASSIS_TYPE_BIPED);
+        battleArmor.setSquadSize(4);
+        return battleArmor;
+    }
+
+    private static Mounted<?> addToSquad(BattleArmor battleArmor, String internalName) throws Exception {
+        Mounted<?> mounted = Mounted.createMounted(battleArmor, EquipmentType.get(internalName));
+        battleArmor.addEquipment(mounted, BattleArmor.LOC_SQUAD, false);
+        return mounted;
+    }
+
+    private static String verifierErrors(BattleArmor battleArmor) {
+        EntityVerifier entityVerifier = EntityVerifier.getInstance(
+              new File("testresources/data/mekfiles/UnitVerifierOptions.xml"));
+        TestBattleArmor testBattleArmor = new TestBattleArmor(battleArmor, entityVerifier.baOption, null);
+        StringBuffer errors = new StringBuffer();
+        testBattleArmor.hasIllegalEquipmentCombinations(errors);
+        return errors.toString();
+    }
+
+    @Test
+    @DisplayName("a Disposable Weapon mounted in the AP weapon mount passes verification")
+    void disposableInApMountIsLegal() throws Exception {
+        BattleArmor battleArmor = buildSuit();
+        Mounted<?> apMount = addToSquad(battleArmor, EquipmentTypeLookup.BA_APM);
+        Mounted<?> disposable = addToSquad(battleArmor, DISPOSABLE_WEAPON);
+        BaConstructionUtil.mountOnApm(disposable, apMount);
+
+        String errors = verifierErrors(battleArmor);
+        assertFalse(errors.contains(DISPOSABLE_ERROR_MARKER), errors);
+    }
+
+    @Test
+    @DisplayName("a Disposable Weapon carried by an armored glove on a two-glove suit passes verification")
+    void disposableOnGloveWithTwoGlovesIsLegal() throws Exception {
+        BattleArmor battleArmor = buildSuit();
+        Mounted<?> leftGlove = addToSquad(battleArmor, ARMORED_GLOVE);
+        addToSquad(battleArmor, ARMORED_GLOVE);
+        Mounted<?> disposable = addToSquad(battleArmor, DISPOSABLE_WEAPON);
+        BaConstructionUtil.mountOnApm(disposable, leftGlove);
+
+        String errors = verifierErrors(battleArmor);
+        assertFalse(errors.contains(DISPOSABLE_ERROR_MARKER), errors);
+    }
+
+    @Test
+    @DisplayName("a Disposable Weapon on a single glove fails even when the suit's AP mount holds another weapon")
+    void disposableOnSingleGloveWithOccupiedApMountIsIllegal() throws Exception {
+        BattleArmor battleArmor = buildSuit();
+        Mounted<?> apMount = addToSquad(battleArmor, EquipmentTypeLookup.BA_APM);
+        Mounted<?> otherWeapon = addToSquad(battleArmor, OTHER_AP_WEAPON);
+        BaConstructionUtil.mountOnApm(otherWeapon, apMount);
+        Mounted<?> glove = addToSquad(battleArmor, ARMORED_GLOVE);
+        Mounted<?> disposable = addToSquad(battleArmor, DISPOSABLE_WEAPON);
+        BaConstructionUtil.mountOnApm(disposable, glove);
+
+        String errors = verifierErrors(battleArmor);
+        assertTrue(errors.contains(DISPOSABLE_ERROR_MARKER), errors);
+    }
+
+    @Test
+    @DisplayName("a Disposable Weapon attached to nothing fails verification even when an AP mount exists")
+    void unattachedDisposableIsIllegal() throws Exception {
+        BattleArmor battleArmor = buildSuit();
+        addToSquad(battleArmor, EquipmentTypeLookup.BA_APM);
+        addToSquad(battleArmor, DISPOSABLE_WEAPON);
+
+        String errors = verifierErrors(battleArmor);
+        assertTrue(errors.contains(DISPOSABLE_ERROR_MARKER), errors);
     }
 }


### PR DESCRIPTION
## Root Cause
  Follow-up to #8326, from review feedback on the BA verifier check ([comment](https://github.com/MegaMek/megamek/pull/8326/changes#diff-5b9
  12d92af0ee9a434f20a234302015a47776c789f5d312f89f38d1f1e2f9598R1335)): `TestBattleArmor.hasIllegalEquipmentCombinations` only checked the suit-level `canCarryDisposableWeapons()` ("does an AP weapon mount or two armored gloves exist anywhere on the suit?"). It never checked where the Disposable Weapon itself is attached, so a suit whose AP mount is occupied by a different AP weapon could carry a Disposable Weapon on a single armored glove and still pass verification.

  ## Changes
  1. `TestBattleArmor` - new private helper `isValidDisposableWeaponMounting()` validates the Disposable Weapon's actual attachment point (`getLinkedBy()`): legal only in a dedicated anti-personnel weapon mount (`F_AP_MOUNT` and not an armored glove - gloves carry `F_AP_MOUNT` too), or on an armored glove when the suit is equipped with two armored gloves (TO:AuE p.116, Corrected Sixth Printing). The suit-level eligibility check at line 1335 now calls this instead, with an updated error message.
  2. `BattleArmor.canCarryDisposableWeapons()` is unchanged - it remains the correct suit-level eligibility statement (AP mount or two armored gloves).

  ## Files Changed
  - `megamek/src/megamek/common/verifier/TestBattleArmor.java` - per-mount attachment validation
  - `megamek/unittests/megamek/common/battleArmor/BattleArmorDisposableWeaponTest.java` - 4 new integration tests using real equipment and `BaConstructionUtil.mountOnApm`

  ## Testing
  - New tests: Disposable Weapon in the AP mount passes; on a glove with two gloves passes; on a single glove while the AP mount holds another weapon fails (the reported scenario); attached to nothing fails even when an AP mount exists.
  - All 8 tests in `BattleArmorDisposableWeaponTest` green (4 existing eligibility + 4 new); `:megamek:test` incl. checkstyle passes.