### PR TITLE
fix: safety check for non-existent infantry calling for support (MM-8412)

### DIFF
--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -29776,7 +29776,8 @@ public class TWGameManager extends AbstractGameManager {
      */
     public void resolveCallSupport() {
         for (Entity e : game.getEntitiesVector()) {
-            if ((e instanceof Infantry) && ((Infantry) e).getIsCallingSupport()) {
+        	// some infantry can "call support", but should only be able to do so if they are on the board
+            if ((e instanceof Infantry) && ((Infantry) e).getIsCallingSupport() && e.getPosition() != null) {
 
                 // Now let's create a new foot platoon
                 var guerrilla = new ConvInfantry();


### PR DESCRIPTION
When an infantry unit calls for support but is no longer on the board for some reason during movement phase resolution, skip that "support call request".

Fixes #8412 