### PR TITLE
Princess artillery messaging + Rounds-in-Air follow-up (final review files)

### DIFF
--- a/megamek/resources/megamek/client/messages.properties
+++ b/megamek/resources/megamek/client/messages.properties
@@ -1177,6 +1177,7 @@ CommonMenuBar.viewPlayerList=Player List
 CommonMenuBar.viewRoundsInAir=Rounds in the Air
 CommonMenuBar.viewRoundReport=Round Report
 RoundsInAirDialog.title=Rounds in the Air
+RoundsInAirDialog.col.team=Team
 RoundsInAirDialog.col.firedBy=Fired By
 RoundsInAirDialog.col.player=Player
 RoundsInAirDialog.col.landsIn=Lands In
@@ -1187,6 +1188,8 @@ RoundsInAirDialog.landsInTurns={0} turn(s)
 RoundsInAirDialog.unknownUnit=(unknown unit)
 RoundsInAirDialog.unknownPlayer=(unknown)
 RoundsInAirDialog.unknownHex=(off-board)
+RoundsInAirDialog.counterBattery=Counter-battery (off-board)
+RoundsInAirDialog.unknown=Unknown
 RoundsInAirDialog.warhead.homing=Homing
 RoundsInAirDialog.warhead.cluster=Cluster
 RoundsInAirDialog.warhead.fascam=FASCAM
@@ -5662,10 +5665,10 @@ Nuke.exploded=Dangerous radiation levels detected in the area of the nuke explos
 # Trench/Fieldworks Engineers (TO:AUE p.153) - server-raised board toasts
 Fortify.completeToast={0} completed a fortified hex.
 Fortify.delayedToast={0}''s fortification was set back a turn by damage.
-# Artillery call-for-fire board toasts (firing player + team only). {0}=battery (firing player) name
+# Artillery call-for-fire board toasts (firing player + team only). {0}=battery (firing player) name, {1}=target grid
 Artillery.offBoardTarget=Offboard Target
-Artillery.netToast.shot={0}: Shot, out.
-Artillery.netToast.splash={0}: Rounds inbound - Splash, over.
+Artillery.netToast.shot={0}: Shot, out - target {1}.
+Artillery.netToast.splash={0}: Rounds inbound on {1} - Splash, over.
 # Homing-inbound reminder, shown to the firing team in the movement phase the turn before a homing round lands
 Artillery.netToast.homingInbound={0}: Homing rounds inbound - put a TAG on the target.
 Artillery.counterBatteryToast={0}: enemy off-board battery spotted - fall of shot grid {1}. Request counter-battery, fire for effect, over.

--- a/megamek/resources/megamek/common/report-messages.properties
+++ b/megamek/resources/megamek/common/report-messages.properties
@@ -373,22 +373,13 @@
 3119=Missile(s) detect and target <B><data></B> (<data>).
 3120=<data> at <B><data></B>
 3121=<data>, will land in <data> turn(s).
+# Counter-battery variant of 3121 (target is an off-board enemy battery, so there is no on-board hex)
+3127=<data>, conducting counter-battery fire, will land in <data> turn(s).
 3122=<data> launches bearings-only capital missile(s), will go active in <data> turn(s).
 3123=<B>Message from missile at <data></B>: No targets found within specified detection parameters. <span class='warning'>Self destructing.</span>
 3124=<data> (<data> <data> round(s)) at <B><data></B> (<data>);
 3125=, but a friendly unit with an attached iNarc Nemesis Pod is standing in the way!
 3126=<data> (<data> <data> round(s)) at <B><data></B> ;
-# Artillery call-for-fire pro-words. Shot has three variants by fire type.
-# 3127 Shot (unobserved fire at a hex): <data>=battery, <data>=weapon, <data>=target grid, <data>=impact round
-3127=<data>: <span class='info'>Shot, out.</span> <data> on the way to grid <B><data></B>, unobserved fire. Impact round <data>.
-# 3131 Shot (observed fire, a unit is spotting): <data>=battery, <data>=weapon, <data>=target grid, <data>=spotter, <data>=impact round
-3131=<data>: <span class='info'>Shot, out.</span> <data> on the way to grid <B><data></B>, observed fire, <data> spotting. Impact round <data>.
-# 3132 Shot (registered/pre-sighted target, rounds auto-hit): <data>=battery, <data>=weapon, <data>=target grid, <data>=impact round
-3132=<data>: <span class='info'>Shot, out.</span> <data> on the way to grid <B><data></B>, fire for effect on registered target. Impact round <data>.
-# 3133 Shot (homing round, guides onto a TAGged target): <data>=battery, <data>=weapon, <data>=target grid, <data>=impact round
-3133=<data>: <span class='info'>Shot, out.</span> <data> on the way to grid <B><data></B>, homing - will guide onto a tagged target. Impact round <data>.
-# 3128 Splash: <data>=battery, <data>=target grid
-3128=<data>: Rounds inbound to <B><data></B>, <span class='info'>Splash, over.</span>
 3130=Now targeting original Target again
 3135=, but the shot is impossible (<data>)
 3140=, the shot is an automatic miss (<data>),

