### PR TITLE
Avoid per-call board-map wrapper allocation in getBoard(int)

### DIFF
--- a/megamek/src/megamek/common/game/AbstractGame.java
+++ b/megamek/src/megamek/common/game/AbstractGame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2022-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -233,6 +233,15 @@ public abstract class AbstractGame implements IGame {
     @Override
     public Map<Integer, Board> getBoards() {
         return Collections.unmodifiableMap(gameBoards);
+    }
+
+    @Override
+    @Nullable
+    public Board getBoard(int boardId) {
+        // Direct map lookup. The IGame default routes through getBoards(), which allocates an unmodifiable-map
+        // wrapper on every call; this method is called very heavily in the to-hit/LOS/ECM inner loops. Uses the
+        // gameBoards field directly (no new serialized state) so a deserialized game cannot get a null view.
+        return gameBoards.get(boardId);
     }
 
     public Set<Integer> getBoardIds() {

--- a/megamek/src/megamek/common/game/IGame.java
+++ b/megamek/src/megamek/common/game/IGame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2022-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -385,7 +385,7 @@ public interface IGame {
      */
     @Nullable
     default Board getBoard(BoardLocation boardLocation) {
-        return getBoards().get(boardLocation.boardId());
+        return getBoard(boardLocation.boardId());
     }
 
     /**


### PR DESCRIPTION
## Root Cause
`IGame.getBoard(int)` routed through `getBoards()`, and `AbstractGame.getBoards()` wraps the boards map in a fresh `Collections.unmodifiableMap(...)` on every call. `getBoard(int)` (and `hasBoardLocation`, which uses it) is called extremely heavily in the Princess to-hit/LOS/ECM inner loops, so each lookup allocated a throwaway wrapper — a top self-time leaf and a large source of allocation pressure in profiling.

## Changes
1. `AbstractGame` — override `getBoard(int)` to look up the `gameBoards` field directly, bypassing the
   `getBoards()` wrapper. Uses only the existing field, so it adds no new serialized state.
2. `IGame.getBoard(BoardLocation)` — route through `getBoard(int)` so it uses the direct lookup too
   (`getBoard(Targetable)`/`getBoard()` already do).

`getBoards()` is left unchanged (still returns a fresh unmodifiable view); caching it in a new field would be
`null` on a deserialized `Game` (field initializers are skipped on deserialization) and NPE in callers.

## Files Changed
- `megamek/src/megamek/common/game/AbstractGame.java` — direct `getBoard(int)` override.
- `megamek/src/megamek/common/game/IGame.java` — `getBoard(BoardLocation)` routes through `getBoard(int)`.

## Testing
- Behavior-preserving (a view-get and a direct map-get return the same board); game tests pass.
- Real-game profiling (before/after JFRs of the same C3-dense game): the `Collections$UnmodifiableMap.get`
  self-time leaf dropped from ~11% of CPU samples to 0, object-allocation samples fell ~11%, and it also
  reduced the C3 spotter path cost (which calls `getBoard` internally). No functional change.