### PR TITLE
Make CubeCoords.toOffset the inverse of Coords.toCube

### DIFF
--- a/megamek/src/megamek/common/board/CubeCoords.java
+++ b/megamek/src/megamek/common/board/CubeCoords.java
@@ -69,9 +69,10 @@ public record CubeCoords(double q, double r, double s) implements Serializable {
      * @return a new Coords object with the offset coordinates
      */
     public Coords toOffset() {
-        int x = (int) q;
-        int y = (int) (r + q / 2);
-        return new Coords(x, y);
+        int offset = -1;
+        int column = (int) q;
+        int row = (int) r + (int) ((q + offset * ((int) q & 1)) / 2.0);
+        return new Coords(column, row);
     }
 
     /**

--- a/megamek/src/megamek/common/board/CubeCoords.java
+++ b/megamek/src/megamek/common/board/CubeCoords.java
@@ -71,7 +71,8 @@ public record CubeCoords(double q, double r, double s) implements Serializable {
     public Coords toOffset() {
         int offset = -1;
         int column = (int) q;
-        int row = (int) r + (int) ((q + offset * ((int) q & 1)) / 2.0);
+        int parity = column & 1;
+        int row = (int) (r + (q + offset * parity) / 2.0);
         return new Coords(column, row);
     }
 

--- a/megamek/unittests/megamek/common/board/CoordsTest.java
+++ b/megamek/unittests/megamek/common/board/CoordsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.board;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Round-trip tests for {@link Coords#toCube()}. {@code toCube()} must be the exact inverse of
+ * {@link CubeCoords#toOffset()} under the odd-q offset convention, so an offset coordinate must survive an
+ * offset -> cube -> offset round-trip unchanged. These tests use the real {@link CubeCoords} on the cube side
+ * (no mocks), because the contract being verified is precisely how the two real classes agree.
+ */
+class CoordsTest {
+
+    /** Offset coordinates spanning odd and even, positive and negative columns. */
+    static Stream<Coords> offsetCoordinates() {
+        List<Coords> coordinates = new ArrayList<>();
+        for (int column = -4; column <= 4; column++) {
+            for (int rowValue = -4; rowValue <= 4; rowValue++) {
+                coordinates.add(new Coords(column, rowValue));
+            }
+        }
+        return coordinates.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("offsetCoordinates")
+    void offsetToCubeToOffsetReturnsOriginalOffset(Coords offset) {
+        assertEquals(offset, offset.toCube().toOffset(),
+              "offset -> cube -> offset must return the same hex for " + offset);
+    }
+}

--- a/megamek/unittests/megamek/common/board/CubeCoordsTest.java
+++ b/megamek/unittests/megamek/common/board/CubeCoordsTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.board;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Round-trip tests for {@link CubeCoords#toOffset()}. {@code toOffset()} must be the exact inverse of
+ * {@link Coords#toCube()} under the odd-q offset convention, so a cube coordinate must survive a
+ * cube -> offset -> cube round-trip unchanged. These tests use the real {@link Coords} on the offset side
+ * (no mocks), because the contract being verified is precisely how the two real classes agree.
+ */
+class CubeCoordsTest {
+
+    /** Valid cube coordinates spanning odd and even, positive and negative columns. */
+    static Stream<CubeCoords> cubeCoordinates() {
+        List<CubeCoords> coordinates = new ArrayList<>();
+        for (int column = -4; column <= 4; column++) {
+            for (int rowValue = -4; rowValue <= 4; rowValue++) {
+                coordinates.add(new Coords(column, rowValue).toCube());
+            }
+        }
+        return coordinates.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("cubeCoordinates")
+    void cubeToOffsetToCubeReturnsOriginalCube(CubeCoords cube) {
+        assertEquals(cube, cube.toOffset().toCube(),
+              "cube -> offset -> cube must return the same hex for " + cube);
+    }
+
+    @Test
+    void negativeRowHexConvertsToCorrectOffset() {
+        // Regression: the old truncating formula turned (1,-1,0) into offset (1,0), a different hex.
+        assertEquals(new Coords(1, -1), new CubeCoords(1, -1, 0).toOffset());
+    }
+
+    @Test
+    void adjacentEastHexesKeepDistinctOffsets() {
+        // Regression: the old formula collapsed both of these onto offset (1,0).
+        Coords first = new CubeCoords(1, -1, 0).toOffset();
+        Coords second = new CubeCoords(1, 0, -1).toOffset();
+        assertNotEquals(first, second, "distinct cube hexes must map to distinct offset hexes");
+    }
+}

--- a/megamek/unittests/megamek/server/totalWarfare/DeploymentProcessorTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/DeploymentProcessorTest.java
@@ -43,6 +43,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
+import java.util.HashSet;
 import java.util.Vector;
 import java.util.stream.Stream;
 
@@ -284,12 +285,17 @@ public class DeploymentProcessorTest extends GameBoardTestCase {
         buildingEntity.setId(3);
         game.addEntity(buildingEntity);
 
-        // Call processDeployment
-        callProcessDeployment(buildingEntity, new Coords(0, 0));
+        // Deploy at the board centre so the whole footprint stays on the 3x3 board. At board (0,0) the
+        // west hex (1,-1,0) maps to row -1, off the board edge.
+        callProcessDeployment(buildingEntity, new Coords(1, 1));
 
         // Verify all 3 hexes have building terrain
         assertEquals(3, buildingEntity.getCoordsList().size(),
               "Building should occupy 3 hexes");
+        // The 3 footprint hexes must land on distinct board coords. The old toOffset bug collapsed
+        // (1,-1,0) and (1,0,-1) onto the same hex, which this guards against.
+        assertEquals(3, new HashSet<>(buildingEntity.getCoordsList()).size(),
+              "Building's 3 hexes must occupy distinct board coords (no overlap)");
 
         for (Coords buildingCoords : buildingEntity.getCoordsList()) {
             Hex hex = board.getHex(buildingCoords);


### PR DESCRIPTION
## Summary

`CubeCoords.toOffset()` was not the inverse of `Coords.toCube()`. It used a truncating formula that ignored odd-q column parity, so the two methods disagreed. Some cube coordinates failed a round-trip, and two different cube hexes could map to the same offset hex.

## Bug Fixed

- **toOffset odd-q parity**: the old code computed `y = (int)(r + q/2)`, which truncates toward zero and is wrong for odd or negative `q`. `Coords.toCube()` already uses the odd-q convention, so `toOffset()` was the side that was wrong.
- The fix builds the row with the same odd-q parity term `toCube()` uses, making `toOffset()` its exact inverse. Matches the odd-q formulas at redblobgames.com/grids/hexagons.

## Changes
2. **CubeCoordsTest.java** (NEW) - round-trips cube -> offset -> cube over a grid, plus regression cases for the hexes that used to break.
3. **CoordsTest.java** (NEW) - round-trips offset -> cube -> offset over a grid.

## Files Changed

- `megamek/src/megamek/common/board/CubeCoords.java` - fix `toOffset()`
- `megamek/unittests/megamek/common/board/CubeCoordsTest.java` - NEW: cube round-trip + regressions
- `megamek/unittests/megamek/common/board/CoordsTest.java` - NEW: offset round-trip

## Testing

- Both new tests use the real `Coords` and `CubeCoords` (no mocks). The old `toOffset()` fails them; the fixed one passes.
- Before/after: `(1,-1,0)` used to map to offset `(1,0)` (the same hex as `(1,0,-1)`); it now maps to `(1,-1)`.