### PR TITLE
MegaMek side of fix for MML #2222: cannot load primitive meks

### DIFF
--- a/megamek/src/megamek/common/equipment/EquipmentType.java
+++ b/megamek/src/megamek/common/equipment/EquipmentType.java
@@ -750,6 +750,16 @@ public class EquipmentType implements ITechnology {
     }
 
     /**
+     * Explicit structure lookup by name, to avoid armor type collisions (mainly "IS Standard")
+     * Works because all structure names (q.v.) are added to the hash with " structure" appended.
+     * @param key   String name, probably generated from looking up a structure type name using an index
+     * @return      The matching Structure-specific Equipment Type.
+     */
+    public static @Nullable EquipmentType getStructureFromName(String key) {
+        return EquipmentType.get(String.format("%s structure", key));
+    }
+
+    /**
      * Add a way to find if a given equipment type matches a particular string in _any_ of its names (Case sensitive)
      */
     public boolean matchesName(String name) {


### PR DESCRIPTION
Adds an explicit structure lookup to EquipmentType.
We were getting armor equipment rather than structure equipment when refreshing the Mek structure drop-down, due to a name collision between "IS Standard" (the armor type) and "IS Standard" (the structure type).
It probably only affects primitive units made prior to IS Standard Armor becoming available, which is... the Mackie MSK-5S.
We never noticed because it somehow still worked; only units built prior to ~2445 or so would encounter the error.

Required by MML portion of fix: https://github.com/MegaMek/megameklab/pull/2224

Testing:
- Ran all 3 projects' unit tests
- Confirmed fix resolves issue for both Mackie MSK-5S and OP's custom unit.