### PR TITLE
Fix Princess findClosestEnemy distance-metric inconsistency

### DIFF
--- a/megamek/src/megamek/client/bot/princess/NewtonianAerospacePathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/NewtonianAerospacePathRanker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2018-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -78,13 +78,17 @@ public class NewtonianAerospacePathRanker extends BasicPathRanker {
             }
 
             // If a unit has not moved, assume it will move away from me.
-            int unmovedDistMod = 0;
+            int unmovedDistanceModifier = 0;
             if (enemy.isSelectableThisTurn() && !enemy.isImmobile()) {
-                unmovedDistMod = enemy.getWalkMP();
+                unmovedDistanceModifier = enemy.getWalkMP();
             }
 
-            if ((position.distance(enemy.getPosition()) + unmovedDistMod) < range) {
-                range = position.distance(enemy.getPosition());
+            // "Closest" is measured by the adjusted distance (an unmoved enemy is treated as farther), so store the
+            // same adjusted value we compare against, not the raw distance.
+            int distance = position.distance(enemy.getPosition());
+            int adjustedDistance = distance + unmovedDistanceModifier;
+            if (adjustedDistance < range) {
+                range = adjustedDistance;
                 closest = enemy;
             }
         }

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -391,10 +391,15 @@ public abstract class PathRanker implements IPathRanker {
                 unmovedDistanceModifier = enemy.getWalkMP();
             }
 
+            // "Closest" is measured by the adjusted distance (an unmoved enemy is treated as farther, since it can
+            // still move away), so store the same adjusted value we compare against - not the raw distance. The
+            // minDistance filter is a "not within N raw hexes" gate (e.g. the not-zero-distance facing target), so
+            // it is tested against the raw hex distance, otherwise a same-hex enemy could pass it via its movement
+            // allowance.
             int distance = position.distance(enemy.getPosition());
-            if (((distance + unmovedDistanceModifier) < range) && ((distance + unmovedDistanceModifier)
-                  >= minDistance)) {
-                range = distance;
+            int adjustedDistance = distance + unmovedDistanceModifier;
+            if ((adjustedDistance < range) && (distance >= minDistance)) {
+                range = adjustedDistance;
                 closest = enemy;
             }
         }

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -1242,6 +1242,68 @@ class BasicPathRankerTest {
     }
 
     @Test
