### PR TITLE
Fix nondeterministic Princess path selection: make RankedPath.compareTo a valid total order

### DIFF
--- a/megamek/src/megamek/client/bot/princess/RankedPath.java
+++ b/megamek/src/megamek/client/bot/princess/RankedPath.java
@@ -56,8 +56,8 @@ public class RankedPath implements Comparable<RankedPath> {
     private final transient Map<String, Double> scores = new HashMap<>();
 
     /**
-     * Creation-order id, used only to break {@link #compareTo} ties so the ordering is a valid total order. Not
-     * part of {@link #equals(Object)}/{@link #hashCode()} identity.
+     * Creation-order id, used only to break {@link #compareTo} ties in favour of the earliest-created path so the
+     * ordering is a valid total order. Not part of {@link #equals(Object)}/{@link #hashCode()} identity.
      */
     private final long creationId = ID_GENERATOR.getAndIncrement();
 
@@ -114,11 +114,15 @@ public class RankedPath implements Comparable<RankedPath> {
         if (other.expectedDamage < expectedDamage) {
             return 1;
         }
-        // Final tie-break on a stable, unique creation-order id, so this is a valid total order (antisymmetric,
-        // transitive, consistent) as required for the TreeSet<RankedPath> best-path selection in PathRanker. The
-        // previous `hashCode() > 0 ? 1 : -1` ignored the argument and never returned a symmetric result, which
-        // could misorder or drop tied paths in the TreeSet so getBestPath was not guaranteed the true maximum.
-        return Long.compare(creationId, other.creationId);
+        // Final tie-break: among paths tied on rank, hexes moved and expected damage, prefer the
+        // earliest-enumerated one, so the choice is stable and reproducible. The only consumer of this ordering is
+        // PathRanker's reverse-ordered TreeSet<RankedPath>, whose first() (used by getBestPath) returns the natural
+        // maximum - so the earliest path (lowest creationId) must compare as the greatest, hence other.creationId
+        // is placed first in the comparison. This yields a valid total order (antisymmetric, transitive,
+        // consistent) as required for correct TreeSet selection; the previous `hashCode() > 0 ? 1 : -1` ignored
+        // the argument and was non-antisymmetric, so it could misorder or drop tied paths and getBestPath was not
+        // guaranteed the true maximum.
+        return Long.compare(other.creationId, creationId);
     }
 
     @Override

--- a/megamek/src/megamek/client/bot/princess/RankedPath.java
+++ b/megamek/src/megamek/client/bot/princess/RankedPath.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2011 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -36,6 +36,7 @@ package megamek.client.bot.princess;
 import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 import megamek.common.moves.MovePath;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -46,10 +47,19 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
  * @since 12/5/13 10:19 AM
  */
 public class RankedPath implements Comparable<RankedPath> {
+    /** Source of the monotonic {@link #creationId} used only as a stable final tie-breaker in {@link #compareTo}. */
+    private static final AtomicLong ID_GENERATOR = new AtomicLong();
+
     private final MovePath path;
     private final double rank;
     private final String reason;
     private final transient Map<String, Double> scores = new HashMap<>();
+
+    /**
+     * Creation-order id, used only to break {@link #compareTo} ties so the ordering is a valid total order. Not
+     * part of {@link #equals(Object)}/{@link #hashCode()} identity.
+     */
+    private final long creationId = ID_GENERATOR.getAndIncrement();
 
     // the expected damage resulting from the calculation of this ranked path
     private double expectedDamage;
@@ -85,26 +95,30 @@ public class RankedPath implements Comparable<RankedPath> {
     }
 
     @Override
-    public int compareTo(RankedPath p) {
-        if (rank < p.rank) {
+    public int compareTo(RankedPath other) {
+        if (rank < other.rank) {
             return -1;
         }
-        if (p.rank < rank) {
+        if (other.rank < rank) {
             return 1;
         }
-        if (path.getHexesMoved() < p.path.getHexesMoved()) {
+        if (path.getHexesMoved() < other.path.getHexesMoved()) {
             return -1;
         }
-        if (p.path.getHexesMoved() < path.getHexesMoved()) {
+        if (other.path.getHexesMoved() < path.getHexesMoved()) {
             return 1;
         }
-        if (expectedDamage < p.expectedDamage) {
+        if (expectedDamage < other.expectedDamage) {
             return -1;
         }
-        if (p.expectedDamage < expectedDamage) {
+        if (other.expectedDamage < expectedDamage) {
             return 1;
         }
-        return hashCode() > 0 ? 1 : -1;
+        // Final tie-break on a stable, unique creation-order id, so this is a valid total order (antisymmetric,
+        // transitive, consistent) as required for the TreeSet<RankedPath> best-path selection in PathRanker. The
+        // previous `hashCode() > 0 ? 1 : -1` ignored the argument and never returned a symmetric result, which
+        // could misorder or drop tied paths in the TreeSet so getBestPath was not guaranteed the true maximum.
+        return Long.compare(creationId, other.creationId);
     }
 
     @Override

--- a/megamek/unittests/megamek/client/bot/princess/RankedPathTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/RankedPathTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.bot.princess;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import java.util.TreeSet;
+
+import megamek.common.moves.MovePath;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link RankedPath#compareTo(RankedPath)} implements a valid total order (issue #8436). The previous
+ * final tie-break (`hashCode() > 0 ? 1 : -1`) ignored the argument and was not antisymmetric, corrupting the
+ * {@code TreeSet<RankedPath>} that {@code PathRanker} uses for best-path selection.
+ */
+class RankedPathTest {
+
+    private static RankedPath rankedPath(double rank, int hexesMoved, double expectedDamage) {
+        MovePath mockPath = mock(MovePath.class);
+        when(mockPath.getHexesMoved()).thenReturn(hexesMoved);
+        RankedPath rankedPath = new RankedPath(rank, mockPath, "test");
+        rankedPath.setExpectedDamage(expectedDamage);
+        return rankedPath;
+    }
+
+    /**
+     * @return A spread of paths: distinct ranks, ties on rank broken by hexes/damage, and a group fully tied on all
+     *       three ranking keys (so only the creation-order tie-break separates them).
+     */
+    private static List<RankedPath> samplePaths() {
+        List<RankedPath> paths = new ArrayList<>();
+        paths.add(rankedPath(10.0, 3, 5.0));
+        paths.add(rankedPath(10.0, 3, 8.0));
+        paths.add(rankedPath(10.0, 5, 5.0));
+        paths.add(rankedPath(-4.0, 2, 0.0));
+        paths.add(rankedPath(139.17, 4, 12.0));
+        // Three paths identical on every ranking key - the pathological tie the old comparator mishandled.
+        paths.add(rankedPath(50.0, 4, 7.0));
+        paths.add(rankedPath(50.0, 4, 7.0));
+        paths.add(rankedPath(50.0, 4, 7.0));
+        return paths;
+    }
+
+    @Test
+    void comparatorIsAntisymmetricForEveryPair() {
+        List<RankedPath> paths = samplePaths();
+        for (RankedPath first : paths) {
+            for (RankedPath second : paths) {
+                int forward = first.compareTo(second);
+                int backward = second.compareTo(first);
+                assertEquals(Integer.signum(forward), -Integer.signum(backward),
+                      "compareTo must be antisymmetric: sgn(a.compareTo(b)) == -sgn(b.compareTo(a))");
+            }
+        }
+    }
+
+    @Test
+    void comparatorIsTransitive() {
+        List<RankedPath> paths = samplePaths();
+        for (RankedPath first : paths) {
+            for (RankedPath second : paths) {
+                for (RankedPath third : paths) {
+                    boolean firstBeforeSecond = first.compareTo(second) < 0;
+                    boolean secondBeforeThird = second.compareTo(third) < 0;
+                    if (firstBeforeSecond && secondBeforeThird) {
+                        assertTrue(first.compareTo(third) < 0,
+                              "compareTo must be transitive: a < b and b < c implies a < c");
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    void everyDistinctInstanceComparesNonZeroAndIsSelfConsistent() {
+        List<RankedPath> paths = samplePaths();
+        for (RankedPath first : paths) {
+            assertEquals(0, first.compareTo(first), "A path must compare equal to itself");
+            for (RankedPath second : paths) {
+                if (first != second) {
+                    assertTrue(first.compareTo(second) != 0,
+                          "Distinct instances must never tie, so the TreeSet keeps them all");
+                }
+            }
+        }
+    }
+
+    @Test
+    void treeSetRetainsAllFullyTiedPaths() {
+        List<RankedPath> tiedPaths = List.of(
+              rankedPath(50.0, 4, 7.0),
+              rankedPath(50.0, 4, 7.0),
+              rankedPath(50.0, 4, 7.0),
+              rankedPath(50.0, 4, 7.0));
+        TreeSet<RankedPath> treeSet = new TreeSet<>(tiedPaths);
+        assertEquals(tiedPaths.size(), treeSet.size(),
+              "A valid total order must not collapse paths that are tied on every ranking key");
+    }
+
+    @Test
+    void reverseOrderedTreeSetSelectsHighestRankFirst() {
+        // Mirrors PathRanker.getBestPath, which reads the first element of a reverse-ordered TreeSet.
+        RankedPath best = rankedPath(200.0, 4, 9.0);
+        List<RankedPath> paths = new ArrayList<>(samplePaths());
+        paths.add(best);
+        Collections.shuffle(paths, new Random(1));
+
+        TreeSet<RankedPath> reverseOrdered = new TreeSet<>(Collections.reverseOrder());
+        reverseOrdered.addAll(paths);
+
+        assertEquals(best, reverseOrdered.first(), "The highest-ranked path must be selected deterministically");
+    }
+}

--- a/megamek/unittests/megamek/client/bot/princess/RankedPathTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/RankedPathTest.java
@@ -33,6 +33,7 @@
 package megamek.client.bot.princess;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -133,6 +134,24 @@ class RankedPathTest {
         TreeSet<RankedPath> treeSet = new TreeSet<>(tiedPaths);
         assertEquals(tiedPaths.size(), treeSet.size(),
               "A valid total order must not collapse paths that are tied on every ranking key");
+    }
+
+    @Test
+    void reverseOrderedTreeSetBreaksTiesTowardTheEarliestPath() {
+        // Among paths tied on every ranking key, the earliest-created (earliest-enumerated) path wins, so the
+        // choice follows PathRanker's deterministic enumeration order rather than construction-timing luck.
+        RankedPath firstEnumerated = rankedPath(50.0, 4, 7.0);
+        RankedPath secondEnumerated = rankedPath(50.0, 4, 7.0);
+        RankedPath thirdEnumerated = rankedPath(50.0, 4, 7.0);
+
+        TreeSet<RankedPath> reverseOrdered = new TreeSet<>(Collections.reverseOrder());
+        // Insert out of creation order to prove the winner depends on creation order, not insertion order.
+        reverseOrdered.add(thirdEnumerated);
+        reverseOrdered.add(firstEnumerated);
+        reverseOrdered.add(secondEnumerated);
+
+        assertSame(firstEnumerated, reverseOrdered.first(),
+              "The earliest-created path must win a tie on every ranking key");
     }
 
     @Test


### PR DESCRIPTION
## Root Cause
`RankedPath.compareTo`'s final tie-break was `hashCode() > 0 ? 1 : -1`. This ignores the object being compared against, never returns `0`, and is not antisymmetric - for two paths tied on rank, hexes moved, and expected damage, `a.compareTo(b)` and `b.compareTo(a)` can both return the same sign, i.e. `a < b` and `b < a` at the same time. Every path ranker selects the best path from a `TreeSet<RankedPath>` (`PathRanker.getBestPath`), and a comparator that violates the `Comparable` contract can misorder or silently drop tied paths in that set. The result: `getBestPath` was not guaranteed to return the true maximum, and Princess's chosen move could differ from run to run on identical game state. It also blocked writing reproducible characterization/golden tests over path ranking.

## Changes
1. `RankedPath` - break ties on a stable, unique creation-order id (a `static AtomicLong`, compared with `Long.compare`) instead of the object's own hash code. This yields an antisymmetric, transitive, self-consistent total order while still keeping every distinct
   candidate path (the previous code also never collapsed ties, so no dedup behavior changes).   The id is not part of `equals`/`hashCode` identity. Also renamed the abbreviated `compareTo` parameter while touching it.

## Files Changed
- `megamek/src/megamek/client/bot/princess/RankedPath.java` - valid total-order tie-break
- `megamek/unittests/megamek/client/bot/princess/RankedPathTest.java` - new: comparator-contract
  coverage (antisymmetry, transitivity, self-consistency) plus that a `TreeSet` retains fully
  tied paths and selects the highest rank deterministically

## Testing
New `RankedPathTest` and the existing `BasicPathRankerTest` suite pass. The comparator-contract tests fail against the old `hashCode`-based tie-break and pass with the fix.

Fixes #8436