### PR TITLE
Fix save games failing to load due to unconverted HeatContribution record

### DIFF
--- a/megamek/src/megamek/common/util/SerializationHelper.java
+++ b/megamek/src/megamek/common/util/SerializationHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -58,6 +58,7 @@ import megamek.common.rolls.Roll;
 import megamek.common.units.BTObject;
 import megamek.common.units.Crew;
 import megamek.common.units.EntityMovementMode;
+import megamek.common.units.HeatBreakdown;
 import megamek.common.units.IBuilding;
 import megamek.common.units.InfantryMount;
 import megamek.common.weapons.handlers.AttackHandler;
@@ -439,6 +440,41 @@ public class SerializationHelper {
                 } else {
                     return null;
                 }
+            }
+
+            @Override
+            public void marshal(Object object, HierarchicalStreamWriter writer, MarshallingContext context) {
+                // Unused here
+            }
+        });
+
+        // Necessary because XStream 1.4.x cannot deserialize records natively. HeatContribution is stored in
+        // Entity.heatBreakdown, so without this converter any save game containing heat-breakdown data fails to
+        // load.
+        xStream.registerConverter(new Converter() {
+            @Override
+            public boolean canConvert(Class cls) {
+                return (cls == HeatBreakdown.HeatContribution.class);
+            }
+
+            @Override
+            public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+                int count = 0;
+                int totalHeat = 0;
+                while (reader.hasMoreChildren()) {
+                    reader.moveDown();
+                    try {
+                        switch (reader.getNodeName()) {
+                            case "count" -> count = Integer.parseInt(reader.getValue());
+                            case "totalHeat" -> totalHeat = Integer.parseInt(reader.getValue());
+                        }
+                        reader.moveUp();
+                    } catch (NumberFormatException e) {
+                        // HeatContribution entries with malformed numbers are silently ignored
+                        return null;
+                    }
+                }
+                return new HeatBreakdown.HeatContribution(count, totalHeat);
             }
 
             @Override

--- a/megamek/src/megamek/common/util/SerializationHelper.java
+++ b/megamek/src/megamek/common/util/SerializationHelper.java
@@ -468,11 +468,11 @@ public class SerializationHelper {
                             case "count" -> count = Integer.parseInt(reader.getValue());
                             case "totalHeat" -> totalHeat = Integer.parseInt(reader.getValue());
                         }
-                        reader.moveUp();
                     } catch (NumberFormatException e) {
-                        // HeatContribution entries with malformed numbers are silently ignored
-                        return null;
+                        // Keep the default for this field on a malformed value; never return null, because a
+                        // null contribution stored in HeatBreakdown.buildup would NPE in buildupTooltip().
                     }
+                    reader.moveUp();
                 }
                 return new HeatBreakdown.HeatContribution(count, totalHeat);
             }

--- a/megamek/unittests/megamek/common/util/SerializationHelperTest.java
+++ b/megamek/unittests/megamek/common/util/SerializationHelperTest.java
@@ -33,6 +33,8 @@
 package megamek.common.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.thoughtworks.xstream.XStream;
 import megamek.common.units.HeatBreakdown;
@@ -57,5 +59,26 @@ class SerializationHelperTest {
         Object restored = loadXStream.fromXML(xml);
 
         assertEquals(original, restored);
+    }
+
+    /**
+     * A malformed numeric value must not deserialize to a {@code null} {@link HeatBreakdown.HeatContribution}: a
+     * null stored in {@link HeatBreakdown}'s buildup map would later NPE (for example in
+     * {@code buildupTooltip()}). The converter keeps the field default instead and returns a non-null record.
+     */
+    @Test
+    void malformedHeatContributionValueDeserializesToNonNullDefault() {
+        XStream saveXStream = SerializationHelper.getSaveGameXStream();
+        String xml = saveXStream.toXML(new HeatBreakdown.HeatContribution(3, 99));
+        String corrupted = xml.replace("99", "notANumber");
+
+        XStream loadXStream = SerializationHelper.getLoadSaveGameXStream();
+        Object restored = loadXStream.fromXML(corrupted);
+
+        assertNotNull(restored);
+        assertInstanceOf(HeatBreakdown.HeatContribution.class, restored);
+        HeatBreakdown.HeatContribution contribution = (HeatBreakdown.HeatContribution) restored;
+        assertEquals(3, contribution.count());
+        assertEquals(0, contribution.totalHeat());
     }
 }

--- a/megamek/unittests/megamek/common/util/SerializationHelperTest.java
+++ b/megamek/unittests/megamek/common/util/SerializationHelperTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.thoughtworks.xstream.XStream;
+import megamek.common.units.HeatBreakdown;
+import org.junit.jupiter.api.Test;
+
+class SerializationHelperTest {
+
+    /**
+     * XStream 1.4 can serialize records but cannot deserialize them without an explicit converter.
+     * {@link HeatBreakdown.HeatContribution} is a {@code Serializable} record stored in {@code Entity}, so a
+     * missing converter makes save games containing heat-breakdown data fail to load. This pins the converter
+     * registered in {@link SerializationHelper#getLoadSaveGameXStream()}.
+     */
+    @Test
+    void heatContributionRecordSurvivesSaveGameRoundTrip() {
+        HeatBreakdown.HeatContribution original = new HeatBreakdown.HeatContribution(3, 30);
+
+        XStream saveXStream = SerializationHelper.getSaveGameXStream();
+        String xml = saveXStream.toXML(original);
+
+        XStream loadXStream = SerializationHelper.getLoadSaveGameXStream();
+        Object restored = loadXStream.fromXML(xml);
+
+        assertEquals(original, restored);
+    }
+}


### PR DESCRIPTION
## Root Cause
`HeatBreakdown.HeatContribution` is a `Serializable` **record** (added to `Entity.heatBreakdown` in #8387).
Save games are (de)serialized with XStream 1.4.x, which can serialize records but **cannot deserialize them natively** — so any save game whose entities carry heat-breakdown data cannot be loaded. This is the same failure mode as the `BoardLocation` class→record conversion (MHQ #8679 / PR #7949): a record without a registered XStream converter breaks save loading.

Because `HeatBreakdown` is cleared when heat resolves, the record only lands in a save taken while heat is still pending, which is why the failure is intermittent and slipped through — the same "few players noticed" pattern as `BoardLocation`.

## Changes
1. `SerializationHelper.getLoadSaveGameXStream()` — register a `Converter` for `HeatBreakdown.HeatContribution` that rebuilds the record from its `count` / `totalHeat` child nodes, modeled on the existing `BoardLocation` / `InitiativeBonusBreakdown` converters.

## Files Changed
- `megamek/src/megamek/common/util/SerializationHelper.java` — add the `HeatContribution` converter (+ import).
- `megamek/unittests/megamek/common/util/SerializationHelperTest.java` — new save→load round-trip regression
  test for the record (fails without the converter, passes with it).

## Testing
- Unit: `SerializationHelperTest.heatContributionRecordSurvivesSaveGameRoundTrip` — serialize with `getSaveGameXStream()`, deserialize with `getLoadSaveGameXStream()`, assert equality. Fails on `main`, passes with the fix.
- Runtime: verified the round-trip end-to-end through the real `SerializationHelper` factories (`HeatContribution[count=2, totalHeat=20]` restored intact); confirmed normal save loading is unaffected.
- `./gradlew :megamek:compileJava :megamek:compileTestJava` and the relevant tests green.

Fixes #8387