### PR TITLE
Add bot factory ai type

### DIFF
--- a/megamek/src/megamek/client/bot/AiType.java
+++ b/megamek/src/megamek/client/bot/AiType.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.bot;
+
+/**
+ * Identifies which bot AI implementation to construct. Used by {@link BotFactory} as the single selection point for
+ * building bots, so callers (lobby, scenario loaders, headless runners) no longer hardcode a concrete bot class.
+ * Additional AI types (for example a future experimental bot) are added here as their implementations land.
+ */
+public enum AiType {
+    /** The default MegaMek bot, {@link megamek.client.bot.princess.Princess}. */
+    PRINCESS
+}

--- a/megamek/src/megamek/client/bot/BotFactory.java
+++ b/megamek/src/megamek/client/bot/BotFactory.java
@@ -32,6 +32,8 @@
  */
 package megamek.client.bot;
 
+import java.util.Objects;
+
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.Princess;
 import megamek.logging.MMLogger;
@@ -63,6 +65,9 @@ public final class BotFactory {
      * @return a started {@link BotClient} of the requested type, not yet connected
      */
     public static BotClient createBot(AiType aiType, String name, String host, int port) {
+        Objects.requireNonNull(aiType, "aiType");
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(host, "host");
         LOGGER.debug("Creating {} bot '{}' for {}:{}", aiType, name, host, port);
         return switch (aiType) {
             case PRINCESS -> {
@@ -86,6 +91,7 @@ public final class BotFactory {
      */
     public static BotClient createBot(AiType aiType, String name, String host, int port,
           BehaviorSettings behaviorSettings) {
+        Objects.requireNonNull(behaviorSettings, "behaviorSettings");
         BotClient bot = createBot(aiType, name, host, port);
         bot.setBehaviorSettings(behaviorSettings);
         return bot;

--- a/megamek/src/megamek/client/bot/BotFactory.java
+++ b/megamek/src/megamek/client/bot/BotFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.bot;
+
+import megamek.client.bot.princess.BehaviorSettings;
+import megamek.client.bot.princess.Princess;
+import megamek.logging.MMLogger;
+
+/**
+ * The single construction point for bot clients. Instead of scattering {@code new Princess(...)} calls across the
+ * lobby, scenario loaders and headless runners, callers ask this factory for a bot by {@link AiType}. This keeps the
+ * choice of AI in one place (so a new AI type only has to be wired here and offered in the selection surfaces) and
+ * returns the abstract {@link BotClient} type, so callers do not depend on a concrete bot class.
+ *
+ * <p>The returned bot has had its background processing started (equivalent to the previous
+ * {@code new Princess(...); startPrecognition();} pairing), so callers only need to connect it and, if not using the
+ * behavior-settings overload, apply its behavior.</p>
+ */
+public final class BotFactory {
+    private static final MMLogger LOGGER = MMLogger.create(BotFactory.class);
+
+    private BotFactory() {
+    }
+
+    /**
+     * Creates and starts a bot of the given type, leaving its behavior settings at the default.
+     *
+     * @param aiType the AI implementation to build
+     * @param name   the bot player's display name
+     * @param host   the server host to connect to
+     * @param port   the server port to connect to
+     *
+     * @return a started {@link BotClient} of the requested type, not yet connected
+     */
+    public static BotClient createBot(AiType aiType, String name, String host, int port) {
+        LOGGER.debug("Creating {} bot '{}' for {}:{}", aiType, name, host, port);
+        return switch (aiType) {
+            case PRINCESS -> {
+                Princess princess = new Princess(name, host, port);
+                princess.startPrecognition();
+                yield princess;
+            }
+        };
+    }
+
+    /**
+     * Creates and starts a bot of the given type and applies the given behavior settings.
+     *
+     * @param aiType           the AI implementation to build
+     * @param name             the bot player's display name
+     * @param host             the server host to connect to
+     * @param port             the server port to connect to
+     * @param behaviorSettings the behavior settings to apply to the new bot
+     *
+     * @return a started {@link BotClient} of the requested type, not yet connected
+     */
+    public static BotClient createBot(AiType aiType, String name, String host, int port,
+          BehaviorSettings behaviorSettings) {
+        BotClient bot = createBot(aiType, name, host, port);
+        bot.setBehaviorSettings(behaviorSettings);
+        return bot;
+    }
+}

--- a/megamek/src/megamek/client/ui/clientGUI/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/ClientGUI.java
@@ -70,7 +70,6 @@ import megamek.client.Client;
 import megamek.client.TimerSingleton;
 import megamek.client.bot.BotClient;
 import megamek.client.bot.princess.BehaviorSettings;
-import megamek.client.bot.princess.Princess;
 import megamek.client.commands.*;
 import megamek.client.event.BoardViewEvent;
 import megamek.client.event.BoardViewListener;
@@ -3722,12 +3721,12 @@ public class ClientGUI extends AbstractClientGUI
         Map<String, BehaviorSettings> newBotSettings = rpd.getNewBots();
         for (String ghostName : newBotSettings.keySet()) {
             StringBuilder message = new StringBuilder();
-            Princess princess = util.replaceGhostWithBot(newBotSettings.get(ghostName), ghostName, client, message);
+            BotClient botClient = util.replaceGhostWithBot(newBotSettings.get(ghostName), ghostName, client, message);
             systemMessage(message.toString());
-            // Make this princess a locally owned bot. This way it can be configured, and if on the lobby
+            // Make this bot a locally owned bot. This way it can be configured, and if on the lobby
             // it will faithfully press Done when the local player does.
-            if (princess != null) {
-                getLocalBots().put(ghostName, princess);
+            if (botClient != null) {
+                getLocalBots().put(ghostName, botClient);
             }
         }
 

--- a/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
@@ -73,8 +73,9 @@ import megamek.Version;
 import megamek.client.Client;
 import megamek.client.IClient;
 import megamek.client.SBFClient;
+import megamek.client.bot.AiType;
 import megamek.client.bot.BotClient;
-import megamek.client.bot.princess.Princess;
+import megamek.client.bot.BotFactory;
 import megamek.client.bot.ui.swing.BotGUI;
 import megamek.client.ui.Messages;
 import megamek.client.ui.boardeditor.BoardEditorPanel;
@@ -1075,16 +1076,18 @@ public class MegaMekGUI implements IPreferenceChangeListener {
             for (int x = 0; x < pa.length; x++) {
                 if (playerTypes[x] == ScenarioDialog.T_BOT) {
                     LOGGER.info("Adding bot {} as Princess", pa[x].getName());
-                    Princess c = new Princess(pa[x].getName(), MMConstants.LOCALHOST, port);
-                    c.startPrecognition();
+                    BotClient botClient = BotFactory.createBot(AiType.PRINCESS,
+                          pa[x].getName(),
+                          MMConstants.LOCALHOST,
+                          port);
                     if (scenario.hasBotInfo(pa[x].getName()) &&
                           scenario.getBotInfo(pa[x].getName()) instanceof BotParser.PrincessRecord(
                                 megamek.client.bot.princess.BehaviorSettings behaviorSettings
                           )) {
-                        c.setBehaviorSettings(behaviorSettings);
+                        botClient.setBehaviorSettings(behaviorSettings);
                     }
-                    c.getGame().addGameListener(new BotGUI(frame, c));
-                    c.connect();
+                    botClient.getGame().addGameListener(new BotGUI(frame, botClient));
+                    botClient.connect();
                 }
             }
         }
@@ -1138,7 +1141,8 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         if (bcd.getResult() == DialogResult.CANCELLED) {
             return;
         }
-        client = Princess.createPrincess(bcd.getBotName(),
+        client = BotFactory.createBot(AiType.PRINCESS,
+              bcd.getBotName(),
               cd.getServerAddress(),
               cd.getPort(),
               bcd.getBehaviorSettings());

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/BoardView.java
@@ -60,9 +60,6 @@ import javax.swing.plaf.metal.MetalTheme;
 
 import megamek.MMConstants;
 import megamek.client.TimerSingleton;
-import megamek.client.bot.princess.PathEnumerator;
-import megamek.client.bot.princess.Princess;
-import megamek.client.bot.princess.geometry.ConvexBoardArea;
 import megamek.client.event.BoardViewEvent;
 import megamek.client.event.BoardViewListener;
 import megamek.client.ui.IDisplayable;
@@ -1299,7 +1296,6 @@ public final class BoardView extends AbstractBoardView
 
         // debugging method that renders the bounding box of a unit's movement envelope.
         // renderClusters((Graphics2D) graphics2D);
-        // renderMovementBoundingBox((Graphics2D) graphics2D);
         // renderDonut(graphics2D, new Coords(10, 10), 2);
         // renderApproxHexDirection((Graphics2D) graphics2D);
     }
@@ -1323,58 +1319,6 @@ public final class BoardView extends AbstractBoardView
         Point p = getCentreHexLocation(donutCoords.getX(), donutCoords.getY(), true);
         p.translate(HEX_W / 2, HEX_H / 2);
         drawHexBorder(g, p, Color.BLUE, 0, 6);
-    }
-
-    /**
-     * Debugging method that renders the bounding hex of a unit's movement envelope. Warning: very slow when rendering
-     * the bounding hex for really fast units.
-     *
-     * @param graphics2D Graphics object on which to draw.
-     */
-    @SuppressWarnings("unused")
-    private void renderMovementBoundingBox(Graphics2D graphics2D) {
-        if (getSelectedEntity() != null) {
-            Princess princess = new Princess("test", MMConstants.LOCALHOST, 2020);
-            princess.startPrecognition();
-            princess.getGame().setBoard(game.getBoard(boardId));
-            PathEnumerator pathEnum = new PathEnumerator(princess, game);
-            pathEnum.recalculateMovesFor(getSelectedEntity());
-
-            ConvexBoardArea cba = pathEnum.getUnitMovableAreas().get(getSelectedEntity().getId());
-            for (int x = 0;
-                  x < game.getBoard(boardId).getWidth();
-                  x++) {
-                for (int y = 0;
-                      y < game.getBoard(boardId).getHeight();
-                      y++) {
-                    Point centreHexLocation = getCentreHexLocation(x, y, true);
-                    centreHexLocation.translate(HEX_W / 2, HEX_H / 2);
-                    Coords coords = new Coords(x, y);
-
-                    if (cba.contains(coords)) {
-                        drawHexBorder(graphics2D, centreHexLocation, Color.PINK, 0, 6);
-                    }
-                }
-            }
-
-            for (int x = 0;
-                  x < 6;
-                  x++) {
-                Coords coords = cba.getVertexNum(x);
-                if (coords == null) {
-                    continue;
-                }
-
-                Point centreHexLocation = getCentreHexLocation(coords.getX(), coords.getY(), true);
-                centreHexLocation.translate(HEX_W / 2, HEX_H / 2);
-
-                drawHexBorder(graphics2D, centreHexLocation, Color.yellow, 0, 3);
-                new StringDrawer(Integer.toString(x)).at(centreHexLocation)
-                      .center()
-                      .color(Color.YELLOW)
-                      .draw(graphics2D);
-            }
-        }
     }
 
     /**

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
@@ -95,10 +95,11 @@ import megamek.MMConstants;
 import megamek.SuiteConstants;
 import megamek.client.AbstractClient;
 import megamek.client.Client;
+import megamek.client.bot.AiType;
 import megamek.client.bot.BotClient;
+import megamek.client.bot.BotFactory;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.BehaviorSettingsFactory;
-import megamek.client.bot.princess.Princess;
 import megamek.client.bot.ui.swing.BotGUI;
 import megamek.client.generator.RandomCallsignGenerator;
 import megamek.client.generator.RandomNameGenerator;
@@ -2232,7 +2233,8 @@ public class ChatLounge extends AbstractPhaseDisplay
         if (bcd.getResult() == DialogResult.CANCELLED) {
             return;
         }
-        Princess botClient = Princess.createPrincess(bcd.getBotName(),
+        BotClient botClient = BotFactory.createBot(AiType.PRINCESS,
+              bcd.getBotName(),
               client().getHost(),
               client().getPort(),
               bcd.getBehaviorSettings());

--- a/megamek/src/megamek/common/moves/MovePath.java
+++ b/megamek/src/megamek/common/moves/MovePath.java
@@ -37,7 +37,6 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.*;
 
-import megamek.client.bot.princess.Princess;
 import megamek.common.Hex;
 import megamek.common.ManeuverType;
 import megamek.common.annotations.Nullable;
@@ -50,7 +49,6 @@ import megamek.common.equipment.Minefield;
 import megamek.common.game.Game;
 import megamek.common.options.OptionsConstants;
 import megamek.common.pathfinder.CachedEntityState;
-import megamek.common.pathfinder.DestructionAwareDestinationPathfinder;
 import megamek.common.pathfinder.ShortestPathFinder;
 import megamek.common.pathfinder.StopConditionTimeout;
 import megamek.common.pathfinder.comparators.MovePathGreedyComparator;
@@ -1359,8 +1357,6 @@ public class MovePath implements Cloneable, Serializable {
 
         pf.run(clone());
         MovePath finPath = pf.getComputedPath(dest);
-        // this can be used for debugging the "destruction aware pathfinder"
-        // MovePath finPath = calculateDestructionAwarePath(dest);
 
         if (timeoutCondition.timeoutEngaged || finPath == null) {
             /*
@@ -1995,30 +1991,6 @@ public class MovePath implements Cloneable, Serializable {
         }
 
         return stepCount;
-    }
-
-    /**
-     * Debugging method that calculates a destruction-aware move path to the destination coordinates
-     */
-    @SuppressWarnings("unused")
-    public MovePath calculateDestructionAwarePath(Coords dest) {
-        // code that's useful to test the destruction-aware pathfinder
-        DestructionAwareDestinationPathfinder dpf = new DestructionAwareDestinationPathfinder();
-        // the destruction aware pathfinder takes either a CardinalEdge or an explicit
-        // set of coordinates
-        Set<Coords> destinationSet = new HashSet<>();
-        destinationSet.add(dest);
-
-        // debugging code that can be used to find a path to a specific edge
-        Princess princess = new Princess("test", "test", 2020);
-        princess.startPrecognition();
-
-        long marker1 = java.lang.System.currentTimeMillis();
-        MovePath finPath = dpf.findPathToCoords(entity, destinationSet, false, princess.getClusterTracker());
-        long marker2 = java.lang.System.currentTimeMillis();
-        long marker3 = marker2 - marker1;
-
-        return finPath;
     }
 
     /**

--- a/megamek/src/megamek/common/util/AddBotUtil.java
+++ b/megamek/src/megamek/common/util/AddBotUtil.java
@@ -43,10 +43,11 @@ import javax.swing.JFrame;
 
 import megamek.client.AbstractClient;
 import megamek.client.Client;
+import megamek.client.bot.AiType;
 import megamek.client.bot.BotClient;
+import megamek.client.bot.BotFactory;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.BehaviorSettingsFactory;
-import megamek.client.bot.princess.Princess;
 import megamek.client.bot.ui.swing.BotGUI;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.Player;
@@ -203,7 +204,7 @@ public class AddBotUtil {
         return concatResults();
     }
 
-    public @Nullable Princess replaceGhostWithBot(final BehaviorSettings behavior, final String playerName,
+    public @Nullable BotClient replaceGhostWithBot(final BehaviorSettings behavior, final String playerName,
           final Client client, StringBuilder message) {
         Objects.requireNonNull(client);
         Objects.requireNonNull(behavior);
@@ -227,18 +228,17 @@ public class AddBotUtil {
         }
 
         final Player target = possible.get();
-        final Princess princess = new Princess(target.getName(), host, port);
-        princess.startPrecognition();
-        princess.setBehaviorSettings(behavior);
+        final BotClient botClient = BotFactory.createBot(AiType.PRINCESS, target.getName(), host, port);
+        botClient.setBehaviorSettings(behavior);
 
         try {
-            princess.connect();
+            botClient.connect();
         } catch (final Exception ex) {
             message.append("Princess failed to connect.");
         }
-        princess.setLocalPlayerNumber(target.getId());
+        botClient.setLocalPlayerNumber(target.getId());
         message.append("Princess has replaced ").append(playerName).append(".");
-        return princess;
+        return botClient;
     }
 
     /**
@@ -269,15 +269,14 @@ public class AddBotUtil {
 
         final Player target = possible.get();
         if (target.isGhost()) {
-            final Princess princess = new Princess(target.getName(), host, port);
-            princess.setBehaviorSettings(behavior);
+            final BotClient botClient = BotFactory.createBot(AiType.PRINCESS, target.getName(), host, port);
+            botClient.setBehaviorSettings(behavior);
             try {
-                princess.connect();
-                princess.startPrecognition();
+                botClient.connect();
             } catch (final Exception ex) {
                 message.append("Princess failed to connect.");
             }
-            princess.setLocalPlayerNumber(target.getId());
+            botClient.setLocalPlayerNumber(target.getId());
             message.append("Princess has replaced ").append(playerName).append(".");
         } else {
             AbstractClient bot = client.getBots().get(target.getName());
@@ -319,8 +318,6 @@ public class AddBotUtil {
     }
 
     BotClient makeNewPrincessClient(final Player target, final String host, final int port) {
-        Princess princess = new Princess(target.getName(), host, port);
-        princess.startPrecognition();
-        return princess;
+        return BotFactory.createBot(AiType.PRINCESS, target.getName(), host, port);
     }
 }

--- a/megamek/src/megamek/common/util/AddBotUtil.java
+++ b/megamek/src/megamek/common/util/AddBotUtil.java
@@ -231,13 +231,19 @@ public class AddBotUtil {
         final BotClient botClient = BotFactory.createBot(AiType.PRINCESS, target.getName(), host, port);
         botClient.setBehaviorSettings(behavior);
 
+        boolean connected;
         try {
-            botClient.connect();
+            connected = botClient.connect();
         } catch (final Exception ex) {
-            message.append("Princess failed to connect.");
+            connected = false;
+        }
+        if (!connected) {
+            botClient.die();
+            message.append("Bot failed to connect.");
+            return null;
         }
         botClient.setLocalPlayerNumber(target.getId());
-        message.append("Princess has replaced ").append(playerName).append(".");
+        message.append("Bot has replaced ").append(playerName).append(".");
         return botClient;
     }
 
@@ -271,13 +277,19 @@ public class AddBotUtil {
         if (target.isGhost()) {
             final BotClient botClient = BotFactory.createBot(AiType.PRINCESS, target.getName(), host, port);
             botClient.setBehaviorSettings(behavior);
+            boolean connected;
             try {
-                botClient.connect();
+                connected = botClient.connect();
             } catch (final Exception ex) {
-                message.append("Princess failed to connect.");
+                connected = false;
+            }
+            if (!connected) {
+                botClient.die();
+                message.append("Bot failed to connect.");
+                return;
             }
             botClient.setLocalPlayerNumber(target.getId());
-            message.append("Princess has replaced ").append(playerName).append(".");
+            message.append("Bot has replaced ").append(playerName).append(".");
         } else {
             AbstractClient bot = client.getBots().get(target.getName());
             if (bot == null) {

--- a/megamek/src/megamek/utilities/QuickGameRunner.java
+++ b/megamek/src/megamek/utilities/QuickGameRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -52,7 +52,9 @@ import megamek.client.AbstractClient;
 import megamek.client.Client;
 import megamek.client.CloseClientListener;
 import megamek.client.HeadlessClient;
-import megamek.client.bot.princess.Princess;
+import megamek.client.bot.AiType;
+import megamek.client.bot.BotClient;
+import megamek.client.bot.BotFactory;
 import megamek.client.ui.clientGUI.ClientGUI;
 import megamek.client.ui.clientGUI.CommanderGUI;
 import megamek.client.ui.clientGUI.IClientGUI;
@@ -297,8 +299,8 @@ public class QuickGameRunner {
 
             for (var ghost : ghosts) {
                 var behavior = ((Game) server.getGame()).getBotSettings().get(ghost.getName());
-                Princess botClient = Princess.createPrincess(ghost.getName(), server.getHost(), server.getPort(),
-                      behavior);
+                BotClient botClient = BotFactory.createBot(AiType.PRINCESS, ghost.getName(), server.getHost(),
+                      server.getPort(), behavior);
                 if (botClient.connect()) {
                     getLocalBots().put(botClient.getName(), botClient);
                     int retryCount = 0;

--- a/megamek/src/megamek/utilities/ScenarioGameRunner.java
+++ b/megamek/src/megamek/utilities/ScenarioGameRunner.java
@@ -170,11 +170,11 @@ public class ScenarioGameRunner {
                   server.getPort(),
                   behaviorFor(botSlot.getName()));
             if (!botClient.connect()) {
-                throw new IllegalStateException("Princess failed to connect for player " + botSlot.getName());
+                throw new IllegalStateException("Bot failed to connect for player " + botSlot.getName());
             }
             waitForLocalPlayer(botClient.getName(), () -> botClient.getLocalPlayer() != null);
             botClient.sendPlayerInfo();
-            logger.info("Connected Princess for {}", botSlot.getName());
+            logger.info("Connected bot for {}", botSlot.getName());
         }
 
         logger.info("Running scenario '{}' for up to {} rounds ({} minute timeout)",

--- a/megamek/src/megamek/utilities/ScenarioGameRunner.java
+++ b/megamek/src/megamek/utilities/ScenarioGameRunner.java
@@ -46,9 +46,11 @@ import java.util.function.BooleanSupplier;
 
 import megamek.MMConstants;
 import megamek.client.HeadlessClient;
+import megamek.client.bot.AiType;
+import megamek.client.bot.BotClient;
+import megamek.client.bot.BotFactory;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.BehaviorSettingsFactory;
-import megamek.client.bot.princess.Princess;
 import megamek.common.Player;
 import megamek.common.enums.GamePhase;
 import megamek.common.event.GameListenerAdapter;
@@ -162,15 +164,16 @@ public class ScenarioGameRunner {
         waitForLocalPlayer(watcher.getName(), () -> watcher.getLocalPlayer() != null);
 
         for (Player botSlot : players.subList(1, players.size())) {
-            Princess princess = Princess.createPrincess(botSlot.getName(),
+            BotClient botClient = BotFactory.createBot(AiType.PRINCESS,
+                  botSlot.getName(),
                   LOCALHOST_IP,
                   server.getPort(),
                   behaviorFor(botSlot.getName()));
-            if (!princess.connect()) {
+            if (!botClient.connect()) {
                 throw new IllegalStateException("Princess failed to connect for player " + botSlot.getName());
             }
-            waitForLocalPlayer(princess.getName(), () -> princess.getLocalPlayer() != null);
-            princess.sendPlayerInfo();
+            waitForLocalPlayer(botClient.getName(), () -> botClient.getLocalPlayer() != null);
+            botClient.sendPlayerInfo();
             logger.info("Connected Princess for {}", botSlot.getName());
         }
 

--- a/megamek/unittests/megamek/client/bot/BotFactoryTest.java
+++ b/megamek/unittests/megamek/client/bot/BotFactoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.bot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import megamek.client.bot.princess.BehaviorSettings;
+import megamek.client.bot.princess.Princess;
+import megamek.client.bot.princess.PrincessException;
+import org.junit.jupiter.api.Test;
+
+class BotFactoryTest {
+
+    private static final String TEST_HOST = "localhost";
+    private static final int TEST_PORT = 2020;
+
+    @Test
+    void createBotBuildsPrincessForPrincessType() {
+        BotClient bot = BotFactory.createBot(AiType.PRINCESS, "TestBot", TEST_HOST, TEST_PORT);
+        try {
+            assertNotNull(bot);
+            assertInstanceOf(Princess.class, bot);
+            assertEquals("TestBot", bot.getName());
+        } finally {
+            bot.die();
+        }
+    }
+
+    @Test
+    void createBotAppliesBehaviorSettings() throws PrincessException {
+        BehaviorSettings behavior = new BehaviorSettings();
+        behavior.setDescription("FactoryTestBehavior");
+        BotClient bot = BotFactory.createBot(AiType.PRINCESS, "TestBot", TEST_HOST, TEST_PORT, behavior);
+        try {
+            assertEquals("FactoryTestBehavior", bot.getBehaviorSettings().getDescription());
+        } finally {
+            bot.die();
+        }
+    }
+}

--- a/megamek/unittests/megamek/client/bot/BotFactoryTest.java
+++ b/megamek/unittests/megamek/client/bot/BotFactoryTest.java
@@ -54,7 +54,9 @@ class BotFactoryTest {
             assertInstanceOf(Princess.class, bot);
             assertEquals("TestBot", bot.getName());
         } finally {
-            bot.die();
+            if (bot != null) {
+                bot.die();
+            }
         }
     }
 
@@ -66,7 +68,9 @@ class BotFactoryTest {
         try {
             assertEquals("FactoryTestBehavior", bot.getBehaviorSettings().getDescription());
         } finally {
-            bot.die();
+            if (bot != null) {
+                bot.die();
+            }
         }
     }
 }


### PR DESCRIPTION

Body:
## Summary
Second step of the switchable-AI work (after the `BotClient` behavior-settings hoist, #8455). Introduces one place that builds bots by `AiType` instead of scattering `new Princess(...)` / `Princess.createPrincess(...)` across the lobby, scenario loaders and headless runners — so a future AI type only has to be wired here and offered in the selection surfaces. Behavior-preserving.

## Changes
1. New `AiType` enum (`PRINCESS`; more types added as they land) and `BotFactory` with `createBot(type, name, host, port)` and a behavior-settings overload. The factory owns construction + `startPrecognition` and returns the abstract `BotClient`, so callers no longer name a concrete bot class.
2. Routed the production construction sites through the factory: `ScenarioGameRunner`, `QuickGameRunner`, `MegaMekGUI` (scenario bots + lobby add-bot), `ChatLounge`, and `AddBotUtil` (`replaceGhostWithBot` now returns `BotClient`; `changeBotSettings`; `makeNewPrincessClient`). Updated the one `replaceGhostWithBot` caller in `ClientGUI`.
3. Removed two dead `@SuppressWarnings("unused")` debug methods that constructed throwaway `Princess` clients: `MovePath.calculateDestructionAwarePath` (also drops a `common -> bot.princess` package dependency) and `BoardView.renderMovementBoundingBox`, plus their commented-out call sites and now-unused imports.

## Files Changed
- `megamek/src/megamek/client/bot/AiType.java` — new enum.
- `megamek/src/megamek/client/bot/BotFactory.java` — new single construction point.
- `MegaMekGUI.java`, `ChatLounge.java`, `AddBotUtil.java`, `ClientGUI.java`, `QuickGameRunner.java`,
  `ScenarioGameRunner.java` — route construction through the factory.
- `BoardView.java`, `MovePath.java` — remove dead Princess-constructing debug methods.
- `megamek/unittests/megamek/client/bot/BotFactoryTest.java` — new test (type selection + behavior).

## Testing
- `BotFactoryTest` (2 tests): `createBot(PRINCESS, ...)` returns a started `Princess`, and the behavior
  overload applies the settings.
- Runtime: headless Bot-vs-Bot game (`ScenarioGameRunner`) — both bots are built via `BotFactory.createBot`,
  connect and play a full game.
- `./gradlew :megamek:compileJava :megamek:compileTestJava` and the bot tests green.

Princess's public constructor and `createPrincess` remain, so MekHQ's frozen surface is unchanged.

One benign ordering normalization: in `AddBotUtil.changeBotSettings` the ghost bot now starts precognition at
construction (as every other site and `createPrincess` already did) rather than after connect.

No Fixes # — this is part of the switchable-AI initiative; Builds off #8455 as the prior step. 