### PR TITLE
Fix artillery scatter drifting off-line and Oblique Artilleryman negating scatter

### DIFF
--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -6467,10 +6467,14 @@ public class Compute {
     }
 
     /**
-     * scatter from a hex according, roll d6 to choose scatter direction
+     * Scatters from a hex in a random direction, rolling 1d6 to pick one of the six straight-line
+     * directions.
      *
-     * @param coords The <code>Coords</code> to scatter from
-     * @param margin the <code>int</code> margin of failure; the scatter distance is its magnitude
+     * @param coords the <code>Coords</code> to scatter from
+     * @param margin the scatter distance in hexes; its magnitude is used, so a negative value (such
+     *               as a negative margin of failure) scatters the same distance as its positive
+     *               counterpart. Callers may also pass a fixed distance unrelated to a margin of
+     *               failure.
      *
      * @return the <code>Coords</code> scattered to
      */

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -6470,13 +6470,16 @@ public class Compute {
      * scatter from a hex according, roll d6 to choose scatter direction
      *
      * @param coords The <code>Coords</code> to scatter from
-     * @param margin the <code>int</code> margin of failure, scatter distance will be the margin of failure
+     * @param margin the <code>int</code> margin of failure; the scatter distance is its magnitude
      *
      * @return the <code>Coords</code> scattered to
      */
     public static Coords scatter(Coords coords, int margin) {
         int scatterDirection = Compute.d6(1) - 1;
-        return coords.translated(scatterDirection, margin);
+        // Scatter distance is a magnitude. A negative margin would push the shot one hex off the
+        // straight-line scatter path, because Coords.translated() truncates toward zero on the
+        // diagonal directions (e.g. -5 / 2 == -2, not the floored -3).
+        return coords.translated(scatterDirection, Math.abs(margin));
     }
 
     /**

--- a/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryWeaponIndirectFireHandler.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2007-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2007-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -554,14 +554,14 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
             // direct fire artillery only scatters by one d6
             // we do this here to avoid duplicating handle()
             // in the ArtilleryWeaponDirectFireHandler
-            Coords origPos = targetPos;
-            int moF = toHit.getMoS();
-            if (attackingEntity.hasAbility("oblique_artillery")) {
-                // getMoS returns a negative MoF
-                // simple math is better so lets make it positive
-                moF = Math.max(moF + 2, 0);
+            Coords originalPosition = targetPos;
+            // getMoS() is negative on a miss; the scatter distance is its magnitude.
+            int scatterDistance = Math.abs(toHit.getMoS());
+            if (attackingEntity.hasAbility(OptionsConstants.GUNNERY_OBLIQUE_ARTILLERY)) {
+                // Oblique Artilleryman reduces scatter distance by two hexes, minimum 0 (CamOps p.78).
+                scatterDistance = Math.max(scatterDistance - 2, 0);
             }
-            targetPos = Compute.scatterDirectArty(targetPos, moF);
+            targetPos = Compute.scatterDirectArty(targetPos, scatterDistance);
             if (game.getBoard().contains(targetPos)) {
                 // misses and scatters to another hex
                 if (!isFlak) {
@@ -572,7 +572,7 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
                           + game.getPlayer(aaa.getPlayerId()).getName()
                           + ", drifted to " + targetPos.getBoardNum();
                     game.getBoard().addSpecialHexDisplay(
-                          origPos,
+                          originalPosition,
                           new SpecialHexDisplay(Type.ARTILLERY_MISS,
                                 game.getRoundCount(),
                                 game.getPlayer(aaa.getPlayerId()),
@@ -605,7 +605,7 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
                       + game.getPlayer(aaa.getPlayerId()).getName()
                       + ", drifted off the board";
                 game.getBoard().addSpecialHexDisplay(
-                      origPos,
+                      originalPosition,
                       new SpecialHexDisplay(Type.ARTILLERY_MISS,
                             game.getRoundCount(),
                             game.getPlayer(aaa.getPlayerId()),

--- a/megamek/unittests/megamek/common/ComputeTest.java
+++ b/megamek/unittests/megamek/common/ComputeTest.java
@@ -44,7 +44,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.Vector;
 
 import megamek.client.Client;
@@ -709,6 +711,37 @@ class ComputeTest {
         assertEquals(TargetRoll.IMPOSSIBLE,
               mods.getValue(),
               "Right leg-mounted weapon should be impossible to fire when prone");
+    }
+
+    @Test
+    @DisplayName("scatter stays on the straight-line path for a negative margin")
+    void scatterStaysOnStraightLineForNegativeMargin() {
+        // Regression for issues 7695 and 8227. On a miss, toHit.getMoS() is negative, and the old
+        // code passed it straight into Coords.translated(). That truncates toward zero on the four
+        // diagonal directions (e.g. -5 / 2 == -2 instead of the floored -3), so the shot landed one
+        // hex off the straight-line scatter path. scatter() now uses the magnitude, so every result
+        // must sit exactly |margin| hexes away on one of the six straight-line directions.
+        for (int startX : new int[] { 6, 7 }) { // even and odd column parity behave differently
+            Coords target = new Coords(startX, 9);
+            for (int distance : new int[] { 1, 3, 5, 6 }) {
+                Set<Coords> straightLineHexes = new HashSet<>();
+                for (int direction = 0; direction < 6; direction++) {
+                    Coords landing = target.translated(direction, distance);
+                    assertEquals(distance, target.distance(landing),
+                          "a straight-line hex must be exactly " + distance + " hexes from the target");
+                    straightLineHexes.add(landing);
+                }
+
+                for (int trial = 0; trial < 300; trial++) {
+                    Coords scattered = Compute.scatter(target, -distance);
+                    assertTrue(straightLineHexes.contains(scattered),
+                          "scatter(-" + distance + ") from " + target.getBoardNum()
+                                + " drifted off the straight line to " + scattered.getBoardNum());
+                    assertEquals(distance, target.distance(scattered),
+                          "a scattered hex must be exactly " + distance + " hexes from the target");
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Two bugs in artillery scatter, both in the same small block of code. Missed shots sometimes drifted one hex off the straight-line scatter path, and the Oblique Artilleryman ability wiped out scatter entirely instead of reducing it by 2. This fixes both.

## Bug Fixed

- **Scatter drifts one hex off the line** (#7695, #8227): when a shot misses, the margin of failure is a negative number. The old code passed that negative value straight into the hex-stepping math. Java rounds negative division toward zero (`-5 / 2 == -2`, not `-3`), so on the four diagonal directions the shot landed one hex off the straight line. North and South were never affected, which is why it only showed up sometimes.
- **Oblique Artilleryman negates scatter** (#5148): the ability is meant to reduce scatter distance by 2 hexes, minimum 0 (CamOps p.78). The old code did `Math.max(moF + 2, 0)` on a negative margin, so a margin of 5 became 0. The shot landed dead on the target hex no matter how badly it missed. The fix reduces the scatter distance by 2 from its magnitude instead.

Fixes #7695
Fixes #8227
Fixes #5148 (Partial)

## Changes

1. **Compute.java** - `scatter()` now uses the magnitude of the margin, so a negative value can no longer push the shot off the straight line. Fixes the drift for both the standard and bay artillery handlers.
2. **ArtilleryWeaponIndirectFireHandler.java** - the Oblique reduction now works on the magnitude (`max(distance - 2, 0)`). Also swapped the `"oblique_artillery"` string literal for the `OptionsConstants.GUNNERY_OBLIQUE_ARTILLERY` constant and renamed two local variables to full names.

## Files Changed

- `megamek/src/megamek/common/compute/Compute.java` - scatter distance uses the margin's magnitude
- `megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryWeaponIndirectFireHandler.java` - Oblique reduction fix + constant + rename
- `megamek/unittests/megamek/common/ComputeTest.java` - NEW test: scatter stays on a straight line for negative margins

## Testing

- Unit test: `ComputeTest.scatterStaysOnStraightLineForNegativeMargin` checks that every scattered hex lands exactly `|margin|` hexes from the target on one of the six straight-line directions, for both column parities. Fails before the fix.
- Manual (from the attached issue saves):
  - #7695 / #8227: advance to artillery landing and refire; every scatter is straight.
  - #5148: an Oblique miss now scatters by margin minus 2, instead of hitting the target hex.
  - Save and load mid-resolution with a pending artillery attack.

## Out of scope

Oblique Artilleryman also extends weapon range by 10% (CamOps p.78). That part is separately unimplemented and is not addressed here. The reported "-1 to-hit" is not a real effect of the ability and is not changed.