### PR TITLE
  Add End-Phase activation toggle for vehicle minesweepers

### DIFF
--- a/megamek/resources/megamek/client/messages.properties
+++ b/megamek/resources/megamek/client/messages.properties
@@ -4089,6 +4089,8 @@ ReportDisplay.reportAbandon=Abandon Units
 ReportDisplay.reportAbandon.tooltip=Announce abandonment of eligible units (Meks: prone+shutdown, Vehicles: any)
 ReportDisplay.reportDetonateCharges=Detonate Charges
 ReportDisplay.reportDetonateCharges.tooltip=Detonate demolition charges set on structures (TO:AUE p.152)
+ReportDisplay.reportMinesweeper=Minesweepers
+ReportDisplay.reportMinesweeper.tooltip=Activate or deactivate minesweepers (TO:AUE p.138)
 #Nova Network Dialog
 NovaNetworkDialog.title=Nova CEWS Network Management
 NovaNetworkDialog.instructions=Select units to link or unlink Nova CEWS networks. Changes take effect next turn. (Max 3 units per network)
@@ -4152,6 +4154,20 @@ VariableRangeTargetingDialog.modeShort.tooltip=Bonus at short range (-1 TN), pen
 VariableRangeTargetingDialog.btnApply=Apply
 VariableRangeTargetingDialog.btnApply.tooltip=Apply mode changes (takes effect next turn)
 VariableRangeTargetingDialog.btnCancel=Cancel
+#Minesweeper Activation Dialog
+MinesweeperActivationDialog.title=Minesweeper Activation
+MinesweeperActivationDialog.instructions=<html>Activate or deactivate minesweepers for the next turn (TO:AUE p.138).<br>Only an activated minesweeper clears mines when its vehicle enters a mined hex.</html>
+MinesweeperActivationDialog.unitHeader=Unit
+MinesweeperActivationDialog.currentStateHeader=Current State
+MinesweeperActivationDialog.newStateHeader=State for Next Turn
+MinesweeperActivationDialog.stateOn=On
+MinesweeperActivationDialog.stateOff=Off
+MinesweeperActivationDialog.stateTransition=->
+MinesweeperActivationDialog.stateOn.tooltip=Activated: clears mines when entering a mined hex
+MinesweeperActivationDialog.stateOff.tooltip=Deactivated: the vehicle trips mines normally
+MinesweeperActivationDialog.btnApply=Apply
+MinesweeperActivationDialog.btnApply.tooltip=Apply state changes (takes effect next turn)
+MinesweeperActivationDialog.btnCancel=Cancel
 #Abandon Unit Dialog
 AbandonUnitDialog.title=Abandon Units
 AbandonUnitDialog.instructions=<html>Select units to abandon.<br>Crew will exit during the End Phase of the next turn.<br>Meks must remain prone and shutdown or abandonment is cancelled.<br>Vehicles can be abandoned at any time.</html>