+    void testFindClosestEnemyUsesAdjustedDistanceConsistently() {
+        // A moved enemy at raw distance 20 (it cannot move again, so adjusted distance 20) versus an unmoved fast
+        // enemy at raw distance 16 that can still travel 6 hexes (adjusted distance 22). By adjusted distance the
+        // moved enemy is the nearer threat and must be chosen regardless of enemy iteration order. The old code
+        // compared the adjusted distance but stored the raw one, so the unmoved enemy could win when enumerated
+        // first (issue #8437). Positions share a column, where hex distance equals the row difference.
+        final Coords position = new Coords(0, 0);
+
+        final Entity movedEnemy = mock(BipedMek.class);
+        when(movedEnemy.getPosition()).thenReturn(new Coords(0, 20));
+        when(movedEnemy.isSelectableThisTurn()).thenReturn(false);
+        when(movedEnemy.isImmobile()).thenReturn(false);
+
+        final Entity unmovedFastEnemy = mock(BipedMek.class);
+        when(unmovedFastEnemy.getPosition()).thenReturn(new Coords(0, 16));
+        when(unmovedFastEnemy.isSelectableThisTurn()).thenReturn(true);
+        when(unmovedFastEnemy.isImmobile()).thenReturn(false);
+        when(unmovedFastEnemy.getWalkMP()).thenReturn(6);
+
+        final Entity me = mock(BipedMek.class);
+        final Game mockGame = mock(Game.class);
+        when(mockGame.onTheSameBoard(any(Targetable.class), any(Targetable.class))).thenCallRealMethod();
+        final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
+
+        doReturn(List.of(movedEnemy, unmovedFastEnemy)).when(mockPrincess).getEnemyEntities();
+        assertEquals(movedEnemy, testRanker.findClosestEnemy(me, position, mockGame, false),
+              "The nearer enemy by adjusted distance must be chosen");
+
+        doReturn(List.of(unmovedFastEnemy, movedEnemy)).when(mockPrincess).getEnemyEntities();
+        assertEquals(movedEnemy, testRanker.findClosestEnemy(me, position, mockGame, false),
+              "The result must not depend on enemy iteration order");
+    }
+
+    @Test
+    void testFindClosestEnemyMinDistanceIgnoresMovementAllowance() {
+        // A same-hex enemy that can still move (raw distance 0, adjusted distance 5) must be excluded by a
+        // minDistance of 1, because minDistance is a not-within-N-raw-hexes gate. The old code tested the adjusted
+        // distance, letting the same-hex enemy satisfy the gate through its movement allowance (issue #8437).
+        final Coords position = new Coords(0, 0);
+
+        final Entity sameHexEnemy = mock(BipedMek.class);
+        when(sameHexEnemy.getPosition()).thenReturn(position);
+        when(sameHexEnemy.isSelectableThisTurn()).thenReturn(true);
+        when(sameHexEnemy.isImmobile()).thenReturn(false);
+        when(sameHexEnemy.getWalkMP()).thenReturn(5);
+
+        final Entity nearbyEnemy = mock(BipedMek.class);
+        when(nearbyEnemy.getPosition()).thenReturn(new Coords(0, 4));
+        when(nearbyEnemy.isSelectableThisTurn()).thenReturn(false);
+        when(nearbyEnemy.isImmobile()).thenReturn(false);
+
+        final Entity me = mock(BipedMek.class);
+        final Game mockGame = mock(Game.class);
+        when(mockGame.onTheSameBoard(any(Targetable.class), any(Targetable.class))).thenCallRealMethod();
+        final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
+        doReturn(List.of(sameHexEnemy, nearbyEnemy)).when(mockPrincess).getEnemyEntities();
+
+        assertEquals(nearbyEnemy, testRanker.findClosestEnemy(me, position, mockGame, false, 1),
+              "A minDistance of 1 must exclude the same-hex enemy by its raw distance");
+    }
+
+    @Test
     void testCalcAllyCenter() {
         final int myId = 1;
 


### PR DESCRIPTION
## Root Cause
`PathRanker.findClosestEnemy` picks the nearest enemy by an *adjusted* distance - `distance + movement allowance`, so an enemy that has not moved yet is treated as farther (it can still close or flee). But the loop compared that adjusted distance while storing the *raw* distance into the running minimum:

```
java
int distance = position.distance(enemy.getPosition());
if (((distance + unmovedDistanceModifier) < range) && ((distance + unmovedDistanceModifier) >= minDistance)) {
    range = distance;   // stores RAW, but the comparison used ADJUSTED
    closest = enemy;
}
```

Because later enemies were then compared against a previous enemy's raw value, the result depended on iteration order and an unmoved fast enemy could hijack the "closest" slot from a genuinely nearer moved one. That closest enemy feeds the aggression term (distanceToClosestEnemy) and the desired facing target, so it skewed both every turn. The same bug existed in NewtonianAerospacePathRanker.findClosestEnemy.

Separately, the minDistance argument is a "not within N raw hexes" gate - its only non-zero caller asks for closestEnemyPositionNotZeroDistance (the not-zero-distance facing target). It was tested against the adjusted distance, so a same-hex enemy (raw distance 0) could satisfy minDistance = 1 through its movement allowance.

Changes

1. PathRanker.findClosestEnemy - store the adjusted distance that is actually compared, and test minDistance against the raw hex distance.
2. NewtonianAerospacePathRanker.findClosestEnemy - same store-what-you-compare fix; also renamed
the abbreviated unmovedDistMod local while touching it.

Files Changed

- megamek/src/megamek/client/bot/princess/PathRanker.java - metric consistency + raw-distance minDistance gate
- megamek/src/megamek/client/bot/princess/NewtonianAerospacePathRanker.java - m
- megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java - two regression tests

Testing

Added testFindClosestEnemyUsesAdjustedDistanceConsistently (the nearer-by-adjusted-distance enemy
wins regardless of enemy iteration order) and testFindClosestEnemyMinDistanceIg
(a minDistance of 1 excludes a same-hex enemy). Both were verified to fail against the unfixed
code and pass with the fix; the full BasicPathRankerTest suite is green.

Fixes #8437