### PR TITLE
Fix swapped VTOL MP for Microlite/Micro-Copter

### DIFF
--- a/megamek/src/megamek/common/units/ConvInfantry.java
+++ b/megamek/src/megamek/common/units/ConvInfantry.java
@@ -169,6 +169,11 @@ public class ConvInfantry extends Infantry {
      */
     private boolean isMicrolite = false;
 
+    /** Base VTOL MP for a Microlite VTOL platoon (TO p.324). */
+    private static final int MICROLITE_VTOL_MP = 6;
+    /** Base VTOL MP for a Micro-Copter VTOL platoon (TO p.324). */
+    private static final int MICRO_COPTER_VTOL_MP = 5;
+
     private boolean pheromoneImpaired = false;
 
     public static final int ANTI_MEK_SKILL_NO_GEAR = 8;
@@ -1769,11 +1774,7 @@ public class ConvInfantry extends Infantry {
                 setSpecializations(getSpecializations() | SCUBA);
                 break;
             case VTOL:
-                if (hasMicrolite()) {
-                    setOriginalJumpMP(6);
-                } else {
-                    setOriginalJumpMP(5);
-                }
+                setOriginalJumpMP(hasMicrolite() ? MICROLITE_VTOL_MP : MICRO_COPTER_VTOL_MP);
                 setOriginalWalkMP(1);
                 break;
             case INF_UMU:
@@ -1859,6 +1860,11 @@ public class ConvInfantry extends Infantry {
 
     public void setMicrolite(boolean microlite) {
         this.isMicrolite = microlite;
+        // Keep VTOL MP in sync when the unit is already in VTOL mode, so the MP is correct no matter
+        // whether the microlite flag is set before or after the movement mode (TO p.324).
+        if (getMovementMode() == EntityMovementMode.VTOL) {
+            setOriginalJumpMP(microlite ? MICROLITE_VTOL_MP : MICRO_COPTER_VTOL_MP);
+        }
     }
 
     public void setMount(InfantryMount mount) {

--- a/megamek/src/megamek/common/units/ConvInfantry.java
+++ b/megamek/src/megamek/common/units/ConvInfantry.java
@@ -169,9 +169,9 @@ public class ConvInfantry extends Infantry {
      */
     private boolean isMicrolite = false;
 
-    /** Base VTOL MP for a Microlite VTOL platoon (TO p.324). */
+    /** Base VTOL MP for a Microlite VTOL platoon (TO:AUE p.136). */
     private static final int MICROLITE_VTOL_MP = 6;
-    /** Base VTOL MP for a Micro-Copter VTOL platoon (TO p.324). */
+    /** Base VTOL MP for a Micro-Copter VTOL platoon (TO:AUE p.136). */
     private static final int MICRO_COPTER_VTOL_MP = 5;
 
     private boolean pheromoneImpaired = false;
@@ -1861,7 +1861,7 @@ public class ConvInfantry extends Infantry {
     public void setMicrolite(boolean microlite) {
         this.isMicrolite = microlite;
         // Keep VTOL MP in sync when the unit is already in VTOL mode, so the MP is correct no matter
-        // whether the microlite flag is set before or after the movement mode (TO p.324).
+        // whether the microlite flag is set before or after the movement mode (TO:AUE p.136).
         if (getMovementMode() == EntityMovementMode.VTOL) {
             setOriginalJumpMP(microlite ? MICROLITE_VTOL_MP : MICRO_COPTER_VTOL_MP);
         }

--- a/megamek/unittests/megamek/common/units/ConvInfantryVtolMovementTest.java
+++ b/megamek/unittests/megamek/common/units/ConvInfantryVtolMovementTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.units;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import megamek.common.equipment.EquipmentType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the base VTOL movement points of mechanized VTOL conventional infantry: Microlite platoons get 6 VTOL MP and
+ * Micro-Copter platoons get 5 VTOL MP (TO p.324). The MP must come out correct regardless of whether the microlite flag
+ * is set before or after the movement mode, because the two construction paths set them in different orders (the .blk
+ * loader sets microlite first; the MegaMekLab structure tab set the mode first). Regression test for mm-data issue #416.
+ */
+class ConvInfantryVtolMovementTest {
+
+    private static final int MICROLITE_VTOL_MP = 6;
+    private static final int MICRO_COPTER_VTOL_MP = 5;
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    @Test
+    @DisplayName("Microlite gets 6 VTOL MP when the flag is set before the movement mode (.blk loader order)")
+    void microliteFlagBeforeMode() {
+        ConvInfantry infantry = new ConvInfantry();
+        infantry.setMicrolite(true);
+        infantry.setMovementMode(EntityMovementMode.VTOL);
+
+        assertEquals(MICROLITE_VTOL_MP, infantry.getOriginalJumpMP());
+    }
+
+    @Test
+    @DisplayName("Microlite gets 6 VTOL MP when the flag is set after the movement mode (MegaMekLab order)")
+    void microliteFlagAfterMode() {
+        ConvInfantry infantry = new ConvInfantry();
+        infantry.setMovementMode(EntityMovementMode.VTOL);
+        infantry.setMicrolite(true);
+
+        assertEquals(MICROLITE_VTOL_MP, infantry.getOriginalJumpMP());
+    }
+
+    @Test
+    @DisplayName("Micro-Copter gets 5 VTOL MP when the flag is set before the movement mode (.blk loader order)")
+    void microCopterFlagBeforeMode() {
+        ConvInfantry infantry = new ConvInfantry();
+        infantry.setMicrolite(false);
+        infantry.setMovementMode(EntityMovementMode.VTOL);
+
+        assertEquals(MICRO_COPTER_VTOL_MP, infantry.getOriginalJumpMP());
+    }
+
+    @Test
+    @DisplayName("Micro-Copter gets 5 VTOL MP when switching from Microlite while already in VTOL mode")
+    void switchMicroliteToMicroCopterInVtolMode() {
+        ConvInfantry infantry = new ConvInfantry();
+        infantry.setMicrolite(true);
+        infantry.setMovementMode(EntityMovementMode.VTOL);
+
+        // Switching the platoon type without re-selecting the movement mode must still correct the MP.
+        infantry.setMicrolite(false);
+
+        assertEquals(MICRO_COPTER_VTOL_MP, infantry.getOriginalJumpMP());
+    }
+}

--- a/megamek/unittests/megamek/common/units/ConvInfantryVtolMovementTest.java
+++ b/megamek/unittests/megamek/common/units/ConvInfantryVtolMovementTest.java
@@ -43,7 +43,7 @@ import org.junit.jupiter.api.Test;
  * Tests the base VTOL movement points of mechanized VTOL conventional infantry: Microlite platoons get 6 VTOL MP and
  * Micro-Copter platoons get 5 VTOL MP (TO p.324). The MP must come out correct regardless of whether the microlite flag
  * is set before or after the movement mode, because the two construction paths set them in different orders (the .blk
- * loader sets microlite first; the MegaMekLab structure tab set the mode first). Regression test for mm-data issue #416.
+ * loader sets microlite first; the MegaMekLab structure tab sets the mode first). Regression test for MegaMek issue #8354.
  */
 class ConvInfantryVtolMovementTest {
 

--- a/megamek/unittests/megamek/common/units/ConvInfantryVtolMovementTest.java
+++ b/megamek/unittests/megamek/common/units/ConvInfantryVtolMovementTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests the base VTOL movement points of mechanized VTOL conventional infantry: Microlite platoons get 6 VTOL MP and
- * Micro-Copter platoons get 5 VTOL MP (TO p.324). The MP must come out correct regardless of whether the microlite flag
+ * Micro-Copter platoons get 5 VTOL MP (TO:AUE p.136). The MP must come out correct regardless of whether the microlite flag
  * is set before or after the movement mode, because the two construction paths set them in different orders (the .blk
  * loader sets microlite first; the MegaMekLab structure tab sets the mode first). Regression test for MegaMek issue #8354.
  */


### PR DESCRIPTION
Fixes #8354

Microlite VTOL infantry should have 6 VTOL MP and Micro-Copter platoons 5 (TO p.324). They were built with the values swapped.

Root cause: ConvInfantry.setMovementMode() picks the VTOL MP from the microlite flag, but MegaMekLab sets the flag after the movement mode, so the MP was read from a stale flag.

Fix: Added MICROLITE_VTOL_MP (6) and MICRO_COPTER_VTOL_MP (5) constants used by setMovementMode(). setMicrolite() now re-syncs the VTOL MP when the unit is already in VTOL mode, so the MP is correct regardless of the order the flag and movement mode are set. Adds ConvInfantryVtolMovementTest covering both call orders.