### PR TITLE
Cut Princess path-ranking cost; fix bogus move-completion ETA

### DIFF
--- a/megamek/src/megamek/client/bot/princess/Precognition.java
+++ b/megamek/src/megamek/client/bot/princess/Precognition.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000-2011 - Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2005-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2005-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -435,9 +435,11 @@ public class Precognition implements Runnable {
                 if (entityId != null) {
                     Entity entity = getGame().getEntity(entityId);
                     if (entity != null) {
-                        LOGGER.debug("ensureToDate = recalculating paths for {}", entity.getDisplayName());
+                        // Pass the entity itself: log4j only calls toString() when DEBUG is enabled, whereas
+                        // getDisplayName() would build the string eagerly on every pass of this hot loop.
+                        LOGGER.debug("ensureToDate = recalculating paths for {}", entity);
                         getPathEnumerator().recalculateMovesFor(entity);
-                        LOGGER.debug("ensureToDate = finished recalculating paths for {}", entity.getDisplayName());
+                        LOGGER.debug("ensureToDate = finished recalculating paths for {}", entity);
                     }
                 }
             }
@@ -462,9 +464,10 @@ public class Precognition implements Runnable {
                         Entity entity = getGame().getEntity(entityId);
                         if ((entity != null) && isEntityOnMap(entity)) {
                             unPause();
-                            LOGGER.debug("run = recalculating paths for {}", entity.getDisplayName());
+                            // Entity toString() is only evaluated when DEBUG is enabled; see ensureUpToDate.
+                            LOGGER.debug("run = recalculating paths for {}", entity);
                             getPathEnumerator().recalculateMovesFor(entity);
-                            LOGGER.debug("run = finished recalculating paths for {}", entity.getDisplayName());
+                            LOGGER.debug("run = finished recalculating paths for {}", entity);
                         }
 
                     }