--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -1200,6 +1200,9 @@ public class Client extends AbstractClient {
                 case SENDING_ARTILLERY_ATTACKS:
                     Vector<ArtilleryAttackAction> artilleryAttackActions = packet.getArtilleryAttackAction(0);
                     game.setArtilleryVector(artilleryAttackActions);
+                    // Redacted enemy rounds (landing time only; target/munition withheld by the server) for the
+                    // Rounds-in-Air window; this list never feeds the board, so it cannot leak the enemy aim point.
+                    game.setEnemyArtilleryInbound(packet.getEnemyArtilleryInbound(1));
                     // Fire a board-change event so views tracking in-flight artillery (e.g. the Rounds in the Air
                     // window) refresh now. This packet arrives AFTER the phase-change event, so a phase-change-only
                     // refresh would always be one phase stale - notably for off-board counter-battery rounds.

--- a/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
+++ b/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
@@ -1611,6 +1611,9 @@ public class ArtilleryTargetingControl {
     }
 
     /**
+     * Shared "worth killing" value for ranking artillery/TAG targets, used both by TAG/homing target selection here and
+     * by the TAG-spotter positioning in {@link BasicPathRanker}.
+     *
      * @param target A candidate TAG/homing target
      *
      * @return A relative "worth killing" value for ranking targets - the target's CURRENT battle value (BV), which
@@ -1619,7 +1622,7 @@ public class ArtilleryTargetingControl {
      *       targets (ranked by to-hit alone). Floored at {@code 1.0} so even a deprioritized target still ranks by its
      *       hit probability.
      */
-    private double tagTargetValue(Targetable target) {
+    static double tagTargetValue(Targetable target) {
         if (!(target instanceof Entity entity)) {
             return 1.0;
         }

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -705,10 +705,6 @@ public class BasicPathRanker extends PathRanker {
     // the bot prefers a non-jumping path and only jumps when that is the only way to reach a designating position.
     private static final double TAG_JUMP_PENALTY = 10.0;
 
-    // TAG-spotter priority-target tuning (designation-zone positioning). A crippled (mission-killed) enemy is worth
-    // far less as a TAG/homing target, so it is heavily deprioritized when choosing the priority target.
-    private static final double SPOTTER_CRIPPLED_VALUE_FACTOR = 0.1;
-
     // Hysteresis: the spotter keeps painting its current (persisted) priority target across turns unless a different
     // enemy is worth at least this multiple of it - stops a round-to-round flip onto a marginally higher-value unit.
     private static final double SPOTTER_PRIORITY_SWITCH_MARGIN = 1.5;
@@ -801,25 +797,10 @@ public class BasicPathRanker extends PathRanker {
     private record SpotterPriority(@Nullable Entity target, String source) {}
 
     /**
-     * @param entity An enemy entity
-     *
-     * @return The entity's "worth painting" value - current (damage-adjusted) battle value, heavily reduced for a
-     *       crippled (mission-killed) unit - mirrors {@code ArtilleryTargetingControl.tagTargetValue} so positioning
-     *       and firing agree on which target matters.
-     */
-    private double spotterTargetValue(Entity entity) {
-        double value = Math.max(1.0, entity.calculateBattleValue());
-        if (entity.isCrippled()) {
-            value *= SPOTTER_CRIPPLED_VALUE_FACTOR;
-        }
-        return Math.max(1.0, value);
-    }
-
-    /**
      * @param enemies The enemy units
      *
-     * @return The deployed on-board enemy with the highest {@link #spotterTargetValue}, or {@code null} if there is
-     *       none
+     * @return The deployed on-board enemy with the highest {@link ArtilleryTargetingControl#tagTargetValue}, or
+     *       {@code null} if there is none
      */
     private @Nullable Entity highestValueEnemy(List<Entity> enemies) {
         Entity best = null;
@@ -828,7 +809,7 @@ public class BasicPathRanker extends PathRanker {
             if (!enemy.isDeployed() || enemy.isOffBoard() || (enemy.getPosition() == null)) {
                 continue;
             }
-            double value = spotterTargetValue(enemy);
+            double value = ArtilleryTargetingControl.tagTargetValue(enemy);
             if (value > bestValue) {
                 bestValue = value;
                 best = enemy;
@@ -862,8 +843,8 @@ public class BasicPathRanker extends PathRanker {
             Entity persisted = game.getEntity(persistedId);
             boolean persistedValid = (persisted != null) && persisted.isDeployed() && !persisted.isOffBoard()
                   && (persisted.getPosition() != null) && persisted.isEnemyOf(spotter) && !persisted.isDestroyed();
-            if (persistedValid && (spotterTargetValue(highestValue)
-                  < (SPOTTER_PRIORITY_SWITCH_MARGIN * spotterTargetValue(persisted)))) {
+            if (persistedValid && (ArtilleryTargetingControl.tagTargetValue(highestValue)
+                  < (SPOTTER_PRIORITY_SWITCH_MARGIN * ArtilleryTargetingControl.tagTargetValue(persisted)))) {
                 lastSpotterPriorityTarget.put(spotter.getId(), persisted.getId());
                 return new SpotterPriority(persisted, "PERSISTED");
             }

--- a/megamek/src/megamek/client/ui/clientGUI/MapMenu.java
+++ b/megamek/src/megamek/client/ui/clientGUI/MapMenu.java
@@ -424,7 +424,9 @@ public class MapMenu extends JPopupMenu {
         JMenu targetHexMenu = createTargetHexMenuItem(bot);
         menu.add(targetHexMenu);
         menu.add(createWaypointMenu(bot));
-        menu.add(createArtilleryMenu(bot));
+        if (botHasArtillery(bot)) {
+            menu.add(createArtilleryMenu(bot));
+        }
         for (Entity entity : client.getGame().getEntitiesVector(coords)) {
             prioritizeTargetUnitMenu.add(createPrioritizeTargetUnitMenu(bot, entity));
             ignoreTargetMenu.add(createIgnoreTargetUnitMenu(bot, entity));
@@ -618,6 +620,21 @@ public class MapMenu extends JPopupMenu {
               coords.hexCode(board))));
         targetHexMenu.add(item);
         return targetHexMenu;
+    }
+
+    /**
+     * @param bot The bot player
+     *
+     * @return {@code true} if the bot owns at least one unit with an artillery weapon, so the artillery orders menu is
+     *       worth offering (a bot with no artillery would otherwise get an empty, useless menu)
+     */
+    private boolean botHasArtillery(Player bot) {
+        for (Entity entity : client.getGame().getPlayerEntities(bot, false)) {
+            if (entity.hasArtillery()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/megamek/src/megamek/client/ui/dialogs/BotCommands/BotCommandsPanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/BotCommands/BotCommandsPanel.java
@@ -442,6 +442,21 @@ public class BotCommandsPanel extends JPanel {
         return false;
     }
 
+    /**
+     * @param botPlayer The bot to inspect
+     *
+     * @return {@code true} if the bot owns at least one unit with an artillery weapon (on or off board), so the
+     *       artillery orders menu is worth offering for it - a bot with no artillery is left out of the popup entirely
+     */
+    private boolean botHasArtillery(Player botPlayer) {
+        for (InGameObject unit : getUnitsOwnedBy(botPlayer)) {
+            if ((unit instanceof Entity entity) && entity.hasArtillery()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private void holdPosition(Player botPlayer) {
         sendChatCommand(botPlayer, ChatCommands.HOLD_POSITION);
     }
@@ -871,7 +886,7 @@ public class BotCommandsPanel extends JPanel {
             botMenu.add(createArtilleryFireMissionMenu(botPlayer, "ArtilleryVolley", ArtilleryOrder.VOLLEY));
             botMenu.add(createArtilleryFireMissionMenu(botPlayer, "ArtilleryBarrage", ArtilleryOrder.BARRAGE));
             botMenu.add(createCounterBatteryMenu(botPlayer));
-        });
+        }, this::botHasArtillery);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/dialogs/RoundsInAirDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/RoundsInAirDialog.java
@@ -51,7 +51,9 @@ import javax.swing.table.DefaultTableModel;
 import megamek.client.Client;
 import megamek.client.ui.Messages;
 import megamek.client.ui.clientGUI.GUIPreferences;
+import megamek.common.Player;
 import megamek.common.actions.ArtilleryAttackAction;
+import megamek.common.actions.EnemyArtilleryInbound;
 import megamek.common.board.Coords;
 import megamek.common.equipment.AmmoType.Munitions;
 import megamek.common.game.Game;
@@ -112,8 +114,9 @@ public class RoundsInAirDialog extends JDialog {
 
     private static String[] columnNames() {
         return new String[] {
-              Messages.getString("RoundsInAirDialog.col.firedBy"),
+              Messages.getString("RoundsInAirDialog.col.team"),
               Messages.getString("RoundsInAirDialog.col.player"),
+              Messages.getString("RoundsInAirDialog.col.firedBy"),
               Messages.getString("RoundsInAirDialog.col.landsIn"),
               Messages.getString("RoundsInAirDialog.col.targetHex"),
               Messages.getString("RoundsInAirDialog.col.warhead")
@@ -121,49 +124,80 @@ public class RoundsInAirDialog extends JDialog {
     }
 
     /**
-     * Rebuilds the table from the current in-flight artillery attacks, sorted so the soonest-landing rounds are at the
-     * top. Safe to call repeatedly (e.g. on every phase change).
+     * Rebuilds the table from the current in-flight artillery, sorted so the soonest-landing rounds are at the top. Own
+     * and allied rounds are shown in full; enemy rounds (a redacted, team-safe feed from the server) show only their
+     * landing time, with the target hex and warhead listed as "Unknown". Safe to call repeatedly (e.g. on phase change).
      */
     public void refresh() {
         tableModel.setRowCount(0);
         Game game = client.getGame();
+
+        // Own and allied rounds: full detail.
         List<ArtilleryAttackAction> attacks = new ArrayList<>();
         for (Enumeration<ArtilleryAttackAction> attackEnumeration = game.getArtilleryAttacks();
               attackEnumeration.hasMoreElements(); ) {
             attacks.add(attackEnumeration.nextElement());
         }
         attacks.sort(Comparator.comparingInt(ArtilleryAttackAction::getTurnsTilHit));
-
         for (ArtilleryAttackAction attack : attacks) {
             tableModel.addRow(new Object[] {
-                  firingUnitName(game, attack),
-                  playerName(game, attack),
-                  landsInText(attack),
+                  teamName(game, attack.getPlayerId()),
+                  playerName(game, attack.getPlayerId()),
+                  firingUnitName(game, attack.getEntityId()),
+                  landsInText(attack.getTurnsTilHit()),
                   targetHexText(game, attack),
                   warheadName(attack)
             });
         }
+
+        // Enemy rounds: redacted - landing time only; the target hex and warhead are withheld (shown as "Unknown").
+        List<EnemyArtilleryInbound> enemyInbound = new ArrayList<>(game.getEnemyArtilleryInbound());
+        enemyInbound.sort(Comparator.comparingInt(EnemyArtilleryInbound::turnsTilHit));
+        String unknown = Messages.getString("RoundsInAirDialog.unknown");
+        for (EnemyArtilleryInbound inbound : enemyInbound) {
+            tableModel.addRow(new Object[] {
+                  teamName(game, inbound.playerId()),
+                  playerName(game, inbound.playerId()),
+                  firingUnitName(game, inbound.firingEntityId()),
+                  landsInText(inbound.turnsTilHit()),
+                  unknown,
+                  unknown
+            });
+        }
     }
 
-    private static String firingUnitName(Game game, ArtilleryAttackAction attack) {
-        Entity firingEntity = attack.getEntity(game);
+    private static String teamName(Game game, int playerId) {
+        Player player = game.getPlayer(playerId);
+        if (player == null) {
+            return Messages.getString("RoundsInAirDialog.unknownPlayer");
+        }
+        int team = player.getTeam();
+        return ((team >= 0) && (team < Player.TEAM_NAMES.length)) ? Player.TEAM_NAMES[team] : String.valueOf(team);
+    }
+
+    private static String firingUnitName(Game game, int firingEntityId) {
+        Entity firingEntity = game.getEntity(firingEntityId);
         return (firingEntity != null) ? firingEntity.getShortName()
               : Messages.getString("RoundsInAirDialog.unknownUnit");
     }
 
-    private static String playerName(Game game, ArtilleryAttackAction attack) {
-        return (game.getPlayer(attack.getPlayerId()) != null) ? game.getPlayer(attack.getPlayerId()).getName()
-              : Messages.getString("RoundsInAirDialog.unknownPlayer");
+    private static String playerName(Game game, int playerId) {
+        Player player = game.getPlayer(playerId);
+        return (player != null) ? player.getName() : Messages.getString("RoundsInAirDialog.unknownPlayer");
     }
 
-    private static String landsInText(ArtilleryAttackAction attack) {
-        int turns = attack.getTurnsTilHit();
+    private static String landsInText(int turns) {
         return (turns <= 0) ? Messages.getString("RoundsInAirDialog.landsThisTurn")
               : Messages.getString("RoundsInAirDialog.landsInTurns", turns);
     }
 
     private static String targetHexText(Game game, ArtilleryAttackAction attack) {
         Targetable target = attack.getTarget(game);
+        // A counter-battery shot aims at an off-board enemy battery, whose virtual board number is meaningless as a
+        // grid square, so label it instead of printing that number (or losing the value entirely).
+        if ((target != null) && target.isOffBoard()) {
+            return Messages.getString("RoundsInAirDialog.counterBattery");
+        }
         if ((target != null) && (target.getPosition() != null)) {
             return target.getPosition().getBoardNum();
         }

--- a/megamek/src/megamek/client/ui/dialogs/RoundsInAirDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/RoundsInAirDialog.java
@@ -131,40 +131,50 @@ public class RoundsInAirDialog extends JDialog {
     public void refresh() {
         tableModel.setRowCount(0);
         Game game = client.getGame();
+        List<RoundRow> rows = new ArrayList<>();
 
         // Own and allied rounds: full detail.
-        List<ArtilleryAttackAction> attacks = new ArrayList<>();
         for (Enumeration<ArtilleryAttackAction> attackEnumeration = game.getArtilleryAttacks();
               attackEnumeration.hasMoreElements(); ) {
-            attacks.add(attackEnumeration.nextElement());
-        }
-        attacks.sort(Comparator.comparingInt(ArtilleryAttackAction::getTurnsTilHit));
-        for (ArtilleryAttackAction attack : attacks) {
-            tableModel.addRow(new Object[] {
+            ArtilleryAttackAction attack = attackEnumeration.nextElement();
+            rows.add(new RoundRow(attack.getTurnsTilHit(), new Object[] {
                   teamName(game, attack.getPlayerId()),
                   playerName(game, attack.getPlayerId()),
                   firingUnitName(game, attack.getEntityId()),
                   landsInText(attack.getTurnsTilHit()),
                   targetHexText(game, attack),
                   warheadName(attack)
-            });
+            }));
         }
 
         // Enemy rounds: redacted - landing time only; the target hex and warhead are withheld (shown as "Unknown").
-        List<EnemyArtilleryInbound> enemyInbound = new ArrayList<>(game.getEnemyArtilleryInbound());
-        enemyInbound.sort(Comparator.comparingInt(EnemyArtilleryInbound::turnsTilHit));
         String unknown = Messages.getString("RoundsInAirDialog.unknown");
-        for (EnemyArtilleryInbound inbound : enemyInbound) {
-            tableModel.addRow(new Object[] {
+        for (EnemyArtilleryInbound inbound : game.getEnemyArtilleryInbound()) {
+            rows.add(new RoundRow(inbound.turnsTilHit(), new Object[] {
                   teamName(game, inbound.playerId()),
                   playerName(game, inbound.playerId()),
                   firingUnitName(game, inbound.firingEntityId()),
                   landsInText(inbound.turnsTilHit()),
                   unknown,
                   unknown
-            });
+            }));
+        }
+
+        // Sort allied and enemy rounds together so the soonest-landing round is always at the top, regardless of side.
+        rows.sort(Comparator.comparingInt(RoundRow::turnsTilHit));
+        for (RoundRow row : rows) {
+            tableModel.addRow(row.cells());
         }
     }
+
+    /**
+     * One row of the table, carrying its landing time separately so allied and enemy rounds can be sorted together by
+     * soonest landing before being rendered.
+     *
+     * @param turnsTilHit Turns until this round lands (the sort key)
+     * @param cells       The rendered cell values for the row, in column order
+     */
+    private record RoundRow(int turnsTilHit, Object[] cells) {}
 
     private static String teamName(Game game, int playerId) {
         Player player = game.getPlayer(playerId);

--- a/megamek/src/megamek/common/actions/EnemyArtilleryInbound.java
+++ b/megamek/src/megamek/common/actions/EnemyArtilleryInbound.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.actions;
+
+import java.io.Serializable;
+
+/**
+ * A redacted, team-safe summary of an enemy artillery round in flight. It is sent to a player who is entitled to know
+ * that enemy artillery is inbound - the firing is announced in the phase report - but NOT where it is aimed or what
+ * munition it carries. It exists so the Rounds-in-Air window can list enemy rounds with their landing time while
+ * showing the target hex and warhead as "Unknown", without ever sending the actual target to the client (which would
+ * re-leak it, e.g. via the board's incoming-artillery sprites).
+ *
+ * @param firingEntityId The id of the firing enemy unit (may be unresolvable on the client under double-blind)
+ * @param playerId       The id of the firing enemy player (resolves the team and player name)
+ * @param turnsTilHit    Turns until the round lands
+ */
+public record EnemyArtilleryInbound(int firingEntityId, int playerId, int turnsTilHit) implements Serializable {
+    private static final long serialVersionUID = 1L;
+}

--- a/megamek/src/megamek/common/game/Game.java
+++ b/megamek/src/megamek/common/game/Game.java
@@ -56,6 +56,7 @@ import megamek.common.TemporaryECMField;
 import megamek.common.WoodsClearingTracker;
 import megamek.common.actions.ArtilleryAttackAction;
 import megamek.common.actions.AttackAction;
+import megamek.common.actions.EnemyArtilleryInbound;
 import megamek.common.actions.EntityAction;
 import megamek.common.annotations.Nullable;
 import megamek.common.board.Board;
@@ -195,6 +196,10 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
     private Map<BoardLocation, Integer> hexesBeingCut = new HashMap<>();
     private Vector<AttackHandler> attacks = new Vector<>();
     private Vector<ArtilleryAttackAction> offboardArtilleryAttacks = new Vector<>();
+    // Client-display only: redacted summaries of enemy artillery rounds in flight (landing time only; target and
+    // munition withheld), used by the Rounds-in-Air window. Transient - it is pushed fresh from the server each update
+    // and never persisted with a saved game.
+    private transient List<EnemyArtilleryInbound> enemyArtilleryInbound = new ArrayList<>();
     private Vector<OrbitalBombardment> orbitalBombardmentAttacks = new Vector<>();
     private int lastEntityId;
 
@@ -2500,6 +2505,22 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
 
     public Enumeration<ArtilleryAttackAction> getArtilleryAttacks() {
         return offboardArtilleryAttacks.elements();
+    }
+
+    /**
+     * @param inbound Redacted enemy artillery-in-flight summaries for the Rounds-in-Air window (target/munition already
+     *                withheld by the server), or {@code null} to clear
+     */
+    public void setEnemyArtilleryInbound(List<EnemyArtilleryInbound> inbound) {
+        enemyArtilleryInbound = (inbound != null) ? inbound : new ArrayList<>();
+    }
+
+    /**
+     * @return The redacted enemy artillery-in-flight summaries (landing time only; target and munition withheld); never
+     *       {@code null} (empty when none, or after deserializing a saved game where this transient field is unset)
+     */
+    public List<EnemyArtilleryInbound> getEnemyArtilleryInbound() {
+        return (enemyArtilleryInbound != null) ? enemyArtilleryInbound : new ArrayList<>();
     }
 
     @Deprecated(since = "0.51.0", forRemoval = true)

--- a/megamek/src/megamek/common/net/packets/Packet.java
+++ b/megamek/src/megamek/common/net/packets/Packet.java
@@ -54,6 +54,7 @@ import megamek.common.SpecialHexDisplay;
 import megamek.common.TagInfo;
 import megamek.common.TemporaryECMField;
 import megamek.common.actions.ArtilleryAttackAction;
+import megamek.common.actions.EnemyArtilleryInbound;
 import megamek.common.actions.EntityAction;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.annotations.Nullable;
@@ -290,6 +291,25 @@ public record Packet(PacketCommand command, Object... data) implements Serializa
         }
 
         throw new InvalidPacketDataException("Vector", object, index);
+    }
+
+    /**
+     * @param index the index of the desired object
+     *
+     * @return the {@link EnemyArtilleryInbound} entries at the specified index, or an empty list if the object is absent
+     *       (e.g. an older packet without this field) or not a list
+     */
+    public List<EnemyArtilleryInbound> getEnemyArtilleryInbound(int index) {
+        Object object = getObject(index);
+        List<EnemyArtilleryInbound> result = new ArrayList<>();
+        if (object instanceof List<?> list) {
+            for (Object item : list) {
+                if (item instanceof EnemyArtilleryInbound value) {
+                    result.add(value);
+                }
+            }
+        }
+        return result;
     }
 
     /**

--- a/megamek/src/megamek/common/units/Entity.java
+++ b/megamek/src/megamek/common/units/Entity.java
@@ -12316,6 +12316,19 @@ public abstract class Entity extends TurnOrdered
         return false;
     }
 
+    /**
+     * @return {@code true} if this unit mounts at least one artillery weapon (regardless of whether it is currently
+     *       loaded or operational)
+     */
+    public boolean hasArtillery() {
+        for (WeaponMounted weapon : getWeaponList()) {
+            if (weapon.getType().hasFlag(WeaponType.F_ARTILLERY)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public boolean isCanon() {
         return canon;
     }

--- a/megamek/src/megamek/common/weapons/ArtilleryHandlerHelper.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryHandlerHelper.java
@@ -42,6 +42,8 @@ import java.util.Vector;
 
 import megamek.common.LosEffects;
 import megamek.common.Report;
+import megamek.common.annotations.Nullable;
+import megamek.common.board.Board;
 import megamek.common.board.Coords;
 import megamek.common.equipment.INarcPod;
 import megamek.common.equipment.Minefield;
@@ -144,6 +146,32 @@ public final class ArtilleryHandlerHelper {
         for (Minefield mf : mfRemoved) {
             gameManager.removeMinefield(mf);
         }
+    }
+
+    /**
+     * Finds the board-edge hex an artillery round crossed when it scattered off the board: the last on-board hex along
+     * the straight line from where it was aimed to the (off-board) hex it scattered to. The board view can then draw
+     * the drift arrow to that edge hex, showing the direction the round drifted off, since there is no on-board landing
+     * hex.
+     *
+     * @param board           The board the round was fired onto
+     * @param aimedHex        The on-board hex the round was aimed at (the drift line's origin)
+     * @param offBoardScatter The off-board hex the round scattered to
+     *
+     * @return The last on-board hex along the line toward {@code offBoardScatter} (the edge it crossed), or
+     *       {@code null} if {@code aimedHex} is not even on the board
+     */
+    public static @Nullable Coords nearestOnBoardHexTowardOffBoard(Board board, Coords aimedHex,
+          Coords offBoardScatter) {
+        Coords lastOnBoard = board.contains(aimedHex) ? aimedHex : null;
+        for (Coords coords : Coords.intervening(aimedHex, offBoardScatter)) {
+            if (board.contains(coords)) {
+                lastOnBoard = coords;
+            } else {
+                break;
+            }
+        }
+        return lastOnBoard;
     }
 
     private ArtilleryHandlerHelper() {}

--- a/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryBayWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryBayWeaponIndirectFireHandler.java
@@ -158,8 +158,9 @@ public class ArtilleryBayWeaponIndirectFireHandler extends AmmoBayWeaponHandler 
         if (phase.isTargeting()) {
             if (!handledAmmoAndReport) {
                 addHeat();
-                // Report the firing itself
-                Report r = new Report(3121);
+                // Report the firing itself - name it counter-battery when the target is an off-board enemy battery.
+                boolean counterBattery = (target != null) && target.isOffBoard();
+                Report r = new Report(counterBattery ? 3127 : 3121);
                 r.indent();
                 r.newlines = 0;
                 r.subject = subjectId;

--- a/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryBayWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryBayWeaponIndirectHomingHandler.java
@@ -102,8 +102,9 @@ public class ArtilleryBayWeaponIndirectHomingHandler extends ArtilleryBayWeaponI
         if (phase.isTargeting()) {
             if (!handledAmmoAndReport) {
                 addHeat();
-                // Report the firing itself
-                Report report = new Report(3121);
+                // Report the firing itself - name it counter-battery when the target is an off-board enemy battery.
+                boolean counterBattery = (target != null) && target.isOffBoard();
+                Report report = new Report(counterBattery ? 3127 : 3121);
                 report.indent();
                 report.newlines = 0;
                 report.subject = subjectId;

--- a/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryCannonWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryCannonWeaponHandler.java
@@ -58,6 +58,7 @@ import megamek.common.loaders.EntityLoadingException;
 import megamek.common.rolls.TargetRoll;
 import megamek.common.units.Entity;
 import megamek.common.units.Targetable;
+import megamek.common.weapons.ArtilleryHandlerHelper;
 import megamek.common.weapons.handlers.AmmoWeaponHandler;
 import megamek.common.weapons.handlers.AreaEffectHelper;
 import megamek.logging.MMLogger;
@@ -189,7 +190,8 @@ public class ArtilleryCannonWeaponHandler extends AmmoWeaponHandler {
                     report.add(targetPos.getBoardNum());
                     vPhaseReport.addElement(report);
                 } else {
-                    // misses and scatters off-board
+                    // misses and scatters off-board: draw the drift arrow to the board edge the round crossed, since
+                    // there is no on-board landing hex.
                     if (isFlak) {
                         report = new Report(3193);
                     } else {
@@ -197,6 +199,16 @@ public class ArtilleryCannonWeaponHandler extends AmmoWeaponHandler {
                     }
                     report.subject = subjectId;
                     vPhaseReport.addElement(report);
+
+                    SpecialHexDisplay offBoardMissMarker = new SpecialHexDisplay(
+                          SpecialHexDisplay.Type.ARTILLERY_MISS, game.getRoundCount(), attackingEntity.getOwner(),
+                          "Artillery cannon missed here on round " + game.getRoundCount() + ", drifted off the board");
+                    Coords edgeHex = ArtilleryHandlerHelper.nearestOnBoardHexTowardOffBoard(board, originalPosition,
+                          targetPos);
+                    if (edgeHex != null) {
+                        offBoardMissMarker.setDriftHex(edgeHex);
+                    }
+                    board.addSpecialHexDisplay(originalPosition, offBoardMissMarker);
                     return !bMissed;
                 }
             } else {

--- a/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryWeaponIndirectFireHandler.java
@@ -43,7 +43,6 @@ import megamek.client.ui.Messages;
 import megamek.common.Hex;
 import megamek.common.HexTarget;
 import megamek.common.LosEffects;
-import megamek.common.Player;
 import megamek.common.Report;
 import megamek.common.SpecialHexDisplay;
 import megamek.common.SpecialHexDisplay.Type;
@@ -129,8 +128,10 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
         if (phase.isTargeting()) {
             if (!handledAmmoAndReport) {
                 addHeat();
-                // Report the firing itself
-                Report r = new Report(3121);
+                // Report the firing itself - name it counter-battery when the target is an off-board enemy battery
+                // (there is no on-board hex), so a teammate reading the report can tell it from a normal fire mission.
+                boolean counterBattery = (target != null) && target.isOffBoard();
+                Report r = new Report(counterBattery ? 3127 : 3121);
                 r.indent();
                 r.newlines = 0;
                 r.subject = subjectId;
@@ -141,7 +142,7 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
                 handledAmmoAndReport = true;
 
                 // "Shot, over" - the battery announces the round is on the way, characterised by fire type
-                reportShot(vPhaseReport, artilleryAttackAction);
+                reportShot(artilleryAttackAction);
 
                 artyMsg = "Artillery fire Incoming, landing on round "
                       + (game.getRoundCount() + artilleryAttackAction.getTurnsTilHit())
@@ -201,9 +202,8 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
         String splashTarget = target.isOffBoard()
               ? Messages.getString("Artillery.offBoardTarget")
               : targetPos.getBoardNum();
-        addProWordReport(vPhaseReport, 3128, batteryName(artilleryAttackAction), splashTarget);
         if (attackingEntity != null) {
-            gameManager.sendArtilleryNetToast("splash", attackingEntity, game.getRoundCount());
+            gameManager.sendArtilleryNetToast("splash", attackingEntity, game.getRoundCount(), splashTarget);
         }
 
         boolean isFlak = targetIsEntity && Compute.isFlakAttack(attackingEntity, (Entity) target);
@@ -537,76 +537,22 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
     }
 
     /**
-     * @param artilleryAttackAction The artillery attack being resolved
+     * Sends the team-only "Shot, over" call-for-fire toast naming the target grid. The aim point travels only in this
+     * team toast (and the team-only map marker), never in the shared phase report - which would leak it to the enemy,
+     * who otherwise sees exactly the same announcement as in {@code main} (the firing unit + "will land in N turns").
      *
-     * @return The name of the firing player (the "battery") for call-for-fire pro-word reports, falling back to the
-     *       weapon name if the player cannot be resolved
-     */
-    protected String batteryName(ArtilleryAttackAction artilleryAttackAction) {
-        Player firingPlayer = game.getPlayer(artilleryAttackAction.getPlayerId());
-        return (firingPlayer != null) ? firingPlayer.getName() : weaponType.getName();
-    }
-
-    /**
-     * Adds the "Shot, over" pro-word, choosing the wording by fire type: a registered (pre-sighted) target whose rounds
-     * auto-hit, observed fire when a friendly unit is spotting, or unobserved fire at a bare hex.
-     *
-     * @param vPhaseReport          The phase report to add to
      * @param artilleryAttackAction The artillery attack being fired
      */
-    private void reportShot(Vector<Report> vPhaseReport, ArtilleryAttackAction artilleryAttackAction) {
-        String battery = batteryName(artilleryAttackAction);
-        String weaponName = weaponType.getName();
-        String impactRound = String.valueOf(game.getRoundCount() + artilleryAttackAction.getTurnsTilHit());
+    private void reportShot(ArtilleryAttackAction artilleryAttackAction) {
+        if (attackingEntity == null) {
+            return;
+        }
         Coords targetPos = (target != null) ? target.getPosition() : null;
         // A counter-battery shot aims at an off-board enemy battery, whose virtual board number is meaningless to read
         // out as a grid square, so name it as an off-board target instead.
         boolean offBoardTarget = ((target != null) && target.isOffBoard()) || (targetPos == null);
         String grid = offBoardTarget ? Messages.getString("Artillery.offBoardTarget") : targetPos.getBoardNum();
-
-        // Board toast for the firing player and team (deduped to one per volley moment)
-        if (attackingEntity != null) {
-            gameManager.sendArtilleryNetToast("shot", attackingEntity, game.getRoundCount());
-        }
-
-        boolean registeredTarget = (weapon != null) && (attackingEntity != null) && (targetPos != null)
-              && (attackingEntity.aTracker.getModifier(weapon, targetPos) == TargetRoll.AUTOMATIC_SUCCESS);
-        if (registeredTarget) {
-            // pre-sighted hex: rounds land automatically
-            addProWordReport(vPhaseReport, 3132, battery, weaponName, grid, impactRound);
-            return;
-        }
-
-        Optional<Entity> spotter = ArtilleryHandlerHelper.findSpotter(artilleryAttackAction.getSpotterIds(),
-              artilleryAttackAction.getPlayerId(), game, target);
-        if (spotter.isPresent()) {
-            // a friendly unit is spotting and adjusting the fire
-            addProWordReport(vPhaseReport, 3131, battery, weaponName, grid, spotter.get().getDisplayName(),
-                  impactRound);
-            return;
-        }
-
-        // bare hex, no observer
-        addProWordReport(vPhaseReport, 3127, battery, weaponName, grid, impactRound);
-    }
-
-    /**
-     * Adds a call-for-fire pro-word line (Shot / Splash) to the phase report. The report is scoped to the firing entity
-     * (its subject) so it respects double-blind visibility like the other artillery reports.
-     *
-     * @param vPhaseReport The phase report to add to
-     * @param reportId     The report-messages id for the pro-word line
-     * @param data         The ordered data values to substitute into the report
-     */
-    protected void addProWordReport(Vector<Report> vPhaseReport, int reportId, String... data) {
-        Report report = new Report(reportId);
-        report.indent();
-        report.subject = subjectId;
-        for (String value : data) {
-            report.add(value);
-        }
-        vPhaseReport.addElement(report);
-        Report.addNewline(vPhaseReport);
+        gameManager.sendArtilleryNetToast("shot", attackingEntity, game.getRoundCount(), grid);
     }
 
     /**
@@ -710,12 +656,18 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
                       + game.getRoundCount() + ", by "
                       + game.getPlayer(aaa.getPlayerId()).getName()
                       + ", drifted off the board";
-                game.getBoard().addSpecialHexDisplay(
-                      originalPosition,
-                      new SpecialHexDisplay(Type.ARTILLERY_MISS,
-                            game.getRoundCount(),
-                            game.getPlayer(aaa.getPlayerId()),
-                            artyMsg));
+                SpecialHexDisplay missMarker = new SpecialHexDisplay(Type.ARTILLERY_MISS,
+                      game.getRoundCount(),
+                      game.getPlayer(aaa.getPlayerId()),
+                      artyMsg);
+                // There is no on-board landing hex, so draw the drift arrow to the board edge the round crossed,
+                // showing the direction it drifted off the map.
+                Coords edgeHex = ArtilleryHandlerHelper.nearestOnBoardHexTowardOffBoard(game.getBoard(),
+                      originalPosition, targetPos);
+                if (edgeHex != null) {
+                    missMarker.setDriftHex(edgeHex);
+                }
+                game.getBoard().addSpecialHexDisplay(originalPosition, missMarker);
                 return null;
             }
         }

--- a/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryWeaponIndirectFireHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryWeaponIndirectFireHandler.java
@@ -142,7 +142,7 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
                 handledAmmoAndReport = true;
 
                 // "Shot, over" - the battery announces the round is on the way, characterised by fire type
-                reportShot(artilleryAttackAction);
+                reportShot();
 
                 artyMsg = "Artillery fire Incoming, landing on round "
                       + (game.getRoundCount() + artilleryAttackAction.getTurnsTilHit())
@@ -540,10 +540,8 @@ public class ArtilleryWeaponIndirectFireHandler extends AmmoWeaponHandler {
      * Sends the team-only "Shot, over" call-for-fire toast naming the target grid. The aim point travels only in this
      * team toast (and the team-only map marker), never in the shared phase report - which would leak it to the enemy,
      * who otherwise sees exactly the same announcement as in {@code main} (the firing unit + "will land in N turns").
-     *
-     * @param artilleryAttackAction The artillery attack being fired
      */
-    private void reportShot(ArtilleryAttackAction artilleryAttackAction) {
+    private void reportShot() {
         if (attackingEntity == null) {
             return;
         }

--- a/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryWeaponIndirectHomingHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryWeaponIndirectHomingHandler.java
@@ -101,8 +101,9 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
         if (phase.isTargeting()) {
             if (!handledAmmoAndReport) {
                 addHeat();
-                // Report the firing itself
-                Report report = new Report(3121);
+                // Report the firing itself - name it counter-battery when the target is an off-board enemy battery.
+                boolean counterBattery = (target != null) && target.isOffBoard();
+                Report report = new Report(counterBattery ? 3127 : 3121);
                 report.indent();
                 report.newlines = 0;
                 report.subject = subjectId;
@@ -112,15 +113,14 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
                 Report.addNewline(vPhaseReport);
                 handledAmmoAndReport = true;
 
-                // "Shot, out" - homing round, will guide onto a tagged target
+                // "Shot, out" - homing round, will guide onto a tagged target (team-only toast; the target grid never
+                // goes in the shared phase report, so the enemy cannot read the aim point).
                 boolean offBoardTarget = (target == null) || (target.getPosition() == null) || target.isOffBoard();
                 String shotGrid = offBoardTarget
                       ? Messages.getString("Artillery.offBoardTarget")
                       : target.getPosition().getBoardNum();
-                addProWordReport(vPhaseReport, 3133, batteryName(aaa), weaponType.getName(), shotGrid,
-                      String.valueOf(game.getRoundCount() + aaa.getTurnsTilHit()));
                 if (attackingEntity != null) {
-                    gameManager.sendArtilleryNetToast("shot", attackingEntity, game.getRoundCount());
+                    gameManager.sendArtilleryNetToast("shot", attackingEntity, game.getRoundCount(), shotGrid);
                 }
             }
             // if this is the last targeting phase before we hit,
@@ -135,12 +135,10 @@ public class ArtilleryWeaponIndirectHomingHandler extends ArtilleryWeaponIndirec
             aaa.decrementTurnsTilHit();
             return true;
         }
-        // "Splash, over" - homing rounds about to land and seek the tagged target near the aim hex
-        if ((target != null) && (target.getPosition() != null)) {
-            addProWordReport(vPhaseReport, 3128, batteryName(aaa), target.getPosition().getBoardNum());
-            if (attackingEntity != null) {
-                gameManager.sendArtilleryNetToast("splash", attackingEntity, game.getRoundCount());
-            }
+        // "Splash, over" - homing rounds about to land and seek the tagged target near the aim hex (team-only toast)
+        if ((target != null) && (target.getPosition() != null) && (attackingEntity != null)) {
+            gameManager.sendArtilleryNetToast("splash", attackingEntity, game.getRoundCount(),
+                  target.getPosition().getBoardNum());
         }
         Entity entityTarget;
         try {

--- a/megamek/src/megamek/server/totalWarfare/ArtilleryNotifications.java
+++ b/megamek/src/megamek/server/totalWarfare/ArtilleryNotifications.java
@@ -39,6 +39,7 @@ import java.util.Set;
 import megamek.client.ui.Messages;
 import megamek.common.Player;
 import megamek.common.actions.ArtilleryAttackAction;
+import megamek.common.annotations.Nullable;
 import megamek.common.board.Coords;
 import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.AmmoType.Munitions;
@@ -82,6 +83,22 @@ public class ArtilleryNotifications {
      * @param momentRound  the round the moment occurs in, used only to scope de-duplication
      */
     public void sendArtilleryNetToast(String momentKey, Entity firingEntity, int momentRound) {
+        sendArtilleryNetToast(momentKey, firingEntity, momentRound, null);
+    }
+
+    /**
+     * Sends a single artillery call-for-fire toast naming the target grid, to the firing player and their teammates
+     * only - never to enemies. The target grid is the team-only channel for the aim point: it travels in this toast
+     * (and the team-only map marker), never in the shared phase report, so the other team cannot read it.
+     *
+     * @param momentKey    the call-for-fire moment ({@code Artillery.netToast.<momentKey>})
+     * @param firingEntity the artillery unit (its owner and team define the audience)
+     * @param momentRound  the round the moment occurs in, used only to scope de-duplication
+     * @param targetGrid   the target grid square to name in the toast (team-only), or {@code null} for a moment with no
+     *                     specific target hex
+     */
+    public void sendArtilleryNetToast(String momentKey, Entity firingEntity, int momentRound,
+          @Nullable String targetGrid) {
         Player owner = firingEntity.getOwner();
         if (owner == null) {
             LOGGER.debug("[Artillery] No net toast for {}: firing entity has no owner", firingEntity.getShortName());
@@ -98,7 +115,9 @@ public class ArtilleryNotifications {
                   momentKey, owner.getName());
             return;
         }
-        String message = Messages.getString("Artillery.netToast." + momentKey, owner.getName());
+        String message = (targetGrid == null)
+              ? Messages.getString("Artillery.netToast." + momentKey, owner.getName())
+              : Messages.getString("Artillery.netToast." + momentKey, owner.getName(), targetGrid);
         for (Player player : gameManager.getGame().getPlayersList()) {
             if (!player.isEnemyOf(owner)) {
                 gameManager.send(player.getId(), new Packet(PacketCommand.SEND_TOAST,

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -27437,19 +27437,42 @@ public class TWGameManager extends AbstractGameManager {
      */
     Packet createArtilleryPacket(Player p) {
         Vector<ArtilleryAttackAction> v = new Vector<>();
+        List<EnemyArtilleryInbound> enemyInbound = new ArrayList<>();
         int team = p.getTeam();
         for (Enumeration<AttackHandler> i = game.getAttacks(); i.hasMoreElements(); ) {
             WeaponHandler wh = (WeaponHandler) i.nextElement();
             if (wh.weaponAttackAction instanceof ArtilleryAttackAction aaa) {
-                if ((aaa.getPlayerId() == p.getId()) ||
-                      ((team != Player.TEAM_NONE) && (team == game.getPlayer(aaa.getPlayerId()).getTeam())) ||
-                      p.canIgnoreDoubleBlind() ||
-                      p.isArtilleryRevealAll()) {
+                boolean ownOrAllied = (aaa.getPlayerId() == p.getId())
+                      || ((team != Player.TEAM_NONE) && (team == game.getPlayer(aaa.getPlayerId()).getTeam()));
+                if (ownOrAllied || p.canIgnoreDoubleBlind() || p.isArtilleryRevealAll()) {
                     v.addElement(aaa);
+                } else if (enemyArtilleryRoundIsKnownTo(aaa, p)) {
+                    // The player knows an enemy round is inbound (its firing is announced in the report) but not its
+                    // target hex or munition - send only a redacted summary so the Rounds-in-Air window can list it with
+                    // "Unknown" target/warhead, without ever sending the aim point to the client.
+                    enemyInbound.add(new EnemyArtilleryInbound(aaa.getEntityId(), aaa.getPlayerId(),
+                          aaa.getTurnsTilHit()));
                 }
             }
         }
-        return new Packet(PacketCommand.SENDING_ARTILLERY_ATTACKS, v);
+        return new Packet(PacketCommand.SENDING_ARTILLERY_ATTACKS, v, enemyInbound);
+    }
+
+    /**
+     * @param aaa An enemy artillery attack in flight
+     * @param p   The viewing player
+     *
+     * @return {@code true} if the player is entitled to know the enemy round exists (so it can be listed, redacted, in
+     *       the Rounds-in-Air window): always without double-blind, and under double-blind only when the firing unit is
+     *       off-board (treated as public) or the player has detected it - matching when the firing is announced in the
+     *       report
+     */
+    private boolean enemyArtilleryRoundIsKnownTo(ArtilleryAttackAction aaa, Player p) {
+        if (!doBlind()) {
+            return true;
+        }
+        Entity firingEntity = aaa.getEntity(game);
+        return (firingEntity != null) && (firingEntity.isOffBoard() || firingEntity.hasSeenEntity(p));
     }
 
     private Packet createIlluminatedHexesPacket() {
@@ -31479,6 +31502,21 @@ public class TWGameManager extends AbstractGameManager {
      */
     public void sendArtilleryNetToast(String momentKey, Entity firingEntity, int momentRound) {
         artilleryNotifications.sendArtilleryNetToast(momentKey, firingEntity, momentRound);
+    }
+
+    /**
+     * Sends a single artillery call-for-fire toast naming the target grid, to the firing player and their teammates
+     * only. The grid is the team-only channel for the aim point. Delegates to
+     * {@link ArtilleryNotifications#sendArtilleryNetToast(String, Entity, int, String)}.
+     *
+     * @param momentKey    the call-for-fire moment ({@code Artillery.netToast.<momentKey>})
+     * @param firingEntity the artillery unit (its owner and team define the audience)
+     * @param momentRound  the round the moment occurs in, used to scope de-duplication
+     * @param targetGrid   the target grid square to name in the toast (team-only), or {@code null} for none
+     */
+    public void sendArtilleryNetToast(String momentKey, Entity firingEntity, int momentRound,
+          @Nullable String targetGrid) {
+        artilleryNotifications.sendArtilleryNetToast(momentKey, firingEntity, momentRound, targetGrid);
     }
 
     /**


### PR DESCRIPTION
## Follow-up PR
This is a **follow-up to the already-merged [Princess artillery / bot-command work](https://github.com/MegaMek/megamek/pull/8369)**. `main` was merged before this final batch of review files landed, so this PR simply adds the missing files. No new feature direction — it completes the merged work.

## Summary
Finishes the artillery messaging hidden-information model, adds enemy rounds to the Rounds-in-Air window, labels counter-battery fire, draws drift arrows for off-board scatter, gates the bot artillery menu to units that actually have artillery, and de-duplicates two helpers.

## Changes

### 1. Artillery targeting messaging (hidden info, aligned with main)
- The targeting-phase report shows only the public announcement (firing unit + `will land in N turn(s)`); the **target hex is no longer in the shared report**.
- The target hex is delivered to the firing player's **team only**, via the call-for-fire toast (now naming the grid) and the team-only `ARTILLERY_INCOMING` map marker. (Required because off-board artillery reports are public and reports aren't filtered without double-blind, so a hex in the report would leak.)
- **Counter-battery** shots are labeled in the report (new report id `3127`, "...conducting counter-battery fire, will land in N turn(s)"), since they have no on-board hex.

### 2. Off-board scatter drift arrows
- When a round scatters **off the board**, the drift arrow is now drawn to the board edge it crossed (previously nothing was drawn). New shared helper `ArtilleryHandlerHelper.nearestOnBoardHexTowardOffBoard(...)`; applied to the indirect-fire and
  cannon handlers.

### 3. Rounds-in-Air window: enemy rounds + Team column
- Enemy artillery rounds are now listed, **redacted**: landing time is shown; **Target Hex and Warhead show "Unknown"**.
- Columns reordered/added to: **Team, Player, Fired By, Lands In, Target Hex, Warhead**.
- Implemented via a redacted server→client feed — new `EnemyArtilleryInbound` record, a `Packet` getter, a transient `Game` field, the client handler, and `TWGameManager.createArtilleryPacket` — so the enemy target/munition is **never sent to the client** (it can't leak via the board's incoming-artillery sprites). Counter-battery targets display as "Counter-battery (off-board)".

### 4. Bot artillery menu gated to artillery units
- The bot **Artillery** menu (right-click map menu and the Bot Commands panel popup) now only appears for bots that own an artillery unit. New `Entity.hasArtillery()` helper.
  
### 5. Refactor (de-duplication)
- `Entity.hasArtillery()` replaces duplicated `F_ARTILLERY` weapon-list checks (mirrors the existing `Entity.hasTAG()` pattern).
- `ArtilleryTargetingControl.tagTargetValue(...)` made shared (static); `BasicPathRanker` reuses it, removing the mirrored `spotterTargetValue` and its duplicate constant.

## Files Changed
- `common/actions/EnemyArtilleryInbound.java` (new) — redacted enemy-round record
- `common/net/packets/Packet.java`, `common/game/Game.java`, `client/Client.java`,
  `server/totalWarfare/TWGameManager.java` — redacted enemy-rounds feed + team toast grid
- `client/ui/dialogs/RoundsInAirDialog.java` — Team column, enemy rows, counter-battery label
- `server/totalWarfare/ArtilleryNotifications.java` — toast grid overload + `[Artillery]` logging
- `common/weapons/handlers/artillery/{ArtilleryWeaponIndirectFireHandlerngHandler,
  ArtilleryBayWeaponIndirectFireHandler, ArtilleryBayWeaponIndirectHomingHandler, ArtilleryCannonWeaponHandler}.java`
  — counter-battery label, hex→team-only, off-board drift
- `common/weapons/ArtilleryHandlerHelper.java` — `nearestOnBoardHexTowardOffBoard` helper
- `client/ui/clientGUI/MapMenu.java`, `client/ui/dialogs/BotCommands/BotCommandsPanel.java`,
  `common/units/Entity.java` — artillery-menu gating + `hasArtillery()`
- `client/bot/princess/ArtilleryTargetingControl.java`, `client/bot/princess/BasicPathRanker.java`
  — shared `tagTargetValue`
- `resources/megamek/client/messages.properties`, `resources/megamek/coms`
  — new keys (col.team, unknown, counter-battery, toast grid, report 3127); removed dead pro-word report ids