### PR TITLE
Fix VTOL Mast Mount spotting and Ruler display (Fixes #8385)

### DIFF
--- a/megamek/resources/megamek/client/messages.properties
+++ b/megamek/resources/megamek/client/messages.properties
@@ -4282,6 +4282,7 @@ Ruler.attackerPOV=Attacker POV
 Ruler.targetPOV=Target POV
 Ruler.povFormat={0} POV
 Ruler.terrainClear=Clear
+Ruler.mastMount=(Mast Mount)
 Ruler.lock=Lock
 Ruler.lockTooltip=When set, clicks update only the other point. Click again or click the other lock to unlock.
 Ruler.Start=Start:

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/LOSDiagramData.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/LOSDiagramData.java
@@ -63,6 +63,16 @@ import megamek.common.board.Coords;
  *                           hatches the lower endpoint's hex column as a marker
  * @param deadZoneVictimPos  the lower-elevation endpoint - the unit sitting inside the dead-zone shadow.
  *                           {@code null} when {@code deadZone} is false
+ * @param attackerHasMastMount whether the attacker is a VTOL with a working Mast Mount. The Mast Mount raises
+ *                             onboard sensors by 1 level for spotting only (TacOps), so the diagram draws a
+ *                             "+1 spotting eye" marker one level above the attacker silhouette
+ * @param targetHasMastMount   whether the target is a VTOL with a working Mast Mount (same marker as the attacker)
+ * @param attackerSpottingClear whether the attacker, spotting from its +1 Mast Mount elevation, has clear LOS to
+ *                              the target. Colors the attacker's eye marker. Meaningful only when
+ *                              {@code attackerHasMastMount} is true
+ * @param targetSpottingClear  whether the target, spotting from its +1 Mast Mount elevation, has clear LOS to the
+ *                             attacker. Colors the target's eye marker. Meaningful only when
+ *                             {@code targetHasMastMount} is true
  */
 record LOSDiagramData(
       List<HexRow> hexPath,
@@ -81,7 +91,11 @@ record LOSDiagramData(
       String targetName,
       LosRuleMode losRuleMode,
       boolean deadZone,
-      @Nullable Coords deadZoneVictimPos
+      @Nullable Coords deadZoneVictimPos,
+      boolean attackerHasMastMount,
+      boolean targetHasMastMount,
+      boolean attackerSpottingClear,
+      boolean targetSpottingClear
 ) {
 
     /**

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/LOSDiagramDataBuilder.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/LOSDiagramDataBuilder.java
@@ -75,7 +75,9 @@ final class LOSDiagramDataBuilder {
           DiagramUnitType attackerUnitType, DiagramUnitType targetUnitType,
           boolean attackerAtAltitude, boolean targetAtAltitude,
           String attackerName, String targetName,
-          LosRuleMode losRuleMode) {
+          LosRuleMode losRuleMode,
+          boolean attackerHasMastMount, boolean targetHasMastMount,
+          boolean attackerSpottingClear, boolean targetSpottingClear) {
         LosEffects losEffects = LosEffects.calculateLos(game, attackInfo);
         boolean losBlocked = !losEffects.canSee();
 
@@ -84,7 +86,9 @@ final class LOSDiagramDataBuilder {
               attackerUnitType, targetUnitType,
               attackerAtAltitude, targetAtAltitude,
               attackerName, targetName,
-              losRuleMode);
+              losRuleMode,
+              attackerHasMastMount, targetHasMastMount,
+              attackerSpottingClear, targetSpottingClear);
     }
 
     /**
@@ -101,7 +105,9 @@ final class LOSDiagramDataBuilder {
           DiagramUnitType attackerUnitType, DiagramUnitType targetUnitType,
           boolean attackerAtAltitude, boolean targetAtAltitude,
           String attackerName, String targetName,
-          LosRuleMode losRuleMode) {
+          LosRuleMode losRuleMode,
+          boolean attackerHasMastMount, boolean targetHasMastMount,
+          boolean attackerSpottingClear, boolean targetSpottingClear) {
         Board board = game.getBoard();
         Coords attackPos = attackInfo.attackPos;
         Coords targetPos = attackInfo.targetPos;
@@ -222,7 +228,11 @@ final class LOSDiagramDataBuilder {
               targetName,
               losRuleMode,
               deadZone,
-              deadZoneVictimPos
+              deadZoneVictimPos,
+              attackerHasMastMount,
+              targetHasMastMount,
+              attackerSpottingClear,
+              targetSpottingClear
         );
     }
 

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/LOSElevationDiagramPanel.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/LOSElevationDiagramPanel.java
@@ -251,9 +251,13 @@ class LOSElevationDiagramPanel extends JPanel {
         }
 
         int scaledMinHexWidth = UIUtil.scaleForGUI(MIN_HEX_WIDTH);
-        int scaledLeftMargin = UIUtil.scaleForGUI(LEFT_MARGIN);
         int scaledRightMargin = UIUtil.scaleForGUI(RIGHT_MARGIN);
         int hexCount = diagramData.hexPath().size();
+
+        // Match the dynamic left gutter the renderer uses, so a gutter widened for tall/negative labels
+        // doesn't push content past the preferred width and clip the right side inside the scroll pane.
+        LevelRange range = computeLevelRange(diagramData.hexPath());
+        int scaledLeftMargin = computeLeftMargin(range.minLevel(), range.maxLevel());
         int neededWidth = scaledLeftMargin + (hexCount * scaledMinHexWidth) + scaledRightMargin;
 
         // Only set preferred width if content is wider than the parent would give us
@@ -276,7 +280,7 @@ class LOSElevationDiagramPanel extends JPanel {
             g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 
             List<HexRow> hexPath = diagramData.hexPath();
-            DiagramMetrics metrics = calculateMetrics(hexPath, axisLabelFontMetrics());
+            DiagramMetrics metrics = calculateMetrics(hexPath);
 
             drawGrid(g2d, metrics);
             drawSkyGradient(g2d, metrics, hexPath);
@@ -317,23 +321,55 @@ class LOSElevationDiagramPanel extends JPanel {
         return getFontMetrics(getFont().deriveFont(UIUtil.scaleForGUI(AXIS_LABEL_FONT_SIZE)));
     }
 
+    /** Vertical display range (in levels) and clip flags derived from the diagram data. */
+    private record LevelRange(int minLevel, int maxLevel, int actualMinLevel, int actualMaxLevel,
+          boolean clippedTop, boolean clippedBottom) { }
+
     /**
      * Calculates rendering metrics (scale, offsets) for the current panel size and data. The left gutter is widened
      * when the level labels are wider than the default margin so they are not clipped at the left edge.
      */
-    private DiagramMetrics calculateMetrics(List<HexRow> hexPath, FontMetrics axisFontMetrics) {
-        int scaledLeftMargin = UIUtil.scaleForGUI(LEFT_MARGIN);
+    private DiagramMetrics calculateMetrics(List<HexRow> hexPath) {
         int scaledRightMargin = UIUtil.scaleForGUI(RIGHT_MARGIN);
         int scaledTopMargin = UIUtil.scaleForGUI(TOP_MARGIN);
         int scaledBottomMargin = UIUtil.scaleForGUI(BOTTOM_MARGIN);
 
-        int drawAreaWidth = getWidth() - scaledLeftMargin - scaledRightMargin;
-        int drawAreaHeight = getHeight() - scaledTopMargin - scaledBottomMargin;
-
         int hexCount = hexPath.size();
         int scaledMinHexWidth = UIUtil.scaleForGUI(MIN_HEX_WIDTH);
+
+        LevelRange range = computeLevelRange(hexPath);
+        int minLevel = range.minLevel();
+        int maxLevel = range.maxLevel();
+
+        // Left gutter sized to the widest axis label so negative/multi-digit levels aren't clipped. The same
+        // value feeds updatePreferredWidth() so the scroll pane reserves enough width and the right side of
+        // the diagram is not clipped when the gutter grows.
+        int scaledLeftMargin = computeLeftMargin(minLevel, maxLevel);
+
+        int drawAreaWidth = getWidth() - scaledLeftMargin - scaledRightMargin;
+        int drawAreaHeight = getHeight() - scaledTopMargin - scaledBottomMargin;
         int hexColumnWidth = Math.max(scaledMinHexWidth, drawAreaWidth / Math.max(hexCount, 1));
 
+        int levelRange = Math.max(maxLevel - minLevel, 1);
+        double levelHeight = (double) drawAreaHeight / levelRange;
+
+        return new DiagramMetrics(
+              scaledLeftMargin, scaledTopMargin,
+              drawAreaWidth, drawAreaHeight,
+              hexColumnWidth, levelHeight,
+              minLevel, maxLevel, hexCount,
+              range.clippedTop(), range.clippedBottom(),
+              range.actualMinLevel(), range.actualMaxLevel(),
+              diagramData.attackerAtAltitude(), diagramData.targetAtAltitude()
+        );
+    }
+
+    /**
+     * Computes the vertical level range to display, capped at {@link #MAX_DISPLAY_RANGE} and centered on the ground
+     * units when the natural range is too large. Shared by {@link #calculateMetrics} (rendering) and
+     * {@link #updatePreferredWidth} (scroll sizing) so both agree on the range and the resulting gutter width.
+     */
+    private LevelRange computeLevelRange(List<HexRow> hexPath) {
         // Find elevation range across all hexes, units, and LOS line
         int minLevel = Integer.MAX_VALUE;
         int maxLevel = Integer.MIN_VALUE;
@@ -416,33 +452,21 @@ class LOSElevationDiagramPanel extends JPanel {
             clippedTop = true;
         }
 
-        // Widen the left gutter when the level labels are wider than the default margin (negative levels or
-        // 2-3 digit elevations). The labels are right-aligned into the gutter at (leftMargin - labelWidth - 4),
-        // so the gutter must hold the widest label plus that offset, otherwise it clips at the left edge.
-        // Recompute the dependent column width when the margin grows. minLevel/maxLevel are a safe upper bound
-        // for the widest drawn label (the padding levels at the extremes are not labeled).
+        return new LevelRange(minLevel, maxLevel, actualMinLevel, actualMaxLevel, clippedTop, clippedBottom);
+    }
+
+    /**
+     * Returns the left gutter width, widened beyond {@link #LEFT_MARGIN} when the level labels (negative or
+     * multi-digit) would otherwise clip at the left edge. The labels are right-aligned into the gutter at
+     * (leftMargin - labelWidth - 4), so it must hold the widest label plus that offset. {@code minLevel}/
+     * {@code maxLevel} are a safe upper bound for the widest drawn label (the padding levels are not labeled).
+     */
+    private int computeLeftMargin(int minLevel, int maxLevel) {
+        FontMetrics axisFontMetrics = axisLabelFontMetrics();
         int widestLabelWidth = Math.max(
               axisFontMetrics.stringWidth(String.valueOf(minLevel)),
               axisFontMetrics.stringWidth(String.valueOf(maxLevel)));
-        int neededLeftMargin = widestLabelWidth + UIUtil.scaleForGUI(8);
-        if (neededLeftMargin > scaledLeftMargin) {
-            scaledLeftMargin = neededLeftMargin;
-            drawAreaWidth = getWidth() - scaledLeftMargin - scaledRightMargin;
-            hexColumnWidth = Math.max(scaledMinHexWidth, drawAreaWidth / Math.max(hexCount, 1));
-        }
-
-        int levelRange = Math.max(maxLevel - minLevel, 1);
-        double levelHeight = (double) drawAreaHeight / levelRange;
-
-        return new DiagramMetrics(
-              scaledLeftMargin, scaledTopMargin,
-              drawAreaWidth, drawAreaHeight,
-              hexColumnWidth, levelHeight,
-              minLevel, maxLevel, hexCount,
-              clippedTop, clippedBottom,
-              actualMinLevel, actualMaxLevel,
-              attackerIsAltitude, targetIsAltitude
-        );
+        return Math.max(UIUtil.scaleForGUI(LEFT_MARGIN), widestLabelWidth + UIUtil.scaleForGUI(8));
     }
 
     /**
@@ -2432,7 +2456,7 @@ class LOSElevationDiagramPanel extends JPanel {
         }
 
         List<HexRow> hexPath = diagramData.hexPath();
-        DiagramMetrics metrics = calculateMetrics(hexPath, axisLabelFontMetrics());
+        DiagramMetrics metrics = calculateMetrics(hexPath);
 
         int hexIndex = (mouseX - metrics.leftMargin) / metrics.hexColumnWidth;
         if (hexIndex < 0 || hexIndex >= hexPath.size()) {

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/LOSElevationDiagramPanel.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/LOSElevationDiagramPanel.java
@@ -77,6 +77,9 @@ class LOSElevationDiagramPanel extends JPanel {
     private static final int LEVEL_PADDING = 2;
     private static final int MAX_DISPLAY_RANGE = 40;
 
+    /** Point size (before GUI scaling) of the elevation axis level labels. */
+    private static final float AXIS_LABEL_FONT_SIZE = 10.0f;
+
 
     private static final Color COLOR_GROUND = new Color(139, 119, 101);
     private static final Color COLOR_GROUND_OUTLINE = new Color(100, 80, 60);
@@ -114,6 +117,13 @@ class LOSElevationDiagramPanel extends JPanel {
     private static final float[] DASH_PATTERN = { 6.0f, 4.0f };
     private static final Stroke STROKE_SPLIT = new BasicStroke(
           1.0f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER, 10.0f, DASH_PATTERN, 0.0f);
+
+    /** Dotted stroke for the VTOL Mast Mount "antenna" between the unit top and its +1 sensor eye marker. */
+    private static final Stroke STROKE_MAST_MOUNT = new BasicStroke(
+          1.0f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND, 10.0f, new float[] { 2.0f, 2.0f }, 0.0f);
+
+    /** Half-size of the Mast Mount "+1 spotting eye" diamond marker, in unscaled pixels. */
+    private static final int MAST_MOUNT_EYE_RADIUS = 5;
 
     /** Width of the unit silhouette as a fraction of the hex column width. */
     private static final float SILHOUETTE_WIDTH_FACTOR = 0.7f;
@@ -266,7 +276,7 @@ class LOSElevationDiagramPanel extends JPanel {
             g2d.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 
             List<HexRow> hexPath = diagramData.hexPath();
-            DiagramMetrics metrics = calculateMetrics(hexPath);
+            DiagramMetrics metrics = calculateMetrics(hexPath, axisLabelFontMetrics());
 
             drawGrid(g2d, metrics);
             drawSkyGradient(g2d, metrics, hexPath);
@@ -300,9 +310,18 @@ class LOSElevationDiagramPanel extends JPanel {
     }
 
     /**
-     * Calculates rendering metrics (scale, offsets) for the current panel size and data.
+     * Returns the font metrics for the elevation axis level labels, used both to draw the labels and to size the
+     * left gutter so wide labels (negative or multi-digit levels) are not clipped.
      */
-    private DiagramMetrics calculateMetrics(List<HexRow> hexPath) {
+    private FontMetrics axisLabelFontMetrics() {
+        return getFontMetrics(getFont().deriveFont(UIUtil.scaleForGUI(AXIS_LABEL_FONT_SIZE)));
+    }
+
+    /**
+     * Calculates rendering metrics (scale, offsets) for the current panel size and data. The left gutter is widened
+     * when the level labels are wider than the default margin so they are not clipped at the left edge.
+     */
+    private DiagramMetrics calculateMetrics(List<HexRow> hexPath, FontMetrics axisFontMetrics) {
         int scaledLeftMargin = UIUtil.scaleForGUI(LEFT_MARGIN);
         int scaledRightMargin = UIUtil.scaleForGUI(RIGHT_MARGIN);
         int scaledTopMargin = UIUtil.scaleForGUI(TOP_MARGIN);
@@ -397,6 +416,21 @@ class LOSElevationDiagramPanel extends JPanel {
             clippedTop = true;
         }
 
+        // Widen the left gutter when the level labels are wider than the default margin (negative levels or
+        // 2-3 digit elevations). The labels are right-aligned into the gutter at (leftMargin - labelWidth - 4),
+        // so the gutter must hold the widest label plus that offset, otherwise it clips at the left edge.
+        // Recompute the dependent column width when the margin grows. minLevel/maxLevel are a safe upper bound
+        // for the widest drawn label (the padding levels at the extremes are not labeled).
+        int widestLabelWidth = Math.max(
+              axisFontMetrics.stringWidth(String.valueOf(minLevel)),
+              axisFontMetrics.stringWidth(String.valueOf(maxLevel)));
+        int neededLeftMargin = widestLabelWidth + UIUtil.scaleForGUI(8);
+        if (neededLeftMargin > scaledLeftMargin) {
+            scaledLeftMargin = neededLeftMargin;
+            drawAreaWidth = getWidth() - scaledLeftMargin - scaledRightMargin;
+            hexColumnWidth = Math.max(scaledMinHexWidth, drawAreaWidth / Math.max(hexCount, 1));
+        }
+
         int levelRange = Math.max(maxLevel - minLevel, 1);
         double levelHeight = (double) drawAreaHeight / levelRange;
 
@@ -417,7 +451,7 @@ class LOSElevationDiagramPanel extends JPanel {
     private void drawGrid(Graphics2D g2d, DiagramMetrics metrics) {
         g2d.setStroke(STROKE_GRID);
         g2d.setColor(getGridColor());
-        Font labelFont = g2d.getFont().deriveFont(UIUtil.scaleForGUI(10.0f));
+        Font labelFont = g2d.getFont().deriveFont(UIUtil.scaleForGUI(AXIS_LABEL_FONT_SIZE));
         g2d.setFont(labelFont);
         FontMetrics fontMetrics = g2d.getFontMetrics();
 
@@ -1181,6 +1215,9 @@ class LOSElevationDiagramPanel extends JPanel {
             drawUnitSilhouette(g2d, metrics, 0, attackerBottom, attackerTop,
                   RulerDialog.color1,
                   diagramData.attackerUnitType(), true);
+            if (diagramData.attackerHasMastMount()) {
+                drawMastMountEye(g2d, metrics, 0, attackerTop, diagramData.attackerSpottingClear());
+            }
         }
 
         // Target silhouette
@@ -1195,7 +1232,46 @@ class LOSElevationDiagramPanel extends JPanel {
             drawUnitSilhouette(g2d, metrics, hexPath.size() - 1, targetBottom, targetTop,
                   RulerDialog.color2,
                   diagramData.targetUnitType(), false);
+            if (diagramData.targetHasMastMount()) {
+                drawMastMountEye(g2d, metrics, hexPath.size() - 1, targetTop,
+                      diagramData.targetSpottingClear());
+            }
         }
+    }
+
+    /**
+     * Draws a VTOL Mast Mount "+1 spotting eye": a small diamond marker one level above the unit silhouette, joined
+     * to the unit top by a short dotted antenna. The Mast Mount raises onboard sensors by 1 level for spotting only
+     * (TacOps), so this marks the elevation the unit actually sees from when spotting. The marker is green when the
+     * unit has clear spotting LOS to the other endpoint from the raised eye, red when blocked. The direct-fire LOS
+     * line is drawn separately and is unaffected.
+     *
+     * @param hexIndex      the hex column the unit occupies
+     * @param unitTopLevel  the unit silhouette top elevation (its absolute height)
+     * @param spottingClear whether spotting LOS from the +1 eye to the other endpoint is clear
+     */
+    private void drawMastMountEye(Graphics2D g2d, DiagramMetrics metrics, int hexIndex,
+          int unitTopLevel, boolean spottingClear) {
+        int xCenter = metrics.leftMargin + (hexIndex * metrics.hexColumnWidth)
+              + (metrics.hexColumnWidth / 2);
+        int yUnitTop = metrics.levelToY(unitTopLevel);
+        int yEye = metrics.levelToY(unitTopLevel + 1);
+        Color eyeColor = spottingClear ? COLOR_LOS_CLEAR : COLOR_LOS_BLOCKED;
+
+        // Dotted antenna from the unit top up to the raised sensor eye.
+        Stroke oldStroke = g2d.getStroke();
+        g2d.setColor(eyeColor);
+        g2d.setStroke(STROKE_MAST_MOUNT);
+        g2d.drawLine(xCenter, yUnitTop, xCenter, yEye);
+        g2d.setStroke(oldStroke);
+
+        // Diamond marker at the +1 sensor eye elevation.
+        int half = Math.max(UIUtil.scaleForGUI(MAST_MOUNT_EYE_RADIUS), 3);
+        int[] xPoints = { xCenter, xCenter + half, xCenter, xCenter - half };
+        int[] yPoints = { yEye - half, yEye, yEye + half, yEye };
+        g2d.fillPolygon(xPoints, yPoints, 4);
+        g2d.setColor(eyeColor.darker());
+        g2d.drawPolygon(xPoints, yPoints, 4);
     }
 
     /**
@@ -2356,7 +2432,7 @@ class LOSElevationDiagramPanel extends JPanel {
         }
 
         List<HexRow> hexPath = diagramData.hexPath();
-        DiagramMetrics metrics = calculateMetrics(hexPath);
+        DiagramMetrics metrics = calculateMetrics(hexPath, axisLabelFontMetrics());
 
         int hexIndex = (mouseX - metrics.leftMargin) / metrics.hexColumnWidth;
         if (hexIndex < 0 || hexIndex >= hexPath.size()) {

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/RulerDialog.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/RulerDialog.java
@@ -1179,16 +1179,19 @@ public class RulerDialog extends JDialog implements BoardViewListener {
         // Pass the active LOS rule through to the diagram so it can pick the matching line shape and overlays.
         LosRuleMode losRuleMode = LosRuleMode.fromGameOptions(game);
 
-        // VTOL Mast Mount: detect it on each endpoint and pre-compute the spotting LOS (spotting=true applies
-        // the +1 sensor elevation per TacOps), so the diagram draws a "+1 spotting eye" marker colored by
-        // whether that unit can spot the other from the raised elevation. The main direct-fire LOS line is
-        // unaffected - the Mast Mount never helps direct fire over cover.
+        // VTOL Mast Mount marker: only on the entity-based path (entityLosBlocked != null), where the diagram
+        // uses the units' real heights, so the "+1 spotting eye" stays consistent with the drawn LOS. The
+        // manual/spinner-override path has no real entity heights to reason about. Never surface it for a
+        // sensor return - that would leak hidden equipment under double-blind, matching the POV-label gating.
+        // The spotting LOS (spotting=true applies the +1 sensor elevation per TacOps) colors the marker;
+        // the main direct-fire LOS line is unaffected (a Mast Mount never helps direct fire over cover).
+        boolean entityPath = (entityLosBlocked != null);
         Entity attackerEntity = getSelectedEntity(flip);
         Entity targetEntity = getSelectedEntity(!flip);
-        boolean attackerHasMastMount = (attackerEntity != null)
-              && attackerEntity.hasWorkingMisc(MiscType.F_MAST_MOUNT);
-        boolean targetHasMastMount = (targetEntity != null)
-              && targetEntity.hasWorkingMisc(MiscType.F_MAST_MOUNT);
+        boolean attackerHasMastMount = entityPath && (attackerEntity != null)
+              && !isSensorReturn(attackerEntity) && attackerEntity.hasWorkingMisc(MiscType.F_MAST_MOUNT);
+        boolean targetHasMastMount = entityPath && (targetEntity != null)
+              && !isSensorReturn(targetEntity) && targetEntity.hasWorkingMisc(MiscType.F_MAST_MOUNT);
         boolean attackerSpottingClear = attackerHasMastMount && (targetEntity != null)
               && LosEffects.calculateLOS(game, attackerEntity, targetEntity, true).canSee();
         boolean targetSpottingClear = targetHasMastMount && (attackerEntity != null)

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/RulerDialog.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/RulerDialog.java
@@ -62,6 +62,7 @@ import megamek.client.ui.clientGUI.GUIPreferences;
 import megamek.client.ui.util.UIUtil;
 import megamek.common.Hex;
 import megamek.common.LosEffects;
+import megamek.common.equipment.MiscType;
 import megamek.common.Player;
 import megamek.common.board.Board;
 import megamek.common.board.Coords;
@@ -648,10 +649,12 @@ public class RulerDialog extends JDialog implements BoardViewListener {
         String targetName = unitOrTerrainNameFor(!attackerIsFirst);
 
         if (attackerPovLabel != null) {
-            attackerPovLabel.setText(formatPovLabel(attackerName, true) + ":");
+            attackerPovLabel.setText(
+                  formatPovLabel(decorateWithMastMount(attackerName, attackerIsFirst), true) + ":");
         }
         if (targetPovLabel != null) {
-            targetPovLabel.setText(formatPovLabel(targetName, false) + ":");
+            targetPovLabel.setText(
+                  formatPovLabel(decorateWithMastMount(targetName, !attackerIsFirst), false) + ":");
         }
 
         String attackerHeader = (attackerName != null)
@@ -697,6 +700,28 @@ public class RulerDialog extends JDialog implements BoardViewListener {
         }
         Coords coords = isFirstPoint ? start : end;
         return describeHexTerrain(coords);
+    }
+
+    /**
+     * Appends a localized "(Mast Mount)" marker to a POV name when that endpoint's unit is a VTOL with a working
+     * Mast Mount whose identity is visible (not a sensor return). Returns {@code name} unchanged otherwise, including
+     * when it is null, so the generic POV fallback still applies.
+     */
+    private String decorateWithMastMount(String name, boolean isFirstPoint) {
+        if (name == null || !hasVisibleMastMount(isFirstPoint)) {
+            return name;
+        }
+        return name + " " + Messages.getString("Ruler.mastMount");
+    }
+
+    /**
+     * Returns whether the unit selected at the given point is a VTOL with a working Mast Mount and a visible identity.
+     * Sensor returns hide equipment, matching how the unit short name is hidden for them.
+     */
+    private boolean hasVisibleMastMount(boolean isFirstPoint) {
+        Entity entity = getSelectedEntity(isFirstPoint);
+        return (entity != null) && !isSensorReturn(entity)
+              && entity.hasWorkingMisc(MiscType.F_MAST_MOUNT);
     }
 
     /**
@@ -1154,19 +1179,38 @@ public class RulerDialog extends JDialog implements BoardViewListener {
         // Pass the active LOS rule through to the diagram so it can pick the matching line shape and overlays.
         LosRuleMode losRuleMode = LosRuleMode.fromGameOptions(game);
 
+        // VTOL Mast Mount: detect it on each endpoint and pre-compute the spotting LOS (spotting=true applies
+        // the +1 sensor elevation per TacOps), so the diagram draws a "+1 spotting eye" marker colored by
+        // whether that unit can spot the other from the raised elevation. The main direct-fire LOS line is
+        // unaffected - the Mast Mount never helps direct fire over cover.
+        Entity attackerEntity = getSelectedEntity(flip);
+        Entity targetEntity = getSelectedEntity(!flip);
+        boolean attackerHasMastMount = (attackerEntity != null)
+              && attackerEntity.hasWorkingMisc(MiscType.F_MAST_MOUNT);
+        boolean targetHasMastMount = (targetEntity != null)
+              && targetEntity.hasWorkingMisc(MiscType.F_MAST_MOUNT);
+        boolean attackerSpottingClear = attackerHasMastMount && (targetEntity != null)
+              && LosEffects.calculateLOS(game, attackerEntity, targetEntity, true).canSee();
+        boolean targetSpottingClear = targetHasMastMount && (attackerEntity != null)
+              && LosEffects.calculateLOS(game, targetEntity, attackerEntity, true).canSee();
+
         LOSDiagramData diagramData;
         if (entityLosBlocked != null) {
             // Use pre-computed entity-based LOS result (matches fire phase)
             diagramData = LOSDiagramDataBuilder.buildWithLosResult(game, attackInfo,
                   entityLosBlocked, entityDeadZone, attackerHullDown, targetHullDown,
                   attackerType, targetType, attackerIsAlt, targetIsAlt,
-                  attackerName, targetName, losRuleMode);
+                  attackerName, targetName, losRuleMode,
+                  attackerHasMastMount, targetHasMastMount,
+                  attackerSpottingClear, targetSpottingClear);
         } else {
             // Use manual AttackInfo-based LOS (scenario testing)
             diagramData = LOSDiagramDataBuilder.build(game, attackInfo,
                   attackerHullDown, targetHullDown, attackerType, targetType,
                   attackerIsAlt, targetIsAlt,
-                  attackerName, targetName, losRuleMode);
+                  attackerName, targetName, losRuleMode,
+                  attackerHasMastMount, targetHasMastMount,
+                  attackerSpottingClear, targetSpottingClear);
         }
 
         diagramPanel.setData(diagramData);

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/FiringDisplay.java
@@ -1630,7 +1630,10 @@ public class FiringDisplay extends AttackPhaseDisplay implements ListSelectionLi
         // allow spotting
         if ((attacker != null) && !attacker.isSpotting() && attacker.canSpot() && (target != null)
               && game.getOptions().booleanOption(OptionsConstants.BASE_INDIRECT_FIRE)) {
-            boolean hasLos = LosEffects.calculateLOS(game, attacker, target).canSee();
+            // Spotting LOS: pass spotting=true so a VTOL Mast Mount's +1 sensor elevation is
+            // applied (TacOps). This matches the server-side spot resolution and lets a mast-mount
+            // VTOL hovering behind cover enable the Spot button. Non-mast units are unaffected.
+            boolean hasLos = LosEffects.calculateLOS(game, attacker, target, true).canSee();
             // In double-blind, we need to "spot" the target as well as LoS
             if (hasLos
                   && game.getOptions().booleanOption(OptionsConstants.ADVANCED_DOUBLE_BLIND)

--- a/megamek/unittests/megamek/common/LosEffectsTest.java
+++ b/megamek/unittests/megamek/common/LosEffectsTest.java
@@ -47,6 +47,9 @@ import static org.mockito.Mockito.when;
 import megamek.common.board.Coords;
 import megamek.common.board.CubeCoords;
 import megamek.common.enums.BuildingType;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.EquipmentTypeLookup;
+import megamek.common.exceptions.LocationFullException;
 import megamek.common.game.Game;
 import megamek.common.options.GameOptions;
 import megamek.common.options.IOption;
@@ -58,7 +61,10 @@ import megamek.common.units.BuildingEntity;
 import megamek.common.units.Crew;
 import megamek.common.units.CrewType;
 import megamek.common.units.Entity;
+import megamek.common.units.EntityMovementMode;
 import megamek.common.units.Mek;
+import megamek.common.units.VTOL;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -207,6 +213,7 @@ public class LosEffectsTest extends GameBoardTestCase {
               hex 0105 0 "geyser:2" ""
               end"""
         );
+
     }
 
     @BeforeEach
@@ -851,6 +858,108 @@ public class LosEffectsTest extends GameBoardTestCase {
             assertNotNull(result);
             assertEquals(0, result.ultraWoods, "A target above the plume should not be engulfed");
             assertTrue(result.hasLoS, "hasLoS should be true for a target raised above the geyser plume");
+        }
+    }
+
+    /**
+     * Tests for the VTOL Mast Mount spotting rule (issue #8385). A Mast Mount treats the VTOL's onboard sensors as
+     * 1 elevation higher for spotting only (TacOps), letting a VTOL hovering behind cover spot over it. The +1 must
+     * apply only when {@code spotting} is true, and never for a unit without a working Mast Mount.
+     */
+    @Nested
+    @DisplayName("VTOL Mast Mount Spotting Tests (Issue #8385)")
+    class MastMountSpottingTests {
+        private static GameOptions mockGameOptions;
+
+        @BeforeAll
+        static void initEquipment() {
+            EquipmentType.initializeTypes();
+        }
+
+        @BeforeEach
+        void setUp() {
+            setBoard("03_BY_05_CENTER_HILLS");
+            mockGameOptions = mock(GameOptions.class);
+            game.setOptions(mockGameOptions);
+            when(mockGameOptions.booleanOption(anyString())).thenReturn(false);
+        }
+
+        private VTOL createVtol(Coords position, int elevation, boolean withMastMount) {
+            VTOL vtol = new VTOL();
+            vtol.setGame(game);
+            vtol.setChassis("Mantis");
+            vtol.setModel("ECCM");
+            vtol.setMovementMode(EntityMovementMode.VTOL);
+            vtol.setCrew(new Crew(CrewType.SINGLE));
+            vtol.setId(1);
+            vtol.setOwnerId(player.getId());
+            vtol.setPosition(position);
+            vtol.setElevation(elevation);
+            if (withMastMount) {
+                try {
+                    vtol.addEquipment(EquipmentType.get(EquipmentTypeLookup.MAST_MOUNT), VTOL.LOC_ROTOR);
+                } catch (LocationFullException exception) {
+                    throw new IllegalStateException("Could not mount Mast Mount on test VTOL", exception);
+                }
+            }
+            return vtol;
+        }
+
+        private Mek createGroundTarget(Coords position) {
+            Mek target = new BipedMek();
+            target.setGame(game);
+            target.setChassis("Target");
+            target.setModel("TGT");
+            target.setCrew(new Crew(CrewType.SINGLE));
+            target.setId(2);
+            target.setOwnerId(player.getId());
+            target.setPosition(position);
+            return target;
+        }
+
+        // Attacker fires from 0305 toward 0301 across the level-3 hill at 0303. At eye height 3 the hill
+        // strictly blocks the line; the Mast Mount's +1 spotting elevation (eye 4) clears it.
+        private static final Coords ATTACKER_POS = new Coords(0, 4);
+        private static final Coords TARGET_POS = new Coords(2, 0);
+        private static final int BLOCKED_EYE_HEIGHT = 3;
+
+        @Test
+        @DisplayName("mast-mount VTOL spotting over a level-3 hill: the +1 elevation clears the block")
+        void shouldSpotOverHill_WithMastMount() {
+            VTOL vtol = createVtol(ATTACKER_POS, 0, true);
+            Mek target = createGroundTarget(TARGET_POS);
+            game.addEntity(vtol);
+            game.addEntity(target);
+            int boardId = vtol.getBoardId();
+
+            boolean directCanSee = LosEffects.calculateLOS(game, vtol, target,
+                  ATTACKER_POS, TARGET_POS, BLOCKED_EYE_HEIGHT, boardId, false).canSee();
+            boolean spottingCanSee = LosEffects.calculateLOS(game, vtol, target,
+                  ATTACKER_POS, TARGET_POS, BLOCKED_EYE_HEIGHT, boardId, true).canSee();
+
+            assertFalse(directCanSee,
+                  "Without the spotting +1, the level-3 hill blocks the VTOL eye at height 3");
+            assertTrue(spottingCanSee,
+                  "Mast Mount +1 spotting elevation should clear the level-3 hill");
+        }
+
+        @Test
+        @DisplayName("VTOL without a mast mount is unaffected by the spotting flag")
+        void shouldNotChangeLos_WithoutMastMount() {
+            VTOL vtol = createVtol(ATTACKER_POS, 0, false);
+            Mek target = createGroundTarget(TARGET_POS);
+            game.addEntity(vtol);
+            game.addEntity(target);
+            int boardId = vtol.getBoardId();
+
+            boolean directCanSee = LosEffects.calculateLOS(game, vtol, target,
+                  ATTACKER_POS, TARGET_POS, BLOCKED_EYE_HEIGHT, boardId, false).canSee();
+            boolean spottingCanSee = LosEffects.calculateLOS(game, vtol, target,
+                  ATTACKER_POS, TARGET_POS, BLOCKED_EYE_HEIGHT, boardId, true).canSee();
+
+            assertFalse(spottingCanSee, "A plain VTOL gets no +1, so the level-3 hill still blocks it");
+            assertEquals(directCanSee, spottingCanSee,
+                  "The spotting flag must not change LOS for a unit without a Mast Mount");
         }
     }
 }


### PR DESCRIPTION
## Summary

A VTOL with a Mast Mount could not enable the Spot button even with clear line of sight. A Mast Mount raises the unit's sensors by 1 level for spotting only (TacOps). The Spot button's LOS check ignored that.

## Bug Fixed

- **Spot button**: the enable check called `LosEffects.calculateLOS` without `spotting=true`, so the Mast Mount +1 never applied. Now passes `spotting=true`. Units without a Mast Mount see no change (the flag only gates the +1).

## Changes Made

- **Ruler display**: the POV label shows "(Mast Mount)", and the diagram draws a "+1 spotting eye" marker above the VTOL — green when it can spot the other unit from the raised eye, red when blocked. The direct-fire LOS line is unchanged.
- **Elevation axis labels**: negative and 2-3 digit level labels were clipped at the left edge. The left gutter now sizes to the widest label.

## Files Changed

- `megamek/src/megamek/client/ui/panels/phaseDisplay/FiringDisplay.java` - pass spotting=true to the Spot LOS check
- `megamek/src/megamek/client/ui/clientGUI/boardview/RulerDialog.java` - POV "(Mast Mount)" label; compute mast-mount + spotting flags
- `megamek/src/megamek/client/ui/clientGUI/boardview/LOSDiagramData.java` - 4 mast-mount fields on the diagram record
- `megamek/src/megamek/client/ui/clientGUI/boardview/LOSDiagramDataBuilder.java` - pass the new fields through
- `megamek/src/megamek/client/ui/clientGUI/boardview/LOSElevationDiagramPanel.java` - draw the +1 eye marker; size the axis gutter
- `megamek/resources/megamek/client/messages.properties` - new Ruler.mastMount key
- `megamek/unittests/megamek/common/LosEffectsTest.java` - NEW: 2 Mast Mount spotting tests

## Testing

- Unit tests: 2 new cases in LosEffectsTest (mast-mount VTOL spots over a level-3 hill; plain VTOL unaffected by the spotting flag). All 25 LosEffectsTest pass. Checkstyle clean.
- Manual: confirmed the Spot button now lights for a mast-mount VTOL in-game.

Fixes #8385
