### PR TITLE
Improve ClickableLabel implementation

### DIFF
--- a/megamek/src/megamek/client/ui/util/ClickableLabel.java
+++ b/megamek/src/megamek/client/ui/util/ClickableLabel.java
@@ -32,6 +32,7 @@
  */
 package megamek.client.ui.util;
 
+import java.awt.Cursor;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.util.Objects;
@@ -62,6 +63,7 @@ public class ClickableLabel extends JLabel implements MouseListener {
     public ClickableLabel(Consumer<MouseEvent> clickCallback) {
         this.clickCallback = Objects.requireNonNull(clickCallback);
         addMouseListener(this);
+        setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
     }
 
     @Override
@@ -75,15 +77,15 @@ public class ClickableLabel extends JLabel implements MouseListener {
     }
 
     @Override
-    public void mouseClicked(MouseEvent e) {
-        clickCallback.accept(e);
-    }
+    public void mouseClicked(MouseEvent e) {}
 
     @Override
     public void mousePressed(MouseEvent e) {}
 
     @Override
-    public void mouseReleased(MouseEvent e) {}
+    public void mouseReleased(MouseEvent e) {
+        clickCallback.accept(e);
+    }
 
     @Override
     public void mouseEntered(MouseEvent e) {


### PR DESCRIPTION
This change makes `ClickableLabel` feel more native by showing hand mouse cursor when hovering over it.

Additionally, it changes the action to be triggered on mouse release instead of a click. It makes action triggers much more reliable on trackpads because even a single pixel move during a button press prevents mouse click event from being triggered.