### PR TITLE
Fix Princess HeatMap.getHotSpot storing a hex direction instead of a distance (Fixes #8438)

### DIFF
--- a/megamek/src/megamek/client/bot/princess/HeatMap.java
+++ b/megamek/src/megamek/client/bot/princess/HeatMap.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.OptionalInt;
 import java.util.stream.Collectors;
 
+import megamek.common.annotations.Nullable;
 import megamek.common.board.Coords;
 import megamek.common.game.Game;
 import megamek.common.moves.MovePath;
@@ -341,11 +342,16 @@ public class HeatMap {
     }
 
     /**
-     * Get the closest hot-spot (position of high activity). May return null if the activity tracker is empty.
+     * Gets the hot-spot (position of high activity) closest to the given position. Among the highest-rated
+     * hot-spots, the one nearest {@code testPosition} is returned.
      *
-     * @return {@link Coords} with nearest hot-spot, or null if no valid position
+     * @param testPosition The position to measure distance from
+     * @param topOnly      When {@code true}, only the single highest-rated tier of hot-spots is considered;
+     *                     otherwise all hot-spots are ranked
+     *
+     * @return The {@link Coords} of the nearest high-activity hot-spot, or {@code null} if there are none
      */
-    public Coords getHotSpot(Coords testPosition, boolean topOnly) {
+    public @Nullable Coords getHotSpot(Coords testPosition, boolean topOnly) {
 
         // If there are no hot-spots, return null
         if (teamActivity.isEmpty() || teamActivity.values().stream().allMatch(w -> w == MIN_WEIGHT)) {
@@ -385,9 +391,10 @@ public class HeatMap {
         int shortestRange = Integer.MAX_VALUE;
         Coords bestPosition = null;
         for (Coords curPosition : rankedPositions) {
-            if (shortestRange > curPosition.distance(testPosition)) {
+            int rangeToTestPosition = curPosition.distance(testPosition);
+            if (rangeToTestPosition < shortestRange) {
                 bestPosition = curPosition;
-                shortestRange = curPosition.direction(testPosition);
+                shortestRange = rangeToTestPosition;
             }
         }
 

--- a/megamek/src/megamek/client/bot/princess/HeatMap.java
+++ b/megamek/src/megamek/client/bot/princess/HeatMap.java
@@ -342,14 +342,16 @@ public class HeatMap {
     }
 
     /**
-     * Gets the hot-spot (position of high activity) closest to the given position. Among the highest-rated
-     * hot-spots, the one nearest {@code testPosition} is returned.
+     * Gets the hot-spot (position of recorded activity) nearest the given position. When {@code topOnly} is
+     * {@code false}, every recorded hot-spot is considered and the nearest one is returned. When {@code topOnly}
+     * is {@code true}, only the single highest-rated tier of hot-spots is considered, and the nearest within that
+     * tier is returned.
      *
      * @param testPosition The position to measure distance from
-     * @param topOnly      When {@code true}, only the single highest-rated tier of hot-spots is considered;
-     *                     otherwise all hot-spots are ranked
+     * @param topOnly      When {@code true}, only the highest-rated tier of hot-spots is considered; when
+     *                     {@code false}, all recorded hot-spots are considered
      *
-     * @return The {@link Coords} of the nearest high-activity hot-spot, or {@code null} if there are none
+     * @return The {@link Coords} of the nearest considered hot-spot, or {@code null} if there are none
      */
     public @Nullable Coords getHotSpot(Coords testPosition, boolean topOnly) {
 

--- a/megamek/unittests/megamek/client/bot/princess/HeatMapTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/HeatMapTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.bot.princess;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import megamek.common.Player;
+import megamek.common.battleValue.BVCalculator;
+import megamek.common.board.Coords;
+import megamek.common.units.BipedMek;
+import megamek.common.units.Entity;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link HeatMap}, in particular that {@link HeatMap#getHotSpot(Coords, boolean)} selects the hot-spot
+ * nearest the query position (issue #8438).
+ */
+class HeatMapTest {
+
+    private static final int TEAM_ID = 1;
+
+    /**
+     * Builds a trackable ground unit at a position with the given Battle Value and walk MP, so that
+     * {@link HeatMap#updateTrackers(List)} records a hot-spot there weighted by that Battle Value.
+     */
+    private static Entity mockTrackedEntity(int id, Coords position, int battleValue, int walkMP) {
+        Entity entity = mock(BipedMek.class);
+        Player owner = mock(Player.class);
+        when(owner.getTeam()).thenReturn(TEAM_ID);
+        when(entity.getOwner()).thenReturn(owner);
+        when(entity.getId()).thenReturn(id);
+        when(entity.getPosition()).thenReturn(position);
+        when(entity.isGround()).thenReturn(true);
+        when(entity.isDeployed()).thenReturn(true);
+        when(entity.isVisibleToEnemy()).thenReturn(true);
+        when(entity.getWalkMP()).thenReturn(walkMP);
+        when(entity.getAnyTypeMaxJumpMP()).thenReturn(0);
+
+        BVCalculator bvCalculator = mock(BVCalculator.class);
+        when(bvCalculator.retrieveBV()).thenReturn(battleValue);
+        when(entity.getBvCalculator()).thenReturn(bvCalculator);
+        return entity;
+    }
+
+    @Test
+    void getHotSpotReturnsTheNearestHotSpotByDistance() {
+        HeatMap heatMap = new HeatMap(TEAM_ID);
+
+        // A far, high-value cluster and a near, low-value one. getHotSpot must return the geometrically nearest
+        // hot-spot to the query position regardless of value ordering. The old code compared distance but stored a
+        // hex direction (0-5), so once the farther (higher-rated, enumerated first) position was seen, the nearer
+        // one - more than 5 hexes away - could never replace it. Positions share a column, where the hex distance
+        // equals the row difference.
+        Entity farHighValue = mockTrackedEntity(1, new Coords(0, 20), 3000, 1);
+        Entity nearLowValue = mockTrackedEntity(2, new Coords(0, 8), 500, 1);
+        heatMap.updateTrackers(List.of(farHighValue, nearLowValue));
+
+        Coords queryPosition = new Coords(0, 0);
+        assertEquals(new Coords(0, 8), heatMap.getHotSpot(queryPosition, false),
+              "getHotSpot must return the hot-spot nearest the query position");
+    }
+
+    @Test
+    void getHotSpotReturnsNullWhenThereIsNoActivity() {
+        HeatMap heatMap = new HeatMap(TEAM_ID);
+        assertNull(heatMap.getHotSpot(new Coords(0, 0), false),
+              "getHotSpot must return null when no hot-spots have been recorded");
+    }
+}


### PR DESCRIPTION
## Root Cause
`HeatMap.getHotSpot` returns the hot-spot nearest a query position. It compared distance but stored a direction:

```
java
int shortestRange = Integer.MAX_VALUE;
for (Coords curPosition : rankedPositions) {
    if (shortestRange > curPosition.distance(testPosition)) {   // compares DISTANCE
        bestPosition = curPosition;
        shortestRange = curPosition.direction(testPosition);    // stores DIRECTION (0-5)
    }
}
```

Coords.direction returns a hex facing (0-5), so after the first candidate shortestRange was at most 5. Any nearer hot-spot more than 5 hexes away could then never replace an earlier, farther one - the method effectively returned the first-ranked hot-spot rather than the closest. This is Princess's primary heat-map read: it supplies the ally-center herding anchor (PathRanker.rankPaths) and the "go where we last saw them" move-to-contact destinations (PathEnumerator), so the anchor those produced was largely accidental.

Changes

1. HeatMap.getHotSpot - store the computed distance that is compared, so the nearest hot-spot is actually selected. While in the method, added its missing @param tags and a @Nullable return (the Javadoc already documented the null case).

Files Changed

- megamek/src/megamek/client/bot/princess/HeatMap.java - distance/direction fix + Javadoc
- megamek/unittests/megamek/client/bot/princess/HeatMapTest.java - new (Hea

Testing

Added HeatMapTest, the first unit tests for HeatMap:
getHotSpotReturnsTheNearestHotSpotByDistance (a far high-value hot-spot and the nearer must be returned) and getHotSpotReturnsNullWhenThereIsNoActivity. The selection test was verified to fail against the unfixed code (which returns the farther hot-spot) and pass with the fix.

Fixes #8438