--- a/megamek/src/megamek/client/ui/dialogs/phaseDisplay/MinesweeperActivationDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/phaseDisplay/MinesweeperActivationDialog.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.ui.dialogs.phaseDisplay;
+
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.io.Serial;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.swing.BorderFactory;
+import javax.swing.ButtonGroup;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JRadioButton;
+import javax.swing.JScrollPane;
+
+import megamek.client.ui.Messages;
+import megamek.client.ui.clientGUI.ClientGUI;
+import megamek.client.ui.clientGUI.boardview.BoardView;
+import megamek.client.ui.util.UIUtil;
+import megamek.common.equipment.MiscMounted;
+import megamek.common.equipment.MiscType;
+import megamek.common.game.Game;
+import megamek.common.units.Entity;
+import megamek.logging.MMLogger;
+
+/**
+ * Dialog for activating or deactivating minesweepers during the End Phase (TO:AUE p.138). Only an activated minesweeper
+ * clears mines when its vehicle enters a mined hex. The change is made in the End Phase and takes effect on the next
+ * turn.
+ */
+public class MinesweeperActivationDialog extends JDialog implements ActionListener {
+    @Serial
+    private static final long serialVersionUID = 1L;
+    private static final MMLogger logger = MMLogger.create(MinesweeperActivationDialog.class);
+    private static final int PADDING = UIUtil.scaleForGUI(10);
+    private static final int PADDING_SMALL = UIUtil.scaleForGUI(5);
+
+    // Mode indexes follow the order declared in MiscType.createISMineSweeper(): setModes("On", "Off")
+    private static final String MODE_ON = "On";
+    private static final String MODE_OFF = "Off";
+    private static final String MODE_NONE = "None";
+    private static final int MODE_INDEX_ON = 0;
+    private static final int MODE_INDEX_OFF = 1;
+
+    private final ClientGUI clientGUI;
+    private final Game game;
+    private final int localPlayerId;
+
+    private JButton btnApply;
+    private JButton btnCancel;
+
+    private List<Entity> playerUnits;
+    private final Map<Integer, JRadioButton> onModeButtons = new HashMap<>();
+
+    public MinesweeperActivationDialog(JFrame parent, ClientGUI clientGUI) {
+        super(parent, Messages.getString("MinesweeperActivationDialog.title"), true);
+        this.clientGUI = clientGUI;
+        this.game = clientGUI.getClient().getGame();
+        this.localPlayerId = clientGUI.getClient().getLocalPlayer().getId();
+
+        initializeData();
+        initializeUI();
+
+        pack();
+        setLocationRelativeTo(parent);
+
+        // Clear highlighting when dialog is closed via X button
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowClosing(WindowEvent e) {
+                clearHighlighting();
+            }
+        });
+
+        logger.debug("Minesweeper Activation Dialog initialized: {} units", playerUnits.size());
+    }
+
+    /**
+     * Collects the local player's units that mount a minesweeper.
+     */
+    private void initializeData() {
+        playerUnits = new ArrayList<>();
+
+        for (Entity entity : game.getEntitiesVector()) {
+            if ((entity.getOwnerId() == localPlayerId) && entity.hasMinesweeper()) {
+                playerUnits.add(entity);
+            }
+        }
+    }
+
+    /**
+     * Returns the first minesweeper mounted on the entity, or {@code null} if it has none.
+     */
+    private static MiscMounted getMinesweeper(Entity entity) {
+        for (MiscMounted mounted : entity.getMisc()) {
+            if (mounted.getType().hasFlag(MiscType.F_MINESWEEPER)) {
+                return mounted;
+            }
+        }
+        return null;
+    }
+
+    private void initializeUI() {
+        setLayout(new BorderLayout(PADDING, PADDING));
+        setResizable(false);
+
+        JPanel mainPanel = new JPanel(new BorderLayout(PADDING, PADDING));
+        mainPanel.setBorder(BorderFactory.createEmptyBorder(PADDING, PADDING, PADDING, PADDING));
+
+        JLabel instructions = new JLabel(Messages.getString("MinesweeperActivationDialog.instructions"));
+        instructions.setBorder(BorderFactory.createEmptyBorder(0, 0, PADDING, 0));
+        mainPanel.add(instructions, BorderLayout.NORTH);
+
+        JPanel unitPanel = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
+        gbc.insets = new Insets(PADDING_SMALL, PADDING_SMALL, PADDING_SMALL, PADDING_SMALL);
+        gbc.anchor = GridBagConstraints.WEST;
+
+        // Header row
+        gbc.gridx = 0;
+        gbc.gridy = 0;
+        unitPanel.add(new JLabel("<html><b>"
+              + Messages.getString("MinesweeperActivationDialog.unitHeader")
+              + "</b></html>"), gbc);
+
+        gbc.gridx = 1;
+        gbc.anchor = GridBagConstraints.CENTER;
+        unitPanel.add(new JLabel("<html><b>"
+              + Messages.getString("MinesweeperActivationDialog.currentStateHeader")
+              + "</b></html>"), gbc);
+
+        gbc.gridx = 2;
+        unitPanel.add(new JLabel("<html><b>"
+              + Messages.getString("MinesweeperActivationDialog.newStateHeader")
+              + "</b></html>"), gbc);
+        gbc.anchor = GridBagConstraints.WEST;
+
+        int row = 1;
+        for (Entity entity : playerUnits) {
+            MiscMounted minesweeper = getMinesweeper(entity);
+            if (minesweeper == null) {
+                continue;
+            }
+            gbc.gridy = row++;
+
+            // Unit name
+            gbc.gridx = 0;
+            unitPanel.add(new JLabel(entity.getShortName()), gbc);
+
+            // Current state (center aligned)
+            gbc.gridx = 1;
+            gbc.anchor = GridBagConstraints.CENTER;
+            unitPanel.add(new JLabel(getStateDisplayText(minesweeper)), gbc);
+
+            // State selection (center aligned)
+            gbc.gridx = 2;
+            JPanel statePanel = new JPanel(new FlowLayout(FlowLayout.CENTER, PADDING_SMALL, 0));
+            ButtonGroup stateGroup = new ButtonGroup();
+
+            JRadioButton onButton = new JRadioButton(Messages.getString("MinesweeperActivationDialog.stateOn"));
+            JRadioButton offButton = new JRadioButton(Messages.getString("MinesweeperActivationDialog.stateOff"));
+            onButton.setToolTipText(Messages.getString("MinesweeperActivationDialog.stateOn.tooltip"));
+            offButton.setToolTipText(Messages.getString("MinesweeperActivationDialog.stateOff.tooltip"));
+
+            ActionListener highlightListener = e -> highlightEntity(entity);
+            onButton.addActionListener(highlightListener);
+            offButton.addActionListener(highlightListener);
+
+            stateGroup.add(onButton);
+            stateGroup.add(offButton);
+
+            // Select based on the pending state if any, otherwise the current state
+            if (isEffectivelyOff(minesweeper)) {
+                offButton.setSelected(true);
+            } else {
+                onButton.setSelected(true);
+            }
+
+            statePanel.add(onButton);
+            statePanel.add(offButton);
+            unitPanel.add(statePanel, gbc);
+            gbc.anchor = GridBagConstraints.WEST;
+
+            onModeButtons.put(entity.getId(), onButton);
+        }
+
+        JScrollPane scrollPane = new JScrollPane(unitPanel);
+
+        int headerRowHeight = UIUtil.scaleForGUI(35);
+        int unitRowHeight = UIUtil.scaleForGUI(30);
+        int contentHeight = headerRowHeight + (playerUnits.size() * unitRowHeight);
+        int minHeight = UIUtil.scaleForGUI(95);
+        int maxHeight = UIUtil.scaleForGUI(335);
+        int scrollHeight = Math.clamp(contentHeight, minHeight, maxHeight);
+
+        scrollPane.setPreferredSize(UIUtil.scaleForGUI(600, scrollHeight));
+        mainPanel.add(scrollPane, BorderLayout.CENTER);
+
+        JPanel buttonPanel = new JPanel(new FlowLayout(FlowLayout.CENTER, PADDING, PADDING));
+
+        btnApply = new JButton(Messages.getString("MinesweeperActivationDialog.btnApply"));
+        btnApply.addActionListener(this);
+        btnApply.setToolTipText(Messages.getString("MinesweeperActivationDialog.btnApply.tooltip"));
+
+        btnCancel = new JButton(Messages.getString("MinesweeperActivationDialog.btnCancel"));
+        btnCancel.addActionListener(this);
+
+        buttonPanel.add(btnApply);
+        buttonPanel.add(btnCancel);
+
+        mainPanel.add(buttonPanel, BorderLayout.SOUTH);
+
+        add(mainPanel);
+    }
+
+    /**
+     * @return True if the minesweeper's effective state (pending if set, otherwise current) is Off.
+     */
+    private static boolean isEffectivelyOff(MiscMounted minesweeper) {
+        if (!minesweeper.pendingMode().equals(MODE_NONE)) {
+            return minesweeper.pendingMode().isOff();
+        }
+        return minesweeper.curMode().isOff();
+    }
+
+    /**
+     * Builds the "current -> pending" state text for a minesweeper.
+     */
+    private String getStateDisplayText(MiscMounted minesweeper) {
+        String current = minesweeper.curMode().isOff()
+              ? Messages.getString("MinesweeperActivationDialog.stateOff")
+              : Messages.getString("MinesweeperActivationDialog.stateOn");
+
+        boolean hasPending = !minesweeper.pendingMode().equals(MODE_NONE)
+              && !minesweeper.pendingMode().equals(minesweeper.curMode().getName());
+        if (hasPending) {
+            String pending = minesweeper.pendingMode().isOff()
+                  ? Messages.getString("MinesweeperActivationDialog.stateOff")
+                  : Messages.getString("MinesweeperActivationDialog.stateOn");
+            current += Messages.getString("MinesweeperActivationDialog.stateTransition") + pending;
+        }
+        return current;
+    }
+
+    private void highlightEntity(Entity entity) {
+        BoardView boardView = clientGUI.getBoardView();
+        boardView.highlightSelectedEntities(Collections.singletonList(entity));
+        if (entity.getPosition() != null) {
+            boardView.setHighlightedEntityHexes(Collections.singletonList(entity.getPosition()));
+        }
+        boardView.repaint();
+    }
+
+    private void clearHighlighting() {
+        BoardView boardView = clientGUI.getBoardView();
+        boardView.highlightSelectedEntities(Collections.emptyList());
+        boardView.setHighlightedEntityHexes(Collections.emptyList());
+        boardView.repaint();
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        if (e.getSource() == btnApply) {
+            applyChanges();
+            clearHighlighting();
+            dispose();
+        } else if (e.getSource() == btnCancel) {
+            clearHighlighting();
+            dispose();
+        }
+    }
+
+    /**
+     * Sends a mode change for every minesweeper whose selected state differs from its effective state. The server
+     * applies it as a pending mode that takes effect next turn (instantModeSwitch = false).
+     */
+    private void applyChanges() {
+        for (Entity entity : playerUnits) {
+            JRadioButton onButton = onModeButtons.get(entity.getId());
+            MiscMounted minesweeper = getMinesweeper(entity);
+            if ((onButton == null) || (minesweeper == null)) {
+                continue;
+            }
+
+            boolean selectOff = !onButton.isSelected();
+            if (selectOff == isEffectivelyOff(minesweeper)) {
+                continue; // no change
+            }
+
+            int newMode = selectOff ? MODE_INDEX_OFF : MODE_INDEX_ON;
+            logger.debug("Entity {} switching minesweeper to {}", entity.getId(), selectOff ? MODE_OFF : MODE_ON);
+            clientGUI.getClient().sendModeChange(entity.getId(), entity.getEquipmentNum(minesweeper), newMode);
+        }
+    }
+}

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/ReportDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/ReportDisplay.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2004 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2002-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2002-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -44,6 +44,7 @@ import megamek.client.ui.Messages;
 import megamek.client.ui.clientGUI.ClientGUI;
 import megamek.client.ui.dialogs.phaseDisplay.AbandonUnitDialog;
 import megamek.client.ui.dialogs.phaseDisplay.DetonateChargesDialog;
