### PR TITLE
Hopefully Fixed Unit Test Faction Race Condition

### DIFF
--- a/megamek/src/megamek/common/universe/Factions2.java
+++ b/megamek/src/megamek/common/universe/Factions2.java
@@ -105,7 +105,7 @@ public final class Factions2 {
     private static final MMLogger LOGGER = MMLogger.create(Factions2.class);
     private static Factions2 instance;
 
-    private static final String TEST_DIR = "testresources/data/universe/factions";
+    public static final String FACTIONS2_TEST_DIRECTORY = "testresources/data/universe/factions";
 
     private final Map<String, Faction2> factions = new HashMap<>();
 
@@ -118,11 +118,15 @@ public final class Factions2 {
     }
 
     public static synchronized Factions2 getInstance(boolean useTestDirectory) {
-        if (instance == null || useTestDirectory) {
-            instance = useTestDirectory ? new Factions2(TEST_DIR) : new Factions2();
+        if (instance == null) {
+            instance = useTestDirectory ? new Factions2(FACTIONS2_TEST_DIRECTORY) : new Factions2();
         }
 
         return instance;
+    }
+
+    public static void setInstance(@Nullable Factions2 instance) {
+        Factions2.instance = instance;
     }
 
     /**

--- a/megamek/src/megamek/common/universe/Factions2.java
+++ b/megamek/src/megamek/common/universe/Factions2.java
@@ -125,7 +125,7 @@ public final class Factions2 {
         return instance;
     }
 
-    public static void setInstance(@Nullable Factions2 instance) {
+    public static synchronized void setInstance(@Nullable Factions2 instance) {
         Factions2.instance = instance;
     }
 

--- a/megamek/src/megamek/common/universe/Factions2.java
+++ b/megamek/src/megamek/common/universe/Factions2.java
@@ -118,7 +118,7 @@ public final class Factions2 {
     }
 
     public static synchronized Factions2 getInstance(boolean useTestDirectory) {
-        if (instance == null) {
+        if (instance == null || useTestDirectory) {
             instance = useTestDirectory ? new Factions2(TEST_DIR) : new Factions2();
         }
 


### PR DESCRIPTION
MekHQ has an annoying Unit Test race condition where if another test initializes factions before a test that relies on faction data the stale data can persist. Polluting all future tests. Generally this isn't an issue unless you are specifically testing factional behavior.

This PR adds a method to explicitly set the `Faction2` instance. I cannot be sure if this will fix the issue due to the nature of a race condition, however I'm hopeful.