### PR TITLE
Fix game summary GIF crash from multiple writers (Fixes #8379)

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/minimap/MinimapPanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/minimap/MinimapPanel.java
@@ -352,15 +352,18 @@ public final class MinimapPanel extends JPanel implements IPreferenceChangeListe
                             ImageIO.write(image, "png", imgFile);
                         }
                         if (GUIP.getGifGameSummaryMinimap()) {
-                            // Claim GIF ownership for this game exactly once. In a multi-board game every board's
-                            // panel reaches this code, but only the first to add the UUID becomes the writer; the
-                            // others skip it so they don't write the same file and race when saving at game end.
-                            if (!ownsSummaryGif && (gifWriterThread == null)
-                                  && GIF_WRITING_GAMES.add(game.getUUIDString())) {
-                                ownsSummaryGif = true;
-                                gifWriterThread = new GifWriterThread(new GifWriter(game.getUUIDString()),
-                                      "GifWriterThread");
-                                gifWriterThread.start();
+                            // Only one panel per game writes the GIF. In a multi-board game every board's panel
+                            // reaches this code, but only the owner (first to claim the game UUID) writes; the others
+                            // skip it so they don't share the file and race when saving at game end. Ownership is
+                            // tracked separately from the thread instance, so the owner also restarts its writer if
+                            // that thread has died, instead of silently ending the GIF for the rest of the game.
+                            if ((gifWriterThread == null) || !gifWriterThread.isAlive()) {
+                                if (ownsSummaryGif || GIF_WRITING_GAMES.add(game.getUUIDString())) {
+                                    ownsSummaryGif = true;
+                                    gifWriterThread = new GifWriterThread(new GifWriter(game.getUUIDString()),
+                                          "GifWriterThread");
+                                    gifWriterThread.start();
+                                }
                             }
                             if (ownsSummaryGif && (gifWriterThread != null) && gifWriterThread.isAlive()) {
                                 gifWriterThread.addFrame(image, 400);

--- a/megamek/src/megamek/client/ui/dialogs/minimap/MinimapPanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/minimap/MinimapPanel.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2002-2005 Ben Mazur (bmazur@sev.org)
  * Copyright (c) 2013 Edward Cullen (eddy@obsessedcomputers.co.uk)
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -62,6 +62,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.Vector;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.imageio.ImageIO;
 import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JDialog;
@@ -188,7 +189,15 @@ public final class MinimapPanel extends JPanel implements IPreferenceChangeListe
     private final JDialog dialog;
     private Client client;
     private final IClientGUI clientGui;
+    /**
+     * Game UUIDs that already have a {@link MinimapPanel} writing the summary GIF. A multi-board game creates one
+     * MinimapPanel per board, but the GIF file is keyed per game, so without this guard several panels would write
+     * the same file at once and then race when saving at game end. Only the first panel per game owns the GIF.
+     */
+    private static final Set<String> GIF_WRITING_GAMES = ConcurrentHashMap.newKeySet();
+
     private GifWriterThread gifWriterThread;
+    private volatile boolean ownsSummaryGif = false;
     private int margin = MARGIN;
     private int topMargin;
     private int leftMargin;
@@ -343,23 +352,34 @@ public final class MinimapPanel extends JPanel implements IPreferenceChangeListe
                             ImageIO.write(image, "png", imgFile);
                         }
                         if (GUIP.getGifGameSummaryMinimap()) {
-                            if (gifWriterThread == null || !gifWriterThread.isAlive()) {
+                            // Claim GIF ownership for this game exactly once. In a multi-board game every board's
+                            // panel reaches this code, but only the first to add the UUID becomes the writer; the
+                            // others skip it so they don't write the same file and race when saving at game end.
+                            if (!ownsSummaryGif && (gifWriterThread == null)
+                                  && GIF_WRITING_GAMES.add(game.getUUIDString())) {
+                                ownsSummaryGif = true;
                                 gifWriterThread = new GifWriterThread(new GifWriter(game.getUUIDString()),
                                       "GifWriterThread");
                                 gifWriterThread.start();
                             }
-                            gifWriterThread.addFrame(image, 400);
+                            if (ownsSummaryGif && (gifWriterThread != null) && gifWriterThread.isAlive()) {
+                                gifWriterThread.addFrame(image, 400);
+                            }
                         }
                     } catch (Exception ex) {
                         logger.error(ex, "Error saving game summary image.");
                     }
                 }
 
-                if (e.getNewPhase().isVictory() && (gifWriterThread != null) && gifWriterThread.isAlive()) {
+                if (e.getNewPhase().isVictory() && ownsSummaryGif && (gifWriterThread != null)) {
                     try {
-                        gifWriterThread.stopThread();
+                        if (gifWriterThread.isAlive()) {
+                            gifWriterThread.stopThread();
+                        }
                     } catch (Exception ex) {
                         logger.error(ex, "Error closing gif writer.");
+                    } finally {
+                        releaseSummaryGifOwnership();
                     }
                 }
 
@@ -421,12 +441,26 @@ public final class MinimapPanel extends JPanel implements IPreferenceChangeListe
         }
         if (client != null) {
             client.addCloseClientListener(() -> {
-                if (gifWriterThread != null && gifWriterThread.isAlive()) {
-                    gifWriterThread.stopThread(true);
+                if (ownsSummaryGif && (gifWriterThread != null)) {
+                    if (gifWriterThread.isAlive()) {
+                        gifWriterThread.stopThread(true);
+                    }
+                    releaseSummaryGifOwnership();
                 }
             });
         }
         GUIP.addPreferenceChangeListener(this);
+    }
+
+    /**
+     * Releases this panel's claim on the summary GIF so a later game (a new UUID) can be written, and so the entry
+     * does not linger after the writer has stopped. Safe to call when this panel is not the owner.
+     */
+    private void releaseSummaryGifOwnership() {
+        if (ownsSummaryGif) {
+            GIF_WRITING_GAMES.remove(game.getUUIDString());
+            ownsSummaryGif = false;
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

The game summary GIF could throw an error popup at the end of a game. In a multi-board game, the client creates one `MinimapPanel` per board, and each started its own writer for the same per-game GIF file. The writers raced when saving at game end. This makes only the first panel per game write the GIF.

## Bug Fixed

- **Multiple GIF writers on one file**: each board's `MinimapPanel` started a `GifWriterThread` for the same per-game GIF (`game.getUUIDString()`). At game end the threads raced on save and delete, producing an "Unable to save GIF in destination" popup and a corrupt GIF.

## Changes

1. **MinimapPanel.java** - The first panel per game claims the GIF via a shared `ConcurrentHashMap`-backed set of game UUIDs. Other boards' panels skip GIF writing. The owner releases its claim when the writer stops (victory or client close).

## Files Changed

- `megamek/src/megamek/client/ui/dialogs/minimap/MinimapPanel.java` - single-owner guard for the summary GIF writer

## Testing

- `./gradlew compileJava` passes.
- Manual: multi-board game with the summary GIF enabled -> one GIF is written and there is no popup at game end.
- Single-board games (the common case) behave exactly as before.

Fixes #8379
