### PR TITLE
Rename AiType -> AIType and gate CASPAR behind a hidden UseCASPAR client option

### DIFF
--- a/megamek/src/megamek/client/bot/AIType.java
+++ b/megamek/src/megamek/client/bot/AIType.java
@@ -39,7 +39,7 @@ import megamek.common.annotations.Nullable;
  * building bots, so callers (lobby, scenario loaders, headless runners) no longer hardcode a concrete bot class.
  * Additional AI types (for example a future experimental bot) are added here as their implementations land.
  */
-public enum AiType {
+public enum AIType {
     /** The default MegaMek bot, {@link megamek.client.bot.princess.Princess}. */
     PRINCESS,
 
@@ -52,14 +52,14 @@ public enum AiType {
      *
      * @param value the string to parse, may be {@code null}
      *
-     * @return the matching {@link AiType}, or {@code null} if the value is {@code null} or matches no type
+     * @return the matching {@link AIType}, or {@code null} if the value is {@code null} or matches no type
      */
-    public static @Nullable AiType fromString(@Nullable String value) {
+    public static @Nullable AIType fromString(@Nullable String value) {
         if (value == null) {
             return null;
         }
         String trimmed = value.trim();
-        for (AiType aiType : values()) {
+        for (AIType aiType : values()) {
             if (aiType.name().equalsIgnoreCase(trimmed)) {
                 return aiType;
             }

--- a/megamek/src/megamek/client/bot/BotFactory.java
+++ b/megamek/src/megamek/client/bot/BotFactory.java
@@ -41,7 +41,7 @@ import megamek.logging.MMLogger;
 
 /**
  * The single construction point for bot clients. Instead of scattering {@code new Princess(...)} calls across the
- * lobby, scenario loaders and headless runners, callers ask this factory for a bot by {@link AiType}. This keeps the
+ * lobby, scenario loaders and headless runners, callers ask this factory for a bot by {@link AIType}. This keeps the
  * choice of AI in one place (so a new AI type only has to be wired here and offered in the selection surfaces) and
  * returns the abstract {@link BotClient} type, so callers do not depend on a concrete bot class.
  *
@@ -65,7 +65,7 @@ public final class BotFactory {
      *
      * @return a started {@link BotClient} of the requested type, not yet connected
      */
-    public static BotClient createBot(AiType aiType, String name, String host, int port) {
+    public static BotClient createBot(AIType aiType, String name, String host, int port) {
         Objects.requireNonNull(aiType, "aiType");
         Objects.requireNonNull(name, "name");
         Objects.requireNonNull(host, "host");
@@ -95,7 +95,7 @@ public final class BotFactory {
      *
      * @return a started {@link BotClient} of the requested type, not yet connected
      */
-    public static BotClient createBot(AiType aiType, String name, String host, int port,
+    public static BotClient createBot(AIType aiType, String name, String host, int port,
           BehaviorSettings behaviorSettings) {
         Objects.requireNonNull(behaviorSettings, "behaviorSettings");
         BotClient bot = createBot(aiType, name, host, port);

--- a/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
@@ -73,7 +73,7 @@ import megamek.Version;
 import megamek.client.Client;
 import megamek.client.IClient;
 import megamek.client.SBFClient;
-import megamek.client.bot.AiType;
+import megamek.client.bot.AIType;
 import megamek.client.bot.BotClient;
 import megamek.client.bot.BotFactory;
 import megamek.client.bot.princess.BehaviorSettings;
@@ -1076,13 +1076,13 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         if (scenario.getGameType() == GameType.TW) {
             for (int x = 0; x < pa.length; x++) {
                 if (playerTypes[x] == ScenarioDialog.T_BOT) {
-                    AiType aiType = AiType.PRINCESS;
+                    AIType aiType = AIType.PRINCESS;
                     BehaviorSettings scenarioBehavior = null;
                     if (scenario.hasBotInfo(pa[x].getName()) &&
                           scenario.getBotInfo(pa[x].getName()) instanceof BotParser.PrincessRecord(
-                                AiType recordAiType, BehaviorSettings behaviorSettings
+                                AIType recordAIType, BehaviorSettings behaviorSettings
                           )) {
-                        aiType = recordAiType;
+                        aiType = recordAIType;
                         scenarioBehavior = behaviorSettings;
                     }
                     LOGGER.info("Adding bot {} as {}", pa[x].getName(), aiType);
@@ -1148,7 +1148,7 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         if (bcd.getResult() == DialogResult.CANCELLED) {
             return;
         }
-        client = BotFactory.createBot(bcd.getSelectedAiType(),
+        client = BotFactory.createBot(bcd.getSelectedAIType(),
               bcd.getBotName(),
               cd.getServerAddress(),
               cd.getPort(),

--- a/megamek/src/megamek/client/ui/dialogs/buttonDialogs/BotConfigDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/buttonDialogs/BotConfigDialog.java
@@ -244,7 +244,12 @@ public class BotConfigDialog extends AbstractButtonDialog
     private JPanel aiTypePanel() {
         JPanel result = new JPanel();
         result.add(new JLabel(Messages.getString("BotConfigDialog.aiTypeLabel")));
+        boolean useCaspar = CLIENT_PREFERENCES.getUseCASPAR();
         for (AIType aiType : AIType.values()) {
+            if ((aiType == AIType.CASPAR) && !useCaspar) {
+                logger.debug("[Caspar] CASPAR AI option hidden - UseCASPAR client setting is off");
+                continue;
+            }
             JRadioButton radioButton = new JRadioButton(
                   Messages.getString("BotConfigDialog.aiType." + aiType.name()));
             radioButton.setActionCommand(aiType.name());

--- a/megamek/src/megamek/client/ui/dialogs/buttonDialogs/BotConfigDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/buttonDialogs/BotConfigDialog.java
@@ -69,7 +69,7 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 
 import megamek.client.Client;
-import megamek.client.bot.AiType;
+import megamek.client.bot.AIType;
 import megamek.client.bot.BotClient;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.BehaviorSettingsFactory;
@@ -109,7 +109,7 @@ public class BotConfigDialog extends AbstractButtonDialog
     private final transient BehaviorSettingsFactory behaviorSettingsFactory = BehaviorSettingsFactory.getInstance();
     private BehaviorSettings princessBehavior;
 
-    /** Radio-button group for choosing which bot AI to use; defaults to {@link AiType#PRINCESS}. */
+    /** Radio-button group for choosing which bot AI to use; defaults to {@link AIType#PRINCESS}. */
     private final ButtonGroup aiTypeGroup = new ButtonGroup();
 
     private final JLabel nameLabel = new JLabel(Messages.getString("BotConfigDialog.nameLabel"));
@@ -238,17 +238,17 @@ public class BotConfigDialog extends AbstractButtonDialog
 
     /**
      * The bot-AI chooser, shown as a compact line under the name field. Presents one radio button per
-     * {@link AiType}, defaulting to {@link AiType#PRINCESS}; with a single AI type available it shows a single
+     * {@link AIType}, defaulting to {@link AIType#PRINCESS}; with a single AI type available it shows a single
      * (selected) option.
      */
     private JPanel aiTypePanel() {
         JPanel result = new JPanel();
         result.add(new JLabel(Messages.getString("BotConfigDialog.aiTypeLabel")));
-        for (AiType aiType : AiType.values()) {
+        for (AIType aiType : AIType.values()) {
             JRadioButton radioButton = new JRadioButton(
                   Messages.getString("BotConfigDialog.aiType." + aiType.name()));
             radioButton.setActionCommand(aiType.name());
-            radioButton.setSelected(aiType == AiType.PRINCESS);
+            radioButton.setSelected(aiType == AIType.PRINCESS);
             String tooltipKey = "BotConfigDialog.aiType." + aiType.name() + ".tooltip";
             if (Messages.keyExists(tooltipKey)) {
                 radioButton.setToolTipText(Messages.getString(tooltipKey));
@@ -260,12 +260,12 @@ public class BotConfigDialog extends AbstractButtonDialog
     }
 
     /**
-     * @return the {@link AiType} selected in the AI chooser, or {@link AiType#PRINCESS} if nothing is selected
+     * @return the {@link AIType} selected in the AI chooser, or {@link AIType#PRINCESS} if nothing is selected
      */
-    public AiType getSelectedAiType() {
+    public AIType getSelectedAIType() {
         ButtonModel selection = aiTypeGroup.getSelection();
-        AiType selected = (selection != null) ? AiType.fromString(selection.getActionCommand()) : null;
-        return (selected != null) ? selected : AiType.PRINCESS;
+        AIType selected = (selection != null) ? AIType.fromString(selection.getActionCommand()) : null;
+        return (selected != null) ? selected : AIType.PRINCESS;
     }
 
     /**

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
@@ -95,7 +95,7 @@ import megamek.MMConstants;
 import megamek.SuiteConstants;
 import megamek.client.AbstractClient;
 import megamek.client.Client;
-import megamek.client.bot.AiType;
+import megamek.client.bot.AIType;
 import megamek.client.bot.BotClient;
 import megamek.client.bot.BotFactory;
 import megamek.client.bot.princess.BehaviorSettings;
@@ -2233,7 +2233,7 @@ public class ChatLounge extends AbstractPhaseDisplay
         if (bcd.getResult() == DialogResult.CANCELLED) {
             return;
         }
-        BotClient botClient = BotFactory.createBot(bcd.getSelectedAiType(),
+        BotClient botClient = BotFactory.createBot(bcd.getSelectedAIType(),
               bcd.getBotName(),
               client().getHost(),
               client().getPort(),

--- a/megamek/src/megamek/common/jacksonAdapters/BotParser.java
+++ b/megamek/src/megamek/common/jacksonAdapters/BotParser.java
@@ -37,7 +37,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import megamek.client.bot.AiType;
+import megamek.client.bot.AIType;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.ui.dialogs.ScenarioDialog;
 
@@ -49,7 +49,7 @@ public final class BotParser {
         int type();
     }
 
-    public record PrincessRecord(AiType aiType, BehaviorSettings behaviorSettings) implements BotInfo {
+    public record PrincessRecord(AIType aiType, BehaviorSettings behaviorSettings) implements BotInfo {
 
         @Override
         public int type() {
@@ -59,11 +59,11 @@ public final class BotParser {
 
     public static BotInfo parse(JsonNode node) throws JsonProcessingException {
         PrincessSettingsBuilder builder = YAML_MAPPER.treeToValue(node, PrincessSettingsBuilder.class);
-        AiType aiType = AiType.PRINCESS;
+        AIType aiType = AIType.PRINCESS;
         if (node.hasNonNull("ai")) {
-            AiType parsedAiType = AiType.fromString(node.get("ai").asText());
-            if (parsedAiType != null) {
-                aiType = parsedAiType;
+            AIType parsedAIType = AIType.fromString(node.get("ai").asText());
+            if (parsedAIType != null) {
+                aiType = parsedAIType;
             }
         }
         return new PrincessRecord(aiType, builder.build());

--- a/megamek/src/megamek/common/preference/ClientPreferences.java
+++ b/megamek/src/megamek/common/preference/ClientPreferences.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2005-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2005-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -80,6 +80,7 @@ public class ClientPreferences extends PreferenceStoreProxy {
     public static final String DATA_LOGGING = "GameDatasetLogging";
     public static final String STAMP_FORMAT = "StampFormat";
     public static final String SHOW_UNIT_ID = "ShowUnitId";
+    public static final String USE_CASPAR = "UseCASPAR";
     public static final String UNIT_START_CHAR = "UnitStartChar";
     public static final String DEFAULT_AUTO_EJECT_DISABLED = "DefaultAutoejectDisabled";
     public static final String USE_AVERAGE_SKILLS = "UseAverageSkills";
@@ -167,6 +168,7 @@ public class ClientPreferences extends PreferenceStoreProxy {
         store.setDefault(DATA_LOGGING, true);
         store.setDefault(SHOW_AUTO_RESOLVE_PANEL, false);
         store.setDefault(STAMP_FILENAMES, false);
+        store.setDefault(USE_CASPAR, false);
         store.setDefault(FAVORITE_PRINCESS_BEHAVIOR_SETTING, DEFAULT_BEHAVIOR_DESCRIPTION);
         store.setDefault(LAST_SCENARIO, "");
 
@@ -289,6 +291,15 @@ public class ClientPreferences extends PreferenceStoreProxy {
 
     public boolean getShowUnitId() {
         return store.getBoolean(SHOW_UNIT_ID);
+    }
+
+    /**
+     * @return {@code true} if the experimental CASPAR bot is offered as a selectable AI. This is a hidden
+     *       option: it is not shown in any settings UI and defaults to {@code false}; enable it by hand-adding
+     *       {@code <UseCASPAR>true</UseCASPAR>} to clientsettings.xml.
+     */
+    public boolean getUseCASPAR() {
+        return store.getBoolean(USE_CASPAR);
     }
 
     public char getUnitStartChar() {

--- a/megamek/src/megamek/common/util/AddBotUtil.java
+++ b/megamek/src/megamek/common/util/AddBotUtil.java
@@ -43,7 +43,7 @@ import javax.swing.JFrame;
 
 import megamek.client.AbstractClient;
 import megamek.client.Client;
-import megamek.client.bot.AiType;
+import megamek.client.bot.AIType;
 import megamek.client.bot.BotClient;
 import megamek.client.bot.BotFactory;
 import megamek.client.bot.princess.BehaviorSettings;
@@ -161,11 +161,11 @@ public class AddBotUtil {
             return concatResults();
         }
 
-        AiType aiType = AiType.fromString(botName.toString());
+        AIType aiType = AIType.fromString(botName.toString());
         if (aiType == null) {
             results.add("Unrecognized bot: '" + botName + "'.  Defaulting to Princess.");
             botName = new StringBuilder("Princess");
-            aiType = AiType.PRINCESS;
+            aiType = AIType.PRINCESS;
         }
         final BotClient botClient = makeNewBotClient(aiType, target, host, port);
         if (!StringUtility.isNullOrBlank(configName)) {
@@ -227,7 +227,7 @@ public class AddBotUtil {
         }
 
         final Player target = possible.get();
-        final BotClient botClient = BotFactory.createBot(AiType.PRINCESS, target.getName(), host, port);
+        final BotClient botClient = BotFactory.createBot(AIType.PRINCESS, target.getName(), host, port);
         botClient.setBehaviorSettings(behavior);
 
         boolean connected;
@@ -274,7 +274,7 @@ public class AddBotUtil {
 
         final Player target = possible.get();
         if (target.isGhost()) {
-            final BotClient botClient = BotFactory.createBot(AiType.PRINCESS, target.getName(), host, port);
+            final BotClient botClient = BotFactory.createBot(AIType.PRINCESS, target.getName(), host, port);
             botClient.setBehaviorSettings(behavior);
             boolean connected;
             try {
@@ -328,7 +328,7 @@ public class AddBotUtil {
         client.sendChat("/kick " + target.getId());
     }
 
-    BotClient makeNewBotClient(final AiType aiType, final Player target, final String host, final int port) {
+    BotClient makeNewBotClient(final AIType aiType, final Player target, final String host, final int port) {
         return BotFactory.createBot(aiType, target.getName(), host, port);
     }
 }

--- a/megamek/src/megamek/utilities/AIMatchRunner.java
+++ b/megamek/src/megamek/utilities/AIMatchRunner.java
@@ -37,31 +37,31 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-import megamek.client.bot.AiType;
+import megamek.client.bot.AIType;
 import megamek.common.Player;
 import megamek.common.preference.PreferenceManager;
 import megamek.logging.MMLogger;
 
 /**
- * Runs a scenario headlessly many times and reports the win rate per team (and the {@link AiType}s on each team),
+ * Runs a scenario headlessly many times and reports the win rate per team (and the {@link AIType}s on each team),
  * so two bot AIs assigned via the scenario {@code ai:} key - for example Princess versus CASPAR - can be compared
  * over a batch of games. The BotLogger TSVs from every game are kept, so the battle-analyzer tooling can also
  * score decision quality per side, not just wins.
  *
- * <p>Usage: {@code AiMatchRunner <scenarioFile> [repetitions] [roundsLimit] [timeoutMinutes]}</p>
+ * <p>Usage: {@code AIMatchRunner <scenarioFile> [repetitions] [roundsLimit] [timeoutMinutes]}</p>
  */
-public final class AiMatchRunner {
-    private static final MMLogger logger = MMLogger.create(AiMatchRunner.class);
+public final class AIMatchRunner {
+    private static final MMLogger logger = MMLogger.create(AIMatchRunner.class);
 
     private static final int DEFAULT_REPETITIONS = 10;
     private static final int DEFAULT_ROUNDS_LIMIT = 12;
     private static final int DEFAULT_TIMEOUT_MINUTES = 10;
 
-    private AiMatchRunner() {}
+    private AIMatchRunner() {}
 
     public static void main(String[] args) {
         if (args.length < 1) {
-            System.out.println("Usage: AiMatchRunner <scenarioFile> [repetitions] [roundsLimit] [timeoutMinutes]");
+            System.out.println("Usage: AIMatchRunner <scenarioFile> [repetitions] [roundsLimit] [timeoutMinutes]");
             System.out.println(" - assign AIs to the scenario's bot factions with the 'ai:' key (e.g. ai: caspar)");
             System.exit(1);
         }
@@ -75,7 +75,7 @@ public final class AiMatchRunner {
         PreferenceManager.getClientPreferences().setStampFilenames(true);
 
         Map<Integer, Integer> teamWins = new TreeMap<>();
-        Map<Integer, Set<AiType>> teamAiTypes = new TreeMap<>();
+        Map<Integer, Set<AIType>> teamAITypes = new TreeMap<>();
         int draws = 0;
         int unfinished = 0;
 
@@ -83,8 +83,8 @@ public final class AiMatchRunner {
             ScenarioGameRunner runner = null;
             try {
                 runner = new ScenarioGameRunner(scenarioFile);
-                if (teamAiTypes.isEmpty()) {
-                    teamAiTypes = runner.getBotTeamAiTypes();
+                if (teamAITypes.isEmpty()) {
+                    teamAITypes = runner.getBotTeamAITypes();
                 }
                 ScenarioGameRunner.GameResult result = runner.runGame(roundsLimit, timeoutMinutes);
                 if (!result.finished()) {
@@ -96,7 +96,7 @@ public final class AiMatchRunner {
                 } else {
                     teamWins.merge(result.winningTeam(), 1, Integer::sum);
                     logger.info("Game {}/{}: team {} {} wins", gameNumber, repetitions, result.winningTeam(),
-                          teamAiTypes.getOrDefault(result.winningTeam(), Set.of()));
+                          teamAITypes.getOrDefault(result.winningTeam(), Set.of()));
                 }
             } catch (Exception exception) {
                 logger.error(exception, "Game " + gameNumber + "/" + repetitions + " failed to run");
@@ -107,7 +107,7 @@ public final class AiMatchRunner {
             }
         }
 
-        logger.info(formatSummary(repetitions, teamWins, teamAiTypes, draws, unfinished));
+        logger.info(formatSummary(repetitions, teamWins, teamAITypes, draws, unfinished));
         System.exit(0);
     }
 
@@ -136,10 +136,10 @@ public final class AiMatchRunner {
     }
 
     private static String formatSummary(int repetitions, Map<Integer, Integer> teamWins,
-          Map<Integer, Set<AiType>> teamAiTypes, int draws, int unfinished) {
+          Map<Integer, Set<AIType>> teamAITypes, int draws, int unfinished) {
         StringBuilder summary = new StringBuilder(
               System.lineSeparator() + "=== AI match results over " + repetitions + " game(s) ===");
-        for (Map.Entry<Integer, Set<AiType>> entry : teamAiTypes.entrySet()) {
+        for (Map.Entry<Integer, Set<AIType>> entry : teamAITypes.entrySet()) {
             summary.append(System.lineSeparator())
                   .append("  Team ").append(entry.getKey())
                   .append(' ').append(entry.getValue())

--- a/megamek/src/megamek/utilities/QuickGameRunner.java
+++ b/megamek/src/megamek/utilities/QuickGameRunner.java
@@ -52,7 +52,7 @@ import megamek.client.AbstractClient;
 import megamek.client.Client;
 import megamek.client.CloseClientListener;
 import megamek.client.HeadlessClient;
-import megamek.client.bot.AiType;
+import megamek.client.bot.AIType;
 import megamek.client.bot.BotClient;
 import megamek.client.bot.BotFactory;
 import megamek.client.ui.clientGUI.ClientGUI;
@@ -299,7 +299,7 @@ public class QuickGameRunner {
 
             for (var ghost : ghosts) {
                 var behavior = ((Game) server.getGame()).getBotSettings().get(ghost.getName());
-                BotClient botClient = BotFactory.createBot(AiType.PRINCESS, ghost.getName(), server.getHost(),
+                BotClient botClient = BotFactory.createBot(AIType.PRINCESS, ghost.getName(), server.getHost(),
                       server.getPort(), behavior);
                 if (botClient.connect()) {
                     getLocalBots().put(botClient.getName(), botClient);

--- a/megamek/src/megamek/utilities/ScenarioGameRunner.java
+++ b/megamek/src/megamek/utilities/ScenarioGameRunner.java
@@ -50,7 +50,7 @@ import java.util.function.BooleanSupplier;
 
 import megamek.MMConstants;
 import megamek.client.HeadlessClient;
-import megamek.client.bot.AiType;
+import megamek.client.bot.AIType;
 import megamek.client.bot.BotClient;
 import megamek.client.bot.BotFactory;
 import megamek.client.bot.princess.BehaviorSettings;
@@ -248,35 +248,35 @@ public class ScenarioGameRunner {
     }
 
     /**
-     * Returns the {@link AiType} declared for the named player in the scenario's {@code ai:} key, or
-     * {@link AiType#PRINCESS} if none is declared.
+     * Returns the {@link AIType} declared for the named player in the scenario's {@code ai:} key, or
+     * {@link AIType#PRINCESS} if none is declared.
      */
-    public AiType aiTypeFor(String playerName) {
+    public AIType aiTypeFor(String playerName) {
         if (scenario.hasBotInfo(playerName)
               && scenario.getBotInfo(playerName) instanceof BotParser.PrincessRecord record) {
             return record.aiType();
         }
-        return AiType.PRINCESS;
+        return AIType.PRINCESS;
     }
 
     /**
-     * Maps each team to the {@link AiType}s of its bot players. The first player slot (by id) is the headless
+     * Maps each team to the {@link AIType}s of its bot players. The first player slot (by id) is the headless
      * watcher and is excluded, so only the competing bot teams are reported.
      *
-     * @return team id to the set of bot {@link AiType}s on that team
+     * @return team id to the set of bot {@link AIType}s on that team
      */
-    public Map<Integer, Set<AiType>> getBotTeamAiTypes() {
-        Map<Integer, Set<AiType>> teamAiTypes = new TreeMap<>();
+    public Map<Integer, Set<AIType>> getBotTeamAITypes() {
+        Map<Integer, Set<AIType>> teamAITypes = new TreeMap<>();
         List<Player> players = new ArrayList<>(game.getPlayersList());
         if (players.isEmpty()) {
-            return teamAiTypes;
+            return teamAITypes;
         }
         players.sort(Comparator.comparingInt(Player::getId));
         for (Player botSlot : players.subList(1, players.size())) {
-            teamAiTypes.computeIfAbsent(botSlot.getTeam(), team -> new TreeSet<>())
+            teamAITypes.computeIfAbsent(botSlot.getTeam(), team -> new TreeSet<>())
                   .add(aiTypeFor(botSlot.getName()));
         }
-        return teamAiTypes;
+        return teamAITypes;
     }
 
     private void waitForLocalPlayer(String clientName, BooleanSupplier connected) throws InterruptedException {

--- a/megamek/unittests/megamek/client/bot/AITypeTest.java
+++ b/megamek/unittests/megamek/client/bot/AITypeTest.java
@@ -37,21 +37,21 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
-class AiTypeTest {
+class AITypeTest {
 
     @Test
     void fromStringMatchesCaseInsensitivelyAndTrims() {
-        assertEquals(AiType.PRINCESS, AiType.fromString("princess"));
-        assertEquals(AiType.PRINCESS, AiType.fromString("PRINCESS"));
-        assertEquals(AiType.PRINCESS, AiType.fromString("  Princess  "));
-        assertEquals(AiType.CASPAR, AiType.fromString("caspar"));
-        assertEquals(AiType.CASPAR, AiType.fromString("CASPAR"));
+        assertEquals(AIType.PRINCESS, AIType.fromString("princess"));
+        assertEquals(AIType.PRINCESS, AIType.fromString("PRINCESS"));
+        assertEquals(AIType.PRINCESS, AIType.fromString("  Princess  "));
+        assertEquals(AIType.CASPAR, AIType.fromString("caspar"));
+        assertEquals(AIType.CASPAR, AIType.fromString("CASPAR"));
     }
 
     @Test
     void fromStringReturnsNullForNullEmptyOrUnknown() {
-        assertNull(AiType.fromString(null));
-        assertNull(AiType.fromString(""));
-        assertNull(AiType.fromString("nonsense"));
+        assertNull(AIType.fromString(null));
+        assertNull(AIType.fromString(""));
+        assertNull(AIType.fromString("nonsense"));
     }
 }

--- a/megamek/unittests/megamek/client/bot/BotFactoryTest.java
+++ b/megamek/unittests/megamek/client/bot/BotFactoryTest.java
@@ -49,7 +49,7 @@ class BotFactoryTest {
 
     @Test
     void createBotBuildsPrincessForPrincessType() {
-        BotClient bot = BotFactory.createBot(AiType.PRINCESS, "TestBot", TEST_HOST, TEST_PORT);
+        BotClient bot = BotFactory.createBot(AIType.PRINCESS, "TestBot", TEST_HOST, TEST_PORT);
         try {
             assertNotNull(bot);
             assertInstanceOf(Princess.class, bot);
@@ -63,7 +63,7 @@ class BotFactoryTest {
 
     @Test
     void createBotBuildsCasparForCasparType() {
-        BotClient bot = BotFactory.createBot(AiType.CASPAR, "TestBot", TEST_HOST, TEST_PORT);
+        BotClient bot = BotFactory.createBot(AIType.CASPAR, "TestBot", TEST_HOST, TEST_PORT);
         try {
             assertNotNull(bot);
             assertInstanceOf(Caspar.class, bot);
@@ -79,7 +79,7 @@ class BotFactoryTest {
     void createBotAppliesBehaviorSettings() throws PrincessException {
         BehaviorSettings behavior = new BehaviorSettings();
         behavior.setDescription("FactoryTestBehavior");
-        BotClient bot = BotFactory.createBot(AiType.PRINCESS, "TestBot", TEST_HOST, TEST_PORT, behavior);
+        BotClient bot = BotFactory.createBot(AIType.PRINCESS, "TestBot", TEST_HOST, TEST_PORT, behavior);
         try {
             assertEquals("FactoryTestBehavior", bot.getBehaviorSettings().getDescription());
         } finally {

--- a/megamek/unittests/megamek/common/jacksonAdapters/BotParserTest.java
+++ b/megamek/unittests/megamek/common/jacksonAdapters/BotParserTest.java
@@ -36,7 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import megamek.client.bot.AiType;
+import megamek.client.bot.AIType;
 import org.junit.jupiter.api.Test;
 
 class BotParserTest {
@@ -50,17 +50,17 @@ class BotParserTest {
 
     @Test
     void defaultsToPrincessWhenNoAiKey() throws Exception {
-        assertEquals(AiType.PRINCESS, parse("name: TestBot").aiType());
+        assertEquals(AIType.PRINCESS, parse("name: TestBot").aiType());
     }
 
     @Test
     void readsExplicitAiKeyCaseInsensitively() throws Exception {
-        assertEquals(AiType.PRINCESS, parse("ai: princess").aiType());
-        assertEquals(AiType.PRINCESS, parse("ai: PRINCESS").aiType());
+        assertEquals(AIType.PRINCESS, parse("ai: princess").aiType());
+        assertEquals(AIType.PRINCESS, parse("ai: PRINCESS").aiType());
     }
 
     @Test
     void unknownAiKeyFallsBackToPrincess() throws Exception {
-        assertEquals(AiType.PRINCESS, parse("ai: nonsense").aiType());
+        assertEquals(AIType.PRINCESS, parse("ai: nonsense").aiType());
     }
 }

--- a/megamek/unittests/megamek/common/util/AddBotUtilTest.java
+++ b/megamek/unittests/megamek/common/util/AddBotUtilTest.java
@@ -47,7 +47,7 @@ import java.util.HashSet;
 import java.util.Vector;
 
 import megamek.client.Client;
-import megamek.client.bot.AiType;
+import megamek.client.bot.AIType;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.BehaviorSettingsFactory;
 import megamek.client.bot.princess.Princess;
@@ -106,7 +106,7 @@ class AddBotUtilTest {
 
         testAddBotUtil = spy(new AddBotUtil());
         doReturn(mockPrincess).when(testAddBotUtil).makeNewBotClient(
-              any(AiType.class), any(Player.class), anyString(), anyInt());
+              any(AIType.class), any(Player.class), anyString(), anyInt());
     }
 
     @Test


### PR DESCRIPTION
## Summary
Two follow-ups to the merged switchable-AI work:
1. Review feedback: "AI" is an acronym, so the type names follow MegaMek's uppercase-acronym convention
   (TWGameManager, IGame, MMLogger).
2. CASPAR is still experimental, so it should not be offered to normal players yet - gate it behind a hidden client option.

## Changes
1. Rename `AiType` -> `AIType` and `AiMatchRunner` -> `AIMatchRunner` (files + all references, including `getSelectedAIType` / `getBotTeamAITypes`). Lowercase `aiType` variables, the `aiTypeFor(...)` method, and the i18n message keys are intentionally unchanged (leading-acronym-lowercase is correct for those).
2. Add a hidden `ClientPreferences.UseCASPAR` option (default `false`); `BotConfigDialog` hides the CASPAR radio unless it is enabled. Not shown in any settings UI - enable by hand-adding `<UseCASPAR>true</UseCASPAR>` to clientsettings.xml. With it off (the default) the AI chooser shows only Princess, exactly as before CASPAR existed, with a `[Caspar]` debug log on the gated path.

## Files Changed
- `AIType.java` (was AiType.java), `AIMatchRunner.java` (was AiMatchRunner.java), and references in `BotFactory`, `BotConfigDialog`, `ChatLounge`, `MegaMekGUI`, `BotParser`, `AddBotUtil`, `ScenarioGameRunner`, `QuickGameRunner` + tests (`AITypeTest`, `BotFactoryTest`, `BotParserTest`, `AddBotUtilTest`).
- `ClientPreferences.java` - the hidden `UseCASPAR` option (key + default false + getter).

## Testing
Rename: covered by the existing (renamed) unit tests - AITypeTest / BotFactoryTest / BotParserTest /
AddBotUtilTest all pass. Gate: UI + config default, so verified manually - with `UseCASPAR` absent/false the bot config dialog shows only Princess (and logs the gated path); wiR>` in clientsettings.xml, CASPAR reappears. No automated test on the gate itself (UI + config default, manual-OK per the testing matrix).