### PR TITLE
Reduce allocation churn in getModesCount and FacingArc (Fixes #8376)

### DIFF
--- a/megamek/src/megamek/common/enums/FacingArc.java
+++ b/megamek/src/megamek/common/enums/FacingArc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -166,6 +166,13 @@ public enum FacingArc {
     }
 
     /**
+     * Cached copy of {@link #values()}. {@code values()} clones its backing array on every call, which showed up
+     * as a heavy allocation source in hot arc lookups (JFR profiling, 2026-06-21). Iterating this shared,
+     * never-modified array avoids that per-call clone. Treat as read-only.
+     */
+    private static final FacingArc[] VALUES = values();
+
+    /**
      * Returns the enum constant of this type with the legacy specified arcCode. The arcCode must match exactly an
      * arcCode used to declare an enum constant in this type.
      *
@@ -174,7 +181,7 @@ public enum FacingArc {
      * @throws IllegalArgumentException – if this enum type has no constant with the specified arcCode
      */
     public static FacingArc valueOf(int arcCode) {
-        for (FacingArc facingArc : FacingArc.values()) {
+        for (FacingArc facingArc : VALUES) {
             if (facingArc.arcCode == arcCode) {
                 return facingArc;
             }

--- a/megamek/src/megamek/common/weapons/lasers/LaserWeapon.java
+++ b/megamek/src/megamek/common/weapons/lasers/LaserWeapon.java
@@ -105,18 +105,25 @@ public abstract class LaserWeapon extends EnergyWeapon {
     @Override
     public int getModesCount(Mounted<?> mounted) {
         Mounted<?> linkedBy = mounted.getLinkedBy();
-        if ((linkedBy instanceof MiscMounted)
+        boolean hasRiscPulseModule = (linkedBy instanceof MiscMounted miscMounted)
               && !linkedBy.isInoperable()
-              && ((MiscMounted) linkedBy).getType().hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE)) {
-            return super.getModesCount();
-        } else if (this instanceof PulseLaserWeapon) {
+              && miscMounted.getType().hasFlag(MiscType.F_RISC_LASER_PULSE_MODULE);
+        if (hasRiscPulseModule || (this instanceof PulseLaserWeapon)) {
             return super.getModesCount();
         }
 
         if (hasModes()) {
-            //Only works if laser pulse module's "Pulse" modes are added last.
+            // Counts only non-Pulse modes; relies on the pulse module's "Pulse" modes being added last.
+            // Uses an indexed loop instead of a stream: this runs in hot UI and to-hit paths where a
+            // per-call stream pipeline was a major allocation source (JFR profiling, 2026-06-21).
             synchronized (modes) {
-                return (int) modes.stream().filter(mode -> !mode.getName().startsWith("Pulse")).count();
+                int nonPulseModeCount = 0;
+                for (int index = 0; index < modes.size(); index++) {
+                    if (!modes.get(index).getName().startsWith("Pulse")) {
+                        nonPulseModeCount++;
+                    }
+                }
+                return nonPulseModeCount;
             }
         }
         return super.getModesCount();

--- a/megamek/src/megamek/common/weapons/lasers/LaserWeapon.java
+++ b/megamek/src/megamek/common/weapons/lasers/LaserWeapon.java
@@ -118,7 +118,8 @@ public abstract class LaserWeapon extends EnergyWeapon {
             // per-call stream pipeline was a major allocation source (JFR profiling, 2026-06-21).
             synchronized (modes) {
                 int nonPulseModeCount = 0;
-                for (int index = 0; index < modes.size(); index++) {
+                int modeCount = modes.size();
+                for (int index = 0; index < modeCount; index++) {
                     if (!modes.get(index).getName().startsWith("Pulse")) {
                         nonPulseModeCount++;
                     }

--- a/megamek/unittests/megamek/common/DazzleModeTest.java
+++ b/megamek/unittests/megamek/common/DazzleModeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -36,8 +36,11 @@ package megamek.common;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.Mounted;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.lasers.LaserWeapon;
@@ -158,6 +161,40 @@ class DazzleModeTest {
         assertTrue(dazzleIndex >= 0, "Dazzle mode should exist");
         assertTrue(firstPulseIndex >= 0, "Pulse mode should exist");
         assertTrue(dazzleIndex < firstPulseIndex, "Dazzle mode should come before Pulse mode for proper filtering");
+    }
+
+    @Test
+    void testGetModesCountExcludesPulseModes() {
+        // Regression guard for LaserWeapon.getModesCount(Mounted): it must return only the non-Pulse
+        // modes. A non-pulse laser has "Pulse ..." modes appended, so the filtered count must be smaller
+        // than the full mode list. Independently re-counts via getModes() to catch off-by-one errors.
+        LaserWeapon weapon = new ISERLaserLarge();
+
+        GameOptions options = new GameOptions();
+        options.getOption(OptionsConstants.ADVANCED_COMBAT_GOTHIC_DAZZLE_MODE).setValue(true);
+        weapon.adaptToGameOptions(options);
+
+        // A Mounted with nothing linked exercises the filtered-count path (no RISC pulse module).
+        Mounted<?> mounted = mock(Mounted.class);
+        when(mounted.getLinkedBy()).thenReturn(null);
+
+        int totalModes = 0;
+        int expectedNonPulseModes = 0;
+        int pulseModes = 0;
+        for (var mode : java.util.Collections.list(weapon.getModes())) {
+            totalModes++;
+            if (mode.getName().startsWith("Pulse")) {
+                pulseModes++;
+            } else {
+                expectedNonPulseModes++;
+            }
+        }
+
+        assertTrue(pulseModes > 0, "Test setup should produce at least one Pulse mode to filter");
+        assertEquals(expectedNonPulseModes, weapon.getModesCount(mounted),
+              "getModesCount should count only non-Pulse modes");
+        assertTrue(weapon.getModesCount(mounted) < totalModes,
+              "Filtered mode count should be smaller than the full mode list");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Two methods allocated a lot of short-lived garbage on hot paths. JFR profiling of a Princess bot game flagged `LaserWeapon.getModesCount` as the top allocation source and `FacingArc.valueOf` as a smaller one. This removes the garbage with no behavior change.

Fixes #8376

## Changes Made

- **LaserWeapon.getModesCount**: replaced `modes.stream().filter(...).count()` with a plain indexed loop. The stream built a fresh pipeline on every call; the loop allocates nothing.
- **LaserWeapon.getModesCount** (cleanup): used pattern-matching `instanceof` to drop a cast, and merged the two duplicate `return super.getModesCount()` branches.
- **FacingArc.valueOf**: `values()` clones the enum array on every call. Cache it once in a `static final` array and iterate that.

## Files Changed

- `megamek/src/megamek/common/weapons/lasers/LaserWeapon.java` - stream count replaced with an indexed loop; small readability cleanup
- `megamek/src/megamek/common/enums/FacingArc.java` - cache `values()` in a static final array; copyright year bump

## Testing

- `./gradlew compileJava` passes.
- Re-profiled the same map, forces, and settings. Both sites drop out of the allocation data: `getModesCount` goes from the top allocator to absent, and `FacingArc[]` clones go to ~0. The `ReduceOps$CountingSink` temporaries fall from ~4 GB to ~0.1 GB.
- Heap-after-GC trend unchanged (healthy sawtooth, no leak).

## Notes

Behavior is identical - same mode count, same arc lookup. Enums serialize by name, so there is no save-format impact. The larger LOS and pathfinding allocators (`BoardLocation.of`, `LosEffects`) are out of scope here.