+import megamek.client.ui.dialogs.phaseDisplay.MinesweeperActivationDialog;
 import megamek.client.ui.dialogs.phaseDisplay.NovaNetworkDialog;
 import megamek.client.ui.dialogs.phaseDisplay.VariableRangeTargetingDialog;
 import megamek.client.ui.util.KeyCommandBind;
@@ -69,7 +70,8 @@ public class ReportDisplay extends StatusBarPhaseDisplay {
         REPORT_NOVA_NETWORK("reportNovaNetwork"),
         REPORT_VAR_RANGE_TARGETING("reportVarRangeTargeting"),
         REPORT_ABANDON("reportAbandon"),
-        REPORT_DETONATE_CHARGES("reportDetonateCharges");
+        REPORT_DETONATE_CHARGES("reportDetonateCharges"),
+        REPORT_MINESWEEPER("reportMinesweeper");
 
         final String cmd;
 
@@ -244,6 +246,8 @@ public class ReportDisplay extends StatusBarPhaseDisplay {
             showAbandonDialog();
         } else if ((ev.getActionCommand().equalsIgnoreCase(ReportCommand.REPORT_DETONATE_CHARGES.getCmd()))) {
             showDetonateChargesDialog();
+        } else if ((ev.getActionCommand().equalsIgnoreCase(ReportCommand.REPORT_MINESWEEPER.getCmd()))) {
+            showMinesweeperDialog();
         }
     }
 
