### PR TITLE
Fix NullPointerException when a unit with a null heat breakdown gains heat

### DIFF
--- a/megamek/src/megamek/common/units/Entity.java
+++ b/megamek/src/megamek/common/units/Entity.java
@@ -5619,6 +5619,11 @@ public abstract class Entity extends TurnOrdered
      *       Heat Phase report's "gains N heat" / "sinks N heat" breakdown tooltips.
      */
     public HeatBreakdown getHeatBreakdown() {
+        if (heatBreakdown == null) {
+            // A unit deserialized from a stream written before this field existed restores it as null; lazily
+            // recreate it so the documented never-null contract holds and heat sources can always be recorded.
+            heatBreakdown = new HeatBreakdown();
+        }
         return heatBreakdown;
     }
 

--- a/megamek/unittests/megamek/common/units/HeatBuildupBreakdownTest.java
+++ b/megamek/unittests/megamek/common/units/HeatBuildupBreakdownTest.java
@@ -33,12 +33,14 @@
 package megamek.common.units;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -134,6 +136,24 @@ class HeatBuildupBreakdownTest {
         assertEquals(9, mek.heatBuildup, "Heat still accrues even when no usable source label is given");
         assertTrue(mek.getHeatBreakdown().buildup().isEmpty(),
               "Zero or unlabeled contributions are not added to the itemized breakdown");
+    }
+
+    @Test
+    void nullBreakdownIsLazilyRecreatedWhenHeatIsApplied() throws Exception {
+        BipedMek mek = new BipedMek();
+        // Simulate a unit restored from a stream written before the heatBreakdown field existed: Java
+        // deserialization skips field initializers, so the field comes back null. Force that state directly.
+        Field heatBreakdownField = Entity.class.getDeclaredField("heatBreakdown");
+        heatBreakdownField.setAccessible(true);
+        heatBreakdownField.set(mek, null);
+
+        // Applying heat must not throw an NPE; the breakdown is lazily recreated and records the contribution.
+        mek.changeHeatBuildup(10, "PPC");
+
+        assertNotNull(mek.getHeatBreakdown(), "A null breakdown is lazily recreated to honor the never-null contract");
+        assertEquals(10, mek.heatBuildup, "Heat still accrues after the breakdown is recreated");
+        assertEquals(10, mek.getHeatBreakdown().buildup().get("PPC").totalHeat(),
+              "The contribution is recorded in the recreated breakdown");
     }
 
     @Test


### PR DESCRIPTION
## Root Cause
`Entity.getHeatBreakdown()` is documented never-null and is dereferenced by `changeHeatBuildup()` and `clearHeatBreakdown()`. The `heatBreakdown` field is only set by its inline initializer (`= new HeatBreakdown()`). Java deserialization restores a class's fields from the stream and **skips field initializers**, so any unit deserialized from a stream written before this field existed (older save games, cached units, cross-version clients) comes back with `heatBreakdown == null`. The first heat source applied to such a unit then throws an NPE.

Observed in a playtest during artillery fire:

```
java.lang.NullPointerException: Cannot invoke "megamek.common.units.HeatBreakdown.addBuildup(int, String)" because the return value of "megamek.common.units.Entity.getHeatBreakdown()" is null
    at megamek.common.units.Entity.changeHeatBuildup(Entity.java:5581)
    at megamek.common.weapons.handlers.WeaponHandler.addHeat(WeaponHandler.java:1957)
    at megamek.common.weapons.handlers.artillery.ArtilleryWeaponIndirectFireHandler.handle(ArtilleryWeaponIndirectFireHandler.java:111)
    at megamek.server.totalWarfare.TWGameManager.handleAttacks(TWGameManager.java:31705)
```

## Changes
1. `Entity.getHeatBreakdown()` - lazily recreate the breakdown when it is `null`, restoring the documented never-null contract so `changeHeatBuildup()` / `clearHeatBreakdown()` can always record heat. Behavior is otherwise unchanged when the field is already populated.

## Files Changed
- `megamek/src/megamek/common/units/Entity.java` - lazy-init guard in `getHeatBreakdown()`.

## Testing
- Reproduced the NPE above during artillery fire; with the guard the unit records heat normally and no NPE occurs.
- Compiles clean (`./gradlew :megamek:compileJava`).
- This is a defensive null-guard with identical behavior when the field is populated, so no game-state behavior changes (manual/observed testing per the testing matrix).