### PR TITLE
Stopped Princess Attacking Abandoned Units

### DIFF
--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -123,11 +123,11 @@ public abstract class BotClient extends Client {
     protected boolean rerolledInitiative = false;
 
     /**
-     * The bot's personality/configuration state. Held on {@link BotClient} because it is generic bot-personality
-     * state (sliders, targeting, retreat edges) shared by every bot implementation, not specific to any one AI.
-     * Initialized to a default so it is never {@code null}: subclasses normally replace it via
-     * {@link #setBehaviorSettings(BehaviorSettings)} during construction, but the default preserves the
-     * non-null contract that {@link #getBehaviorSettings()} callers rely on even if a subclass does not.
+     * The bot's personality/configuration state. Held on {@link BotClient} because it is generic bot-personality state
+     * (sliders, targeting, retreat edges) shared by every bot implementation, not specific to any one AI. Initialized
+     * to a default so it is never {@code null}: subclasses normally replace it via
+     * {@link #setBehaviorSettings(BehaviorSettings)} during construction, but the default preserves the non-null
+     * contract that {@link #getBehaviorSettings()} callers rely on even if a subclass does not.
      */
     protected BehaviorSettings behaviorSettings = new BehaviorSettings();
 
@@ -521,6 +521,7 @@ public abstract class BotClient extends Client {
                       !entity.isOffBoard() &&
                       (entity.getCrew() != null) &&
                       !entity.getCrew().isDead() &&
+                      !entity.isAbandoned() &&
                       !entity.isHidden()) {
                     currentTurnEnemyEntities.add(entity);
                 }

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2511,9 +2511,9 @@ public class FireControl {
      * @param weapon the weapon to test
      *
      * @return {@code true} if the weapon is a 2-point Directional Torso Mount whose arc Princess can plan (front or
-     *       rear). The 3-point 360-degree quad turret is deliberately excluded: Princess only plans the front/rear
-     *       flip and cannot represent that mount's 0-5 facing offset, so it must not be mutated by the fire planner
-     *       (doing so would snap it to front/rear).
+     *       rear). The 3-point 360-degree quad turret is deliberately excluded: Princess only plans the front/rear flip
+     *       and cannot represent that mount's 0-5 facing offset, so it must not be mutated by the fire planner (doing
+     *       so would snap it to front/rear).
      */
     private static boolean isPlannableDirectionalMount(WeaponMounted weapon) {
         return weapon.hasDirectionalTorsoMount()
@@ -2829,6 +2829,7 @@ public class FireControl {
                   && (null != entity.getPosition())
                   && !entity.isOffBoard()
                   && entity.isTargetable()
+                  && !entity.isAbandoned()
                   && (null != entity.getCrew()) && !entity.getCrew().isDead()) {
                 targetableEnemyList.add(entity);
             }

--- a/megamek/src/megamek/common/units/EjectedCrew.java
+++ b/megamek/src/megamek/common/units/EjectedCrew.java
@@ -41,6 +41,7 @@ import megamek.common.Player;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.equipment.EquipmentTypeLookup;
 import megamek.common.game.Game;
+import megamek.common.game.InitiativeRoll;
 import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.infantry.InfantryWeapon;
 import megamek.logging.MMLogger;
@@ -80,7 +81,7 @@ public class EjectedCrew extends ConvInfantry {
         logger.debug("Ejecting crew size: {}", originalRide.getCrew().getSize());
         setChassis(VEE_EJECT_NAME);
         setModel(originalRide.getCrew().getName());
-        setInitiative(originalRide.getInitiative());
+        setInitiative(new InitiativeRoll(originalRide.getInitiative()));
 
         // Generate the display name, then add the original ride's name.
         setDisplayName(getDisplayName() + " of " + originalRide.getDisplayName());

--- a/megamek/src/megamek/common/units/EjectedCrew.java
+++ b/megamek/src/megamek/common/units/EjectedCrew.java
@@ -41,7 +41,6 @@ import megamek.common.Player;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.equipment.EquipmentTypeLookup;
 import megamek.common.game.Game;
-import megamek.common.game.InitiativeRoll;
 import megamek.common.options.OptionsConstants;
 import megamek.common.weapons.infantry.InfantryWeapon;
 import megamek.logging.MMLogger;
@@ -81,7 +80,7 @@ public class EjectedCrew extends ConvInfantry {
         logger.debug("Ejecting crew size: {}", originalRide.getCrew().getSize());
         setChassis(VEE_EJECT_NAME);
         setModel(originalRide.getCrew().getName());
-        setInitiative(new InitiativeRoll(originalRide.getInitiative()));
+        setInitiative(originalRide.getInitiative());
 
         // Generate the display name, then add the original ride's name.
         setDisplayName(getDisplayName() + " of " + originalRide.getDisplayName());

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -62,6 +62,7 @@ import megamek.codeUtilities.StringUtility;
 import megamek.common.CriticalSlot;
 import megamek.common.Hex;
 import megamek.common.LosEffects;
+import megamek.common.Player;
 import megamek.common.TargetRollModifier;
 import megamek.common.ToHitData;
 import megamek.common.battleArmor.BattleArmor;
@@ -3189,5 +3190,37 @@ class FireControlTest {
               mockGame,
               testToHitThreshold);
         assertFalse(0.00001 > Math.abs(0 - plan.getUtility()), "Expected not 0.0.  Got " + plan.getUtility());
+    }
+
+    @Test
+    void getAllTargetableEnemyEntitiesSkipsAbandonedUnits() {
+        final Player localPlayer = mock(Player.class);
+        final Player enemyPlayer = mock(Player.class);
+        when(enemyPlayer.isEnemyOf(localPlayer)).thenReturn(true);
+
+        final Entity liveEnemy = mockTargetableEnemy(enemyPlayer, false);
+        final Entity abandonedEnemy = mockTargetableEnemy(enemyPlayer, true);
+
+        when(mockGame.getEntitiesVector()).thenReturn(List.of(liveEnemy, abandonedEnemy));
+
+        final List<Targetable> targets =
+              FireControl.getAllTargetableEnemyEntities(localPlayer, mockGame, new FireControlState());
+
+        assertTrue(targets.contains(liveEnemy), "a crewed enemy should be targetable");
+        assertFalse(targets.contains(abandonedEnemy), "an abandoned (crewless, intact) enemy should be skipped");
+    }
+
+    /** Builds an enemy entity that passes every targetability gate except, optionally, the abandoned check. */
+    private Entity mockTargetableEnemy(final Player owner, final boolean abandoned) {
+        final Entity entity = mock(Entity.class);
+        when(entity.getOwner()).thenReturn(owner);
+        when(entity.getPosition()).thenReturn(new Coords(5, 5));
+        when(entity.isOffBoard()).thenReturn(false);
+        when(entity.isTargetable()).thenReturn(true);
+        when(entity.isAbandoned()).thenReturn(abandoned);
+        final Crew crew = mock(Crew.class);
+        when(crew.isDead()).thenReturn(false);
+        when(entity.getCrew()).thenReturn(crew);
+        return entity;
     }
 }


### PR DESCRIPTION
When a unit is abandoned, such as a 'Mek, the unit remains on the field. Princess would then treat it like a shutdown unit and focus-fire it. Essentially destroying her own salvage _and_ resulting in the loss of more valuable attacks.

Now Princess wholly ignores abandoned enemy units in her pathfinding and attack calculations.

Added AI tests.