### PR TITLE
Fix Princess Precognition facing-5 omission and dead evade/searchlight gate

### DIFF
--- a/megamek/src/megamek/client/bot/princess/PathEnumerator.java
+++ b/megamek/src/megamek/client/bot/princess/PathEnumerator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2011 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2011-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2011-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -129,7 +129,9 @@ public class PathEnumerator {
                 continue;
             }
 
-            for (int facing = 0; facing < 5; facing++) {
+            // Hex facings are 0-5, so all six must be checked - stopping at 4 missed units whose only potential
+            // location here faces 5 (NW), leaving them under-dirtied with stale predicted paths.
+            for (int facing = 0; facing < 6; facing++) {
                 if (getUnitPotentialLocations().get(id)
                       .contains(CoordFacingCombo.createCoordFacingCombo(location, facing))) {
                     returnSet.add(id);

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -3921,8 +3921,12 @@ public class Princess extends BotClient {
      */
     private MovePath performPathPostProcessing(MovePath path, double expectedDamage) {
         MovePath retVal = path;
-        evadeIfNotFiring(retVal, expectedDamage >= 0);
-        turnOnSearchLight(retVal, expectedDamage >= 0);
+        // Guard on expectedDamage > 0, not >= 0: expected damage is never negative, so >= 0 was always true. That
+        // left evadeIfNotFiring (which only evades when NOT able to inflict damage) permanently dead, and turned
+        // the searchlight on even with no firing solution, giving away position for nothing.
+        boolean canInflictDamage = expectedDamage > 0;
+        evadeIfNotFiring(retVal, canInflictDamage);
+        turnOnSearchLight(retVal, canInflictDamage);
         unloadTransportedInfantry(retVal);
         launchFighters(retVal);
         abandonShip(retVal);

--- a/megamek/unittests/megamek/client/bot/princess/PathEnumeratorTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PathEnumeratorTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.bot.princess;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import megamek.client.bot.princess.geometry.CoordFacingCombo;
+import megamek.common.board.Coords;
+import megamek.common.game.Game;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link PathEnumerator#getEntitiesWithLocation(Coords, boolean)}, in particular that a unit is found at
+ * a location regardless of which of the six hex facings its potential location uses (issue #8439).
+ */
+class PathEnumeratorTest {
+
+    @Test
+    void getEntitiesWithLocationDetectsEveryFacing() {
+        Princess mockPrincess = mock(Princess.class);
+        Game mockGame = mock(Game.class);
+        PathEnumerator pathEnumerator = new PathEnumerator(mockPrincess, mockGame);
+
+        Coords location = new Coords(3, 4);
+        // Hex facings are 0-5. A unit whose only potential location at this hex uses a given facing must be found
+        // for every facing; the old loop stopped at 4, so facing 5 (NW) was missed.
+        for (int facing = 0; facing < 6; facing++) {
+            int entityId = 10 + facing;
+            Set<CoordFacingCombo> potentialLocations = new HashSet<>();
+            potentialLocations.add(CoordFacingCombo.createCoordFacingCombo(location, facing));
+            pathEnumerator.getUnitPotentialLocations().put(entityId, potentialLocations);
+
+            assertTrue(pathEnumerator.getEntitiesWithLocation(location, false).contains(entityId),
+                  "A unit whose only potential location faces " + facing + " must be found");
+        }
+    }
+
+    @Test
+    void getEntitiesWithLocationExcludesUnitAtAnotherHex() {
+        Princess mockPrincess = mock(Princess.class);
+        Game mockGame = mock(Game.class);
+        PathEnumerator pathEnumerator = new PathEnumerator(mockPrincess, mockGame);
+
+        Coords queriedLocation = new Coords(3, 4);
+        Coords otherLocation = new Coords(9, 9);
+        int entityId = 7;
+        Set<CoordFacingCombo> potentialLocations = new HashSet<>();
+        potentialLocations.add(CoordFacingCombo.createCoordFacingCombo(otherLocation, 2));
+        pathEnumerator.getUnitPotentialLocations().put(entityId, potentialLocations);
+
+        assertFalse(pathEnumerator.getEntitiesWithLocation(queriedLocation, false).contains(entityId),
+              "A unit with no potential location at the queried hex must not be found");
+    }
+}


### PR DESCRIPTION
## Root Cause
Two independent Princess movement defects, batched because both are small one-line gate fixes.

**#8439 - `PathEnumerator.getEntitiesWithLocation` misses hex facing 5.** The method looped`for (int facing = 0; facing < 5; facing++)`, but hex facings are 0-5, so facing 5 (NW) was never checked. Precognition uses this to decide which units a game event has dirtied and must re-enumerate; a unit whose only potential location at a hex faced 5 was therefore under-dirtied
and kept last round's stale predicted paths.

**#8440 - evade/searchlight gate is always true.** `Princess.performPathPostProcessing` gated`evadeIfNotFiring` and `turnOnSearchLight` on `expectedDamage >= 0`. Expected damage is never negative, so the flag was always `true`. Consequences: `evadeIfNotFiring` only adds an EVADE step when it is told the unit CANNOT inflict damage, so that branch was permanently dead (airborne units never took the free evade when they had no shot); and `turnOnSearchLight` was told a firing
solution existed unconditionally, so it enabled the searchlight in the dark even with no target, giving away position for nothing.

## Changes
1. `PathEnumerator.getEntitiesWithLocation` - iterate all six facings (`facing < 6`).
2. `Princess.performPathPostProcessing` - gate evade/searchlight on `expectedDamage > 0` via a named `canInflictDamage` local. The adjacent `unjamRAC` uses `expectedDamage >= 5`, which is correct and left unchanged.

## Files Changed
- `megamek/src/megamek/client/bot/princess/PathEnumerator.java` - check facing 5
- `megamek/src/megamek/client/bot/princess/Princess.java` - correct the evade/searchlight gate
- `megamek/unittests/megamek/client/bot/princess/PathEnumeratorTest.java` - new

## Testing
Added `PathEnumeratorTest`: `getEntitiesWithLocationDetectsEveryFacing` (a unit is found at a hex for each facing 0-5; verified to fail at facing 5 against the unfixed loop) and `getEntitiesWithLocationExcludesUnitAtAnotherHex`. The evade/searchlight change (#8440) is a one-line boolean correction inside private post-processing methods that would require a live airborne-aero + Princess harness to drive, so it is covered by inspection and manual testing rather than a unit test.

Fixes #8439
Fixes #8440