### PR TITLE
Add FontHandler.symbolIcon for crisp Material Symbol icons

### DIFF
--- a/megamek/src/megamek/client/ui/util/FontHandler.java
+++ b/megamek/src/megamek/client/ui/util/FontHandler.java
@@ -41,6 +41,7 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.GraphicsEnvironment;
 import java.awt.RenderingHints;
+import java.awt.font.FontRenderContext;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -124,9 +125,13 @@ public final class FontHandler {
      * @param size      the glyph height in (already scaled) pixels
      * @param color     the color to paint the glyph
      *
-     * @return an {@link Icon} drawing the glyph, or {@code null} if the symbols font cannot display the code point
+     * @return an {@link Icon} drawing the glyph, or {@code null} on invalid input (out-of-range code point, non-positive
+     *       size, or null color) or if the symbols font cannot display the code point
      */
     public static Icon symbolIcon(int codePoint, int size, Color color) {
+        if (!Character.isValidCodePoint(codePoint) || size <= 0 || color == null) {
+            return null;
+        }
         Font font = symbolFont().deriveFont((float) size);
         if (!font.canDisplay(codePoint)) {
             return null;
@@ -143,8 +148,8 @@ public final class FontHandler {
         private final Color color;
         private final int width;
         private final int height;
-        private final int drawX;
-        private final int drawY;
+        private final float drawX;
+        private final float drawY;
 
         private MaterialSymbolIcon(Font font, String glyph, Color color) {
             this.font = font;
@@ -162,23 +167,32 @@ public final class FontHandler {
             drawY = metrics.getAscent();
             // Width uses the visual (ink) bounds instead, because Material Symbols bake uneven left/right side bearing
             // into each glyph; trimming to the painted pixels lets a single icon center cleanly inside a button.
-            Rectangle2D inkBounds = font.createGlyphVector(graphics.getFontRenderContext(), glyph).getVisualBounds();
+            // Measure with fractional metrics and keep the offsets as floats, so paintIcon can position the glyph
+            // sub-pixel instead of rounding the bearing to a whole pixel (which would clip an edge or add a 1px gap).
+            FontRenderContext renderContext = new FontRenderContext(null, true, true);
+            Rectangle2D inkBounds = font.createGlyphVector(renderContext, glyph).getVisualBounds();
             width = Math.max(1, (int) Math.ceil(inkBounds.getWidth()));
             // getX() is the left bearing (offset from the pen origin to the first visible pixel); cancel it so the
             // glyph paints flush at x = 0 with no leading gap.
-            drawX = (int) Math.round(-inkBounds.getX());
+            drawX = (float) -inkBounds.getX();
             graphics.dispose();
         }
 
         @Override
         public void paintIcon(Component component, Graphics g, int x, int y) {
             Graphics2D graphics = (Graphics2D) g.create();
-            graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-            graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-            graphics.setFont(font);
-            graphics.setColor(color);
-            graphics.drawString(glyph, x + drawX, y + drawY);
-            graphics.dispose();
+            try {
+                graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+                graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+                // Match the fractional metrics used when the ink bounds were measured, so the glyph lands exactly
+                // where width/drawX expect; mismatched metrics could otherwise clip an edge or shift it a pixel.
+                graphics.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
+                graphics.setFont(font);
+                graphics.setColor(color);
+                graphics.drawString(glyph, x + drawX, y + drawY);
+            } finally {
+                graphics.dispose();
+            }
         }
 
         @Override

--- a/megamek/src/megamek/client/ui/util/FontHandler.java
+++ b/megamek/src/megamek/client/ui/util/FontHandler.java
@@ -144,18 +144,28 @@ public final class FontHandler {
         private final int width;
         private final int height;
         private final int drawX;
+        private final int drawY;
 
         private MaterialSymbolIcon(Font font, String glyph, Color color) {
             this.font = font;
             this.glyph = glyph;
             this.color = color;
 
+            // Swing needs a fixed icon size up front, so measure the glyph once and cache it. The 1x1 image only
+            // exists to obtain a real Graphics2D, and therefore accurate font metrics; nothing is ever drawn into it.
             BufferedImage scratch = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
             Graphics2D graphics = scratch.createGraphics();
             FontMetrics metrics = graphics.getFontMetrics(font);
+            // Height uses the full line metrics (ascent + descent + leading) so every icon shares one vertical box;
+            // glyphs then line up on a common baseline instead of jumping around as the height varies per symbol.
             height = Math.max(1, metrics.getHeight());
+            drawY = metrics.getAscent();
+            // Width uses the visual (ink) bounds instead, because Material Symbols bake uneven left/right side bearing
+            // into each glyph; trimming to the painted pixels lets a single icon center cleanly inside a button.
             Rectangle2D inkBounds = font.createGlyphVector(graphics.getFontRenderContext(), glyph).getVisualBounds();
             width = Math.max(1, (int) Math.ceil(inkBounds.getWidth()));
+            // getX() is the left bearing (offset from the pen origin to the first visible pixel); cancel it so the
+            // glyph paints flush at x = 0 with no leading gap.
             drawX = (int) Math.round(-inkBounds.getX());
             graphics.dispose();
         }
@@ -167,7 +177,7 @@ public final class FontHandler {
             graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
             graphics.setFont(font);
             graphics.setColor(color);
-            graphics.drawString(glyph, x + drawX, y + graphics.getFontMetrics().getAscent());
+            graphics.drawString(glyph, x + drawX, y + drawY);
             graphics.dispose();
         }
 

--- a/megamek/src/megamek/client/ui/util/FontHandler.java
+++ b/megamek/src/megamek/client/ui/util/FontHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2023-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/src/megamek/client/ui/util/FontHandler.java
+++ b/megamek/src/megamek/client/ui/util/FontHandler.java
@@ -33,13 +33,22 @@
 
 package megamek.client.ui.util;
 
+import java.awt.Color;
+import java.awt.Component;
 import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
 import java.awt.GraphicsEnvironment;
+import java.awt.RenderingHints;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import javax.swing.Icon;
 
 import megamek.MMConstants;
 import megamek.client.ui.dialogs.buttonDialogs.CommonSettingsDialog;
@@ -103,6 +112,74 @@ public final class FontHandler {
     public static Font symbolFont() {
         ensureInitialization();
         return new Font("Material Symbols Rounded", Font.PLAIN, 12);
+    }
+
+    /**
+     * Creates an {@link Icon} that paints a single Google Material Symbol glyph from {@link #symbolFont()}, sized and
+     * tinted as requested. The glyph is drawn live on each repaint so it stays crisp on HiDPI displays, and is sized to
+     * the glyph's ink box so it carries no uneven side bearing. Code points are listed at
+     * <a href="https://fonts.google.com/icons">fonts.google.com/icons</a>.
+     *
+     * @param codePoint the Material Symbols code point, for example {@code 0xE5D7} for {@code unfold_more}
+     * @param size      the glyph height in (already scaled) pixels
+     * @param color     the color to paint the glyph
+     *
+     * @return an {@link Icon} drawing the glyph, or {@code null} if the symbols font cannot display the code point
+     */
+    public static Icon symbolIcon(int codePoint, int size, Color color) {
+        Font font = symbolFont().deriveFont((float) size);
+        if (!font.canDisplay(codePoint)) {
+            return null;
+        }
+        return new MaterialSymbolIcon(font, new String(Character.toChars(codePoint)), color);
+    }
+
+    /**
+     * An {@link Icon} that paints one glyph live through the host component's graphics, sized to the glyph's ink box.
+     */
+    private static final class MaterialSymbolIcon implements Icon {
+        private final Font font;
+        private final String glyph;
+        private final Color color;
+        private final int width;
+        private final int height;
+        private final int drawX;
+
+        private MaterialSymbolIcon(Font font, String glyph, Color color) {
+            this.font = font;
+            this.glyph = glyph;
+            this.color = color;
+
+            BufferedImage scratch = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+            Graphics2D graphics = scratch.createGraphics();
+            FontMetrics metrics = graphics.getFontMetrics(font);
+            height = Math.max(1, metrics.getHeight());
+            Rectangle2D inkBounds = font.createGlyphVector(graphics.getFontRenderContext(), glyph).getVisualBounds();
+            width = Math.max(1, (int) Math.ceil(inkBounds.getWidth()));
+            drawX = (int) Math.round(-inkBounds.getX());
+            graphics.dispose();
+        }
+
+        @Override
+        public void paintIcon(Component component, Graphics g, int x, int y) {
+            Graphics2D graphics = (Graphics2D) g.create();
+            graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            graphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+            graphics.setFont(font);
+            graphics.setColor(color);
+            graphics.drawString(glyph, x + drawX, y + graphics.getFontMetrics().getAscent());
+            graphics.dispose();
+        }
+
+        @Override
+        public int getIconWidth() {
+            return width;
+        }
+
+        @Override
+        public int getIconHeight() {
+            return height;
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds a small helper, `FontHandler.symbolIcon(int codePoint, int size, Color color)`, that turns a Google Material Symbol code point into a Swing `Icon`. The glyph is drawn live on every repaint, so it stays sharp on HiDPI displays instead of being baked into a fixed-resolution bitmap, and it sizes itself to the glyph's ink box so there is no uneven side bearing.

This is a single self-contained addition to `FontHandler`; nothing existing is changed. It returns `null` when the symbols font can't display the requested code point, letting callers fall back to text.

## Why

MekHQ (and other consumers) need consistent, scalable Material Symbol icons for toolbar buttons, legends, and table headers. Centralizing this in `FontHandler` next to `symbolFont()` keeps the icon logic in one place and avoids each downstream project hand-rolling its own glyph-to-icon painter.

## Changes

- `FontHandler.symbolIcon(...)` — public factory returning an `Icon` for a code point, size, and color; `null` if the glyph is unavailable.
- `MaterialSymbolIcon` — private `Icon` impl that paints one glyph with antialiasing, sized to the glyph's visual bounds.