### PR TITLE
Fix artillery direct fire vs. airborne targets missing attacker movement modifier (Fixes #8370)

### DIFF
--- a/megamek/src/megamek/common/actions/compute/ComputeToHit.java
+++ b/megamek/src/megamek/common/actions/compute/ComputeToHit.java
@@ -1809,6 +1809,13 @@ public class ComputeToHit {
         ComputeAbilityMods.processAttackerSPAs(toHit, ae, te, weapon, game);
         ComputeAbilityMods.processDefenderSPAs(toHit, ae, te, game);
 
+        // The attacker's movement modifier applies to every direct-fire artillery attack that resolves here,
+        // including flak attacks against airborne VTOL/WiGE/aerospace targets (TO:AR corrected 7th printing,
+        // p.153). It is added here - after the ADA early return above (ADA falls through to the normal to-hit
+        // path, which already applies this modifier) and before the flak branch returns - so that each direct
+        // artillery path includes it exactly once.
+        toHit.append(Compute.getAttackerMovementModifier(game, ae.getId()));
+
         // If an airborne unit occupies the target hex, standard artillery ammo makes a
         // flak attack against it
         // TN is a flat 3 + the altitude mod + the attacker's weapon skill - 2 for Flak
@@ -1836,9 +1843,8 @@ public class ComputeToHit {
             }
         }
 
-        // All other direct fire artillery attacks
+        // All other direct fire artillery attacks (attacker movement modifier already appended above)
         toHit.addModifier(4, Messages.getString("WeaponAttackAction.DirectArty"));
-        toHit.append(Compute.getAttackerMovementModifier(game, ae.getId()));
         // without LOS, it is a short-range indirect attack that ignores LOS modifiers, TO:AR p.153
         if (!losMods.cannotSucceed()) {
             toHit.append(losMods);

--- a/megamek/unittests/megamek/common/actions/WeaponAttackActionToHitTest.java
+++ b/megamek/unittests/megamek/common/actions/WeaponAttackActionToHitTest.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Vector;
 
@@ -60,6 +61,7 @@ import megamek.common.compute.Compute;
 import megamek.common.enums.GamePhase;
 import megamek.common.enums.Gender;
 import megamek.common.equipment.AmmoMounted;
+import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.BombMounted;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.equipment.HandheldWeapon;
@@ -76,15 +78,7 @@ import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
 import megamek.common.planetaryConditions.Light;
 import megamek.common.planetaryConditions.PlanetaryConditions;
-import megamek.common.units.Aero;
-import megamek.common.units.BipedMek;
-import megamek.common.units.Crew;
-import megamek.common.units.CrewType;
-import megamek.common.units.Entity;
-import megamek.common.units.Mek;
-import megamek.common.units.MekWithArms;
-import megamek.common.units.Tank;
-import megamek.common.units.Targetable;
+import megamek.common.units.*;
 import megamek.common.weapons.handlers.AttackHandler;
 import megamek.server.totalWarfare.TWGameManager;
 import org.junit.jupiter.api.BeforeAll;
@@ -887,5 +881,79 @@ public class WeaponAttackActionToHitTest {
         assertFalse(waa.getAssumedHit());
         assertEquals(4.58f, returnValue, 0.1f);
         assertEquals(4.58f, waa.getExpectedDamage(), 0.1f);
+    }
+
+    /**
+     * Regression tests for issue #8370: direct-fire artillery against an airborne VTOL/WiGE/aerospace target resolves
+     * as a flak attack, which must still include the attacker's movement modifier (TO:AR corrected 7th printing,
+     * p.153). The flak branch in {@code ComputeToHit.artilleryDirectToHit} previously short-circuited via special
+     * resolution without applying that modifier.
+     */
+    @Nested
+    class ArtilleryDirectFlakAttackerMovementTests {
+
+        Tank mockAttackingEntity;
+        VTOL mockTarget;
+        AmmoType mockAmmoType;
+
+        @BeforeEach
+        void beforeEach() {
+            // Weapon is a direct-fire artillery piece (Arrow IV) loaded with standard, flak-capable ammo
+            when(mockWeaponType.hasFlag(WeaponType.F_ARTILLERY)).thenReturn(true);
+            when(mockWeaponType.getAmmoType()).thenReturn(AmmoType.AmmoTypeEnum.ARROW_IV);
+
+            mockAmmoType = mock(AmmoType.class);
+            when(mockAmmoType.getAmmoType()).thenReturn(AmmoType.AmmoTypeEnum.ARROW_IV);
+            when(mockAmmoType.getMunitionType()).thenReturn(EnumSet.of(AmmoType.Munitions.M_STANDARD));
+            when(mockAmmoType.countsAsFlak()).thenReturn(true);
+            when(mockAmmo.getType()).thenReturn(mockAmmoType);
+
+            // Attacker is a vehicle (e.g. a Long Tom carrier) that ran this turn, so the movement modifier is
+            // "attacker ran" (+2)
+            mockAttackingEntity = mock(Tank.class);
+            when(mockAttackingEntity.getOwner()).thenReturn(mockPlayer);
+            when(mockAttackingEntity.getPosition()).thenReturn(new Coords(0, 0));
+            when(mockAttackingEntity.getWeapon(anyInt())).thenReturn(mockWeapon);
+            when(mockAttackingEntity.getEquipment(anyInt())).thenReturn(mockWeaponEquipment);
+            when(mockAttackingEntity.getCrew()).thenReturn(mockCrew);
+            when(mockAttackingEntity.getSwarmTargetId()).thenReturn(Entity.NONE);
+            when(mockAttackingEntity.getAttackingEntity()).thenReturn(mockAttackingEntity);
+            when(mockAttackingEntity.getGame()).thenReturn(mockGame);
+            mockAttackingEntity.moved = EntityMovementType.MOVE_RUN;
+
+            when(mockWeapon.getEntity()).thenReturn(mockAttackingEntity);
+
+            // Target is an airborne VTOL, which routes the attack through the artillery flak branch. It sits
+            // beyond the 6-hex direct-fire minimum (and within the 17-hex maximum) so the attack is legal.
+            mockTarget = mock(VTOL.class);
+            when(mockTarget.getOwner()).thenReturn(mockEnemy);
+            when(mockTarget.getPosition()).thenReturn(new Coords(0, 10));
+            when(mockTarget.getTargetType()).thenReturn(Targetable.TYPE_ENTITY);
+            when(mockTarget.getSwarmTargetId()).thenReturn(Entity.NONE);
+            when(mockTarget.isAirborneVTOLorWIGE()).thenReturn(true);
+            when(mockTarget.getGame()).thenReturn(mockGame);
+
+            when(mockGame.getEntity(0)).thenReturn(mockAttackingEntity);
+            when(mockGame.getEntity(1)).thenReturn(mockTarget);
+        }
+
+        @Test
+        void testAttackerMovementAppliedToArtilleryFlak() {
+            try (MockedStatic<LosEffects> mockedLosEffects = mockStatic(LosEffects.class,
+                  invocationOnMock -> mockLos)) {
+                mockedLosEffects.when(() -> LosEffects.calculateLOS(any(), any(), any(), anyBoolean()))
+                      .thenReturn(mockLos);
+
+                ToHitData toHit = WeaponAttackAction.toHit(mockGame, 0, mockTarget, 0, false);
+
+                boolean hasAttackerRanModifier = toHit.getModifiers().stream()
+                      .anyMatch(modifier -> "attacker ran".equals(modifier.description()) && (modifier.value() == 2));
+                assertTrue(hasAttackerRanModifier,
+                      "Direct-fire artillery flak vs. an airborne VTOL must include the attacker movement modifier. "
+                            + "Modifiers: " + toHit.getModifiers().stream()
+                            .map(modifier -> "[" + modifier.value() + ": " + modifier.description() + "]")
+                            .collect(java.util.stream.Collectors.joining(", ")));
+            }
+        }
     }
 }

--- a/megamek/unittests/megamek/common/actions/WeaponAttackActionToHitTest.java
+++ b/megamek/unittests/megamek/common/actions/WeaponAttackActionToHitTest.java
@@ -919,6 +919,9 @@ public class WeaponAttackActionToHitTest {
             when(mockAttackingEntity.getSwarmTargetId()).thenReturn(Entity.NONE);
             when(mockAttackingEntity.getAttackingEntity()).thenReturn(mockAttackingEntity);
             when(mockAttackingEntity.getGame()).thenReturn(mockGame);
+            // Not grappling: an unstubbed mock returns 0, which is != Entity.NONE (-1) and would send the
+            // impossible-checks down the grapple-only targeting path; keep the test focused on flak behavior.
+            when(mockAttackingEntity.getGrappled()).thenReturn(Entity.NONE);
             mockAttackingEntity.moved = EntityMovementType.MOVE_RUN;
 
             when(mockWeapon.getEntity()).thenReturn(mockAttackingEntity);


### PR DESCRIPTION
## Root Cause
`ComputeToHit.artilleryDirectToHit()` resolves direct fire against an airborne VTOL/WiGE/aerospace target through a flak branch that calls `srt.setSpecialResolution(true)` and returns early. This short-circuits the normal to-hit pipeline (`ComputeAttackerToHitMods`), which is where the attacker's movement modifier is normally applied — so the flak branch silently dropped it. Per TO:AR (corrected 7th printing, p.153), artillery flak vs. an airborne target is +3 base, gunnery, the -2 flak bonus, **and** the attacker's movement modifier.

## Changes
1. `ComputeToHit.artilleryDirectToHit()` — relocated the single `toHit.append(Compute.getAttackerMovementModifier(...))` call to run after the ADA early-return but before the flak branch returns, so every direct-artillery path applies the modifier exactly once. Added a comment citing TO:AR p.153.
   - Note: the modifier is intentionally *not* moved above the ADA branch. ADA missiles return without special resolution and already pick the modifier up through the normal pipeline; placing it above the ADA return would double-count it.
2. Added a regression test covering the flak path.

<img width="654" height="196" alt="image" src="https://github.com/user-attachments/assets/e3e0af2e-a15b-405c-8300-d8efdae97a4c" />


## Files Changed
- `megamek/src/megamek/common/actions/compute/ComputeToHit.java` — moved the attacker-movement append in `artilleryDirectToHit()`; added explanatory comment.
- `megamek/unittests/megamek/common/actions/WeaponAttackActionToHitTest.java` — new nested `ArtilleryDirectFlakAttackerMovementTests`: a vehicle artillery attacker that ran this turn, firing standard (flak-capable) Arrow IV at an airborne VTOL beyond the 6-hex minimum, must include the "attacker ran" (+2) movement modifier in its to-hit.

## Testing
- New regression test passes; verified it fails (modifier absent) when the fix is reverted.
- `megamek.common.actions.*` and `megamek.common.actions.compute.*` suites pass.

Fixes #8370