### PR TITLE
Load Force Generator faction rulesets from the userdata folder

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/Ruleset.java
+++ b/megamek/src/megamek/client/ratgenerator/Ruleset.java
@@ -650,13 +650,31 @@ public class Ruleset {
     }
 
     /**
-     * The directories to search, built-in first so that later entries override earlier ones.
+     * The user data mirror of {@link #baseRulesetDirectory()}, resolving to
+     * {@code userdata/data/forcegenerator/faction_rules}. Composed the same way as MegaMek's other user
+     * data overlays - see {@code MekSummaryCache} for units and {@code ServerBoardHelper} for boards - and
+     * honouring the userdata contract that a duplicated file overrides the shipped one.
+     *
+     * <p>The directory need not exist; {@link #loadRulesetDirectory(File)} skips a missing one.</p>
+     *
+     * @return the user data faction rules directory
+     */
+    private static File userDataRulesetDirectory() {
+        return new File(Configuration.userDataDir(), baseRulesetDirectory().toString());
+    }
+
+    /**
+     * The directories to search, in override order: the directory shipped with MegaMek, then the user data
+     * directory, then any directory registered through {@link #addRulesetDirectory(String)}. Later entries
+     * override earlier ones, because {@link #loadData()} keys rulesets by faction and a later load replaces
+     * the ruleset already held for that faction.
      *
      * @return the ordered ruleset search path
      */
     static List<File> rulesetDirectories() {
         List<File> directories = new ArrayList<>();
         directories.add(baseRulesetDirectory());
+        directories.add(userDataRulesetDirectory());
         for (String additionalDirectory : additionalRulesetDirectories) {
             directories.add(new File(additionalDirectory));
         }

--- a/megamek/src/megamek/client/ratgenerator/Ruleset.java
+++ b/megamek/src/megamek/client/ratgenerator/Ruleset.java
@@ -94,9 +94,11 @@ public class Ruleset {
     /**
      * Extra ruleset directories registered through {@link #addRulesetDirectory(String)}, searched after the
      * built-in one so a user file can override a stock faction. Copy-on-write because {@link #loadData()}
-     * runs on a background thread while callers register directories from the EDT.
+     * runs on a background thread while callers register directories from the EDT. Declared as the concrete
+     * type so registration can use {@link CopyOnWriteArrayList#addIfAbsent(Object)}, making the duplicate
+     * check and the insert a single atomic step.
      */
-    private static final List<String> additionalRulesetDirectories = new CopyOnWriteArrayList<>();
+    private static final CopyOnWriteArrayList<String> additionalRulesetDirectories = new CopyOnWriteArrayList<>();
 
     // Progress-bar weights for the phases of processRoot(), as fractions of the force-generation
     // pass. They are display hints for the ProgressListener only and do not affect generation.
@@ -625,11 +627,12 @@ public class Ruleset {
             logger.warn("addRulesetDirectory: ignoring null or blank ruleset directory path");
             return;
         }
-        if (additionalRulesetDirectories.contains(rulesetDirectoryPath)) {
+        // addIfAbsent rather than contains() followed by add(): the pair is not atomic, so two concurrent
+        // registrations of the same path could both pass the check and insert a duplicate.
+        if (!additionalRulesetDirectories.addIfAbsent(rulesetDirectoryPath)) {
             logger.debug("addRulesetDirectory: {} already registered, ignoring", rulesetDirectoryPath);
             return;
         }
-        additionalRulesetDirectories.add(rulesetDirectoryPath);
         if (initialized || initializing) {
             logger.warn("addRulesetDirectory: {} registered after loadData(); it will not be searched until"
                         + " the next loadData() call", rulesetDirectoryPath);
@@ -703,6 +706,13 @@ public class Ruleset {
     private static void loadRulesetDirectory(File directory) {
         if (!directory.exists()) {
             logger.warn("Skipping ruleset directory {}: it does not exist", directory);
+            return;
+        }
+        // Checked separately from listFiles() returning null: a registered path that points at a file
+        // rather than a directory would otherwise be reported as unreadable, which sends the reader
+        // looking for a permissions problem that does not exist.
+        if (!directory.isDirectory()) {
+            logger.warn("Skipping ruleset directory {}: it is not a directory", directory);
             return;
         }
         File[] files = directory.listFiles();

--- a/megamek/src/megamek/client/ratgenerator/Ruleset.java
+++ b/megamek/src/megamek/client/ratgenerator/Ruleset.java
@@ -41,11 +41,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.xml.parsers.DocumentBuilder;
 
 import megamek.client.generator.RandomNameGenerator;
+import megamek.common.Configuration;
 import megamek.common.annotations.Nullable;
 import megamek.common.units.EntityWeightClass;
 import megamek.logging.MMLogger;
@@ -86,8 +88,15 @@ public class Ruleset {
         }
     }
 
-    private static final String directory = "data/forcegenerator/faction_rules";
+    private static final String FACTION_RULES_DIR_NAME = "faction_rules";
     private static final String CONSTANTS_FILE = "constants.txt";
+
+    /**
+     * Extra ruleset directories registered through {@link #addRulesetDirectory(String)}, searched after the
+     * built-in one so a user file can override a stock faction. Copy-on-write because {@link #loadData()}
+     * runs on a background thread while callers register directories from the EDT.
+     */
+    private static final List<String> additionalRulesetDirectories = new CopyOnWriteArrayList<>();
 
     // Progress-bar weights for the phases of processRoot(), as fractions of the force-generation
     // pass. They are display hints for the ProgressListener only and do not affect generation.
@@ -110,6 +119,12 @@ public class Ruleset {
     private final HashMap<Integer, String> customRanks;
     private final ArrayList<ForceNode> forceNodes;
     private String parent;
+    /**
+     * {@code true} only for the placeholder returned by {@link #findRuleset(String)} when no ruleset matched
+     * the requested faction or any of its parents. Never set on a ruleset parsed from a file, including a
+     * genuine {@link FactionRecord#IS_GENERAL_KEY} one.
+     */
+    private boolean defaultsOnly;
 
     private Ruleset() {
         faction = FactionRecord.IS_GENERAL_KEY;
@@ -168,8 +183,34 @@ public class Ruleset {
         }
         // This shouldn't happen unless the data is missing. Throw out a default ruleset
         // to prevent barfing.
-        logger.warn("findRuleset({}): no match in any parent — returning empty default ruleset", faction);
-        return new Ruleset();
+        logger.warn("findRuleset({}): no match in any parent - returning empty default ruleset", faction);
+        return createDefaultsOnlyRuleset();
+    }
+
+    /**
+     * Builds the empty placeholder ruleset returned when no faction ruleset matched, flagged so callers can
+     * distinguish it from a real ruleset via {@link #isDefaultsOnly()}.
+     *
+     * @return a placeholder ruleset carrying no faction rules
+     */
+    static Ruleset createDefaultsOnlyRuleset() {
+        Ruleset defaultRuleset = new Ruleset();
+        defaultRuleset.defaultsOnly = true;
+        return defaultRuleset;
+    }
+
+    /**
+     * Reports whether this ruleset is the empty placeholder produced by {@link #findRuleset(String)} when the
+     * requested faction matched neither a ruleset of its own nor one of any parent faction.
+     *
+     * <p>Consumers use this to warn before generating a force from rules that are not the faction's own.
+     * A ruleset loaded from {@code IS_General.xml} is a real ruleset and returns {@code false}, even though
+     * its faction is {@link FactionRecord#IS_GENERAL_KEY}.</p>
+     *
+     * @return {@code true} if this is the fallback placeholder, otherwise {@code false}
+     */
+    public boolean isDefaultsOnly() {
+        return defaultsOnly;
     }
 
     @Deprecated(since = "0.51.0", forRemoval = true)
@@ -556,19 +597,84 @@ public class Ruleset {
         }
     }
 
+    /**
+     * The directory shipped with MegaMek, resolved through {@link Configuration#forceGeneratorDir()} rather
+     * than a hardcoded path, so a relocated force generator data directory is honoured.
+     *
+     * @return the built-in faction rules directory
+     */
+    private static File baseRulesetDirectory() {
+        return new File(Configuration.forceGeneratorDir(), FACTION_RULES_DIR_NAME);
+    }
+
+    /**
+     * Registers an additional directory to be searched for faction ruleset XML files.
+     *
+     * <p>Directories are searched in registration order <em>after</em> the built-in one, so a ruleset in an
+     * added directory replaces a built-in ruleset for the same faction. Intended for user data directories,
+     * for example MekHQ's {@code userdata/forcegenerator/faction_rules}.</p>
+     *
+     * <p>Call this before {@link #loadData()}. Registering a directory afterwards has no effect until the
+     * next {@code loadData()} call; that case is logged rather than silently ignored.</p>
+     *
+     * @param rulesetDirectoryPath path to a directory containing faction ruleset XML files; ignored when
+     *                             {@code null}, blank, or already registered
+     */
+    public static void addRulesetDirectory(@Nullable String rulesetDirectoryPath) {
+        if ((rulesetDirectoryPath == null) || rulesetDirectoryPath.isBlank()) {
+            logger.warn("addRulesetDirectory: ignoring null or blank ruleset directory path");
+            return;
+        }
+        if (additionalRulesetDirectories.contains(rulesetDirectoryPath)) {
+            logger.debug("addRulesetDirectory: {} already registered, ignoring", rulesetDirectoryPath);
+            return;
+        }
+        additionalRulesetDirectories.add(rulesetDirectoryPath);
+        if (initialized || initializing) {
+            logger.warn("addRulesetDirectory: {} registered after loadData(); it will not be searched until"
+                        + " the next loadData() call", rulesetDirectoryPath);
+        } else {
+            logger.debug("addRulesetDirectory: registered {}", rulesetDirectoryPath);
+        }
+    }
+
+    /**
+     * Removes every directory registered through {@link #addRulesetDirectory(String)}, leaving only the
+     * built-in one. Exists so tests do not leak registrations into one another.
+     */
+    static void clearAdditionalRulesetDirectories() {
+        additionalRulesetDirectories.clear();
+    }
+
+    /**
+     * The directories to search, built-in first so that later entries override earlier ones.
+     *
+     * @return the ordered ruleset search path
+     */
+    static List<File> rulesetDirectories() {
+        List<File> directories = new ArrayList<>();
+        directories.add(baseRulesetDirectory());
+        for (String additionalDirectory : additionalRulesetDirectories) {
+            directories.add(new File(additionalDirectory));
+        }
+        return directories;
+    }
+
     public static void loadData() {
         initialized = false;
         initializing = true;
         rulesets = new HashMap<>();
 
-        File dir = new File(directory);
-        if (!dir.exists()) {
-            logger.error("Could not locate force generator faction rules.");
+        File baseDirectory = baseRulesetDirectory();
+        if (!baseDirectory.exists()) {
+            logger.error("Could not locate force generator faction rules at {}.", baseDirectory);
             initializing = false;
             return;
         }
 
-        loadConstants(new File(dir, CONSTANTS_FILE));
+        // Constants come from the built-in directory only: loadConstants replaces the map wholesale, so
+        // reading a second constants.txt would discard the built-in definitions the stock rulesets rely on.
+        loadConstants(new File(baseDirectory, CONSTANTS_FILE));
 
         // We need this so we can determine parent faction if not stated explicitly.
         while (!RATGenerator.getInstance().isInitialized()) {
@@ -579,26 +685,52 @@ public class Ruleset {
             }
         }
 
-        File[] files = dir.listFiles();
-
-        if (files != null) {
-            for (File file : files) {
-                if (!file.getPath().endsWith(".xml")) {
-                    continue;
-                }
-                try {
-                    Ruleset ruleset = createFromFile(file);
-                    if (ruleset != null) {
-                        rulesets.put(ruleset.getFaction(), ruleset);
-                    }
-                } catch (Exception ex) {
-                    logger.error(ex, "Failed while parsing file {}", file);
-                }
-            }
+        for (File directory : rulesetDirectories()) {
+            loadRulesetDirectory(directory);
         }
 
         initialized = true;
         initializing = false;
+    }
+
+    /**
+     * Parses every ruleset XML file in one directory into {@link #rulesets}, replacing any ruleset already
+     * loaded for the same faction.
+     *
+     * @param directory a directory from the ruleset search path; a missing directory is skipped with a
+     *                  warning, since an added user directory need not exist
+     */
+    private static void loadRulesetDirectory(File directory) {
+        if (!directory.exists()) {
+            logger.warn("Skipping ruleset directory {}: it does not exist", directory);
+            return;
+        }
+        File[] files = directory.listFiles();
+        if (files == null) {
+            logger.warn("Skipping ruleset directory {}: could not list its contents", directory);
+            return;
+        }
+
+        int loadedCount = 0;
+        int overriddenCount = 0;
+        for (File file : files) {
+            if (!file.getPath().endsWith(".xml")) {
+                continue;
+            }
+            try {
+                Ruleset ruleset = createFromFile(file);
+                if (ruleset != null) {
+                    if (rulesets.put(ruleset.getFaction(), ruleset) != null) {
+                        overriddenCount++;
+                    }
+                    loadedCount++;
+                }
+            } catch (Exception parseException) {
+                logger.error(parseException, "Failed while parsing file {}", file);
+            }
+        }
+        logger.info("Loaded {} faction ruleset(s) from {} ({} overrode an earlier ruleset)",
+              loadedCount, directory, overriddenCount);
     }
 
     private static @Nullable Ruleset createFromFile(File f) {

--- a/megamek/unittests/megamek/client/ratgenerator/RulesetTest.java
+++ b/megamek/unittests/megamek/client/ratgenerator/RulesetTest.java
@@ -59,6 +59,9 @@ import org.junit.jupiter.api.Test;
 @SuppressWarnings("removal")
 class RulesetTest {
 
+    /** The shipped directory plus its user data mirror, both always present in the search path. */
+    private static final int ALWAYS_PRESENT_DIRECTORIES = 2;
+
     private File originalForceGeneratorDir;
 
     @BeforeEach
@@ -74,11 +77,26 @@ class RulesetTest {
     }
 
     @Test
-    void searchPathContainsOnlyTheBuiltInDirectoryByDefault() {
+    void searchPathContainsTheBuiltInAndUserDataDirectoriesByDefault() {
         List<File> directories = Ruleset.rulesetDirectories();
 
-        assertEquals(1, directories.size(), "no directories should be registered by default");
+        assertEquals(ALWAYS_PRESENT_DIRECTORIES, directories.size(),
+              "no extra directories should be registered by default");
         assertEquals(new File(Configuration.forceGeneratorDir(), "faction_rules"), directories.get(0));
+    }
+
+    /**
+     * A player drops a faction ruleset into {@code userdata/data/forcegenerator/faction_rules} to override
+     * the shipped one, matching the userdata contract documented in {@code megamek/userdata/README.md}.
+     */
+    @Test
+    void userDataDirectoryMirrorsTheBuiltInDirectoryAndIsSearchedAfterIt() {
+        List<File> directories = Ruleset.rulesetDirectories();
+
+        // Asserted as literal paths rather than by recomposing them from Configuration, so the test fails
+        // if the location a player is told to use in megamek/userdata/README.md ever moves.
+        assertEquals(new File("data/forcegenerator/faction_rules"), directories.get(0));
+        assertEquals(new File("userdata/data/forcegenerator/faction_rules"), directories.get(1));
     }
 
     /**
@@ -95,18 +113,20 @@ class RulesetTest {
     }
 
     /**
-     * Added directories must come after the built-in one, because {@code loadData} keys rulesets by faction
-     * and a later entry replaces an earlier one. Reversing the order would make user rulesets unreachable.
+     * Added directories must come after the built-in and user data ones, because {@code loadData} keys
+     * rulesets by faction and a later entry replaces an earlier one. Reversing the order would make the
+     * registered rulesets unreachable.
      */
     @Test
-    void addedDirectoriesAreSearchedAfterTheBuiltInDirectory() {
-        Ruleset.addRulesetDirectory("userdata/forcegenerator/faction_rules");
+    void addedDirectoriesAreSearchedLast() {
+        Ruleset.addRulesetDirectory("campaign/forcegenerator/faction_rules");
 
         List<File> directories = Ruleset.rulesetDirectories();
 
-        assertEquals(2, directories.size());
+        assertEquals(ALWAYS_PRESENT_DIRECTORIES + 1, directories.size());
         assertEquals(new File(Configuration.forceGeneratorDir(), "faction_rules"), directories.get(0));
-        assertEquals(new File("userdata/forcegenerator/faction_rules"), directories.get(1));
+        assertEquals(new File("campaign/forcegenerator/faction_rules"),
+              directories.get(ALWAYS_PRESENT_DIRECTORIES));
     }
 
     @Test
@@ -116,31 +136,32 @@ class RulesetTest {
 
         List<File> directories = Ruleset.rulesetDirectories();
 
-        assertEquals(3, directories.size());
-        assertEquals(new File("first"), directories.get(1));
-        assertEquals(new File("second"), directories.get(2));
+        assertEquals(ALWAYS_PRESENT_DIRECTORIES + 2, directories.size());
+        assertEquals(new File("first"), directories.get(ALWAYS_PRESENT_DIRECTORIES));
+        assertEquals(new File("second"), directories.get(ALWAYS_PRESENT_DIRECTORIES + 1));
     }
 
     @Test
     void duplicateDirectoryIsIgnored() {
-        Ruleset.addRulesetDirectory("userdata/forcegenerator/faction_rules");
-        Ruleset.addRulesetDirectory("userdata/forcegenerator/faction_rules");
+        Ruleset.addRulesetDirectory("campaign/forcegenerator/faction_rules");
+        Ruleset.addRulesetDirectory("campaign/forcegenerator/faction_rules");
 
-        assertEquals(2, Ruleset.rulesetDirectories().size(), "duplicate registration should be ignored");
+        assertEquals(ALWAYS_PRESENT_DIRECTORIES + 1, Ruleset.rulesetDirectories().size(),
+              "duplicate registration should be ignored");
     }
 
     @Test
     void nullDirectoryIsIgnored() {
         Ruleset.addRulesetDirectory(null);
 
-        assertEquals(1, Ruleset.rulesetDirectories().size());
+        assertEquals(ALWAYS_PRESENT_DIRECTORIES, Ruleset.rulesetDirectories().size());
     }
 
     @Test
     void blankDirectoryIsIgnored() {
         Ruleset.addRulesetDirectory("   ");
 
-        assertEquals(1, Ruleset.rulesetDirectories().size());
+        assertEquals(ALWAYS_PRESENT_DIRECTORIES, Ruleset.rulesetDirectories().size());
     }
 
     @Test
@@ -169,11 +190,11 @@ class RulesetTest {
 
     @Test
     void clearAdditionalRulesetDirectoriesResetsTheSearchPath() {
-        Ruleset.addRulesetDirectory("userdata/forcegenerator/faction_rules");
-        assertEquals(2, Ruleset.rulesetDirectories().size());
+        Ruleset.addRulesetDirectory("campaign/forcegenerator/faction_rules");
+        assertEquals(ALWAYS_PRESENT_DIRECTORIES + 1, Ruleset.rulesetDirectories().size());
 
         Ruleset.clearAdditionalRulesetDirectories();
 
-        assertEquals(1, Ruleset.rulesetDirectories().size());
+        assertEquals(ALWAYS_PRESENT_DIRECTORIES, Ruleset.rulesetDirectories().size());
     }
 }

--- a/megamek/unittests/megamek/client/ratgenerator/RulesetTest.java
+++ b/megamek/unittests/megamek/client/ratgenerator/RulesetTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.ratgenerator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.lang.reflect.Constructor;
+import java.util.List;
+
+import megamek.common.Configuration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the custom ruleset directory search path and the defaults-only marker.
+ *
+ * <p>Nothing here calls {@link Ruleset#loadData()} or {@link Ruleset#findRuleset(String)}: both reach
+ * {@link RATGenerator#getInstance()}, which spawns a background thread that reads the whole force generator
+ * data directory. The behaviour under test is the search path and the placeholder flag, both reachable
+ * without that.</p>
+ */
+// Configuration.setForceGeneratorDir is deprecated for removal in 0.51.0, but it is the only supported way
+// to relocate the directory, and this test must relocate it to prove Ruleset follows Configuration. When
+// the setter goes, point builtInDirectoryFollowsConfiguredForceGeneratorDir at its replacement.
+@SuppressWarnings("removal")
+class RulesetTest {
+
+    private File originalForceGeneratorDir;
+
+    @BeforeEach
+    void captureConfiguration() {
+        originalForceGeneratorDir = Configuration.forceGeneratorDir();
+        Ruleset.clearAdditionalRulesetDirectories();
+    }
+
+    @AfterEach
+    void restoreConfiguration() {
+        Configuration.setForceGeneratorDir(originalForceGeneratorDir);
+        Ruleset.clearAdditionalRulesetDirectories();
+    }
+
+    @Test
+    void searchPathContainsOnlyTheBuiltInDirectoryByDefault() {
+        List<File> directories = Ruleset.rulesetDirectories();
+
+        assertEquals(1, directories.size(), "no directories should be registered by default");
+        assertEquals(new File(Configuration.forceGeneratorDir(), "faction_rules"), directories.get(0));
+    }
+
+    /**
+     * {@code Ruleset} previously hardcoded {@code "data/forcegenerator/faction_rules"}, silently ignoring a
+     * caller that had relocated the data with {@code setForceGeneratorDir}.
+     */
+    @Test
+    void builtInDirectoryFollowsConfiguredForceGeneratorDir() {
+        Configuration.setForceGeneratorDir(new File("relocated/forcegenerator"));
+
+        List<File> directories = Ruleset.rulesetDirectories();
+
+        assertEquals(new File("relocated/forcegenerator", "faction_rules"), directories.get(0));
+    }
+
+    /**
+     * Added directories must come after the built-in one, because {@code loadData} keys rulesets by faction
+     * and a later entry replaces an earlier one. Reversing the order would make user rulesets unreachable.
+     */
+    @Test
+    void addedDirectoriesAreSearchedAfterTheBuiltInDirectory() {
+        Ruleset.addRulesetDirectory("userdata/forcegenerator/faction_rules");
+
+        List<File> directories = Ruleset.rulesetDirectories();
+
+        assertEquals(2, directories.size());
+        assertEquals(new File(Configuration.forceGeneratorDir(), "faction_rules"), directories.get(0));
+        assertEquals(new File("userdata/forcegenerator/faction_rules"), directories.get(1));
+    }
+
+    @Test
+    void addedDirectoriesKeepRegistrationOrder() {
+        Ruleset.addRulesetDirectory("first");
+        Ruleset.addRulesetDirectory("second");
+
+        List<File> directories = Ruleset.rulesetDirectories();
+
+        assertEquals(3, directories.size());
+        assertEquals(new File("first"), directories.get(1));
+        assertEquals(new File("second"), directories.get(2));
+    }
+
+    @Test
+    void duplicateDirectoryIsIgnored() {
+        Ruleset.addRulesetDirectory("userdata/forcegenerator/faction_rules");
+        Ruleset.addRulesetDirectory("userdata/forcegenerator/faction_rules");
+
+        assertEquals(2, Ruleset.rulesetDirectories().size(), "duplicate registration should be ignored");
+    }
+
+    @Test
+    void nullDirectoryIsIgnored() {
+        Ruleset.addRulesetDirectory(null);
+
+        assertEquals(1, Ruleset.rulesetDirectories().size());
+    }
+
+    @Test
+    void blankDirectoryIsIgnored() {
+        Ruleset.addRulesetDirectory("   ");
+
+        assertEquals(1, Ruleset.rulesetDirectories().size());
+    }
+
+    @Test
+    void defaultsOnlyRulesetIsFlaggedAndCarriesTheGenericFaction() {
+        Ruleset defaultsOnlyRuleset = Ruleset.createDefaultsOnlyRuleset();
+
+        assertTrue(defaultsOnlyRuleset.isDefaultsOnly());
+        assertEquals(FactionRecord.IS_GENERAL_KEY, defaultsOnlyRuleset.getFaction());
+    }
+
+    /**
+     * A ruleset parsed from {@code IS_General.xml} is a real ruleset even though its faction key is
+     * {@link FactionRecord#IS_GENERAL_KEY}. If it reported {@code true} here, consumers would warn about
+     * falling back to generic rules for every faction that legitimately uses them.
+     */
+    @Test
+    void ordinaryRulesetIsNotFlaggedAsDefaultsOnly() throws Exception {
+        Constructor<Ruleset> constructor = Ruleset.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        Ruleset ordinaryRuleset = constructor.newInstance();
+
+        assertFalse(ordinaryRuleset.isDefaultsOnly());
+        assertEquals(FactionRecord.IS_GENERAL_KEY, ordinaryRuleset.getFaction(),
+              "guards the premise of this test: the generic faction key alone must not imply defaults-only");
+    }
+
+    @Test
+    void clearAdditionalRulesetDirectoriesResetsTheSearchPath() {
+        Ruleset.addRulesetDirectory("userdata/forcegenerator/faction_rules");
+        assertEquals(2, Ruleset.rulesetDirectories().size());
+
+        Ruleset.clearAdditionalRulesetDirectories();
+
+        assertEquals(1, Ruleset.rulesetDirectories().size());
+    }
+}

--- a/megamek/userdata/README.md
+++ b/megamek/userdata/README.md
@@ -32,6 +32,19 @@ surnames.csv: This file contains weighted historical ethnic code organized surna
 This file is merge implemented, with names duplicated in the userdata folder having the userdata weight instead of the
 default weight. The first line of this file must be the standard header of "Ethnic Code,Name,Weight".
 
+### data/forcegenerator/faction_rules/
+
+This directory holds the XML faction rulesets used by the Force Generator, which builds faction-correct forces in
+MegaMek's Random Army dialog and in MekHQ's ruleset-based company generation. It is merge implemented: a file placed
+here overrides the shipped ruleset for the same faction, and any faction you do not override keeps using the shipped
+rules.
+
+To customise a faction, copy its file out of `data/forcegenerator/faction_rules/` into this directory under the same
+filename and edit the copy. Because your version lives in the userdata folder, updating MegaMek will not overwrite it.
+The directory is optional; if it is absent, only the shipped rulesets are loaded.
+
+Note that `constants.txt` is read only from the shipped directory. A copy placed here is ignored.
+
 ## MegaMek-specific Folders/Files:
 
 ## MegaMekLab-specific Directories/Files:


### PR DESCRIPTION
## What this does, for a player

The Force Generator builds faction-correct forces (Random Army -> Force Generator). Each faction's structure comes from an XML file shipped in `data/forcegenerator/faction_rules/` — `CJF.xml`, `FedSuns.xml`, and so on.

Today you cannot change those without editing files inside the MegaMek install directory, and the next update overwrites your edits.

After this PR, MegaMek also reads:

```
userdata/data/forcegenerator/faction_rules/
```

A file you put there **replaces** the shipped one for that faction. Factions you do not override keep working exactly as before, and updating MegaMek leaves your files alone. This is the same "userdata overrides the shipped copy" behaviour MegaMek already uses for names, boards and units, and it is now documented in `megamek/userdata/README.md`.

### Worked example

Field Manual: Crusader Clans says Clan Jade Falcon does not use combat vehicles, so the shipped `CJF.xml` largely suppresses them. Say you disagree and want Falcon vehicle stars back.

1. Copy `data/forcegenerator/faction_rules/CJF.xml` to `userdata/data/forcegenerator/faction_rules/CJF.xml`
2. Edit the copy — raise the vehicle `<subforce>` weights
3. Start MegaMek, open Random Army -> Force Generator, pick Clan Jade Falcon, generate

Your Falcon forces now include vehicles. The shipped `CJF.xml` is untouched. Delete your copy to go back to stock.

Nothing else changes. If the userdata folder does not exist, MegaMek behaves exactly as it does today.

---

## What this does, for the code

Three things, in order of how much they matter.

**1. MegaMek now searches a userdata ruleset directory.** `Ruleset.loadData()` walks a list of directories instead of one. Shipped directory first, userdata second, so a userdata file overrides a shipped file of the same faction (`loadData` stores rulesets keyed by faction, so a later load replaces an earlier one). The path is composed the same way as the other userdata overlays — compare `MekSummaryCache` for units and `ServerBoardHelper` for boards.

`constants.txt` is still read **only** from the shipped directory. `loadConstants` replaces its map wholesale, so reading a second copy would throw away the definitions every shipped ruleset depends on.

**2. `Ruleset.addRulesetDirectory(String)`** lets another program register a further directory, searched after the two above. MekHQ needs this to load rulesets from a campaign's own folder. Duplicate, `null` and blank paths are ignored. Registering after `loadData()` has run logs a warning rather than silently doing nothing.

**3. `Ruleset.isDefaultsOnly()`** tells a caller whether `findRuleset()` actually found rules for the faction it asked about, or quietly handed back an empty placeholder.

That third one has a trap worth flagging to reviewers. When no ruleset matches a faction *or any of its parent factions*, `findRuleset` returns `new Ruleset()` so generation does not crash — and that placeholder's faction is `IS_GENERAL_KEY`. But `IS_General.xml` is a real, legitimate ruleset with that same faction key. So a caller checking `getFaction().equals(IS_GENERAL_KEY)` would wrongly report "no rules for this faction" for every faction that properly uses the generic Inner Sphere rules. Hence a flag set only on the fallback path, not a faction-code comparison. `RulesetTest.ordinaryRulesetIsNotFlaggedAsDefaultsOnly` guards exactly this.

**Also:** the shipped directory now resolves through `Configuration.forceGeneratorDir()` instead of a hardcoded `"data/forcegenerator/faction_rules"` string. `Ruleset` was the only force-generator class ignoring the configured directory — `RATGenerator` already used it — so anyone who relocated the data with `setForceGeneratorDir()` was silently ignored by `Ruleset`. Same path by default, so no behaviour change for a normal install.

## Files Changed

- `megamek/src/megamek/client/ratgenerator/Ruleset.java` — directory search path, `addRulesetDirectory`, `isDefaultsOnly`, `Configuration` wiring
- `megamek/unittests/megamek/client/ratgenerator/RulesetTest.java` — new, 10 tests
- `megamek/userdata/README.md` — documents the new directory for players

## Testing

`RulesetTest` — 10 tests, all passing. `compileJava` and `checkstyleMain` clean.

### What is NOT proven yet

Please read this before approving.

- **No test loads an actual XML file from the userdata folder and confirms it overrides the shipped one.** The tests assert the search-path *order* and the literal paths. They do not exercise `loadData()`, because it blocks waiting for `RATGenerator` to finish loading the whole force-generator data directory on a background thread — unusable in a unit test. **This needs one manual check:** copy a faction XML into `userdata/data/forcegenerator/faction_rules/`, change something visible, generate that faction, confirm the change shows up.
- **Smoke test done, but general.** The game was launched against this branch and generated a force without error, so nothing regressed for a normal install. It did *not* specifically exercise a userdata override — the manual check in the first bullet is still the one that matters and has not been ticked.
- `isDefaultsOnly()` has no in-repo caller yet; MekHQ is the first consumer.

The tests deliberately avoid `loadData()` and `findRuleset()` for the reason above. `RulesetTest` uses `Configuration.setForceGeneratorDir`, which is deprecated for removal in 0.51.0, because it is the only supported way to relocate the directory and the test exists to prove `Ruleset` now follows `Configuration`. It carries `@SuppressWarnings("removal")` and a comment naming the test to migrate when the setter goes. Production code uses only the non-deprecated getter.
