### PR TITLE
Optimize game summary GIF writer (Fixes #8389)

### DIFF
--- a/megamek/src/megamek/utilities/GifWriter.java
+++ b/megamek/src/megamek/utilities/GifWriter.java
@@ -91,7 +91,7 @@ public class GifWriter {
     }
 
     private OutputStream outputStream = null;
-    private int[] rgbData = null;
+    private int[] reusableRgbBuffer = null;
 
     /**
      * Appends a frame to the gif.
@@ -106,8 +106,9 @@ public class GifWriter {
         // Reuse the pixel buffer across frames. Frame dimensions are fixed after the first frame
         // (ensureImageSize enforces this), so the same int[] is valid for every frame and avoids
         // allocating a full width*height array per frame on this hot path.
-        rgbData = image.getRGB(START_OFFSET, START_OFFSET, width, height, rgbData, START_OFFSET, width);
-        getEncoder().addImage(rgbData, width, getImageOptions(duration));
+        reusableRgbBuffer = image.getRGB(START_OFFSET, START_OFFSET, width, height, reusableRgbBuffer,
+              START_OFFSET, width);
+        getEncoder().addImage(reusableRgbBuffer, width, getImageOptions(duration));
         LOGGER.debug("Appended frame with duration {} ms, image size: {}x{}", duration, width, height);
     }
 

--- a/megamek/src/megamek/utilities/GifWriter.java
+++ b/megamek/src/megamek/utilities/GifWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -91,6 +91,7 @@ public class GifWriter {
     }
 
     private OutputStream outputStream = null;
+    private int[] rgbData = null;
 
     /**
      * Appends a frame to the gif.
@@ -102,17 +103,12 @@ public class GifWriter {
      */
     public void appendFrame(BufferedImage image, long duration) throws IOException {
         ensureImageSize(image);
-        int[] rgbData = image.getRGB(
-              START_OFFSET,
-              START_OFFSET,
-              width,
-              height,
-              null,
-              START_OFFSET,
-              width);
+        // Reuse the pixel buffer across frames. Frame dimensions are fixed after the first frame
+        // (ensureImageSize enforces this), so the same int[] is valid for every frame and avoids
+        // allocating a full width*height array per frame on this hot path.
+        rgbData = image.getRGB(START_OFFSET, START_OFFSET, width, height, rgbData, START_OFFSET, width);
         getEncoder().addImage(rgbData, width, getImageOptions(duration));
-        LOGGER.info("Appended frame with duration {} ms, image size: {}x{}",
-              duration, width, height);
+        LOGGER.debug("Appended frame with duration {} ms, image size: {}x{}", duration, width, height);
     }
 
     private ImageOptions getImageOptions(long duration) {

--- a/megamek/src/megamek/utilities/GifWriterThread.java
+++ b/megamek/src/megamek/utilities/GifWriterThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -35,8 +35,8 @@ package megamek.utilities;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-import java.util.Deque;
-import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -57,10 +57,13 @@ public class GifWriterThread extends Thread {
     private record Frame(BufferedImage image, long duration) {
     }
 
+    /** Caps queued frames so a slow encoder applies backpressure instead of growing memory without bound. */
+    private static final int MAX_PENDING_FRAMES = 32;
+
     private final GifWriter gifWriter;
-    private final Deque<Frame> imageDeque = new ConcurrentLinkedDeque<>();
-    private boolean isLive = true;
-    private boolean forceInterrupt = false;
+    private final BlockingQueue<Frame> frameQueue = new LinkedBlockingQueue<>(MAX_PENDING_FRAMES);
+    private volatile boolean isLive = true;
+    private volatile boolean forceInterrupt = false;
     public static final String CG_FILE_EXTENSION_GIF = ".gif";
     public static final String CG_FILE_PATH_GIF = "gif";
 
@@ -82,9 +85,15 @@ public class GifWriterThread extends Thread {
      * @param durationMillis the frame duration in milliseconds
      */
     public void addFrame(BufferedImage image, long durationMillis) {
-        synchronized (this) {
-            imageDeque.add(new Frame(image, durationMillis));
-            notifyAll();
+        if (!isLive) {
+            return;
+        }
+        try {
+            // Blocks only if the encoder has fallen MAX_PENDING_FRAMES behind; normally returns immediately.
+            // Crucially, the producer no longer waits on a lock the encoder holds during a frame.
+            frameQueue.put(new Frame(image, durationMillis));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -92,27 +101,18 @@ public class GifWriterThread extends Thread {
     public void run() {
         try {
             while (isLive) {
-                try {
-                    synchronized (this) {
-                        while (imageDeque.isEmpty() && gifWriter.isLive() && isLive) {
-                            wait();
-                        }
-                        if (!gifWriter.isLive()) {
-                            break;
-                        }
-                        Frame frame = imageDeque.pollFirst();
-                        if (frame == null) {
-                            continue;
-                        }
-                        gifWriter.appendFrame(frame.image(), frame.duration());
-                    }
-                } catch (InterruptedException | IOException e) {
-                    break;
-                }
+                // take() blocks without holding any lock, so the encode below never stalls addFrame().
+                Frame frame = frameQueue.take();
+                gifWriter.appendFrame(frame.image(), frame.duration());
             }
+        } catch (InterruptedException e) {
+            // Stop requested while waiting for or encoding a frame.
+            Thread.currentThread().interrupt();
+        } catch (IOException e) {
+            LOGGER.error(e, "Error appending frame to GIF");
         } finally {
             gifWriter.close();
-            imageDeque.clear();
+            frameQueue.clear();
             if (!forceInterrupt) {
                 try {
                     saveGifNag();

--- a/megamek/unittests/megamek/utilities/GifWriterThreadTest.java
+++ b/megamek/unittests/megamek/utilities/GifWriterThreadTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.utilities;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.awt.image.BufferedImage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link GifWriterThread}'s producer/consumer behavior.
+ */
+class GifWriterThreadTest {
+
+    /**
+     * Regression guard: the producer ({@code addFrame}) must not block while the consumer is busy
+     * encoding a frame. The old implementation held a lock across the encode, so the game thread
+     * stalled on every frame. With a bounded queue the producer only blocks if the encoder falls far
+     * behind, never for a single in-progress encode.
+     */
+    @Test
+    void testAddFrameDoesNotBlockWhileEncoding() throws Exception {
+        CountDownLatch encodingStarted = new CountDownLatch(1);
+        CountDownLatch releaseEncode = new CountDownLatch(1);
+
+        GifWriter gifWriter = mock(GifWriter.class);
+        // Make the first encode block until the test releases it, simulating a slow frame.
+        doAnswer(invocation -> {
+            encodingStarted.countDown();
+            releaseEncode.await(5, TimeUnit.SECONDS);
+            return null;
+        }).when(gifWriter).appendFrame(any(), anyLong());
+
+        GifWriterThread thread = new GifWriterThread(gifWriter, "test-gif-thread");
+        thread.start();
+        try {
+            BufferedImage frame = new BufferedImage(2, 2, BufferedImage.TYPE_INT_ARGB);
+
+            // First frame: the consumer picks it up and blocks inside the (mocked) encode.
+            thread.addFrame(frame, 100);
+            assertTrue(encodingStarted.await(2, TimeUnit.SECONDS), "Encoder should have started");
+
+            // Second frame while the encoder is blocked: this call must return promptly.
+            long startNanos = System.nanoTime();
+            thread.addFrame(frame, 100);
+            long elapsedMillis = (System.nanoTime() - startNanos) / 1_000_000;
+            assertTrue(elapsedMillis < 1000,
+                  "addFrame must not block while a frame is encoding (took " + elapsedMillis + " ms)");
+        } finally {
+            releaseEncode.countDown();
+            // forceInterrupt = true skips the interactive save dialog in the thread's shutdown path.
+            thread.stopThread(true);
+            thread.join(5000);
+        }
+    }
+}

--- a/megamek/unittests/megamek/utilities/GifWriterThreadTest.java
+++ b/megamek/unittests/megamek/utilities/GifWriterThreadTest.java
@@ -33,6 +33,7 @@
 
 package megamek.utilities;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -89,6 +90,7 @@ class GifWriterThreadTest {
             // forceInterrupt = true skips the interactive save dialog in the thread's shutdown path.
             thread.stopThread(true);
             thread.join(5000);
+            assertFalse(thread.isAlive(), "GifWriterThread should terminate within the join timeout");
         }
     }
 }


### PR DESCRIPTION
## Summary

Make the game-summary GIF writer faster and lighter. JFR profiling of a live game (2026-06-21) found the writer stalled the game thread on every frame and allocated a fresh pixel buffer per frame. This PR fixes both. GIF output is unchanged.

This is separate from the multi-writer crash fix in #8380.

Fixes #8389

## Changes Made

- **EDT stall** (`GifWriterThread`): The old code shared one lock between `addFrame` and the encoder, and the encoder held it across each encode. The game thread waited for the slow encode every frame. Now frames hand off through a bounded `LinkedBlockingQueue` (cap 32). The producer blocks only if the encoder falls 32 frames behind.
- **Per-frame allocation** (`GifWriter`): `appendFrame` built a new `int[width*height]` every frame. Dimensions are fixed after the first frame, so it now reuses one buffer.
- **Logging**: per-frame line dropped from `info` to `debug`.

## Changes

1. **GifWriterThread.java** - Bounded queue hand-off; `isLive`/`forceInterrupt` made `volatile`.
2. **GifWriter.java** - Reuse one pixel buffer across frames; log line to debug.
3. **GifWriterThreadTest.java** (NEW) - Regression guard for the EDT stall.

## Files Changed

- `megamek/src/megamek/utilities/GifWriterThread.java` - Bounded queue producer/consumer
- `megamek/src/megamek/utilities/GifWriter.java` - Reuse pixel buffer
- `megamek/unittests/megamek/utilities/GifWriterThreadTest.java` - NEW: addFrame does not block while encoder is busy

## Testing

- Unit test: `GifWriterThreadTest.testAddFrameDoesNotBlockWhileEncoding` mocks a slow encode and asserts the second `addFrame` returns fast.
- Manual: ran a battle with the summary GIF on; confirmed the GIF saves and plays back correctly.
