### PR TITLE
Fixed Stack Overflow when Abandoning Units While Using Individual Initiative

### DIFF
--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -52,6 +52,7 @@ import megamek.common.equipment.MiscType;
 import megamek.common.game.Game;
 import megamek.common.game.IGame;
 import megamek.common.game.InGameObject;
+import megamek.common.game.InitiativeRoll;
 import megamek.common.hexArea.BorderHexArea;
 import megamek.common.hexArea.HexArea;
 import megamek.common.icons.Camouflage;
@@ -1105,7 +1106,7 @@ public final class Player extends TurnOrdered {
 
         copy.admitsDefeat = admitsDefeat;
 
-        copy.setInitiative(getInitiative());
+        copy.setInitiative(new InitiativeRoll(getInitiative()));
 
         return copy;
     }

--- a/megamek/src/megamek/common/autoResolve/acar/SimulationContext.java
+++ b/megamek/src/megamek/common/autoResolve/acar/SimulationContext.java
@@ -67,6 +67,7 @@ import megamek.common.event.GameListener;
 import megamek.common.force.Forces;
 import megamek.common.game.IGame;
 import megamek.common.game.InGameObject;
+import megamek.common.game.InitiativeRoll;
 import megamek.common.interfaces.IEntityRemovalConditions;
 import megamek.common.interfaces.PlanetaryConditionsUsing;
 import megamek.common.interfaces.ReportEntry;
@@ -379,7 +380,7 @@ public class SimulationContext implements IGame, PlanetaryConditionsUsing {
         for (Team newTeam : initTeams) {
             for (Team oldTeam : teams) {
                 if (newTeam.equals(oldTeam)) {
-                    newTeam.setInitiative(oldTeam.getInitiative());
+                    newTeam.setInitiative(new InitiativeRoll(oldTeam.getInitiative()));
                 }
             }
         }

--- a/megamek/src/megamek/common/game/Game.java
+++ b/megamek/src/megamek/common/game/Game.java
@@ -546,7 +546,7 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
             for (Team newTeam : initTeams) {
                 for (Team oldTeam : teams) {
                     if (newTeam.equals(oldTeam)) {
-                        newTeam.setInitiative(oldTeam.getInitiative());
+                        newTeam.setInitiative(new InitiativeRoll(oldTeam.getInitiative()));
                     }
                 }
             }

--- a/megamek/src/megamek/common/game/InitiativeRoll.java
+++ b/megamek/src/megamek/common/game/InitiativeRoll.java
@@ -65,6 +65,22 @@ public class InitiativeRoll implements Comparable<InitiativeRoll>, Serializable 
 
     }
 
