### PR TITLE
Add bot AI-type selection surfaces and the CASPAR bot skeleton

### DIFF
--- a/megamek/resources/megamek/client/messages.properties
+++ b/megamek/resources/megamek/client/messages.properties
@@ -5362,6 +5362,7 @@ LosEffects.name_cover_unknown=unknown
 BotConfigDialog.title=Configure Princess Bot
 BotConfigDialog.aiTypeLabel=Bot AI:
 BotConfigDialog.aiType.PRINCESS=Princess
+BotConfigDialog.aiType.CASPAR=CASPAR
 BotConfigDialog.nameLabel=Name:
 BotConfigDialog.namefield.tooltip=The name of the bot player. Must be unique.
 BotConfigDialog.behaviorNameLabel=<HTML><CENTER>Choose Preset <BR>or Configuration:

--- a/megamek/resources/megamek/client/messages.properties
+++ b/megamek/resources/megamek/client/messages.properties
@@ -5359,7 +5359,7 @@ LosEffects.name_cover_75left=left side 75%
 LosEffects.name_cover_75right=right side 75%
 LosEffects.name_cover_unknown=unknown
 #Bot Configuration Dialog
-BotConfigDialog.title=Configure Princess Bot
+BotConfigDialog.title=Configure Bot
 BotConfigDialog.aiTypeLabel=Bot AI:
 BotConfigDialog.aiType.PRINCESS=Princess
 BotConfigDialog.aiType.CASPAR=CASPAR

--- a/megamek/resources/megamek/client/messages.properties
+++ b/megamek/resources/megamek/client/messages.properties
@@ -5360,6 +5360,8 @@ LosEffects.name_cover_75right=right side 75%
 LosEffects.name_cover_unknown=unknown
 #Bot Configuration Dialog
 BotConfigDialog.title=Configure Princess Bot
+BotConfigDialog.aiTypeLabel=Bot AI:
+BotConfigDialog.aiType.PRINCESS=Princess
 BotConfigDialog.nameLabel=Name:
 BotConfigDialog.namefield.tooltip=The name of the bot player. Must be unique.
 BotConfigDialog.behaviorNameLabel=<HTML><CENTER>Choose Preset <BR>or Configuration:

--- a/megamek/resources/megamek/client/messages.properties
+++ b/megamek/resources/megamek/client/messages.properties
@@ -5363,6 +5363,8 @@ BotConfigDialog.title=Configure Bot
 BotConfigDialog.aiTypeLabel=Bot AI:
 BotConfigDialog.aiType.PRINCESS=Princess
 BotConfigDialog.aiType.CASPAR=CASPAR
+BotConfigDialog.aiType.PRINCESS.tooltip=<html><body style='width: 320px'>The stable, well-tested MegaMek bot. Recommended for normal play.</body></html>
+BotConfigDialog.aiType.CASPAR.tooltip=<html><body style='width: 320px'><b>CASPAR</b> is the experimental successor to Princess. It currently plays identically to Princess; experimental AI improvements are added over time and A/B tested against her. Choose CASPAR to try in-progress work and help evaluate it.</body></html>
 BotConfigDialog.nameLabel=Name:
 BotConfigDialog.namefield.tooltip=The name of the bot player. Must be unique.
 BotConfigDialog.behaviorNameLabel=<HTML><CENTER>Choose Preset <BR>or Configuration:

