### PR TITLE
Hoist bot behavior-settings surface to BotClient; remove Princess downcasts

### DIFF
--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2000-2005 Ben Mazur (bmazur@sev.org)
  * Copyright (c) 2013 Edward Cullen (eddy@obsessedcomputers.co.uk)
- * Copyright (C) 2002-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2002-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -60,7 +60,6 @@ import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 import megamek.MMConstants;
-import megamek.client.bot.princess.Princess;
 import megamek.client.generator.skillGenerators.AbstractSkillGenerator;
 import megamek.client.generator.skillGenerators.ModifiedTotalWarfareSkillGenerator;
 import megamek.client.ui.clientGUI.GUIPreferences;
@@ -997,14 +996,20 @@ public class Client extends AbstractClient {
         send(new Packet(PacketCommand.SPECIAL_HEX_DISPLAY_DELETE, c, boardId, shd));
     }
 
+    /**
+     * Hook invoked when the server greets this client, allowing a bot client to push its behavior settings to the
+     * server. Non-bot clients have no settings to send, so this default implementation does nothing; bot clients
+     * override it.
+     */
+    protected void sendBotSettingsToServer() {
+    }
+
     @Override
     protected boolean handleGameSpecificPacket(Packet packet) {
         try {
             switch (packet.command()) {
                 case SERVER_GREETING:
-                    if (this instanceof Princess) {
-                        ((Princess) this).sendPrincessSettings();
-                    }
+                    sendBotSettingsToServer();
                     break;
                 case PRINCESS_SETTINGS:
                     game.setBotSettings(packet.getStringWIthBehaviorSettingsMap(0));

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -47,6 +47,7 @@ import javax.swing.ScrollPaneConstants;
 
 import megamek.client.AbstractClient;
 import megamek.client.Client;
+import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.CardinalEdge;
 import megamek.client.ui.clientGUI.ClientGUI;
 import megamek.common.ECMInfo;
@@ -120,6 +121,12 @@ public abstract class BotClient extends Client {
 
     // Let bots remember whether they've rerolled an initiative roll this round
     protected boolean rerolledInitiative = false;
+
+    /**
+     * The bot's personality/configuration state. Held on {@link BotClient} because it is generic bot-personality
+     * state (sliders, targeting, retreat edges) shared by every bot implementation, not specific to any one AI.
+     */
+    protected BehaviorSettings behaviorSettings;
 
     /**
      * Store a reference to the ClientGUI for the client who created this bot. This is used to ensure keep the ClientGUI
@@ -298,6 +305,22 @@ public abstract class BotClient extends Client {
     protected abstract void calculateFiringTurn();
 
     protected abstract void calculateDeployment() throws Exception;
+
+    /**
+     * @return this bot's current behavior settings (personality/configuration state)
+     */
+    public BehaviorSettings getBehaviorSettings() {
+        return behaviorSettings;
+    }
+
+    /**
+     * Applies the given behavior settings to this bot. Implementations decide how the settings take effect (for
+     * example, re-initializing scorers or notifying the server) and are responsible for storing them in
+     * {@link #behaviorSettings}.
+     *
+     * @param behaviorSettings the new behavior settings to apply
+     */
+    public abstract void setBehaviorSettings(BehaviorSettings behaviorSettings);
 
     protected void initTargeting() {
     }

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -125,8 +125,11 @@ public abstract class BotClient extends Client {
     /**
      * The bot's personality/configuration state. Held on {@link BotClient} because it is generic bot-personality
      * state (sliders, targeting, retreat edges) shared by every bot implementation, not specific to any one AI.
+     * Initialized to a default so it is never {@code null}: subclasses normally replace it via
+     * {@link #setBehaviorSettings(BehaviorSettings)} during construction, but the default preserves the
+     * non-null contract that {@link #getBehaviorSettings()} callers rely on even if a subclass does not.
      */
-    protected BehaviorSettings behaviorSettings;
+    protected BehaviorSettings behaviorSettings = new BehaviorSettings();
 
     /**
      * Store a reference to the ClientGUI for the client who created this bot. This is used to ensure keep the ClientGUI

--- a/megamek/src/megamek/client/bot/ChatProcessor.java
+++ b/megamek/src/megamek/client/bot/ChatProcessor.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2007 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2003-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2003-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -141,7 +141,9 @@ public class ChatProcessor {
             return;
         }
 
-        additionalPrincessCommands(ge, (Princess) bot);
+        if (bot instanceof Princess princess) {
+            additionalPrincessCommands(ge, princess);
+        }
     }
 
     private Player getPlayer(Game game, String playerName) {

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -189,7 +189,6 @@ public class Princess extends BotClient {
 
     private Integer spinUpThreshold = null;
 
-    private BehaviorSettings behaviorSettings;
     private double moveEvaluationTimeEstimate = 0;
     private final Precognition precognition;
     private final Thread precognitionThread;
@@ -825,6 +824,7 @@ public class Princess extends BotClient {
         return closestPosition;
     }
 
+    @Override
     public void setBehaviorSettings(final BehaviorSettings behaviorSettings) {
         LOGGER.info("New behavior settings for {}\n{}", getName(), behaviorSettings.toLog());
         try {
@@ -901,10 +901,6 @@ public class Princess extends BotClient {
             return damageMap.get(targetId);
         }
         return 0.0; // If we have no entry, return zero
-    }
-
-    public BehaviorSettings getBehaviorSettings() {
-        return behaviorSettings;
     }
 
     public Set<Coords> getStrategicBuildingTargets() {
@@ -3876,6 +3872,11 @@ public class Princess extends BotClient {
 
     public void sendPrincessSettings() {
         send(new Packet(PacketCommand.PRINCESS_SETTINGS, behaviorSettings));
+    }
+
+    @Override
+    protected void sendBotSettingsToServer() {
+        sendPrincessSettings();
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/dialogs/buttonDialogs/BotConfigDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/buttonDialogs/BotConfigDialog.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000-2011 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -69,10 +69,10 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 
 import megamek.client.Client;
+import megamek.client.bot.BotClient;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.BehaviorSettingsFactory;
 import megamek.client.bot.princess.CardinalEdge;
-import megamek.client.bot.princess.Princess;
 import megamek.client.bot.princess.PrincessException;
 import megamek.client.generator.RandomCallsignGenerator;
 import megamek.client.ui.Messages;
@@ -802,9 +802,9 @@ public class BotConfigDialog extends AbstractButtonDialog
     /** Copies the Configuration from another local bot player. */
     private void copyFromOtherBot(String botName) {
         var bc = client.getBots().get(botName);
-        if (bc instanceof Princess) {
+        if (bc instanceof BotClient botClient) {
             try {
-                princessBehavior = ((Princess) bc).getBehaviorSettings().getCopy();
+                princessBehavior = botClient.getBehaviorSettings().getCopy();
                 updateDialogFields();
             } catch (Exception e) {
                 logger.error(e, "copyFromOtherBot");

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2000-2006 Ben Mazur (bmazur@sev.org)
  * Copyright (C) 2013 Edward Cullen (eddy@obsessedcomputers.co.uk)
- * Copyright (C) 2002-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2002-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -2355,7 +2355,9 @@ public class ChatLounge extends AbstractPhaseDisplay
 
     private void doBotSettings() {
         Player player = playerModel.getPlayerAt(tablePlayers.getSelectedRow());
-        Princess bot = (Princess) clientgui.getLocalBots().get(player.getName());
+        if (!(clientgui.getLocalBots().get(player.getName()) instanceof BotClient bot)) {
+            return;
+        }
         var bcd = new BotConfigDialog(clientgui.getFrame(),
               bot.getLocalPlayer().getName(),
               bot.getBehaviorSettings(),

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/LobbyActions.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/LobbyActions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -48,8 +48,8 @@ import javax.swing.JOptionPane;
 
 import megamek.client.AbstractClient;
 import megamek.client.Client;
+import megamek.client.bot.BotClient;
 import megamek.client.bot.princess.BehaviorSettings;
-import megamek.client.bot.princess.Princess;
 import megamek.client.generator.RandomCallsignGenerator;
 import megamek.client.generator.RandomGenderGenerator;
 import megamek.client.generator.RandomNameGenerator;
@@ -585,10 +585,10 @@ public class LobbyActions {
     /** Adds the given entities as strategic targets for the given local bot. */
     void setPriorityTarget(String botName, Collection<Entity> entities) {
         Map<String, AbstractClient> bots = lobby.getClientGUI().getLocalBots();
-        if (!bots.containsKey(botName) || !(bots.get(botName) instanceof Princess)) {
+        if (!bots.containsKey(botName) || !(bots.get(botName) instanceof BotClient botClient)) {
             return;
         }
-        BehaviorSettings behavior = ((Princess) bots.get(botName)).getBehaviorSettings();
+        BehaviorSettings behavior = botClient.getBehaviorSettings();
         entities.forEach(e -> behavior.addPriorityUnit(e.getId()));
     }
 

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/PlayerSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/PlayerSettingsDialog.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2004 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -66,7 +66,6 @@ import megamek.MMConstants;
 import megamek.client.Client;
 import megamek.client.bot.BotClient;
 import megamek.client.bot.princess.BehaviorSettings;
-import megamek.client.bot.princess.Princess;
 import megamek.client.generator.ReconfigurationParameters;
 import megamek.client.generator.TeamLoadOutGenerator;
 import megamek.client.ratgenerator.FactionRecord;
@@ -961,15 +960,15 @@ public class PlayerSettingsDialog extends AbstractButtonDialog {
                     munitionTree = originalMT;
                 }
                 // Bot settings button
-            } else if (butBotSettings.equals(e.getSource()) && client instanceof Princess) {
-                BehaviorSettings behavior = ((Princess) client).getBehaviorSettings();
+            } else if (butBotSettings.equals(e.getSource()) && client instanceof BotClient botClient) {
+                BehaviorSettings behavior = botClient.getBehaviorSettings();
                 var bcd = new BotConfigDialog(clientgui.getFrame(),
                       client.getLocalPlayer().getName(),
                       behavior,
                       clientgui);
                 bcd.setVisible(true);
                 if (bcd.getResult() == DialogResult.CONFIRMED) {
-                    ((Princess) client).setBehaviorSettings(bcd.getBehaviorSettings());
+                    botClient.setBehaviorSettings(bcd.getBehaviorSettings());
                 }
             } else if (e.getActionCommand().equals(CMD_ADD_GROUND_OBJECT)) {
                 addGroundObject();

--- a/megamek/src/megamek/common/util/AddBotUtil.java
+++ b/megamek/src/megamek/common/util/AddBotUtil.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2004 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -167,13 +167,13 @@ public class AddBotUtil {
                 final BehaviorSettings behavior = BehaviorSettingsFactory.getInstance()
                       .getBehavior(configName.toString());
                 if (null != behavior) {
-                    ((Princess) botClient).setBehaviorSettings(behavior);
+                    botClient.setBehaviorSettings(behavior);
                 } else {
                     results.add("Unrecognized Behavior Setting: '" + configName + "'.  Using DEFAULT.");
-                    ((Princess) botClient).setBehaviorSettings(BehaviorSettingsFactory.getInstance().DEFAULT_BEHAVIOR);
+                    botClient.setBehaviorSettings(BehaviorSettingsFactory.getInstance().DEFAULT_BEHAVIOR);
                 }
             } else {
-                ((Princess) botClient).setBehaviorSettings(BehaviorSettingsFactory.getInstance().DEFAULT_BEHAVIOR);
+                botClient.setBehaviorSettings(BehaviorSettingsFactory.getInstance().DEFAULT_BEHAVIOR);
             }
         } else {
             results.add("Unrecognized bot: '" + botName + "'.  Defaulting to Princess.");
@@ -196,11 +196,9 @@ public class AddBotUtil {
 
         final StringBuilder result = new StringBuilder(botName);
         result.append(" has replaced ").append(target.getName()).append(".");
-        if (botClient instanceof Princess) {
-            result.append("  Config: ")
-                  .append(((Princess) botClient).getBehaviorSettings().getDescription())
-                  .append(".");
-        }
+        result.append("  Config: ")
+              .append(botClient.getBehaviorSettings().getDescription())
+              .append(".");
         results.add(result.toString());
         return concatResults();
     }
@@ -286,12 +284,12 @@ public class AddBotUtil {
             if (bot == null) {
                 message.append("Player '").append(playerName).append("' is not a local bot.");
                 return;
-            } else if (!(bot instanceof Princess)) {
-                message.append("Player '").append(playerName).append("' is not a Princess bot.");
+            }
+            if (!(bot instanceof BotClient botClient)) {
+                message.append("Player '").append(playerName).append("' is not a configurable bot.");
                 return;
             }
-            Princess princess = (Princess) bot;
-            princess.setBehaviorSettings(behavior);
+            botClient.setBehaviorSettings(behavior);
         }
     }
 


### PR DESCRIPTION
## Pre-amble
I've been working with Claude on Princess and fixing some bugs. I have lots of ideas to improve her, but in conversations with Illiani I'm realizing some of what I want to do could break Princess. Her suggestion was to move Princess to an Abstract Bot that would end up with a Princess and CASPAR (yes resurrecting the name). The goal here would be to leave Princess then add a CASPAR as a second bot. Similar to how we once had TestBot and Princess side by side. 

I would then experiment with CASPAR and hopefully over time develop into a new and improved bot. This represents a first in a series of PRs to refactor to the new model

## Summary
Prep step for switchable AIs (Princess / CASPAR): move the generic bot-configuration surface up to `BotClient` so lobby/config code works against the abstraction instead of downcasting to `Princess`. Behavior-preserving — Princess decides nothing differently.

## Changes
1. `BotClient` now owns the `behaviorSettings` field, a concrete `getBehaviorSettings()`,  and an abstract `setBehaviorSettings(...)`. Princess (the only subclass) implements the setter; its field and getter were removed (now inherited).
2. Replaced the `Client` `SERVER_GREETING` `instanceof Princess` inversion wart with a `protected Client.sendBotSettingsToServer()` no-op hook that Princess overrides to call `sendPrincessSettings()`. `Client` no longer imports `Princess`.
3. Config read/write downcasts replaced with `BotClient` calls / `instanceof BotClient` pattern-guards in `AddBotUtil`, `BotConfigDialog`, `PlayerSettingsDialog`, `LobbyActions`, and `ChatLounge.doBotSettings`.
4. `ChatProcessor` line 144 blind `(Princess) bot` cast is now an `instanceof Princess` guard (Princess-specific chat commands run only for a Princess-type bot).

Not in scope (follow-up PRs): the `new Princess(...)`ry/AiType), and the lobby AI-type selector. `EditBotsDialog`'s type-discriminating display label is left for when CASPAR needs its own name.

## Files Changed
- `BotClient.java` — hoisted field + get/abstract-set accessors
- `Client.java` — `sendBotSettingsToServer()` hook; rwart
- `Princess.java` — removed field/getter; `@Override` setter; override the send hook
- `ChatProcessor.java` — pattern-guard the chat-command dispatch
- `AddBotUtil.java`, `BotConfigDialog.java`, `PlayerS
  `LobbyActions.java`, `ChatLounge.java` — downcasts → `BotClient` / pattern-guards

## Testing
- `./gradlew :megamek:compileJava :megamek:compileTestJava` green.
- Bot/lobby unit tests green: ChatProcessorTest, AddBtests, 0 failures).
- Headless Bot-vs-Bot smoke game (`ScenarioGameRunner BotvBot.mms`): both Princess bots
  received behavior settings, deployed, moved, and completed the game — validating the new
  server-greeting settings hook end to end.