+    /**
+     * Copy constructor. Produces an independent {@link InitiativeRoll} with its own backing vectors, so mutating the
+     * copy (e.g. appending tiebreak rolls) does not affect the source. This is important because several call sites
+     * carry initiative state over between game/team/entity instances; sharing the same instance by reference lets two
+     * distinct candidates compare equal forever, which causes unbounded tie-break recursion.
+     *
+     * @param other The initiative roll to copy; must not be {@code null}
+     */
+    public InitiativeRoll(InitiativeRoll other) {
+        // Integer, Boolean and InitiativeBonusBreakdown are immutable, so copying the vectors themselves is sufficient.
+        rolls.addAll(other.rolls);
+        originalRolls.addAll(other.originalRolls);
+        wasRollReplaced.addAll(other.wasRollReplaced);
+        bonuses.addAll(other.bonuses);
+    }
+
     public void clear() {
         rolls.removeAllElements();
         originalRolls.removeAllElements();

--- a/megamek/src/megamek/common/strategicBattleSystems/SBFGame.java
+++ b/megamek/src/megamek/common/strategicBattleSystems/SBFGame.java
@@ -57,6 +57,7 @@ import megamek.common.event.UnitChangedGameEvent;
 import megamek.common.event.entity.GameEntityChangeEvent;
 import megamek.common.game.AbstractGame;
 import megamek.common.game.InGameObject;
+import megamek.common.game.InitiativeRoll;
 import megamek.common.interfaces.ClientOnly;
 import megamek.common.interfaces.PlanetaryConditionsUsing;
 import megamek.common.interfaces.ReportEntry;
@@ -214,7 +215,7 @@ public final class SBFGame extends AbstractGame implements PlanetaryConditionsUs
             for (Team newTeam : initTeams) {
                 for (Team oldTeam : teams) {
                     if (newTeam.equals(oldTeam)) {
-                        newTeam.setInitiative(oldTeam.getInitiative());
+                        newTeam.setInitiative(new InitiativeRoll(oldTeam.getInitiative()));
                     }
                 }
             }

--- a/megamek/src/megamek/common/turns/TurnOrdered.java
+++ b/megamek/src/megamek/common/turns/TurnOrdered.java
@@ -40,14 +40,7 @@ import static megamek.common.options.OptionsConstants.ATOW_COMBAT_PARALYSIS;
 import static megamek.common.options.OptionsConstants.ATOW_COMBAT_SENSE;
 
 import java.io.Serial;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Vector;
+import java.util.*;
 
 import megamek.common.Player;
 import megamek.common.Team;
@@ -404,6 +397,21 @@ public abstract class TurnOrdered implements ITurnOrdered {
     public static void rollInitAndResolveTies(List<? extends ITurnOrdered> initiativeCandidates,
           List<? extends ITurnOrdered> rerollRequests, boolean bInitCompBonus,
           Map<Team, Integer> initiativeAptitude) {
+        rollInitAndResolveTies(initiativeCandidates, rerollRequests, bInitCompBonus, initiativeAptitude, 0);
+    }
+
+    /**
+     * Backstop that guarantees the tie-break recursion terminates. Genuine ties break within a handful of re-rolls, so
+     * this bound is never approached in practice; it only guards against a degenerate case where candidates compare
+     * equal every pass (e.g. if they were to share the same {@link InitiativeRoll} instance), which would otherwise
+     * recurse until a {@link StackOverflowError}. Kept well below the stack limit while far above any legitimate tie
+     * streak.
+     */
+    private static final int MAX_TIE_BREAK_DEPTH = 100;
+
+    private static void rollInitAndResolveTies(List<? extends ITurnOrdered> initiativeCandidates,
+          List<? extends ITurnOrdered> rerollRequests, boolean bInitCompBonus,
+          Map<Team, Integer> initiativeAptitude, int tieBreakDepth) {
         // Cache the team-level breakdown per player.
         Map<Player, InitiativeBonusBreakdown> playerBreakdownCache = new HashMap<>();
 
@@ -498,23 +506,38 @@ public abstract class TurnOrdered implements ITurnOrdered {
 
         // check for ties
         Vector<ITurnOrdered> ties = new Vector<>();
+        // A tie group is resolved by the single recursive call below, so once an item has been folded into a group we
+        // must not process it again as its own group. Skipping handled items keeps this pass linear: without it, every
+        // member of an unresolvable tie would spawn its own recursion, turning a would-be stack overflow into an
+        // exponential blow-up.
+        Set<ITurnOrdered> alreadyResolved = new HashSet<>();
         for (ITurnOrdered item : initiativeCandidates) {
             // Observers don't have initiative, and were already set to -1
             if (((item instanceof Player) && ((Player) item).isObserver()) ||
                   ((item instanceof Team) && ((Team) item).isObserverTeam())) {
                 continue;
             }
+            if (alreadyResolved.contains(item)) {
+                continue;
+            }
             ties.removeAllElements();
             ties.addElement(item);
             for (ITurnOrdered other : initiativeCandidates) {
-                if ((!Objects.equals(item, other)) && item.getInitiative().equals(other.getInitiative())) {
+                // The identity check guards against two distinct candidates sharing the same InitiativeRoll instance:
+                // that would make equals() trivially true forever and the tie-break below would never resolve.
+                if ((!Objects.equals(item, other)) && (item.getInitiative() != other.getInitiative()) &&
+                      item.getInitiative().equals(other.getInitiative())) {
                     ties.addElement(other);
                 }
             }
 
             if (ties.size() > 1) {
-                // Initiative compensation is retained here, as it should persist in the reroll, like all other bonuses
-                rollInitAndResolveTies(ties, null, bInitCompBonus, initiativeAptitude);
+                alreadyResolved.addAll(ties);
+                if (tieBreakDepth < MAX_TIE_BREAK_DEPTH) {
+                    // Initiative compensation is retained here, as it should persist in the reroll, like all other
+                    // bonuses
+                    rollInitAndResolveTies(ties, null, bInitCompBonus, initiativeAptitude, tieBreakDepth + 1);
+                }
             }
         }
     }

--- a/megamek/src/megamek/common/units/EjectedCrew.java
+++ b/megamek/src/megamek/common/units/EjectedCrew.java
@@ -41,6 +41,7 @@ import megamek.common.Player;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.equipment.EquipmentTypeLookup;
 import megamek.common.game.Game;
+import megamek.common.game.InitiativeRoll;
 import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.infantry.InfantryWeapon;
 import megamek.logging.MMLogger;
@@ -80,7 +81,7 @@ public class EjectedCrew extends ConvInfantry {
         logger.debug("Ejecting crew size: {}", originalRide.getCrew().getSize());
         setChassis(VEE_EJECT_NAME);
         setModel(originalRide.getCrew().getName());
-        setInitiative(originalRide.getInitiative());
+        setInitiative(new InitiativeRoll(originalRide.getInitiative()));
 
         // Generate the display name, then add the original ride's name.
         setDisplayName(getDisplayName() + " of " + originalRide.getDisplayName());

--- a/megamek/unittests/megamek/common/game/InitiativeRollTest.java
+++ b/megamek/unittests/megamek/common/game/InitiativeRollTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.game;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class InitiativeRollTest {
+
+    /**
+     * The copy constructor must produce an independent instance: appending a tiebreak roll to the copy must not affect
+     * the source. Sharing the backing vectors would let two distinct initiative candidates compare equal forever and
+     * cause unbounded tie-break recursion (a StackOverflowError).
+     */
+    @Test
+    void copyConstructorProducesIndependentRoll() {
+        InitiativeRoll source = new InitiativeRoll();
+        source.addRoll(InitiativeBonusBreakdown.fromTotal(2), "");
+
+        InitiativeRoll copy = new InitiativeRoll(source);
+
+        assertNotSame(source, copy);
+        assertEquals(source.size(), copy.size());
+        assertEquals(source, copy);
+
+        // Mutating the copy must leave the source untouched.
+        int sourceSizeBefore = source.size();
+        copy.addRoll(InitiativeBonusBreakdown.fromTotal(0), "");
+
+        assertEquals(sourceSizeBefore, source.size());
+        assertEquals(sourceSizeBefore + 1, copy.size());
+    }
+
+    @Test
+    void copyOfEmptyRollIsEmpty() {
+        InitiativeRoll copy = new InitiativeRoll(new InitiativeRoll());
+        assertEquals(0, copy.size());
+    }
+
+    @Test
+    void copyPreservesEveryRollAndBonus() {
+        InitiativeRoll source = new InitiativeRoll();
+        source.addRoll(InitiativeBonusBreakdown.fromTotal(2), "");
+        source.addRoll(InitiativeBonusBreakdown.fromTotal(-1), "");
+
+        InitiativeRoll copy = new InitiativeRoll(source);
+
+        assertEquals(source.size(), copy.size());
+        for (int i = 0; i < source.size(); i++) {
+            // getRoll() folds in the bonus total, so this verifies both the raw roll and the bonus were copied.
+            assertEquals(source.getRoll(i), copy.getRoll(i), "roll " + i);
+        }
+        assertEquals(source, copy);
+        assertEquals(source.toString(), copy.toString());
+    }
+
+    @Test
+    void mutatingSourceAfterCopyLeavesCopyUnchanged() {
+        InitiativeRoll source = new InitiativeRoll();
+        source.addRoll(InitiativeBonusBreakdown.fromTotal(0), "");
+
+        InitiativeRoll copy = new InitiativeRoll(source);
+        String copyBefore = copy.toString();
+
+        source.addRoll(InitiativeBonusBreakdown.fromTotal(0), "");
+
+        assertEquals(1, copy.size());
+        assertEquals(copyBefore, copy.toString());
+    }
+
+    @Test
+    void copyPreservesReplacedRollState() {
+        // replaceRoll() flags the roll as replaced (Tactical Genius); the flag must survive the copy.
+        InitiativeRoll source = new InitiativeRoll();
+        source.addRoll(InitiativeBonusBreakdown.fromTotal(0), "");
+        source.replaceRoll(InitiativeBonusBreakdown.fromTotal(0), "");
+
+        InitiativeRoll copy = new InitiativeRoll(source);
+
+        assertEquals(source.toString(), copy.toString());
+        assertTrue(copy.toString().contains("Tactical Genius"), copy.toString());
+    }
+}

--- a/megamek/unittests/megamek/common/turns/TurnOrderedTest.java
+++ b/megamek/unittests/megamek/common/turns/TurnOrderedTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.turns;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import megamek.common.MMRandom;
+import megamek.common.Team;
+import megamek.common.compute.Compute;
+import megamek.common.game.IGame;
+import megamek.common.game.InitiativeRoll;
+import megamek.common.interfaces.ITurnOrdered;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class TurnOrderedTest {
+
+    @AfterEach
+    void restoreRng() {
+        // Some tests install a deterministic RNG; make sure the default is restored for everything else.
+        Compute.setRNG(MMRandom.R_DEFAULT);
+    }
+
+    /**
+     * Regression test for the tie-break stack overflow: two distinct initiative candidates that share the same
+     * {@link InitiativeRoll} instance used to compare equal on every re-roll, so {@code rollInitAndResolveTies}
+     * recursed until it threw a {@link StackOverflowError}. It must now terminate.
+     */
+    @Test
+    void sharedInitiativeRollDoesNotStackOverflow() {
+        InitiativeRoll shared = new InitiativeRoll();
+        FakeTurnOrdered a = new FakeTurnOrdered(shared);
+        FakeTurnOrdered b = new FakeTurnOrdered(shared);
+
+        assertDoesNotThrow(() ->
+              TurnOrdered.rollInitAndResolveTies(List.of(a, b), null, false, new HashMap<>()));
+    }
+
+    /**
+     * Two independent candidates must still have their (random) initiative resolved without error. This exercises the
+     * normal path and guarantees the tie-break recursion terminates for ordinary rolls.
+     */
+    @Test
+    void independentCandidatesResolveWithoutError() {
+        FakeTurnOrdered a = new FakeTurnOrdered(new InitiativeRoll());
+        FakeTurnOrdered b = new FakeTurnOrdered(new InitiativeRoll());
+
+        assertDoesNotThrow(() ->
+              TurnOrdered.rollInitAndResolveTies(List.of(a, b), null, false, new HashMap<>()));
+    }
+
+    @Test
+    void threeWayTieResolvesWithoutError() {
+        FakeTurnOrdered a = new FakeTurnOrdered(new InitiativeRoll());
+        FakeTurnOrdered b = new FakeTurnOrdered(new InitiativeRoll());
+        FakeTurnOrdered c = new FakeTurnOrdered(new InitiativeRoll());
+
+        assertDoesNotThrow(() ->
+              TurnOrdered.rollInitAndResolveTies(List.of(a, b, c), null, false, new HashMap<>()));
+    }
+
+    /**
+     * Depth-cap backstop: even two <em>distinct</em> initiative rolls that compare equal on every single re-roll
+     * (forced here with a constant RNG) must terminate rather than recurse into a {@link StackOverflowError}. This
+     * covers the bound independently of the shared-instance identity guard.
+     */
+    @Test
+    void perpetualTieTerminatesViaDepthCap() {
+        // Constant RNG -> every d6 is identical, so two separate rolls tie on every pass forever.
+        Compute.setRNG(new ConstantRandom());
+
+        FakeTurnOrdered a = new FakeTurnOrdered(new InitiativeRoll());
+        FakeTurnOrdered b = new FakeTurnOrdered(new InitiativeRoll());
+
+        assertDoesNotThrow(() ->
+              TurnOrdered.rollInitAndResolveTies(List.of(a, b), null, false, new HashMap<>()));
+    }
+
+    /** Deterministic RNG whose every die shows the same face, guaranteeing identical rolls. */
+    private static final class ConstantRandom extends MMRandom {
+        @Override
+        public int randomInt(int maxValue) {
+            return 0;
+        }
+
+        @Override
+        public float randomFloat() {
+            return 0f;
+        }
+    }
+
+    /**
+     * Minimal {@link ITurnOrdered} that is neither a Team nor an Entity, so {@code rollInitAndResolveTies} takes its
+     * generic path (zero bonus breakdown) and only touches the initiative roll and initiative-compensation bonus.
+     */
+    private static final class FakeTurnOrdered implements ITurnOrdered {
+        private InitiativeRoll initiative;
+        private int initCompBonus;
+
+        private FakeTurnOrdered(InitiativeRoll initiative) {
+            this.initiative = initiative;
+        }
+
+        @Override
+        public InitiativeRoll getInitiative() {
+            return initiative;
+        }
+
+        @Override
+        public void setInitiative(InitiativeRoll newRoll) {
+            this.initiative = newRoll;
+        }
+
+        @Override
+        public void clearInitiative(boolean bUseInitComp, Map<Team, Integer> initiativeAptitude) {
+            getInitiative().clear();
+        }
+
+        @Override
+        public int getInitCompensationBonus() {
+            return initCompBonus;
+        }
+
+        @Override
+        public void setInitCompensationBonus(int newBonus) {
+            this.initCompBonus = newBonus;
+        }
+
+        // ---- Turn-counting members are irrelevant to tie resolution; stub them out. ----
+
+        @Override
+        public int getNormalTurns(IGame game) {
+            return 0;
+        }
+
+        @Override
+        public int getOtherTurns() {
+            return 0;
+        }
+
+        @Override
+        public int getEvenTurns() {
+            return 0;
+        }
+
+        @Override
+        public int getMultiTurns(IGame game) {
+            return 0;
+        }
+
+        @Override
+        public int getSpaceStationTurns() {
+            return 0;
+        }
+
+        @Override
+        public int getJumpshipTurns() {
+            return 0;
+        }
+
+        @Override
+        public int getWarshipTurns() {
+            return 0;
+        }
+
+        @Override
+        public int getDropshipTurns() {
+            return 0;
+        }
+
+        @Override
+        public int getSmallCraftTurns() {
+            return 0;
+        }
+
+        @Override
+        public int getTeleMissileTurns() {
+            return 0;
+        }
+
+        @Override
+        public int getAeroTurns() {
+            return 0;
+        }
+
+        @Override
+        public void incrementOtherTurns() {
+        }
+
+        @Override
+        public void incrementEvenTurns() {
+        }
+
+        @Override
+        public void incrementMultiTurns(int entityClass) {
+        }
+
+        @Override
+        public void incrementSpaceStationTurns() {
+        }
+
+        @Override
+        public void incrementJumpshipTurns() {
+        }
+
+        @Override
+        public void incrementWarshipTurns() {
+        }
+
+        @Override
+        public void incrementDropshipTurns() {
+        }
+
+        @Override
+        public void incrementSmallCraftTurns() {
+        }
+
+        @Override
+        public void incrementTeleMissileTurns() {
+        }
+
+        @Override
+        public void incrementAeroTurns() {
+        }
+
+        @Override
+        public void resetOtherTurns() {
+        }
+
+        @Override
+        public void resetEvenTurns() {
+        }
+
+        @Override
+        public void resetMultiTurns() {
+        }
+
+        @Override
+        public void resetSpaceStationTurns() {
+        }
+
+        @Override
+        public void resetJumpshipTurns() {
+        }
+
+        @Override
+        public void resetWarshipTurns() {
+        }
+
+        @Override
+        public void resetDropshipTurns() {
+        }
+
+        @Override
+        public void resetSmallCraftTurns() {
+        }
+
+        @Override
+        public void resetTeleMissileTurns() {
+        }
+
+        @Override
+        public void resetAeroTurns() {
+        }
+    }
+}


### PR DESCRIPTION
# Must Be Merged **After** #8485

When a unit is abandoned the crew and the abandoned unit share initiative. That means, when comparing initiatives for the purposes of individual initiative the roll will always be equal. Normally equal rolls would be broken with a tiebreaker roll, but because the initiative object was shared those tiebreakers would also be equal. This would continue until a stack overflow occurs.

Now, when duplicating initiative we create a new initiative object. Had the AI conjure some tests for security.