### PR TITLE
Added New Unit Label Style to Show Callsign & Unit Abbreviation

### DIFF
--- a/megamek/src/megamek/client/ui/clientGUI/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/clientGUI/GUIPreferences.java
@@ -783,7 +783,7 @@ public class GUIPreferences extends PreferenceStoreProxy {
         store.setDefault(GAME_SUMMARY_BOARD_VIEW, false);
         store.setDefault(ENTITY_OWNER_LABEL_COLOR, true);
         store.setDefault(UNIT_LABEL_BORDER, true);
-        store.setDefault(UNIT_LABEL_STYLE, LabelDisplayStyle.NICKNAME.name());
+        store.setDefault(UNIT_LABEL_STYLE, LabelDisplayStyle.NICKNAME_AND_ABBREVIATED.name());
         store.setDefault(FIRING_SOLUTIONS, true);
         store.setDefault(CONSTRUCTOR_FACTOR_WARNING, true);
         store.setDefault(GUI_SCALE, 1);

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/LabelDisplayStyle.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/LabelDisplayStyle.java
@@ -37,6 +37,7 @@ public enum LabelDisplayStyle {
     FULL("Chassis and model"),
     ABBREV("Abbreviated chassis and model / Meks only model"),
     NICKNAME("Pilot or unit nickname  / chassis"),
+    NICKNAME_AND_ABBREVIATED("Pilot or unit nickname and abbreviated model / chassis"),
     CHASSIS("Chassis only"),
     ONLY_NICKNAME("Only pilot or unit nickname"),
     ONLY_STATUS("No labels");
@@ -52,7 +53,8 @@ public enum LabelDisplayStyle {
             case FULL -> ABBREV;
             case ABBREV -> CHASSIS;
             case CHASSIS -> NICKNAME;
-            case NICKNAME -> ONLY_NICKNAME;
+            case NICKNAME -> NICKNAME_AND_ABBREVIATED;
+            case NICKNAME_AND_ABBREVIATED -> ONLY_NICKNAME;
             case ONLY_NICKNAME -> ONLY_STATUS;
             default -> FULL;
         };

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/sprite/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/sprite/EntitySprite.java
@@ -182,7 +182,7 @@ public class EntitySprite extends Sprite {
                     } else if (!unitNick().isBlank()) {
                         return "'" + unitNick() + "' (" + abbreviated + ")";
                     } else {
-                        return reduceVehicleName(entity);
+                        return abbreviated;
                     }
                 }
                 case ONLY_NICKNAME:

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/sprite/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/sprite/EntitySprite.java
@@ -174,6 +174,17 @@ public class EntitySprite extends Sprite {
                     } else {
                         return reduceVehicleName(entity);
                     }
+                case NICKNAME_AND_ABBREVIATED: {
+                    String abbreviated = (entity instanceof Mek) ? entity.getModel()
+                          : abbreviateUnitName(standardLabelName());
+                    if (!pilotNick().isBlank()) {
+                        return "\"" + pilotNick().toUpperCase() + "\" (" + abbreviated + ")";
+                    } else if (!unitNick().isBlank()) {
+                        return "'" + unitNick() + "' (" + abbreviated + ")";
+                    } else {
+                        return reduceVehicleName(entity);
+                    }
+                }
                 case ONLY_NICKNAME:
                     if (!pilotNick().isBlank()) {
                         return "\"" + pilotNick().toUpperCase() + "\"";
@@ -783,7 +794,9 @@ public class EntitySprite extends Sprite {
             // draw facing
             graph.setColor(Color.white);
             if ((entity.getFacing() != -1)
-                  && !((entity instanceof ConvInfantry infantry) && !infantry.hasFieldWeapon() && !infantry.isTakingCover())
+                  && !((entity instanceof ConvInfantry infantry)
+                  && !infantry.hasFieldWeapon()
+                  && !infantry.isTakingCover())
                   && !((entity instanceof IAero) && ((IAero) entity).isSpheroid() && !board.isSpace())) {
                 // Indicate a stacked unit with the same facing that can still move
                 if (shouldIndicateNotDone() && bv.game.getPhase().isMovement()) {


### PR DESCRIPTION
This allows players (or MekHQ) to give units callsigns without losing information related to the unit. Currently, if you want to display callsigns you have to hover over the unit and read the tooltip. Now important information is more easily available.

## Examples
| Unit | Pilot callsign | Unit Nickname | Label |
| --- | --- | --- | --- |
| Hunchback HBK-4G | Steamroller | — | "STEAMROLLER" (HBK-4G) |
| Atlas AS7-D | Grim | — | "GRIM" (AS7-D) |
| Hunchback HBK-4G | — | Bruiser | 'Bruiser' (HBK-4G) |
| Locust LCT-1V | — | — |  LCT-1V|
| Bulldog Medium Tank | Ace | — | "ACE" (Bulldog Med. Tk.) |
| Bulldog Medium Tank | — | — | 	Bulldog Med. Tk. |****