### PR TITLE
Stop WeaponType/AmmoType.hasFlag warning spam when saving BattleArmor

### DIFF
--- a/megamek/src/megamek/common/units/EntityListFile.java
+++ b/megamek/src/megamek/common/units/EntityListFile.java
@@ -1264,16 +1264,21 @@ public class EntityListFile {
             }
 
             if (entity instanceof BattleArmor ba) {
-                for (Mounted<?> m : entity.getEquipment()) {
-                    if (m.getType().hasFlag(MiscType.F_BA_MEA)) {
+                for (Mounted<?> mounted : entity.getEquipment()) {
+                    // Only MiscType equipment carries the BA MEA / AP-mount flags; guarding on the type avoids
+                    // calling WeaponType/AmmoType.hasFlag with a MiscType flag, which logs a warning per call.
+                    if (!(mounted.getType() instanceof MiscType miscType)) {
+                        continue;
+                    }
+                    if (miscType.hasFlag(MiscType.F_BA_MEA)) {
                         Mounted<?> manipulator = null;
-                        if (m.getBaMountLoc() == BattleArmor.MOUNT_LOC_LEFT_ARM) {
+                        if (mounted.getBaMountLoc() == BattleArmor.MOUNT_LOC_LEFT_ARM) {
                             manipulator = ba.getLeftManipulator();
-                        } else if (m.getBaMountLoc() == BattleArmor.MOUNT_LOC_RIGHT_ARM) {
+                        } else if (mounted.getBaMountLoc() == BattleArmor.MOUNT_LOC_RIGHT_ARM) {
                             manipulator = ba.getRightManipulator();
                         }
                         output.write(indentStr(indentLvl + 1) + '<' + MULParser.ELE_BA_MEA + ' ');
-                        output.write(MULParser.ATTR_BA_MEA_MOUNT_LOC + "=\"" + m.getBaMountLoc() + "\" ");
+                        output.write(MULParser.ATTR_BA_MEA_MOUNT_LOC + "=\"" + mounted.getBaMountLoc() + "\" ");
                         if (manipulator != null) {
                             output.write(MULParser.ATTR_BA_MEA_TYPE_NAME +
                                   "=\"" +
@@ -1281,11 +1286,11 @@ public class EntityListFile {
                                   "\" ");
                         }
                         output.write("/>\n");
-                    } else if (m.getType().hasFlag(MiscType.F_AP_MOUNT)) {
-                        int mountIdx = entity.getEquipmentNum(m);
+                    } else if (miscType.hasFlag(MiscType.F_AP_MOUNT)) {
+                        int mountIdx = entity.getEquipmentNum(mounted);
                         EquipmentType apType = null;
-                        if (m.getLinked() != null) {
-                            apType = m.getLinked().getType();
+                        if (mounted.getLinked() != null) {
+                            apType = mounted.getLinked().getType();
                         }
                         output.write(indentStr(indentLvl + 1) + '<' + MULParser.ELE_BA_APM + ' ');
                         output.write(MULParser.ATTR_BA_APM_MOUNT_NUM + "=\"" + mountIdx + "\" ");

--- a/megamek/src/megamek/common/units/EntityListFile.java
+++ b/megamek/src/megamek/common/units/EntityListFile.java
@@ -1287,13 +1287,13 @@ public class EntityListFile {
                         }
                         output.write("/>\n");
                     } else if (miscType.hasFlag(MiscType.F_AP_MOUNT)) {
-                        int mountIdx = entity.getEquipmentNum(mounted);
+                        int mountIndex = entity.getEquipmentNum(mounted);
                         EquipmentType apType = null;
                         if (mounted.getLinked() != null) {
                             apType = mounted.getLinked().getType();
                         }
                         output.write(indentStr(indentLvl + 1) + '<' + MULParser.ELE_BA_APM + ' ');
-                        output.write(MULParser.ATTR_BA_APM_MOUNT_NUM + "=\"" + mountIdx + "\" ");
+                        output.write(MULParser.ATTR_BA_APM_MOUNT_NUM + "=\"" + mountIndex + "\" ");
                         if (apType != null) {
                             output.write(MULParser.ATTR_BA_APM_TYPE_NAME + "=\"" + apType.getInternalName() + "\" ");
                         }


### PR DESCRIPTION
## Root Cause
`EntityListFile.writeEntityList` iterates every BattleArmor equipment mount and calls `mounted.getType().hasFlag(MiscType.F_BA_MEA / F_AP_MOUNT)`. For weapon and ammo mounts, `getType()` is a
`WeaponType`/`AmmoType`, and the typed `hasFlag` logs a warning with a full stack trace on every cross-type flag check — producing dozens to hundreds of stack traces (and the wasted `Throwable` construction) each time a force containing BattleArmor is saved.

## Changes
1. `EntityListFile.writeEntityList` — guard the BA equipment loop with an `instanceof MiscType` check (MEA and AP mounts only exist on MiscType equipment), so the MiscType flags are only tested on MiscType mounts. Renamed the loop variable `m` → `mounted` and `mountIdx` → `mountIndex` while there.

## Files Changed
- `megamek/src/megamek/common/units/EntityListFile.java` — `instanceof MiscType` guard in the BA save loop.

## Testing
- Behavior-preserving (weapon/ammo mounts already produced no MEA/AP output and returned false; only the per-call warning and stack construction are removed). Existing `EntityListFileDisposableWeaponTest` stays green.
- Runtime A/B on a real BattleArmor (Achileus, 15 mounts) saved to MUL: `main` logs 12 `Incorrect flag check`
  warnings, this branch logs 0; the save succeeds in both cases.
- `./gradlew :megamek:compileJava` + the save test green.