### PR TITLE
Fix Victory Conditions not persisting between games (Fixes #8469)

### DIFF
--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
@@ -2325,7 +2325,8 @@ public class ChatLounge extends AbstractPhaseDisplay
     /**
      * Shows the victory conditions dialog (the former Victory Conditions tab of the game options; the tab is
      * removed and this dialog is the only place to edit those options). On OK, the changed options are sent to the
-     * server.
+     * server and the full option set is saved to the game options file so the victory conditions persist between
+     * games.
      */
     private void showVictoryConditionsDialog() {
         if (victoryConditionsDialog == null) {
@@ -2337,6 +2338,9 @@ public class ChatLounge extends AbstractPhaseDisplay
             if (!changedOptions.isEmpty()) {
                 clientgui.getClient().sendGameOptions(victoryConditionsDialog.getPassword(), changedOptions);
             }
+            // Persist to the game options file so the victory conditions survive a re-host; the sent options only
+            // update the running server, which reloads defaults from the file when a new game is hosted.
+            victoryConditionsDialog.saveVictoryOptions();
         }
     }
 

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/VictoryConditionsDialog.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/VictoryConditionsDialog.java
@@ -52,6 +52,8 @@ import megamek.client.ui.clientGUI.DialogOptionListener;
 import megamek.client.ui.dialogs.buttonDialogs.AbstractButtonDialog;
 import megamek.client.ui.panels.DialogOptionComponentYPanel;
 import megamek.client.ui.util.UIUtil.FixedYPanel;
+import megamek.common.options.BasicOption;
+import megamek.common.options.GameOptions;
 import megamek.common.options.IBasicOption;
 import megamek.common.options.IOption;
 import megamek.common.options.IOptionGroup;
@@ -143,6 +145,47 @@ public class VictoryConditionsDialog extends AbstractButtonDialog implements Dia
             }
         }
         return changedOptions;
+    }
+
+    /**
+     * Persists all game options - including the victory options as edited in this dialog - to the default game options
+     * file, so that the victory conditions survive between games. This mirrors the save that the former Victory
+     * Conditions tab performed as part of the game options dialog's OK handling; without it, a newly hosted game
+     * reloads the options file and reverts every victory option to its default (the options sent to a running server
+     * are not written to disk).
+     *
+     * <p>The full option set is written because {@link GameOptions#saveOptions(Vector)} overwrites the entire
+     * file; saving only the victory options would drop every other game option. The victory options use the values
+     * currently shown in this dialog (the sent changes are not yet reflected in the local game options, which are only
+     * updated once the server echoes them back), while all other options keep their current game values.</p>
+     */
+    public void saveVictoryOptions() {
+        Vector<IBasicOption> optionsToSave = new Vector<>();
+        for (Enumeration<IOptionGroup> groups = clientGui.getClient().getGame().getOptions().getGroups();
+              groups.hasMoreElements(); ) {
+            IOptionGroup group = groups.nextElement();
+            for (Enumeration<IOption> optionsEnumeration = group.getOptions();
+                  optionsEnumeration.hasMoreElements(); ) {
+                IOption option = optionsEnumeration.nextElement();
+                optionsToSave.addElement(optionForSave(option));
+            }
+        }
+        GameOptions.saveOptions(optionsToSave);
+    }
+
+    /**
+     * @param option a game option being written to the options file
+     *
+     * @return the edited value from this dialog's component when it holds one for the given option, otherwise the
+     *       option's current value unchanged
+     */
+    private IBasicOption optionForSave(IOption option) {
+        for (DialogOptionComponentYPanel optionComponent : victoryOptionComps) {
+            if (optionComponent.getOption().getName().equals(option.getName())) {
+                return optionComponent.changedOption();
+            }
+        }
+        return new BasicOption(option.getName(), option.getValue());
     }
 
     @Override


### PR DESCRIPTION
## Root Cause
The lobby Victory Conditions dialog (added in #8431) only calls `sendGameOptions(...)`, which updates the *running* server. It never writes the options to `mmconf/gameoptions.xml`. The server loads that file once, in the `TWGameManager` constructor, so every newly hosted game reverts the victory options to their defaults. The old Victory Conditions tab avoided this because `GameOptionsDialog.okAction()` did both `send()` and `doSave()` (which persisted the full option set to the file); the new dialog dropped the save half.

## Changes
1. `VictoryConditionsDialog` - new `saveVictoryOptions()` (+ private `optionForSave` helper). It writes the full option set to `gameoptions.xml`, substituting each victory option's edited dialog value (read from the UI, since the server has not echoed the change back yet) and keeping every other option at its current game value. The full set is written because `GameOptions.saveOptions(...)` overwrites the whole file - saving only the victory options would drop everything else.
2. `ChatLounge.showVictoryConditionsDialog()` - calls `saveVictoryOptions()` on OK, after sending the changed options to the server.

## Files Changed
- `megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/VictoryConditionsDialog.java`
  - add `saveVictoryOptions()` / `optionForSave(...)`
- `megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java`
  - invoke the save on dialog confirmation

## Testing
- `./gradlew :megamek:compileJava` clean.
- Manual/runtime: hosted a game, opened Victory Conditions, changed a condition, clicked OK, and confirmed the full victory option group (`check_victory`, `achieve_conditions`, turn limit, BV/kill thresholds, etc.) is now written toreviously the victory group was entirely absent - and survives re-hosting.

Fixes #8469