@@ -270,11 +274,15 @@ public class ReportDisplay extends StatusBarPhaseDisplay {
             // Enable Detonate Charges button if player has set demolition charges (TO:AUE p.152: detonation is
             // announced in any End Phase after the charges are finished)
             setDetonateChargesEnabled(hasDemolitionCharges());
+            // Enable Minesweeper button if player has units mounting a minesweeper (TO:AUE p.138: the sweeper
+            // is activated or deactivated in the End Phase)
+            setMinesweeperEnabled(hasMinesweeperUnits());
         } else {
             setNovaNetworkEnabled(false);
             setVariableRangeTargetingEnabled(false);
             setAbandonEnabled(false);
             setDetonateChargesEnabled(false);
+            setMinesweeperEnabled(false);
         }
     }
 
@@ -438,6 +446,40 @@ public class ReportDisplay extends StatusBarPhaseDisplay {
      */
     private void setDetonateChargesEnabled(boolean enabled) {
         MegaMekButton button = buttons.get(ReportCommand.REPORT_DETONATE_CHARGES);
+        if (button != null) {
+            button.setEnabled(enabled);
+        }
+    }
+
+    /**
+     * Shows the Minesweeper activation dialog (TO:AUE p.138: the sweeper is activated or deactivated in the End Phase,
+     * taking effect next turn).
+     */
+    private void showMinesweeperDialog() {
+        MinesweeperActivationDialog dialog = new MinesweeperActivationDialog(clientgui.getFrame(), clientgui);
+        dialog.setVisible(true);
+        // Clear focus from the button after dialog closes
+        MegaMekButton button = buttons.get(ReportCommand.REPORT_MINESWEEPER);
+        if (button != null) {
+            button.transferFocus();
+        }
+    }
+
+    /**
+     * Checks if the local player has any units mounting a minesweeper.
+     */
+    private boolean hasMinesweeperUnits() {
+        int localPlayerId = clientgui.getClient().getLocalPlayer().getId();
+        return clientgui.getClient().getGame().getEntitiesVector().stream()
+              .filter(e -> e.getOwnerId() == localPlayerId)
+              .anyMatch(Entity::hasMinesweeper);
+    }
+
+    /**
+     * Enables or disables the Minesweeper button.
+     */
+    private void setMinesweeperEnabled(boolean enabled) {
+        MegaMekButton button = buttons.get(ReportCommand.REPORT_MINESWEEPER);
         if (button != null) {
             button.setEnabled(enabled);
         }

--- a/megamek/src/megamek/common/equipment/MiscType.java
+++ b/megamek/src/megamek/common/equipment/MiscType.java
@@ -7805,6 +7805,11 @@ public class MiscType extends EquipmentType {
         misc.cost = 40000;
         misc.flags = misc.flags.or(F_MINESWEEPER, F_TANK_EQUIPMENT, F_SUPPORT_TANK_EQUIPMENT);
         misc.bv = 30;
+        // A Minesweeper is activated or deactivated in the End Phase; only an activated sweeper clears
+        // mines (TO:AUE p.138). Default "On" preserves the prior always-sweep behavior. instantModeSwitch
+        // = false defers the switch to the next turn, matching the rule's End-Phase timing.
+        misc.setModes("On", "Off");
+        misc.instantModeSwitch = false;
         misc.rulesRefs = "138, TO:AUE";
         misc.techAdvancement.setTechBase(TechBase.ALL)
               .setIntroLevel(false)

--- a/megamek/src/megamek/common/units/Entity.java
+++ b/megamek/src/megamek/common/units/Entity.java
@@ -6724,6 +6724,19 @@ public abstract class Entity extends TurnOrdered
         return false;
     }
 
+    /**
+     * @return True if this unit mounts a minesweeper (TO:AUE p.138), whether or not it is currently activated. Used to
+     *       offer the End-Phase activation toggle.
+     */
+    public boolean hasMinesweeper() {
+        for (MiscMounted mounted : getMisc()) {
+            if (mounted.getType().hasFlag(MiscType.F_MINESWEEPER)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public boolean hasC3i() {
         if (isShutDown() || isOffBoard()) {
             return false;

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -7429,6 +7429,23 @@ public class TWGameManager extends AbstractGameManager {
      *
      * @return - <code>true</code> if the entity set off any mines
      */
+    /**
+     * Returns the entity's active (switched-on) minesweeper, or {@code null} if it has none, the sweeper is not ready,
+     * its armor is depleted, or the player has deactivated it in the End Phase (TO:AUE p.138). A unit may mount only
+     * one minesweeper.
+     */
+    private static Mounted<?> getActiveMinesweeper(Entity entity) {
+        for (Mounted<?> mounted : entity.getMisc()) {
+            if (mounted.getType().hasFlag(MiscType.F_MINESWEEPER)
+                  && mounted.isReady()
+                  && (mounted.getArmorValue() > 0)
+                  && !mounted.curMode().equals("Off")) {
+                return mounted;
+            }
+        }
+        return null;
+    }
+
     private boolean enterMinefield(Entity entity, Coords c, int curElev, boolean isOnGround, Vector<Report> vMineReport,
           int target) {
         Report r;
@@ -7438,14 +7455,7 @@ public class TWGameManager extends AbstractGameManager {
             return false;
         }
 
-        // Check for Mine sweepers
-        Mounted<?> minesweeper = null;
-        for (Mounted<?> m : entity.getMisc()) {
-            if (m.getType().hasFlag(MiscType.F_MINESWEEPER) && m.isReady() && (m.getArmorValue() > 0)) {
-                minesweeper = m;
-                break; // Can only have one minesweeper
-            }
-        }
+        Mounted<?> minesweeper = getActiveMinesweeper(entity);
 
         Vector<Minefield> fieldsToRemove = new Vector<>();
         // loop through mines in this hex
@@ -7843,14 +7853,7 @@ public class TWGameManager extends AbstractGameManager {
           Vector<Report> vMineReport) {
         int mass = (int) entity.getWeight();
 
-        // Check for Mine sweepers
-        Mounted<?> minesweeper = null;
-        for (Mounted<?> m : entity.getMisc()) {
-            if (m.getType().hasFlag(MiscType.F_MINESWEEPER) && m.isReady() && (m.getArmorValue() > 0)) {
-                minesweeper = m;
-                break; // Can only have one minesweeper
-            }
-        }
+        Mounted<?> minesweeper = getActiveMinesweeper(entity);
 
         // Check for minesweepers sweeping VB minefields
         if (minesweeper != null) {


### PR DESCRIPTION
##  Summary

  Vehicle minesweepers always swept mines automatically — the player could never turn one off. The rules let a player
  activate or deactivate a minesweeper in the End Phase, and only an activated sweeper clears mines (TO:AUE p.138). This
  adds that toggle.

##  Changes Made

  - Minesweeper On/Off mode (TO:AUE p.138): the Mine Sweeper now has "On"/"Off" modes. Default is On, so existing behavior is unchanged. The switch is deferred (instantModeSwitch = false), so it takes effect next turn — matching the End-Phase timing.
  - End-Phase control: a new "Minesweepers" button on the End-Phase report screen opens a dialog to toggle each minesweeper unit. This mirrors the existing Nova Network and Variable Range Targeting controls.
  - Sweep check honors the mode: a sweeper set to Off no longer clears mines; its vehicle trips mines normally.

##  Changes

  1. MiscType.java - createISMineSweeper adds setModes("On", "Off") and instantModeSwitch = false.
  2. TWGameManager.java - new getActiveMinesweeper(Entity) helper checks the mode; replaces two duplicated detection loops in enterMinefield and checkVibraBombs.
  3. Entity.java - new hasMinesweeper() helper (mirrors hasNovaCEWS).
  4. ReportDisplay.java - new REPORT_MINESWEEPER button, enabled in the End Phase when the player owns a minesweeper unit.
  5. MinesweeperActivationDialog.java (NEW) - per-unit On/Off dialog. Reuses the existing sendModeChange packet.
  6. messages.properties - button and dialog strings.

  No server packet was added. ENTITY_MODE_CHANGE already applies the mode and is not phase-gated.

##  Files Changed

  - megamek/src/megamek/common/equipment/MiscType.java - Mine Sweeper gets On/Off modes
  - megamek/src/megamek/server/totalWarfare/TWGameManager.java - mode-aware sweeper lookup, shared helper
  - megamek/src/megamek/common/units/Entity.java - hasMinesweeper() helper
  - megamek/src/megamek/client/ui/panels/phaseDisplay/ReportDisplay.java - End-Phase button
  - megamek/src/megamek/client/ui/dialogs/phaseDisplay/MinesweeperActivationDialog.java - NEW: activation dialog
  - megamek/resources/megamek/client/messages.properties - i18n strings

##  Testing

  - Compiles clean (:megamek:compileJava).
  - Manual testing:
    - Minesweeper On clears mines on entry (unchanged behavior).
    - Toggle Off in the End Phase → next turn the vehicle takes mine damage instead of sweeping.
    - Unit with no minesweeper → button stays disabled.
    - Save/load with a minesweeper set to Off → state persists.