--- a/megamek/src/megamek/client/bot/AiType.java
+++ b/megamek/src/megamek/client/bot/AiType.java
@@ -41,7 +41,10 @@ import megamek.common.annotations.Nullable;
  */
 public enum AiType {
     /** The default MegaMek bot, {@link megamek.client.bot.princess.Princess}. */
-    PRINCESS;
+    PRINCESS,
+
+    /** The experimental successor to Princess, {@link megamek.client.bot.caspar.Caspar}. */
+    CASPAR;
 
     /**
      * Parses an AI type from a string (case-insensitive match against the enum name), as used by the scenario

--- a/megamek/src/megamek/client/bot/AiType.java
+++ b/megamek/src/megamek/client/bot/AiType.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.bot;
+
+/**
+ * Identifies which bot AI implementation to construct. Used by {@link BotFactory} as the single selection point for
+ * building bots, so callers (lobby, scenario loaders, headless runners) no longer hardcode a concrete bot class.
+ * Additional AI types (for example a future experimental bot) are added here as their implementations land.
+ */
+public enum AiType {
+    /** The default MegaMek bot, {@link megamek.client.bot.princess.Princess}. */
+    PRINCESS
+}

--- a/megamek/src/megamek/client/bot/BotFactory.java
+++ b/megamek/src/megamek/client/bot/BotFactory.java
@@ -32,6 +32,8 @@
  */
 package megamek.client.bot;
 
+import java.util.Objects;
+
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.Princess;
 import megamek.logging.MMLogger;
@@ -63,6 +65,9 @@ public final class BotFactory {
      * @return a started {@link BotClient} of the requested type, not yet connected
      */
     public static BotClient createBot(AiType aiType, String name, String host, int port) {
+        Objects.requireNonNull(aiType, "aiType");
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(host, "host");
         LOGGER.debug("Creating {} bot '{}' for {}:{}", aiType, name, host, port);
         return switch (aiType) {
             case PRINCESS -> {
@@ -86,6 +91,7 @@ public final class BotFactory {
      */
     public static BotClient createBot(AiType aiType, String name, String host, int port,
           BehaviorSettings behaviorSettings) {
+        Objects.requireNonNull(behaviorSettings, "behaviorSettings");
         BotClient bot = createBot(aiType, name, host, port);
         bot.setBehaviorSettings(behaviorSettings);
         return bot;

--- a/megamek/src/megamek/client/bot/BotFactory.java
+++ b/megamek/src/megamek/client/bot/BotFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.bot;
+
+import megamek.client.bot.princess.BehaviorSettings;
+import megamek.client.bot.princess.Princess;
+import megamek.logging.MMLogger;
+
+/**
+ * The single construction point for bot clients. Instead of scattering {@code new Princess(...)} calls across the
+ * lobby, scenario loaders and headless runners, callers ask this factory for a bot by {@link AiType}. This keeps the
+ * choice of AI in one place (so a new AI type only has to be wired here and offered in the selection surfaces) and
+ * returns the abstract {@link BotClient} type, so callers do not depend on a concrete bot class.
+ *
+ * <p>The returned bot has had its background processing started (equivalent to the previous
+ * {@code new Princess(...); startPrecognition();} pairing), so callers only need to connect it and, if not using the
+ * behavior-settings overload, apply its behavior.</p>
+ */
+public final class BotFactory {
+    private static final MMLogger LOGGER = MMLogger.create(BotFactory.class);
+
+    private BotFactory() {
+    }
+
+    /**
+     * Creates and starts a bot of the given type, leaving its behavior settings at the default.
+     *
+     * @param aiType the AI implementation to build
+     * @param name   the bot player's display name
+     * @param host   the server host to connect to
+     * @param port   the server port to connect to
+     *
+     * @return a started {@link BotClient} of the requested type, not yet connected
+     */
+    public static BotClient createBot(AiType aiType, String name, String host, int port) {
+        LOGGER.debug("Creating {} bot '{}' for {}:{}", aiType, name, host, port);
+        return switch (aiType) {
+            case PRINCESS -> {
+                Princess princess = new Princess(name, host, port);
+                princess.startPrecognition();
+                yield princess;
+            }
+        };
+    }
+
+    /**
+     * Creates and starts a bot of the given type and applies the given behavior settings.
+     *
+     * @param aiType           the AI implementation to build
+     * @param name             the bot player's display name
+     * @param host             the server host to connect to
+     * @param port             the server port to connect to
+     * @param behaviorSettings the behavior settings to apply to the new bot
+     *
+     * @return a started {@link BotClient} of the requested type, not yet connected
+     */
+    public static BotClient createBot(AiType aiType, String name, String host, int port,
+          BehaviorSettings behaviorSettings) {
+        BotClient bot = createBot(aiType, name, host, port);
+        bot.setBehaviorSettings(behaviorSettings);
+        return bot;
+    }
+}

--- a/megamek/src/megamek/client/bot/BotFactory.java
+++ b/megamek/src/megamek/client/bot/BotFactory.java
@@ -34,6 +34,7 @@ package megamek.client.bot;
 
 import java.util.Objects;
 
+import megamek.client.bot.caspar.Caspar;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.Princess;
 import megamek.logging.MMLogger;
@@ -74,6 +75,11 @@ public final class BotFactory {
                 Princess princess = new Princess(name, host, port);
                 princess.startPrecognition();
                 yield princess;
+            }
+            case CASPAR -> {
+                Caspar caspar = new Caspar(name, host, port);
+                caspar.startPrecognition();
+                yield caspar;
             }
         };
     }

--- a/megamek/src/megamek/client/bot/caspar/Caspar.java
+++ b/megamek/src/megamek/client/bot/caspar/Caspar.java
@@ -30,28 +30,26 @@
  * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
  * affiliated with Microsoft.
  */
-package megamek.client.bot;
+package megamek.client.bot.caspar;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import megamek.client.bot.princess.Princess;
 
-import org.junit.jupiter.api.Test;
+/**
+ * The CASPAR bot: the experimental successor to {@link Princess}. It shares Princess's entire
+ * network/phase/state plumbing and, in this initial version, plays identically to Princess. Experimental
+ * behavior is added by overriding Princess's wiring seams (for example {@code initializePathRankers()} and
+ * {@code initializeFireControls()}) so that each divergence can be compared against Princess.
+ */
+public class Caspar extends Princess {
 
-class AiTypeTest {
-
-    @Test
-    void fromStringMatchesCaseInsensitivelyAndTrims() {
-        assertEquals(AiType.PRINCESS, AiType.fromString("princess"));
-        assertEquals(AiType.PRINCESS, AiType.fromString("PRINCESS"));
-        assertEquals(AiType.PRINCESS, AiType.fromString("  Princess  "));
-        assertEquals(AiType.CASPAR, AiType.fromString("caspar"));
-        assertEquals(AiType.CASPAR, AiType.fromString("CASPAR"));
-    }
-
-    @Test
-    void fromStringReturnsNullForNullEmptyOrUnknown() {
-        assertNull(AiType.fromString(null));
-        assertNull(AiType.fromString(""));
-        assertNull(AiType.fromString("nonsense"));
+    /**
+     * Creates a new CASPAR bot with the given display name, configured for the given host and port.
+     *
+     * @param name The display name
+     * @param host The host address to which to connect
+     * @param port The port on the host where to connect
+     */
+    public Caspar(final String name, final String host, final int port) {
+        super(name, host, port);
     }
 }

--- a/megamek/src/megamek/client/ui/clientGUI/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/ClientGUI.java
@@ -70,7 +70,6 @@ import megamek.client.Client;
 import megamek.client.TimerSingleton;
 import megamek.client.bot.BotClient;
 import megamek.client.bot.princess.BehaviorSettings;
-import megamek.client.bot.princess.Princess;
 import megamek.client.commands.*;
 import megamek.client.event.BoardViewEvent;
 import megamek.client.event.BoardViewListener;
@@ -3722,12 +3721,12 @@ public class ClientGUI extends AbstractClientGUI
         Map<String, BehaviorSettings> newBotSettings = rpd.getNewBots();
         for (String ghostName : newBotSettings.keySet()) {
             StringBuilder message = new StringBuilder();
-            Princess princess = util.replaceGhostWithBot(newBotSettings.get(ghostName), ghostName, client, message);
+            BotClient botClient = util.replaceGhostWithBot(newBotSettings.get(ghostName), ghostName, client, message);
             systemMessage(message.toString());
-            // Make this princess a locally owned bot. This way it can be configured, and if on the lobby
+            // Make this bot a locally owned bot. This way it can be configured, and if on the lobby
             // it will faithfully press Done when the local player does.
-            if (princess != null) {
-                getLocalBots().put(ghostName, princess);
+            if (botClient != null) {
+                getLocalBots().put(ghostName, botClient);
             }
         }
 

--- a/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
@@ -1091,7 +1091,10 @@ public class MegaMekGUI implements IPreferenceChangeListener {
                         botClient.setBehaviorSettings(scenarioBehavior);
                     }
                     botClient.getGame().addGameListener(new BotGUI(frame, botClient));
-                    botClient.connect();
+                    if (!botClient.connect()) {
+                        LOGGER.error("Bot {} failed to connect; shutting it down", pa[x].getName());
+                        botClient.die();
+                    }
                 }
             }
         }

--- a/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
@@ -76,6 +76,7 @@ import megamek.client.SBFClient;
 import megamek.client.bot.AiType;
 import megamek.client.bot.BotClient;
 import megamek.client.bot.BotFactory;
+import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.ui.swing.BotGUI;
 import megamek.client.ui.Messages;
 import megamek.client.ui.boardeditor.BoardEditorPanel;
@@ -1075,16 +1076,19 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         if (scenario.getGameType() == GameType.TW) {
             for (int x = 0; x < pa.length; x++) {
                 if (playerTypes[x] == ScenarioDialog.T_BOT) {
-                    LOGGER.info("Adding bot {} as Princess", pa[x].getName());
-                    BotClient botClient = BotFactory.createBot(AiType.PRINCESS,
-                          pa[x].getName(),
-                          MMConstants.LOCALHOST,
-                          port);
+                    AiType aiType = AiType.PRINCESS;
+                    BehaviorSettings scenarioBehavior = null;
                     if (scenario.hasBotInfo(pa[x].getName()) &&
                           scenario.getBotInfo(pa[x].getName()) instanceof BotParser.PrincessRecord(
-                                megamek.client.bot.princess.BehaviorSettings behaviorSettings
+                                AiType recordAiType, BehaviorSettings behaviorSettings
                           )) {
-                        botClient.setBehaviorSettings(behaviorSettings);
+                        aiType = recordAiType;
+                        scenarioBehavior = behaviorSettings;
+                    }
+                    LOGGER.info("Adding bot {} as {}", pa[x].getName(), aiType);
+                    BotClient botClient = BotFactory.createBot(aiType, pa[x].getName(), MMConstants.LOCALHOST, port);
+                    if (scenarioBehavior != null) {
+                        botClient.setBehaviorSettings(scenarioBehavior);
                     }
                     botClient.getGame().addGameListener(new BotGUI(frame, botClient));
                     botClient.connect();
@@ -1141,7 +1145,7 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         if (bcd.getResult() == DialogResult.CANCELLED) {
             return;
         }
-        client = BotFactory.createBot(AiType.PRINCESS,
+        client = BotFactory.createBot(bcd.getSelectedAiType(),
               bcd.getBotName(),
               cd.getServerAddress(),
               cd.getPort(),

--- a/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
@@ -73,8 +73,9 @@ import megamek.Version;
 import megamek.client.Client;
 import megamek.client.IClient;
 import megamek.client.SBFClient;
+import megamek.client.bot.AiType;
 import megamek.client.bot.BotClient;
-import megamek.client.bot.princess.Princess;
+import megamek.client.bot.BotFactory;
 import megamek.client.bot.ui.swing.BotGUI;
 import megamek.client.ui.Messages;
 import megamek.client.ui.boardeditor.BoardEditorPanel;
@@ -1075,16 +1076,18 @@ public class MegaMekGUI implements IPreferenceChangeListener {
             for (int x = 0; x < pa.length; x++) {
                 if (playerTypes[x] == ScenarioDialog.T_BOT) {
                     LOGGER.info("Adding bot {} as Princess", pa[x].getName());
-                    Princess c = new Princess(pa[x].getName(), MMConstants.LOCALHOST, port);
-                    c.startPrecognition();
+                    BotClient botClient = BotFactory.createBot(AiType.PRINCESS,
+                          pa[x].getName(),
+                          MMConstants.LOCALHOST,
+                          port);
                     if (scenario.hasBotInfo(pa[x].getName()) &&
                           scenario.getBotInfo(pa[x].getName()) instanceof BotParser.PrincessRecord(
                                 megamek.client.bot.princess.BehaviorSettings behaviorSettings
                           )) {
-                        c.setBehaviorSettings(behaviorSettings);
+                        botClient.setBehaviorSettings(behaviorSettings);
                     }
-                    c.getGame().addGameListener(new BotGUI(frame, c));
-                    c.connect();
+                    botClient.getGame().addGameListener(new BotGUI(frame, botClient));
+                    botClient.connect();
                 }
             }
         }
@@ -1138,7 +1141,8 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         if (bcd.getResult() == DialogResult.CANCELLED) {
             return;
         }
-        client = Princess.createPrincess(bcd.getBotName(),
+        client = BotFactory.createBot(AiType.PRINCESS,
+              bcd.getBotName(),
               cd.getServerAddress(),
               cd.getPort(),
               bcd.getBehaviorSettings());

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/BoardView.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/BoardView.java
@@ -60,9 +60,6 @@ import javax.swing.plaf.metal.MetalTheme;
 
 import megamek.MMConstants;
 import megamek.client.TimerSingleton;
-import megamek.client.bot.princess.PathEnumerator;
-import megamek.client.bot.princess.Princess;
-import megamek.client.bot.princess.geometry.ConvexBoardArea;
 import megamek.client.event.BoardViewEvent;
 import megamek.client.event.BoardViewListener;
 import megamek.client.ui.IDisplayable;
@@ -1299,7 +1296,6 @@ public final class BoardView extends AbstractBoardView
 
         // debugging method that renders the bounding box of a unit's movement envelope.
         // renderClusters((Graphics2D) graphics2D);
-        // renderMovementBoundingBox((Graphics2D) graphics2D);
         // renderDonut(graphics2D, new Coords(10, 10), 2);
         // renderApproxHexDirection((Graphics2D) graphics2D);
     }
@@ -1323,58 +1319,6 @@ public final class BoardView extends AbstractBoardView
         Point p = getCentreHexLocation(donutCoords.getX(), donutCoords.getY(), true);
         p.translate(HEX_W / 2, HEX_H / 2);
         drawHexBorder(g, p, Color.BLUE, 0, 6);
-    }
-
-    /**
-     * Debugging method that renders the bounding hex of a unit's movement envelope. Warning: very slow when rendering
-     * the bounding hex for really fast units.
-     *
-     * @param graphics2D Graphics object on which to draw.
-     */
-    @SuppressWarnings("unused")
-    private void renderMovementBoundingBox(Graphics2D graphics2D) {
-        if (getSelectedEntity() != null) {
-            Princess princess = new Princess("test", MMConstants.LOCALHOST, 2020);
-            princess.startPrecognition();
-            princess.getGame().setBoard(game.getBoard(boardId));
-            PathEnumerator pathEnum = new PathEnumerator(princess, game);
-            pathEnum.recalculateMovesFor(getSelectedEntity());
-
-            ConvexBoardArea cba = pathEnum.getUnitMovableAreas().get(getSelectedEntity().getId());
-            for (int x = 0;
-                  x < game.getBoard(boardId).getWidth();
-                  x++) {
-                for (int y = 0;
-                      y < game.getBoard(boardId).getHeight();
-                      y++) {
-                    Point centreHexLocation = getCentreHexLocation(x, y, true);
-                    centreHexLocation.translate(HEX_W / 2, HEX_H / 2);
-                    Coords coords = new Coords(x, y);
-
-                    if (cba.contains(coords)) {
-                        drawHexBorder(graphics2D, centreHexLocation, Color.PINK, 0, 6);
-                    }
-                }
-            }
-
-            for (int x = 0;
-                  x < 6;
-                  x++) {
-                Coords coords = cba.getVertexNum(x);
-                if (coords == null) {
-                    continue;
-                }
-
-                Point centreHexLocation = getCentreHexLocation(coords.getX(), coords.getY(), true);
-                centreHexLocation.translate(HEX_W / 2, HEX_H / 2);
-
-                drawHexBorder(graphics2D, centreHexLocation, Color.yellow, 0, 3);
-                new StringDrawer(Integer.toString(x)).at(centreHexLocation)
-                      .center()
-                      .color(Color.YELLOW)
-                      .draw(graphics2D);
-            }
-        }
     }
 
     /**

--- a/megamek/src/megamek/client/ui/dialogs/buttonDialogs/BotConfigDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/buttonDialogs/BotConfigDialog.java
@@ -69,6 +69,7 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 
 import megamek.client.Client;
+import megamek.client.bot.AiType;
 import megamek.client.bot.BotClient;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.BehaviorSettingsFactory;
@@ -107,6 +108,9 @@ public class BotConfigDialog extends AbstractButtonDialog
     private static final ClientPreferences CLIENT_PREFERENCES = PreferenceManager.getClientPreferences();
     private final transient BehaviorSettingsFactory behaviorSettingsFactory = BehaviorSettingsFactory.getInstance();
     private BehaviorSettings princessBehavior;
+
+    /** Radio-button group for choosing which bot AI to use; defaults to {@link AiType#PRINCESS}. */
+    private final ButtonGroup aiTypeGroup = new ButtonGroup();
 
     private final JLabel nameLabel = new JLabel(Messages.getString("BotConfigDialog.nameLabel"));
     private final TipTextField nameField = new TipTextField("", 16);
@@ -233,6 +237,34 @@ public class BotConfigDialog extends AbstractButtonDialog
     }
 
     /**
+     * The bot-AI chooser, shown as a compact line under the name field. Presents one radio button per
+     * {@link AiType}, defaulting to {@link AiType#PRINCESS}; with a single AI type available it shows a single
+     * (selected) option.
+     */
+    private JPanel aiTypePanel() {
+        JPanel result = new JPanel();
+        result.add(new JLabel(Messages.getString("BotConfigDialog.aiTypeLabel")));
+        for (AiType aiType : AiType.values()) {
+            JRadioButton radioButton = new JRadioButton(
+                  Messages.getString("BotConfigDialog.aiType." + aiType.name()));
+            radioButton.setActionCommand(aiType.name());
+            radioButton.setSelected(aiType == AiType.PRINCESS);
+            aiTypeGroup.add(radioButton);
+            result.add(radioButton);
+        }
+        return result;
+    }
+
+    /**
+     * @return the {@link AiType} selected in the AI chooser, or {@link AiType#PRINCESS} if nothing is selected
+     */
+    public AiType getSelectedAiType() {
+        ButtonModel selection = aiTypeGroup.getSelection();
+        AiType selected = (selection != null) ? AiType.fromString(selection.getActionCommand()) : null;
+        return (selected != null) ? selected : AiType.PRINCESS;
+    }
+
+    /**
      * The setting section contains the presets list on the left side and the princess settings on the right.
      */
     private JPanel settingSection() {
@@ -277,6 +309,7 @@ public class BotConfigDialog extends AbstractButtonDialog
         namePanel.add(nameField);
 
         panContent.add(namePanel);
+        panContent.add(aiTypePanel());
         return result;
     }
 

--- a/megamek/src/megamek/client/ui/dialogs/buttonDialogs/BotConfigDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/buttonDialogs/BotConfigDialog.java
@@ -249,6 +249,10 @@ public class BotConfigDialog extends AbstractButtonDialog
                   Messages.getString("BotConfigDialog.aiType." + aiType.name()));
             radioButton.setActionCommand(aiType.name());
             radioButton.setSelected(aiType == AiType.PRINCESS);
+            String tooltipKey = "BotConfigDialog.aiType." + aiType.name() + ".tooltip";
+            if (Messages.keyExists(tooltipKey)) {
+                radioButton.setToolTipText(Messages.getString(tooltipKey));
+            }
             aiTypeGroup.add(radioButton);
             result.add(radioButton);
         }

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
@@ -2233,7 +2233,7 @@ public class ChatLounge extends AbstractPhaseDisplay
         if (bcd.getResult() == DialogResult.CANCELLED) {
             return;
         }
-        BotClient botClient = BotFactory.createBot(AiType.PRINCESS,
+        BotClient botClient = BotFactory.createBot(bcd.getSelectedAiType(),
               bcd.getBotName(),
               client().getHost(),
               client().getPort(),

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
@@ -95,10 +95,11 @@ import megamek.MMConstants;
 import megamek.SuiteConstants;
 import megamek.client.AbstractClient;
 import megamek.client.Client;
+import megamek.client.bot.AiType;
 import megamek.client.bot.BotClient;
+import megamek.client.bot.BotFactory;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.BehaviorSettingsFactory;
-import megamek.client.bot.princess.Princess;
 import megamek.client.bot.ui.swing.BotGUI;
 import megamek.client.generator.RandomCallsignGenerator;
 import megamek.client.generator.RandomNameGenerator;
@@ -2232,7 +2233,8 @@ public class ChatLounge extends AbstractPhaseDisplay
         if (bcd.getResult() == DialogResult.CANCELLED) {
             return;
         }
-        Princess botClient = Princess.createPrincess(bcd.getBotName(),
+        BotClient botClient = BotFactory.createBot(AiType.PRINCESS,
+              bcd.getBotName(),
               client().getHost(),
               client().getPort(),
               bcd.getBehaviorSettings());

--- a/megamek/src/megamek/common/jacksonAdapters/BotParser.java
+++ b/megamek/src/megamek/common/jacksonAdapters/BotParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import megamek.client.bot.AiType;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.ui.dialogs.ScenarioDialog;
 
@@ -48,7 +49,7 @@ public final class BotParser {
         int type();
     }
 
-    public record PrincessRecord(BehaviorSettings behaviorSettings) implements BotInfo {
+    public record PrincessRecord(AiType aiType, BehaviorSettings behaviorSettings) implements BotInfo {
 
         @Override
         public int type() {
@@ -58,7 +59,14 @@ public final class BotParser {
 
     public static BotInfo parse(JsonNode node) throws JsonProcessingException {
         PrincessSettingsBuilder builder = YAML_MAPPER.treeToValue(node, PrincessSettingsBuilder.class);
-        return new PrincessRecord(builder.build());
+        AiType aiType = AiType.PRINCESS;
+        if (node.hasNonNull("ai")) {
+            AiType parsedAiType = AiType.fromString(node.get("ai").asText());
+            if (parsedAiType != null) {
+                aiType = parsedAiType;
+            }
+        }
+        return new PrincessRecord(aiType, builder.build());
     }
 
     private BotParser() {}

--- a/megamek/src/megamek/common/moves/MovePath.java
+++ b/megamek/src/megamek/common/moves/MovePath.java
@@ -37,7 +37,6 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.util.*;
 
-import megamek.client.bot.princess.Princess;
 import megamek.common.Hex;
 import megamek.common.ManeuverType;
 import megamek.common.annotations.Nullable;
@@ -50,7 +49,6 @@ import megamek.common.equipment.Minefield;
 import megamek.common.game.Game;
 import megamek.common.options.OptionsConstants;
 import megamek.common.pathfinder.CachedEntityState;
-import megamek.common.pathfinder.DestructionAwareDestinationPathfinder;
 import megamek.common.pathfinder.ShortestPathFinder;
 import megamek.common.pathfinder.StopConditionTimeout;
 import megamek.common.pathfinder.comparators.MovePathGreedyComparator;
@@ -1359,8 +1357,6 @@ public class MovePath implements Cloneable, Serializable {
 
         pf.run(clone());
         MovePath finPath = pf.getComputedPath(dest);
-        // this can be used for debugging the "destruction aware pathfinder"
-        // MovePath finPath = calculateDestructionAwarePath(dest);
 
         if (timeoutCondition.timeoutEngaged || finPath == null) {
             /*
@@ -1995,30 +1991,6 @@ public class MovePath implements Cloneable, Serializable {
         }
 
         return stepCount;
-    }
-
-    /**
-     * Debugging method that calculates a destruction-aware move path to the destination coordinates
-     */
-    @SuppressWarnings("unused")
-    public MovePath calculateDestructionAwarePath(Coords dest) {
-        // code that's useful to test the destruction-aware pathfinder
-        DestructionAwareDestinationPathfinder dpf = new DestructionAwareDestinationPathfinder();
-        // the destruction aware pathfinder takes either a CardinalEdge or an explicit
-        // set of coordinates
-        Set<Coords> destinationSet = new HashSet<>();
-        destinationSet.add(dest);
-
-        // debugging code that can be used to find a path to a specific edge
-        Princess princess = new Princess("test", "test", 2020);
-        princess.startPrecognition();
-
-        long marker1 = java.lang.System.currentTimeMillis();
-        MovePath finPath = dpf.findPathToCoords(entity, destinationSet, false, princess.getClusterTracker());
-        long marker2 = java.lang.System.currentTimeMillis();
-        long marker3 = marker2 - marker1;
-
-        return finPath;
     }
 
     /**

--- a/megamek/src/megamek/common/util/AddBotUtil.java
+++ b/megamek/src/megamek/common/util/AddBotUtil.java
@@ -43,10 +43,11 @@ import javax.swing.JFrame;
 
 import megamek.client.AbstractClient;
 import megamek.client.Client;
+import megamek.client.bot.AiType;
 import megamek.client.bot.BotClient;
+import megamek.client.bot.BotFactory;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.BehaviorSettingsFactory;
-import megamek.client.bot.princess.Princess;
 import megamek.client.bot.ui.swing.BotGUI;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.Player;
@@ -203,7 +204,7 @@ public class AddBotUtil {
         return concatResults();
     }
 
-    public @Nullable Princess replaceGhostWithBot(final BehaviorSettings behavior, final String playerName,
+    public @Nullable BotClient replaceGhostWithBot(final BehaviorSettings behavior, final String playerName,
           final Client client, StringBuilder message) {
         Objects.requireNonNull(client);
         Objects.requireNonNull(behavior);
@@ -227,18 +228,17 @@ public class AddBotUtil {
         }
 
         final Player target = possible.get();
-        final Princess princess = new Princess(target.getName(), host, port);
-        princess.startPrecognition();
-        princess.setBehaviorSettings(behavior);
+        final BotClient botClient = BotFactory.createBot(AiType.PRINCESS, target.getName(), host, port);
+        botClient.setBehaviorSettings(behavior);
 
         try {
-            princess.connect();
+            botClient.connect();
         } catch (final Exception ex) {
             message.append("Princess failed to connect.");
         }
-        princess.setLocalPlayerNumber(target.getId());
+        botClient.setLocalPlayerNumber(target.getId());
         message.append("Princess has replaced ").append(playerName).append(".");
-        return princess;
+        return botClient;
     }
 
     /**
@@ -269,15 +269,14 @@ public class AddBotUtil {
 
         final Player target = possible.get();
         if (target.isGhost()) {
-            final Princess princess = new Princess(target.getName(), host, port);
-            princess.setBehaviorSettings(behavior);
+            final BotClient botClient = BotFactory.createBot(AiType.PRINCESS, target.getName(), host, port);
+            botClient.setBehaviorSettings(behavior);
             try {
-                princess.connect();
-                princess.startPrecognition();
+                botClient.connect();
             } catch (final Exception ex) {
                 message.append("Princess failed to connect.");
             }
-            princess.setLocalPlayerNumber(target.getId());
+            botClient.setLocalPlayerNumber(target.getId());
             message.append("Princess has replaced ").append(playerName).append(".");
         } else {
             AbstractClient bot = client.getBots().get(target.getName());
@@ -319,8 +318,6 @@ public class AddBotUtil {
     }
 
     BotClient makeNewPrincessClient(final Player target, final String host, final int port) {
-        Princess princess = new Princess(target.getName(), host, port);
-        princess.startPrecognition();
-        return princess;
+        return BotFactory.createBot(AiType.PRINCESS, target.getName(), host, port);
     }
 }

--- a/megamek/src/megamek/common/util/AddBotUtil.java
+++ b/megamek/src/megamek/common/util/AddBotUtil.java
@@ -162,8 +162,9 @@ public class AddBotUtil {
         }
 
         final BotClient botClient;
-        if ("Princess".equalsIgnoreCase(botName.toString())) {
-            botClient = makeNewPrincessClient(target, host, port);
+        final AiType aiType = AiType.fromString(botName.toString());
+        if (aiType != null) {
+            botClient = makeNewBotClient(aiType, target, host, port);
             if (!StringUtility.isNullOrBlank(configName)) {
                 final BehaviorSettings behavior = BehaviorSettingsFactory.getInstance()
                       .getBehavior(configName.toString());
@@ -179,7 +180,7 @@ public class AddBotUtil {
         } else {
             results.add("Unrecognized bot: '" + botName + "'.  Defaulting to Princess.");
             botName = new StringBuilder("Princess");
-            botClient = makeNewPrincessClient(target, host, port);
+            botClient = makeNewBotClient(AiType.PRINCESS, target, host, port);
         }
 
         if (!GraphicsEnvironment.isHeadless()) {
@@ -329,7 +330,7 @@ public class AddBotUtil {
         client.sendChat("/kick " + target.getId());
     }
 
-    BotClient makeNewPrincessClient(final Player target, final String host, final int port) {
-        return BotFactory.createBot(AiType.PRINCESS, target.getName(), host, port);
+    BotClient makeNewBotClient(final AiType aiType, final Player target, final String host, final int port) {
+        return BotFactory.createBot(aiType, target.getName(), host, port);
     }
 }

--- a/megamek/src/megamek/common/util/AddBotUtil.java
+++ b/megamek/src/megamek/common/util/AddBotUtil.java
@@ -231,13 +231,19 @@ public class AddBotUtil {
         final BotClient botClient = BotFactory.createBot(AiType.PRINCESS, target.getName(), host, port);
         botClient.setBehaviorSettings(behavior);
 
+        boolean connected;
         try {
-            botClient.connect();
+            connected = botClient.connect();
         } catch (final Exception ex) {
-            message.append("Princess failed to connect.");
+            connected = false;
+        }
+        if (!connected) {
+            botClient.die();
+            message.append("Bot failed to connect.");
+            return null;
         }
         botClient.setLocalPlayerNumber(target.getId());
-        message.append("Princess has replaced ").append(playerName).append(".");
+        message.append("Bot has replaced ").append(playerName).append(".");
         return botClient;
     }
 
@@ -271,13 +277,19 @@ public class AddBotUtil {
         if (target.isGhost()) {
             final BotClient botClient = BotFactory.createBot(AiType.PRINCESS, target.getName(), host, port);
             botClient.setBehaviorSettings(behavior);
+            boolean connected;
             try {
-                botClient.connect();
+                connected = botClient.connect();
             } catch (final Exception ex) {
-                message.append("Princess failed to connect.");
+                connected = false;
+            }
+            if (!connected) {
+                botClient.die();
+                message.append("Bot failed to connect.");
+                return;
             }
             botClient.setLocalPlayerNumber(target.getId());
-            message.append("Princess has replaced ").append(playerName).append(".");
+            message.append("Bot has replaced ").append(playerName).append(".");
         } else {
             AbstractClient bot = client.getBots().get(target.getName());
             if (bot == null) {

--- a/megamek/src/megamek/common/util/AddBotUtil.java
+++ b/megamek/src/megamek/common/util/AddBotUtil.java
@@ -161,26 +161,24 @@ public class AddBotUtil {
             return concatResults();
         }
 
-        final BotClient botClient;
-        final AiType aiType = AiType.fromString(botName.toString());
-        if (aiType != null) {
-            botClient = makeNewBotClient(aiType, target, host, port);
-            if (!StringUtility.isNullOrBlank(configName)) {
-                final BehaviorSettings behavior = BehaviorSettingsFactory.getInstance()
-                      .getBehavior(configName.toString());
-                if (null != behavior) {
-                    botClient.setBehaviorSettings(behavior);
-                } else {
-                    results.add("Unrecognized Behavior Setting: '" + configName + "'.  Using DEFAULT.");
-                    botClient.setBehaviorSettings(BehaviorSettingsFactory.getInstance().DEFAULT_BEHAVIOR);
-                }
+        AiType aiType = AiType.fromString(botName.toString());
+        if (aiType == null) {
+            results.add("Unrecognized bot: '" + botName + "'.  Defaulting to Princess.");
+            botName = new StringBuilder("Princess");
+            aiType = AiType.PRINCESS;
+        }
+        final BotClient botClient = makeNewBotClient(aiType, target, host, port);
+        if (!StringUtility.isNullOrBlank(configName)) {
+            final BehaviorSettings behavior = BehaviorSettingsFactory.getInstance()
+                  .getBehavior(configName.toString());
+            if (null != behavior) {
+                botClient.setBehaviorSettings(behavior);
             } else {
+                results.add("Unrecognized Behavior Setting: '" + configName + "'.  Using DEFAULT.");
                 botClient.setBehaviorSettings(BehaviorSettingsFactory.getInstance().DEFAULT_BEHAVIOR);
             }
         } else {
-            results.add("Unrecognized bot: '" + botName + "'.  Defaulting to Princess.");
-            botName = new StringBuilder("Princess");
-            botClient = makeNewBotClient(AiType.PRINCESS, target, host, port);
+            botClient.setBehaviorSettings(BehaviorSettingsFactory.getInstance().DEFAULT_BEHAVIOR);
         }
 
         if (!GraphicsEnvironment.isHeadless()) {

--- a/megamek/src/megamek/utilities/QuickGameRunner.java
+++ b/megamek/src/megamek/utilities/QuickGameRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -52,7 +52,9 @@ import megamek.client.AbstractClient;
 import megamek.client.Client;
 import megamek.client.CloseClientListener;
 import megamek.client.HeadlessClient;
-import megamek.client.bot.princess.Princess;
+import megamek.client.bot.AiType;
+import megamek.client.bot.BotClient;
+import megamek.client.bot.BotFactory;
 import megamek.client.ui.clientGUI.ClientGUI;
 import megamek.client.ui.clientGUI.CommanderGUI;
 import megamek.client.ui.clientGUI.IClientGUI;
@@ -297,8 +299,8 @@ public class QuickGameRunner {
 
             for (var ghost : ghosts) {
                 var behavior = ((Game) server.getGame()).getBotSettings().get(ghost.getName());
-                Princess botClient = Princess.createPrincess(ghost.getName(), server.getHost(), server.getPort(),
-                      behavior);
+                BotClient botClient = BotFactory.createBot(AiType.PRINCESS, ghost.getName(), server.getHost(),
+                      server.getPort(), behavior);
                 if (botClient.connect()) {
                     getLocalBots().put(botClient.getName(), botClient);
                     int retryCount = 0;

--- a/megamek/src/megamek/utilities/ScenarioGameRunner.java
+++ b/megamek/src/megamek/utilities/ScenarioGameRunner.java
@@ -170,11 +170,11 @@ public class ScenarioGameRunner {
                   server.getPort(),
                   behaviorFor(botSlot.getName()));
             if (!botClient.connect()) {
-                throw new IllegalStateException("Princess failed to connect for player " + botSlot.getName());
+                throw new IllegalStateException("Bot failed to connect for player " + botSlot.getName());
             }
             waitForLocalPlayer(botClient.getName(), () -> botClient.getLocalPlayer() != null);
             botClient.sendPlayerInfo();
-            logger.info("Connected Princess for {}", botSlot.getName());
+            logger.info("Connected bot for {}", botSlot.getName());
         }
 
         logger.info("Running scenario '{}' for up to {} rounds ({} minute timeout)",

--- a/megamek/src/megamek/utilities/ScenarioGameRunner.java
+++ b/megamek/src/megamek/utilities/ScenarioGameRunner.java
@@ -164,7 +164,7 @@ public class ScenarioGameRunner {
         waitForLocalPlayer(watcher.getName(), () -> watcher.getLocalPlayer() != null);
 
         for (Player botSlot : players.subList(1, players.size())) {
-            BotClient botClient = BotFactory.createBot(AiType.PRINCESS,
+            BotClient botClient = BotFactory.createBot(aiTypeFor(botSlot.getName()),
                   botSlot.getName(),
                   LOCALHOST_IP,
                   server.getPort(),
@@ -189,14 +189,26 @@ public class ScenarioGameRunner {
     }
 
     /**
-     * Returns the Princess behavior declared for the named player in the scenario, or default behavior.
+     * Returns the behavior declared for the named player in the scenario, or default behavior.
      */
     private BehaviorSettings behaviorFor(String playerName) {
         if (scenario.hasBotInfo(playerName)
-              && scenario.getBotInfo(playerName) instanceof BotParser.PrincessRecord(BehaviorSettings settings)) {
-            return settings;
+              && scenario.getBotInfo(playerName) instanceof BotParser.PrincessRecord record) {
+            return record.behaviorSettings();
         }
         return BehaviorSettingsFactory.getInstance().DEFAULT_BEHAVIOR;
+    }
+
+    /**
+     * Returns the {@link AiType} declared for the named player in the scenario's {@code ai:} key, or
+     * {@link AiType#PRINCESS} if none is declared.
+     */
+    private AiType aiTypeFor(String playerName) {
+        if (scenario.hasBotInfo(playerName)
+              && scenario.getBotInfo(playerName) instanceof BotParser.PrincessRecord record) {
+            return record.aiType();
+        }
+        return AiType.PRINCESS;
     }
 
     private void waitForLocalPlayer(String clientName, BooleanSupplier connected) throws InterruptedException {

--- a/megamek/src/megamek/utilities/ScenarioGameRunner.java
+++ b/megamek/src/megamek/utilities/ScenarioGameRunner.java
@@ -46,9 +46,11 @@ import java.util.function.BooleanSupplier;
 
 import megamek.MMConstants;
 import megamek.client.HeadlessClient;
+import megamek.client.bot.AiType;
+import megamek.client.bot.BotClient;
+import megamek.client.bot.BotFactory;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.BehaviorSettingsFactory;
-import megamek.client.bot.princess.Princess;
 import megamek.common.Player;
 import megamek.common.enums.GamePhase;
 import megamek.common.event.GameListenerAdapter;
@@ -162,15 +164,16 @@ public class ScenarioGameRunner {
         waitForLocalPlayer(watcher.getName(), () -> watcher.getLocalPlayer() != null);
 
         for (Player botSlot : players.subList(1, players.size())) {
-            Princess princess = Princess.createPrincess(botSlot.getName(),
+            BotClient botClient = BotFactory.createBot(AiType.PRINCESS,
+                  botSlot.getName(),
                   LOCALHOST_IP,
                   server.getPort(),
                   behaviorFor(botSlot.getName()));
-            if (!princess.connect()) {
+            if (!botClient.connect()) {
                 throw new IllegalStateException("Princess failed to connect for player " + botSlot.getName());
             }
-            waitForLocalPlayer(princess.getName(), () -> princess.getLocalPlayer() != null);
-            princess.sendPlayerInfo();
+            waitForLocalPlayer(botClient.getName(), () -> botClient.getLocalPlayer() != null);
+            botClient.sendPlayerInfo();
             logger.info("Connected Princess for {}", botSlot.getName());
         }
 

--- a/megamek/unittests/megamek/client/bot/AiTypeTest.java
+++ b/megamek/unittests/megamek/client/bot/AiTypeTest.java
@@ -32,35 +32,24 @@
  */
 package megamek.client.bot;
 
-import megamek.common.annotations.Nullable;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-/**
- * Identifies which bot AI implementation to construct. Used by {@link BotFactory} as the single selection point for
- * building bots, so callers (lobby, scenario loaders, headless runners) no longer hardcode a concrete bot class.
- * Additional AI types (for example a future experimental bot) are added here as their implementations land.
- */
-public enum AiType {
-    /** The default MegaMek bot, {@link megamek.client.bot.princess.Princess}. */
-    PRINCESS;
+import org.junit.jupiter.api.Test;
 
-    /**
-     * Parses an AI type from a string (case-insensitive match against the enum name), as used by the scenario
-     * {@code ai:} key and the {@code /replacePlayer -b:} chat argument.
-     *
-     * @param value the string to parse, may be {@code null}
-     *
-     * @return the matching {@link AiType}, or {@code null} if the value is {@code null} or matches no type
-     */
-    public static @Nullable AiType fromString(@Nullable String value) {
-        if (value == null) {
-            return null;
-        }
-        String trimmed = value.trim();
-        for (AiType aiType : values()) {
-            if (aiType.name().equalsIgnoreCase(trimmed)) {
-                return aiType;
-            }
-        }
-        return null;
+class AiTypeTest {
+
+    @Test
+    void fromStringMatchesCaseInsensitivelyAndTrims() {
+        assertEquals(AiType.PRINCESS, AiType.fromString("princess"));
+        assertEquals(AiType.PRINCESS, AiType.fromString("PRINCESS"));
+        assertEquals(AiType.PRINCESS, AiType.fromString("  Princess  "));
+    }
+
+    @Test
+    void fromStringReturnsNullForNullEmptyOrUnknown() {
+        assertNull(AiType.fromString(null));
+        assertNull(AiType.fromString(""));
+        assertNull(AiType.fromString("caspar"));
     }
 }

--- a/megamek/unittests/megamek/client/bot/BotFactoryTest.java
+++ b/megamek/unittests/megamek/client/bot/BotFactoryTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.bot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import megamek.client.bot.princess.BehaviorSettings;
+import megamek.client.bot.princess.Princess;
+import megamek.client.bot.princess.PrincessException;
+import org.junit.jupiter.api.Test;
+
+class BotFactoryTest {
+
+    private static final String TEST_HOST = "localhost";
+    private static final int TEST_PORT = 2020;
+
+    @Test
+    void createBotBuildsPrincessForPrincessType() {
+        BotClient bot = BotFactory.createBot(AiType.PRINCESS, "TestBot", TEST_HOST, TEST_PORT);
+        try {
+            assertNotNull(bot);
+            assertInstanceOf(Princess.class, bot);
+            assertEquals("TestBot", bot.getName());
+        } finally {
+            bot.die();
+        }
+    }
+
+    @Test
+    void createBotAppliesBehaviorSettings() throws PrincessException {
+        BehaviorSettings behavior = new BehaviorSettings();
+        behavior.setDescription("FactoryTestBehavior");
+        BotClient bot = BotFactory.createBot(AiType.PRINCESS, "TestBot", TEST_HOST, TEST_PORT, behavior);
+        try {
+            assertEquals("FactoryTestBehavior", bot.getBehaviorSettings().getDescription());
+        } finally {
+            bot.die();
+        }
+    }
+}

--- a/megamek/unittests/megamek/client/bot/BotFactoryTest.java
+++ b/megamek/unittests/megamek/client/bot/BotFactoryTest.java
@@ -36,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import megamek.client.bot.caspar.Caspar;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.Princess;
 import megamek.client.bot.princess.PrincessException;
@@ -52,6 +53,20 @@ class BotFactoryTest {
         try {
             assertNotNull(bot);
             assertInstanceOf(Princess.class, bot);
+            assertEquals("TestBot", bot.getName());
+        } finally {
+            if (bot != null) {
+                bot.die();
+            }
+        }
+    }
+
+    @Test
+    void createBotBuildsCasparForCasparType() {
+        BotClient bot = BotFactory.createBot(AiType.CASPAR, "TestBot", TEST_HOST, TEST_PORT);
+        try {
+            assertNotNull(bot);
+            assertInstanceOf(Caspar.class, bot);
             assertEquals("TestBot", bot.getName());
         } finally {
             if (bot != null) {

--- a/megamek/unittests/megamek/client/bot/BotFactoryTest.java
+++ b/megamek/unittests/megamek/client/bot/BotFactoryTest.java
@@ -54,7 +54,9 @@ class BotFactoryTest {
             assertInstanceOf(Princess.class, bot);
             assertEquals("TestBot", bot.getName());
         } finally {
-            bot.die();
+            if (bot != null) {
+                bot.die();
+            }
         }
     }
 
@@ -66,7 +68,9 @@ class BotFactoryTest {
         try {
             assertEquals("FactoryTestBehavior", bot.getBehaviorSettings().getDescription());
         } finally {
-            bot.die();
+            if (bot != null) {
+                bot.die();
+            }
         }
     }
 }

--- a/megamek/unittests/megamek/common/jacksonAdapters/BotParserTest.java
+++ b/megamek/unittests/megamek/common/jacksonAdapters/BotParserTest.java
@@ -30,37 +30,37 @@
  * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
  * affiliated with Microsoft.
  */
-package megamek.client.bot;
+package megamek.common.jacksonAdapters;
 
-import megamek.common.annotations.Nullable;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
-/**
- * Identifies which bot AI implementation to construct. Used by {@link BotFactory} as the single selection point for
- * building bots, so callers (lobby, scenario loaders, headless runners) no longer hardcode a concrete bot class.
- * Additional AI types (for example a future experimental bot) are added here as their implementations land.
- */
-public enum AiType {
-    /** The default MegaMek bot, {@link megamek.client.bot.princess.Princess}. */
-    PRINCESS;
+import com.fasterxml.jackson.databind.JsonNode;
+import megamek.client.bot.AiType;
+import org.junit.jupiter.api.Test;
 
-    /**
-     * Parses an AI type from a string (case-insensitive match against the enum name), as used by the scenario
-     * {@code ai:} key and the {@code /replacePlayer -b:} chat argument.
-     *
-     * @param value the string to parse, may be {@code null}
-     *
-     * @return the matching {@link AiType}, or {@code null} if the value is {@code null} or matches no type
-     */
-    public static @Nullable AiType fromString(@Nullable String value) {
-        if (value == null) {
-            return null;
-        }
-        String trimmed = value.trim();
-        for (AiType aiType : values()) {
-            if (aiType.name().equalsIgnoreCase(trimmed)) {
-                return aiType;
-            }
-        }
-        return null;
+class BotParserTest {
+
+    private static BotParser.PrincessRecord parse(String yaml) throws Exception {
+        JsonNode node = BotParser.YAML_MAPPER.readTree(yaml);
+        BotParser.BotInfo botInfo = BotParser.parse(node);
+        assertInstanceOf(BotParser.PrincessRecord.class, botInfo);
+        return (BotParser.PrincessRecord) botInfo;
+    }
+
+    @Test
+    void defaultsToPrincessWhenNoAiKey() throws Exception {
+        assertEquals(AiType.PRINCESS, parse("name: TestBot").aiType());
+    }
+
+    @Test
+    void readsExplicitAiKeyCaseInsensitively() throws Exception {
+        assertEquals(AiType.PRINCESS, parse("ai: princess").aiType());
+        assertEquals(AiType.PRINCESS, parse("ai: PRINCESS").aiType());
+    }
+
+    @Test
+    void unknownAiKeyFallsBackToPrincess() throws Exception {
+        assertEquals(AiType.PRINCESS, parse("ai: nonsense").aiType());
     }
 }

--- a/megamek/unittests/megamek/common/util/AddBotUtilTest.java
+++ b/megamek/unittests/megamek/common/util/AddBotUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -47,6 +47,7 @@ import java.util.HashSet;
 import java.util.Vector;
 
 import megamek.client.Client;
+import megamek.client.bot.AiType;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.BehaviorSettingsFactory;
 import megamek.client.bot.princess.Princess;
@@ -104,8 +105,8 @@ class AddBotUtilTest {
         doCallRealMethod().when(mockPrincess).getBehaviorSettings();
 
         testAddBotUtil = spy(new AddBotUtil());
-        doReturn(mockPrincess).when(testAddBotUtil).makeNewPrincessClient(
-              any(Player.class), anyString(), anyInt());
+        doReturn(mockPrincess).when(testAddBotUtil).makeNewBotClient(
+              any(AiType.class), any(Player.class), anyString(), anyInt());
     }
 
     @Test


### PR DESCRIPTION
## Summary
Adds the player-facing bot selection and the second AI it selects, building on the `BotFactory`/`AiType`
construction point from #8464. A chosen `AiType` now flows through three surfaces into `BotFactory.createBot`,
and CASPAR is introduced as the experimental successor to Princess.

## Changes
1. **AiType** — case-insensitive `fromString(...)`; adds `CASPAR`.
2. **Lobby** — `BotConfigDialog` shows a compact "Bot AI:" radio line under the name field (one radio per
   `AiType`, default Princess) with `getSelectedAiType()`; `ChatLounge` and `MegaMekGUI` lobby-add pass the
   selected type to `createBot`.
3. **Scenario** — `BotParser` reads an optional `ai:` key (default princess); `PrincessRecord` carries the
   `AiType`; `MegaMekGUI` scenario bots and `ScenarioGameRunner` pass it through (the blind-playtest hook).
4. **Chat** — `/replacePlayer` maps its existing `-b:` value through `AiType.fromString`;
   `makeNewPrincessClient` → `makeNewBotClient(AiType, ...)`.
5. **CASPAR** — new `Caspar` (`megamek.client.bot.caspar`) extends `Princess`; v0 overrides nothing, so it
   plays identically to Princess. `BotFactory` builds it for `AiType.CASPAR`.

## Files Changed
- `AiType.java`, `BotFactory.java`, `caspar/Caspar.java` — the AI types + construction.
- `BotConfigDialog.java`, `ChatLounge.java`, `MegaMekGUI.java`, `AddBotUtil.java`, `ScenarioGameRunner.java`,
  `BotParser.java` — the three selection surfaces.
- `messages.properties` — the radio labels.
- `AiTypeTest`, `BotFactoryTest`, `BotParserTest`, `AddBotUtilTest` — tests.

## Testing
Unit tests for `AiType.fromString`, the `ai:` scenario key, and `BotFactory` building Princess/CASPAR; existing
bot tests updated and green. Headless bot game creates bots through the factory. Everything defaults to
Princess, and CASPAR v0 is identical to Princess, so existing behav

Builds on #8464.