@@ -553,7 +556,7 @@ public class Precognition implements Runnable {
                         continue; // no sense in updating a unit if it hasn't moved
                     }
                     LOGGER.debug("Received entity change event for {} (ID {})",
-                          changeEvent.getEntity().getDisplayName(),
+                          changeEvent.getEntity(),
                           entity.getId());
                     markUnitAsDirty(changeEvent.getEntity().getId());
                 } else if (event instanceof GamePhaseChangeEvent phaseChange) {

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -3115,13 +3115,17 @@ public class Princess extends BotClient {
 
             final long stop_time = java.lang.System.currentTimeMillis();
 
-            // update path evaluation time estimate
-            final double updatedEstimate = ((double) (stop_time - startTime)) / ((double) paths.size());
-            if (0 == moveEvaluationTimeEstimate) {
-                moveEvaluationTimeEstimate = updatedEstimate;
-            }
+            // update path evaluation time estimate - skip empty path sets, otherwise the division by
+            // paths.size() yields +Infinity in double math and permanently poisons the running average
+            // (the reset guard below never re-fires because Infinity is never equal to 0).
+            if (!paths.isEmpty()) {
+                final double updatedEstimate = ((double) (stop_time - startTime)) / ((double) paths.size());
+                if (0 == moveEvaluationTimeEstimate) {
+                    moveEvaluationTimeEstimate = updatedEstimate;
+                }
 
-            moveEvaluationTimeEstimate = 0.5 * (updatedEstimate + moveEvaluationTimeEstimate);
+                moveEvaluationTimeEstimate = 0.5 * (updatedEstimate + moveEvaluationTimeEstimate);
+            }
 
             if (rankedPaths.isEmpty()) {
                 return performPathPostProcessing(new MovePath(game, entity), 0);
@@ -3141,9 +3145,11 @@ public class Princess extends BotClient {
         }
     }
 
-    private static String getMessage(Entity entity, double thisTimeEstimate, List<MovePath> paths) {
+    static String getMessage(Entity entity, double thisTimeEstimate, List<MovePath> paths) {
         String timeEstimate = "unknown.";
-        if (0 != thisTimeEstimate) {
+        // Guard against non-finite estimates: casting +Infinity to int saturates to Integer.MAX_VALUE
+        // (2147483647), which would otherwise surface as a nonsense "completion" time in chat.
+        if ((0 != thisTimeEstimate) && Double.isFinite(thisTimeEstimate)) {
             timeEstimate = (int) thisTimeEstimate + " seconds";
         }
         return "Moving " +

--- a/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
+++ b/megamek/src/megamek/client/bot/princess/WeaponFireInfo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2011 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -862,10 +862,15 @@ public class WeaponFireInfo {
           final boolean guess,
           final HashMap<String, BombLoadout> bombPayloads) {
 
-        final StringBuilder msg = new StringBuilder("Initializing Damage for ").append(getShooter().getDisplayName())
-              .append(" firing ").append(getWeapon().getDesc())
-              .append(" at ").append(getTarget().getDisplayName())
-              .append(":");
+        // This method runs for every weapon of every enemy of every candidate path the bot ranks, so the
+        // debug message (display names, percentage formatting) must only be built when it will be logged.
+        final boolean debugEnabled = logger.isDebugEnabled();
+        final StringBuilder msg = debugEnabled
+              ? new StringBuilder("Initializing Damage for ").append(getShooter().getDisplayName())
+                    .append(" firing ").append(getWeapon().getDesc())
+                    .append(" at ").append(getTarget().getDisplayName())
+                    .append(":")
+              : null;
 
         // Set up the attack action and calculate the chance to hit.
         if ((null == bombPayloads) || (0 == bombPayloads.get("external").getTotalBombs())) {
@@ -889,10 +894,12 @@ public class WeaponFireInfo {
         }
         // If we can't hit, set everything zero and return...
         if (12 < getToHit().getValue()) {
-            logger.debug(
-                  msg.append("\n\tImpossible toHit: ").append(getToHit().getValue())
-                        .append(" (").append(getToHit().getCumulativePlainDesc()).append(")")
-                        .append((guess) ? " [guess]" : " [real]"));
+            if (debugEnabled) {
+                logger.debug(
+                      msg.append("\n\tImpossible toHit: ").append(getToHit().getValue())
+                            .append(" (").append(getToHit().getCumulativePlainDesc()).append(")")
+                            .append((guess) ? " [guess]" : " [real]"));
+            }
             setProbabilityToHit(0);
             setMaxDamage(ZERO_DAMAGE);
             setHeat(0);
@@ -902,13 +909,15 @@ public class WeaponFireInfo {
             return;
         }
 
-        if (getShooterState().hasNaturalAptGun()) {
+        if (debugEnabled && getShooterState().hasNaturalAptGun()) {
             msg.append("\n\tAttacker has Natural Aptitude Gunnery");
         }
 
         setProbabilityToHit(Compute.oddsAbove(getToHit().getValue(), getShooterState().hasNaturalAptGun()) / 100);
 
-        msg.append("\n\tHit Chance: ").append(LOG_PER.format(getProbabilityToHit()));
+        if (debugEnabled) {
+            msg.append("\n\tHit Chance: ").append(LOG_PER.format(getProbabilityToHit()));
+        }
 
         // now that we've calculated hit odds, if we're shooting
         // a weapon capable of rapid fire, it's time to decide whether we're going to
@@ -921,19 +930,21 @@ public class WeaponFireInfo {
 
         setHeat(computeHeat(weapon));
 
-        msg.append("\n\tHeat: ").append(getHeat());
-
         setMaxDamage(computeExpectedDamage());
         setDamageOnHit(getMaxDamage());
 
-        msg.append("\n\tMax Damage: ").append(LOG_DEC.format(maxDamage));
-        msg.append("\n\tExpected Damage: ").append(LOG_DEC.format(damageOnHit));
+        if (debugEnabled) {
+            msg.append("\n\tHeat: ").append(getHeat());
+            msg.append("\n\tMax Damage: ").append(LOG_DEC.format(maxDamage));
+            msg.append("\n\tExpected Damage: ").append(LOG_DEC.format(damageOnHit));
+        }
 
         // If expected damage from Aero tagging is zero, return out - save attacks for
         // later.
         if (weapon.getType().hasFlag(WeaponType.F_TAG) && shooter.isAero() && getDamageOnHit() <= 0) {
-            logger
-                  .debug(msg.append("\n\tAerospace TAG attack not advised at this juncture").toString());
+            if (debugEnabled) {
+                logger.debug(msg.append("\n\tAerospace TAG attack not advised at this juncture").toString());
+            }
             setProbabilityToHit(0);
             setMaxDamage(ZERO_DAMAGE);
             setHeat(0);
@@ -973,7 +984,9 @@ public class WeaponFireInfo {
         }
         // No target Mek found; nothing to do
         if (null == targetMek) {
-            logger.debug(msg.toString());
+            if (debugEnabled) {
+                logger.debug(msg.toString());
+            }
             return;
         }
 
@@ -1025,7 +1038,9 @@ public class WeaponFireInfo {
             }
         }
 
-        logger.debug(msg.toString());
+        if (debugEnabled) {
+            logger.debug(msg.toString());
+        }
     }
 
     WeaponAttackAction getWeaponAttackAction() {

--- a/megamek/src/megamek/common/actions/compute/ComputeTerrainMods.java
+++ b/megamek/src/megamek/common/actions/compute/ComputeTerrainMods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -301,12 +301,12 @@ public class ComputeTerrainMods {
                   && targetHex.hasVegetation()
                   && !game.getOptions().booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_WOODS_COVER);
             if (los.canSee() && (targetWoodsAffectModifier || los.thruWoods())) {
-                if (bapInRange(game, attacker, entityTarget)) {
+                if (bapInRange(game, attacker, entityTarget, allECMInfo)) {
                     toHit.addModifier(-1, Messages.getString("WeaponAttackAction.BAPInWoods"));
                 } else {
                     boolean bapInRangeUsingC3 = game.getC3NetworkMembers(attacker).stream()
                           .filter(c3Member -> !attacker.equals(c3Member))
-                          .anyMatch(c3Member -> bapInRange(game, c3Member, entityTarget));
+                          .anyMatch(c3Member -> bapInRange(game, c3Member, entityTarget, allECMInfo));
                     if (bapInRangeUsingC3) {
                         toHit.addModifier(-1, Messages.getString("WeaponAttackAction.BAPInWoodsC3"));
                     }
@@ -367,13 +367,16 @@ public class ComputeTerrainMods {
     }
 
     /**
+     * @param allECMInfo Precomputed ECM information for all game entities, or {@code null} to compute it on demand
+     *
      * @return True when the attacker has an active BAP and is not affected by ECM and the target is in range.
      */
-    private static boolean bapInRange(Game game, Entity attacker, Entity target) {
+    private static boolean bapInRange(Game game, Entity attacker, Entity target,
+          @Nullable List<ECMInfo> allECMInfo) {
         return attacker.hasBAP()
               && (target != null) && !target.isOffBoard() && (target.getPosition() != null)
               && (attacker.getBAPRange() >= Compute.effectiveDistance(game, attacker, target))
-              && !ComputeECM.isAffectedByECM(attacker, attacker.getPosition(), target.getPosition());
+              && !ComputeECM.isAffectedByECM(attacker, attacker.getPosition(), target.getPosition(), allECMInfo);
     }
 
     /**

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -4266,12 +4266,12 @@ public class Compute {
      * Determine if autocannon should fire more than one round. Includes standard ACs if the game option for
      * rapid-fire-mode is enabled.
      *
-     * @param atk             Attack action with weapon attack properties
+     * @param game            The current game
+     * @param attackAction    Attack action with weapon attack properties
      * @param spinupThreshold Maximum to-hit number to consider for rapid fire
      *
-     * @return the <code>int</code> ID of weapon mode, which is also the number of mode changes from single shot
+     * @return the {@code int} ID of weapon mode, which is also the number of mode changes from single shot
      */
-
     public static int spinUpCannon(Game game, WeaponAttackAction attackAction, int spinupThreshold) {
         // The number of mode changes needed to set a specific rate of fire
         int finalSpin = 0;
@@ -4288,6 +4288,10 @@ public class Compute {
             return finalSpin;
         }
         Mounted<?> weapon = shooter.getEquipment(attackAction.getWeaponId());
+        if (null == weapon) {
+            LOGGER.warn("attack action with an invalid weapon id passed to Compute.spinUpCannon");
+            return finalSpin;
+        }
         WeaponType weaponType = (WeaponType) weapon.getType();
 
         // Check the weapon type BEFORE computing the to-hit number: this method is called for every weapon

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -4258,8 +4258,8 @@ public class Compute {
      * @return the <code>int</code> ID of weapon mode
      */
     @Deprecated
-    public static int spinUpCannon(Game cgame, WeaponAttackAction atk) {
-        return spinUpCannon(cgame, atk, Compute.d6(2) - 1);
+    public static int spinUpCannon(Game game, WeaponAttackAction attackAction) {
+        return spinUpCannon(game, attackAction, Compute.d6(2) - 1);
     }
 
     /**
@@ -4272,40 +4272,36 @@ public class Compute {
      * @return the <code>int</code> ID of weapon mode, which is also the number of mode changes from single shot
      */
 
-    public static int spinUpCannon(Game cgame, WeaponAttackAction atk, int spinupThreshold) {
-
-        int to_hit;
+    public static int spinUpCannon(Game game, WeaponAttackAction attackAction, int spinupThreshold) {
         // The number of mode changes needed to set a specific rate of fire
-        int final_spin = 0;
-        Entity shooter;
-        Mounted<?> weapon;
-        WeaponType weaponType;
-        boolean isUAC = false;
-        boolean isRAC = false;
+        int finalSpin = 0;
 
         // Basic protections against null values
-        if (null == atk || null == cgame || null == atk.toHit(cgame)) {
+        if ((null == attackAction) || (null == game)) {
             LOGGER.warn("null parameter passed to Compute.spinUpCannon");
-            return final_spin;
+            return finalSpin;
         }
 
-        // Get the to-hit number for this attack
-        to_hit = atk.toHit(cgame).getValue();
-
-        // If weapon can't hit target, exit with the default mode setting
-        if (to_hit > 12) {
-            return final_spin;
+        Entity shooter = attackAction.getEntity(game);
+        if (null == shooter) {
+            LOGGER.warn("attack action with no shooter passed to Compute.spinUpCannon");
+            return finalSpin;
         }
+        Mounted<?> weapon = shooter.getEquipment(attackAction.getWeaponId());
+        WeaponType weaponType = (WeaponType) weapon.getType();
 
-        shooter = atk.getEntity(cgame);
-        weapon = shooter.getEquipment(atk.getWeaponId());
-        weaponType = (WeaponType) shooter.getEquipment(atk.getWeaponId()).getType();
+        // Check the weapon type BEFORE computing the to-hit number: this method is called for every weapon
+        // the bot evaluates while ranking candidate move paths, and the full to-hit calculation is by far
+        // the most expensive part. Anything other than an autocannon can exit without paying for it.
 
         // If optional rapid fire autocannons are enabled, check for conventional, LAC, and
-        // PAC types
+        // PAC types. Test the weapon class first so non-AC weapons skip the option lookup entirely.
         boolean isRapidFireAC =
-              cgame.getOptions().booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_RAPID_AC) &&
-                    weaponType instanceof ACWeapon;
+              weaponType instanceof ACWeapon &&
+                    game.getOptions().booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_RAPID_AC);
+
+        boolean isRAC = false;
+        boolean isUAC = false;
 
         // Anything other than a standard AC or equivalent, UAC, or RAC does not apply
         if (!isRapidFireAC) {
@@ -4313,16 +4309,29 @@ public class Compute {
             isUAC = !isRAC && (weaponType instanceof UACWeapon);
 
             if (!isRAC && !isUAC) {
-                return final_spin;
+                return finalSpin;
             }
+        }
+
+        // Get the to-hit number for this attack, computing it only once
+        ToHitData toHitData = attackAction.toHit(game);
+        if (null == toHitData) {
+            LOGGER.warn("no to-hit data for attack action passed to Compute.spinUpCannon");
+            return finalSpin;
+        }
+        int toHitValue = toHitData.getValue();
+
+        // If weapon can't hit target, exit with the default mode setting
+        if (toHitValue > 12) {
+            return finalSpin;
         }
 
         // Set the weapon to single shot mode
         weapon.setMode(isRapidFireAC ? "" : Weapon.MODE_AC_SINGLE);
 
         // If the to-hit number is under or at the provided threshold, set multiple shots
-        if (to_hit <= spinupThreshold) {
-            final_spin = 1;
+        if (toHitValue <= spinupThreshold) {
+            finalSpin = 1;
             if (isUAC) {
                 weapon.setMode(Weapon.MODE_UAC_ULTRA);
             } else if (isRAC) {
@@ -4332,43 +4341,43 @@ public class Compute {
                 // If the to-hit number is significantly lower than the provided threshold,
                 // set for either five or six shots
 
-                if (to_hit <= (spinupThreshold - 3)) {
-                    final_spin = 5;
+                if (toHitValue <= (spinupThreshold - 3)) {
+                    finalSpin = 5;
                     weapon.setMode(Weapon.MODE_RAC_SIX_SHOT);
-                    return final_spin;
+                    return finalSpin;
                 }
 
-                if (to_hit <= (spinupThreshold - 2)) {
-                    final_spin = 4;
+                if (toHitValue <= (spinupThreshold - 2)) {
+                    finalSpin = 4;
                     weapon.setMode(Weapon.MODE_RAC_FIVE_SHOT);
-                    return final_spin;
+                    return finalSpin;
                 }
 
                 // If the to-hit number is slightly lower than the provided threshold, set for
                 // four shots.  Reduce to three shots for high to-hit numbers to reduce ammo
                 // use and chance of jamming.
-                if (to_hit <= (spinupThreshold - 1)) {
-                    final_spin = to_hit >= 6 ? 2 : 3;
-                    weapon.setMode(to_hit >= 6 ? Weapon.MODE_RAC_THREE_SHOT : Weapon.MODE_RAC_FOUR_SHOT);
-                    return final_spin;
+                if (toHitValue <= (spinupThreshold - 1)) {
+                    finalSpin = toHitValue >= 6 ? 2 : 3;
+                    weapon.setMode(toHitValue >= 6 ? Weapon.MODE_RAC_THREE_SHOT : Weapon.MODE_RAC_FOUR_SHOT);
+                    return finalSpin;
                 }
 
             } else {
                 // Rapid firing standard autocannon is risky, so save it for better to-hit numbers,
                 // infantry field guns, or when the 'kinder' optional rule is set
-                if (to_hit <= (spinupThreshold - 2) ||
+                if (toHitValue <= (spinupThreshold - 2) ||
                       shooter.isConventionalInfantry() ||
-                      cgame.getOptions().booleanOption(OptionsConstants.ADVANCED_COMBAT_KIND_RAPID_AC)) {
+                      game.getOptions().booleanOption(OptionsConstants.ADVANCED_COMBAT_KIND_RAPID_AC)) {
                     weapon.setMode(Weapon.MODE_AC_RAPID);
                 } else {
-                    final_spin = 0;
+                    finalSpin = 0;
                     weapon.setMode("");
                 }
             }
         }
 
         // Return the number of mode changes needed to set the rate of fire
-        return final_spin;
+        return finalSpin;
     }
 
     /**

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -70,6 +70,7 @@ import megamek.common.equipment.WeaponType;
 import megamek.common.exceptions.LocationFullException;
 import megamek.common.game.Game;
 import megamek.common.game.GameTurn;
+import megamek.common.moves.MovePath;
 import megamek.common.moves.MoveStep;
 import megamek.common.options.GameOptions;
 import megamek.common.options.OptionsConstants;
@@ -139,6 +140,27 @@ class PrincessTest {
 
         // Test a null ticks argument.
         assertEquals(0, Princess.calculateAdjustment(null));
+    }
+
+    @Test
+    void testGetMessageGuardsNonFiniteEstimate() {
+        Entity mockEntity = mock(Entity.class);
+        when(mockEntity.getChassis()).thenReturn("Flashman");
+        List<MovePath> paths = new ArrayList<>();
+
+        // A +Infinity estimate (produced when a prior zero-path turn divided elapsed time by 0) must not
+        // surface as the Integer.MAX_VALUE completion time that results from casting the double to int.
+        String infiniteMessage = Princess.getMessage(mockEntity, Double.POSITIVE_INFINITY, paths);
+        assertTrue(infiniteMessage.contains("unknown."));
+        assertFalse(infiniteMessage.contains(Integer.toString(Integer.MAX_VALUE)));
+
+        // NaN is likewise non-finite and must be reported as unknown rather than the 0 that (int) NaN yields.
+        String nanMessage = Princess.getMessage(mockEntity, Double.NaN, paths);
+        assertTrue(nanMessage.contains("unknown."));
+
+        // A normal finite estimate is still rendered as a seconds value.
+        String finiteMessage = Princess.getMessage(mockEntity, 12.0, paths);
+        assertTrue(finiteMessage.contains("12 seconds"));
     }
 
     @Test

--- a/megamek/unittests/megamek/common/compute/ComputeSpinUpCannonTest.java
+++ b/megamek/unittests/megamek/common/compute/ComputeSpinUpCannonTest.java
@@ -119,6 +119,14 @@ class ComputeSpinUpCannonTest {
     }
 
     @Test
+    void testInvalidWeaponIdReturnsZeroWithoutException() {
+        // An out-of-range weapon id makes getEquipment return null; the method must guard it, not NPE.
+        when(mockShooter.getEquipment(WEAPON_ID)).thenReturn(null);
+
+        assertEquals(0, Compute.spinUpCannon(mockGame, mockAttackAction, SPIN_UP_THRESHOLD));
+    }
+
+    @Test
     void testUltraAutocannonAtThresholdSpinsUpWithSingleToHitComputation() {
         arrangeWeaponType(mock(UACWeapon.class));
         arrangeToHitValue(SPIN_UP_THRESHOLD);

--- a/megamek/unittests/megamek/common/compute/ComputeSpinUpCannonTest.java
+++ b/megamek/unittests/megamek/common/compute/ComputeSpinUpCannonTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.compute;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import megamek.common.ToHitData;
+import megamek.common.actions.WeaponAttackAction;
+import megamek.common.equipment.Mounted;
+import megamek.common.equipment.WeaponType;
+import megamek.common.game.Game;
+import megamek.common.options.GameOptions;
+import megamek.common.units.Entity;
+import megamek.common.units.Mek;
+import megamek.common.weapons.Weapon;
+import megamek.common.weapons.autoCannons.RACWeapon;
+import megamek.common.weapons.autoCannons.UACWeapon;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link Compute#spinUpCannon(Game, WeaponAttackAction, int)}.
+ *
+ * <p>Besides the spin-up mode ladder, these tests pin down the performance contract that motivated the
+ * method's guard ordering: the weapon-type check must run BEFORE any to-hit computation, because the
+ * method is invoked for every weapon the bot evaluates while ranking candidate move paths and the full
+ * to-hit calculation is very expensive. A non-autocannon must return without a single {@code toHit} call,
+ * and autocannons must pay for exactly one.</p>
+ */
+class ComputeSpinUpCannonTest {
+
+    private static final int WEAPON_ID = 3;
+    private static final int SPIN_UP_THRESHOLD = 7;
+
+    private Game mockGame;
+    private WeaponAttackAction mockAttackAction;
+    private Entity mockShooter;
+    private Mounted<?> mockWeapon;
+
+    @BeforeEach
+    void beforeEach() {
+        mockGame = mock(Game.class);
+        GameOptions mockOptions = mock(GameOptions.class);
+        when(mockGame.getOptions()).thenReturn(mockOptions);
+
+        mockShooter = mock(Mek.class);
+        mockWeapon = mock(Mounted.class);
+
+        mockAttackAction = mock(WeaponAttackAction.class);
+        when(mockAttackAction.getEntity(mockGame)).thenReturn(mockShooter);
+        when(mockAttackAction.getWeaponId()).thenReturn(WEAPON_ID);
+        // The cast in spinUpCannon uses the raw Mounted, so stub the same accessor it calls.
+        when(mockShooter.getEquipment(WEAPON_ID)).thenAnswer(invocation -> mockWeapon);
+    }
+
+    private void arrangeWeaponType(WeaponType weaponType) {
+        when(mockWeapon.getType()).thenAnswer(invocation -> weaponType);
+    }
+
+    private void arrangeToHitValue(int toHitValue) {
+        when(mockAttackAction.toHit(mockGame)).thenReturn(new ToHitData(toHitValue, "test"));
+    }
+
+    @Test
+    void testNonAutocannonReturnsZeroWithoutComputingToHit() {
+        // A plain (non-AC) weapon type: not an ACWeapon, UACWeapon or RACWeapon
+        arrangeWeaponType(mock(WeaponType.class));
+
+        int spinMode = Compute.spinUpCannon(mockGame, mockAttackAction, SPIN_UP_THRESHOLD);
+
+        assertEquals(0, spinMode);
+        // The performance contract: no to-hit computation and no mode fiddling for non-autocannons.
+        verify(mockAttackAction, never()).toHit(any(Game.class));
+        verify(mockWeapon, never()).setMode(any(String.class));
+        verify(mockWeapon, never()).setMode(anyInt());
+    }
+
+    @Test
+    void testNullArgumentsReturnZero() {
+        assertEquals(0, Compute.spinUpCannon(null, mockAttackAction, SPIN_UP_THRESHOLD));
+        assertEquals(0, Compute.spinUpCannon(mockGame, null, SPIN_UP_THRESHOLD));
+    }
+
+    @Test
+    void testUltraAutocannonAtThresholdSpinsUpWithSingleToHitComputation() {
+        arrangeWeaponType(mock(UACWeapon.class));
+        arrangeToHitValue(SPIN_UP_THRESHOLD);
+
+        int spinMode = Compute.spinUpCannon(mockGame, mockAttackAction, SPIN_UP_THRESHOLD);
+
+        assertEquals(1, spinMode);
+        verify(mockWeapon).setMode(Weapon.MODE_UAC_ULTRA);
+        // The other performance contract: the expensive to-hit number is computed exactly once.
+        verify(mockAttackAction, times(1)).toHit(mockGame);
+    }
+
+    @Test
+    void testUltraAutocannonAboveThresholdStaysSingleShot() {
+        arrangeWeaponType(mock(UACWeapon.class));
+        arrangeToHitValue(SPIN_UP_THRESHOLD + 1);
+
+        int spinMode = Compute.spinUpCannon(mockGame, mockAttackAction, SPIN_UP_THRESHOLD);
+
+        assertEquals(0, spinMode);
+        verify(mockWeapon).setMode(Weapon.MODE_AC_SINGLE);
+        verify(mockAttackAction, times(1)).toHit(mockGame);
+    }
+
+    @Test
+    void testAutocannonThatCannotHitReturnsZero() {
+        arrangeWeaponType(mock(UACWeapon.class));
+        arrangeToHitValue(13);
+
+        int spinMode = Compute.spinUpCannon(mockGame, mockAttackAction, SPIN_UP_THRESHOLD);
+
+        assertEquals(0, spinMode);
+        verify(mockWeapon, never()).setMode(any(String.class));
+    }
+
+    @Test
+    void testRotaryAutocannonAtThresholdSetsTwoShot() {
+        arrangeWeaponType(mock(RACWeapon.class));
+        arrangeToHitValue(SPIN_UP_THRESHOLD);
+
+        int spinMode = Compute.spinUpCannon(mockGame, mockAttackAction, SPIN_UP_THRESHOLD);
+
+        assertEquals(1, spinMode);
+        verify(mockWeapon).setMode(Weapon.MODE_RAC_TWO_SHOT);
+        verify(mockAttackAction, times(1)).toHit(mockGame);
+    }
+
+    @Test
+    void testRotaryAutocannonWellUnderThresholdSetsSixShot() {
+        arrangeWeaponType(mock(RACWeapon.class));
+        arrangeToHitValue(SPIN_UP_THRESHOLD - 3);
+
+        int spinMode = Compute.spinUpCannon(mockGame, mockAttackAction, SPIN_UP_THRESHOLD);
+
+        assertEquals(5, spinMode);
+        verify(mockWeapon).setMode(Weapon.MODE_RAC_SIX_SHOT);
+    }
+
+    @Test
+    void testRotaryAutocannonTwoUnderThresholdSetsFiveShot() {
+        arrangeWeaponType(mock(RACWeapon.class));
+        arrangeToHitValue(SPIN_UP_THRESHOLD - 2);
+
+        int spinMode = Compute.spinUpCannon(mockGame, mockAttackAction, SPIN_UP_THRESHOLD);
+
+        assertEquals(4, spinMode);
+        verify(mockWeapon).setMode(Weapon.MODE_RAC_FIVE_SHOT);
+    }
+
+    @Test
+    void testRotaryAutocannonOneUnderThresholdSetsThreeShotForHighToHit() {
+        arrangeWeaponType(mock(RACWeapon.class));
+        // threshold 7 - 1 = to-hit 6, which is >= 6, so the conservative three-shot mode applies
+        arrangeToHitValue(SPIN_UP_THRESHOLD - 1);
+
+        int spinMode = Compute.spinUpCannon(mockGame, mockAttackAction, SPIN_UP_THRESHOLD);
+
+        assertEquals(2, spinMode);
+        verify(mockWeapon).setMode(Weapon.MODE_RAC_THREE_SHOT);
+    }
+
+    @Test
+    void testRotaryAutocannonOneUnderThresholdSetsFourShotForLowToHit() {
+        arrangeWeaponType(mock(RACWeapon.class));
+        // threshold 5 - 1 = to-hit 4, which is < 6, so the more aggressive four-shot mode applies
+        int lowThreshold = 5;
+        arrangeToHitValue(lowThreshold - 1);
+
+        int spinMode = Compute.spinUpCannon(mockGame, mockAttackAction, lowThreshold);
+
+        assertEquals(3, spinMode);
+        verify(mockWeapon).setMode(Weapon.MODE_RAC_FOUR_SHOT);
+    }
+}


### PR DESCRIPTION
## Root Cause
Princess ranks every candidate move path by simulating a firing plan against each enemy. That made Compute.spinUpCannon run the full WeaponAttackAction.toHit pipeline twice for every weapon - including non-autocannons that can never spin up - and made WeaponFireInfo.initDamage build its debug message eagerly on every evaluation. Separately, a movement turn with zero legal paths divided elapsed time by zero, poisoning the running time-estimate with +Infinity so the move-completion ETA printed Integer.MAX_VALUE ("2147483647 seconds").

## Changes
1. Compute.spinUpCannon - check the weapon type before any to-hit work (non-autocannons return immediately) and compute the to-hit number once instead of twice.
2. WeaponFireInfo.initDamage - build the debug message only when DEBUG is enabled.
3. ComputeTerrainMods.bapInRange - reuse the cached all-entities ECM info instead of recomputing the whole board.
4. Precognition - log entities lazily (pass the entity, not getDisplayName()).
5. Princess.continueMovementFor / getMessage - skip the estimate update for an empty path set and guard the display against non-finite values.

## Files Changed
- megamek/src/megamek/common/compute/Compute.java - spinUpCannon guard ordering + single to-hit
- megamek/src/megamek/client/bot/princess/WeaponFireInfo.java - lazy debug message
- megamek/src/megamek/common/actions/compute/ComputeTerrainMods.java - cached ECM in bapInRange
- megamek/src/megamek/client/bot/princess/Precognition.java - lazy entity logging
- megamek/src/megamek/client/bot/princess/Princess.java - ETA divide-by-zero + non-finite guard
- megamek/unittests/megamek/common/compute/ComputeSpinUpCannonTest.java - new
- megamek/unittests/megamek/client/bot/princess/PrincessTest.java - non-finite ETA regression test

## Testing
ComputeSpinUpCannonTest (10 tests, incl. a verify that non-autocannons never call toHit) and PrincessTest.testGetMessageGuardsNonFiniteEstimate; princess/compute/actions packages green. 

Profiled the same multi-bot save before/after: 
spinUpCannon 48.7% -> 1.1% of turn-calc, 
toHit 61% -> 32.5%, 
whole-board ECM recompute 26% -> 6.4%; 
worst-case ranking pass 9.4s -> 7.2s. 

Also applies to CASPAR, which is a no-override subclass of Princess. No new errors in princess.log.