### PR TITLE
vsp hitmod is not owned by the weapon itself

### DIFF
--- a/megamek/src/megamek/common/actions/compute/ComputeToHit.java
+++ b/megamek/src/megamek/common/actions/compute/ComputeToHit.java
@@ -1643,7 +1643,7 @@ public class ComputeToHit {
 
         // Flat to hit modifiers defined in WeaponType
         int modifier = weaponType.getToHitModifier(weapon);
-        if (target != null) {
+        if ((target != null) && weaponType.hasHitModifiersByRange()) {
             int nRange = ae.getPosition().distance(target.getPosition());
             int[] nRanges = weaponType.getRanges(weapon, ammo);
 

--- a/megamek/src/megamek/common/actions/compute/ComputeToHit.java
+++ b/megamek/src/megamek/common/actions/compute/ComputeToHit.java
@@ -72,7 +72,6 @@ import megamek.common.weapons.battleArmor.clan.CLBALBX;
 import megamek.common.weapons.bayWeapons.ScreenLauncherBayWeapon;
 import megamek.common.weapons.capitalWeapons.CapitalMissileWeapon;
 import megamek.common.weapons.handlers.ARADEquipmentDetector;
-import megamek.common.weapons.lasers.VariableSpeedPulseLaserWeapon;
 import megamek.common.weapons.lasers.innerSphere.ISBombastLaser;
 import megamek.common.weapons.lrms.LRTWeapon;
 import megamek.common.weapons.srms.SRTWeapon;
@@ -1643,20 +1642,20 @@ public class ComputeToHit {
         }
 
         // Flat to hit modifiers defined in WeaponType
-        if (weaponType.getToHitModifier(weapon) != 0) {
-            int modifier = weaponType.getToHitModifier(weapon);
-            if (target != null && weaponType instanceof VariableSpeedPulseLaserWeapon) {
-                int nRange = ae.getPosition().distance(target.getPosition());
-                int[] nRanges = weaponType.getRanges(weapon, ammo);
+        int modifier = weaponType.getToHitModifier(weapon);
+        if (target != null) {
+            int nRange = ae.getPosition().distance(target.getPosition());
+            int[] nRanges = weaponType.getRanges(weapon, ammo);
 
-                if (nRange <= nRanges[RangeType.RANGE_SHORT]) {
-                    modifier += RangeType.RANGE_SHORT;
-                } else if (nRange <= nRanges[RangeType.RANGE_MEDIUM]) {
-                    modifier += RangeType.RANGE_MEDIUM;
-                } else {
-                    modifier += RangeType.RANGE_LONG;
-                }
+            if (nRange <= nRanges[RangeType.RANGE_SHORT]) {
+                modifier = weaponType.getToHitModifierAtRange(weapon, RangeType.RANGE_SHORT);
+            } else if (nRange <= nRanges[RangeType.RANGE_MEDIUM]) {
+                modifier = weaponType.getToHitModifierAtRange(weapon, RangeType.RANGE_MEDIUM);
+            } else {
+                modifier = weaponType.getToHitModifierAtRange(weapon, RangeType.RANGE_LONG);
             }
+        }
+        if (modifier != 0) {
             toHit.addModifier(modifier, Messages.getString("WeaponAttackAction.WeaponMod"));
 
         }

--- a/megamek/src/megamek/common/equipment/EquipmentType.java
+++ b/megamek/src/megamek/common/equipment/EquipmentType.java
@@ -512,7 +512,7 @@ public class EquipmentType implements ITechnology {
     /**
      * Returns {@code true} if this equipment has a range-based to-hit modifier.
      */
-    protected boolean hasHitModifiersByRange() {
+    public boolean hasHitModifiersByRange() {
         return false;
     }
 

--- a/megamek/src/megamek/common/equipment/EquipmentType.java
+++ b/megamek/src/megamek/common/equipment/EquipmentType.java
@@ -36,6 +36,7 @@ package megamek.common.equipment;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import megamek.common.RangeType;
 import megamek.common.SimpleTechLevel;
 import megamek.common.TechAdvancement;
 import megamek.common.TechAdvancement.AdvancementPhase;
@@ -498,6 +499,21 @@ public class EquipmentType implements ITechnology {
 
     public int getToHitModifier(@Nullable Mounted<?> mounted) {
         return toHitModifier;
+    }
+
+    /**
+     * Returns the to-hit modifier for a range band. Equipment without a range-dependent modifier uses its regular
+     * mounted-equipment modifier.
+     */
+    public int getToHitModifierAtRange(@Nullable Mounted<?> mounted, int range) {
+        return getToHitModifier(mounted);
+    }
+
+    /**
+     * If it has a range based hit modifier
+     */
+    protected boolean hasHitModifiersByRange() {
+        return false;
     }
 
     public EquipmentBitSet getFlags() {
@@ -1212,7 +1228,13 @@ public class EquipmentType implements ITechnology {
         if (explosive) {
             stats.put("explosive", true);
         }
-        if (toHitModifier != 0) {
+        if (hasHitModifiersByRange()) {
+            int[] toHitModifiersByRange = {getToHitModifierAtRange(null, RangeType.RANGE_SHORT),
+                getToHitModifierAtRange(null, RangeType.RANGE_MEDIUM),
+                getToHitModifierAtRange(null, RangeType.RANGE_LONG)
+            };
+            stats.put("toHitModifier", toHitModifiersByRange);
+        } else if (toHitModifier != 0) {
             stats.put("toHitModifier", toHitModifier);
         }
         if (tankSlots > -1) {

--- a/megamek/src/megamek/common/equipment/EquipmentType.java
+++ b/megamek/src/megamek/common/equipment/EquipmentType.java
@@ -510,7 +510,7 @@ public class EquipmentType implements ITechnology {
     }
 
     /**
-     * If it has a range based hit modifier
+     * Returns {@code true} if this equipment has a range-based to-hit modifier.
      */
     protected boolean hasHitModifiersByRange() {
         return false;

--- a/megamek/src/megamek/common/weapons/battleArmor/innerSphere/laser/ISBALaserVSPMedium.java
+++ b/megamek/src/megamek/common/weapons/battleArmor/innerSphere/laser/ISBALaserVSPMedium.java
@@ -61,7 +61,6 @@ public class ISBALaserVSPMedium extends VariableSpeedPulseLaserWeapon {
         sortingName = "Laser VSP C";
         heat = 7;
         damage = DAMAGE_VARIABLE;
-        toHitModifier = -4;
         shortRange = 2;
         mediumRange = 5;
         longRange = 9;

--- a/megamek/src/megamek/common/weapons/battleArmor/innerSphere/laser/ISBALaserVSPSmall.java
+++ b/megamek/src/megamek/common/weapons/battleArmor/innerSphere/laser/ISBALaserVSPSmall.java
@@ -62,7 +62,6 @@ public class ISBALaserVSPSmall extends VariableSpeedPulseLaserWeapon {
         sortingName = "Laser VSP B";
         heat = 3;
         damage = WeaponType.DAMAGE_VARIABLE;
-        toHitModifier = -4;
         shortRange = 2;
         mediumRange = 4;
         longRange = 6;

--- a/megamek/src/megamek/common/weapons/lasers/VariableSpeedPulseLaserWeapon.java
+++ b/megamek/src/megamek/common/weapons/lasers/VariableSpeedPulseLaserWeapon.java
@@ -75,7 +75,7 @@ public class VariableSpeedPulseLaserWeapon extends LaserWeapon {
     }
 
     @Override
-    protected boolean hasHitModifiersByRange() {
+    public boolean hasHitModifiersByRange() {
         return true;
     }
 

--- a/megamek/src/megamek/common/weapons/lasers/VariableSpeedPulseLaserWeapon.java
+++ b/megamek/src/megamek/common/weapons/lasers/VariableSpeedPulseLaserWeapon.java
@@ -41,6 +41,7 @@ import java.io.Serial;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.annotations.Nullable;
+import megamek.common.equipment.Mounted;
 import megamek.common.game.Game;
 import megamek.common.loaders.EntityLoadingException;
 import megamek.common.weapons.handlers.AttackHandler;
@@ -54,12 +55,28 @@ public class VariableSpeedPulseLaserWeapon extends LaserWeapon {
 
     @Serial
     private static final long serialVersionUID = -731162221147163665L;
+    private static final int[] TO_HIT_MODIFIERS_BY_RANGE = { -3, -2, -1 };
 
     public VariableSpeedPulseLaserWeapon() {
         super();
         flags = flags.or(F_PULSE).or(F_VSP).andNot(F_PROTO_WEAPON);
         atClass = CLASS_PULSE_LASER;
         infDamageClass = WEAPON_DIRECT_FIRE;
+        toHitModifier = TO_HIT_MODIFIERS_BY_RANGE[0];
+    }
+
+    @Override
+    public int getToHitModifierAtRange(@Nullable Mounted<?> mounted, int range) {
+        return switch (range) {
+            case RANGE_SHORT -> TO_HIT_MODIFIERS_BY_RANGE[0];
+            case RANGE_MED -> TO_HIT_MODIFIERS_BY_RANGE[1];
+            default -> TO_HIT_MODIFIERS_BY_RANGE[2];
+        };
+    }
+
+    @Override
+    protected boolean hasHitModifiersByRange() {
+        return true;
     }
 
     @Override

--- a/megamek/src/megamek/common/weapons/lasers/innerSphere/large/ISVariableSpeedPulseLaserLarge.java
+++ b/megamek/src/megamek/common/weapons/lasers/innerSphere/large/ISVariableSpeedPulseLaserLarge.java
@@ -63,7 +63,6 @@ public class ISVariableSpeedPulseLaserLarge extends VariableSpeedPulseLaserWeapo
         sortingName = "Laser VSP D";
         heat = 10;
         damage = WeaponType.DAMAGE_VARIABLE;
-        toHitModifier = -4;
         shortRange = 4;
         mediumRange = 8;
         longRange = 15;

--- a/megamek/src/megamek/common/weapons/lasers/innerSphere/medium/ISVariableSpeedPulseLaserMedium.java
+++ b/megamek/src/megamek/common/weapons/lasers/innerSphere/medium/ISVariableSpeedPulseLaserMedium.java
@@ -62,7 +62,6 @@ public class ISVariableSpeedPulseLaserMedium extends VariableSpeedPulseLaserWeap
         sortingName = "Laser VSP C";
         heat = 7;
         damage = DAMAGE_VARIABLE;
-        toHitModifier = -4;
         shortRange = 2;
         mediumRange = 5;
         longRange = 9;

--- a/megamek/src/megamek/common/weapons/lasers/innerSphere/small/ISVariableSpeedPulseLaserSmall.java
+++ b/megamek/src/megamek/common/weapons/lasers/innerSphere/small/ISVariableSpeedPulseLaserSmall.java
@@ -63,7 +63,6 @@ public class ISVariableSpeedPulseLaserSmall extends VariableSpeedPulseLaserWeapo
         sortingName = "Laser VSP B";
         heat = 3;
         damage = WeaponType.DAMAGE_VARIABLE;
-        toHitModifier = -4;
         shortRange = 2;
         mediumRange = 4;
         longRange = 6;

--- a/megamek/unittests/megamek/common/WeaponTypeTest.java
+++ b/megamek/unittests/megamek/common/WeaponTypeTest.java
@@ -32,12 +32,15 @@
  */
 package megamek.common;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.Enumeration;
+import java.util.Map;
 
 import megamek.common.equipment.AmmoType.AmmoTypeEnum;
 import megamek.common.equipment.EquipmentType;
@@ -109,5 +112,16 @@ class WeaponTypeTest {
         WeaponMounted isLightGaussRifleBay = setupBayWeapon("ISLightGaussRifle");
         weaponType = isLightGaussRifleBay.getType();
         assertEquals(RangeType.RANGE_EXTREME, weaponType.getMaxRange(isLightGaussRifleBay));
+    }
+
+    @Test
+    void testVariableSpeedPulseLaserYamlHitModifiers() {
+        EquipmentType equipmentType = EquipmentType.get("ISMediumVSPLaser");
+        assertNotNull(equipmentType);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> stats = (Map<String, Object>) equipmentType.getYamlData().get("stats");
+        assertEquals(-3, equipmentType.getToHitModifier(null));
+        assertArrayEquals(new int[] { -3, -2, -1 }, (int[]) stats.get("toHitModifier"));
     }
 }

--- a/megamek/unittests/megamek/common/actions/compute/ComputeToHitTest.java
+++ b/megamek/unittests/megamek/common/actions/compute/ComputeToHitTest.java
@@ -300,13 +300,15 @@ public class ComputeToHitTest extends GameBoardTestCase {
             attacker.setOwnerId(player1.getId());
             attacker.setId(1);
             attacker.setPosition(new Coords(0, 0));
-            attacker.setFacing(2);
+            when(attacker.getCrew().isActive()).thenReturn(true);
+            when(attacker.getCrew().getCrewType()).thenReturn(CrewType.SINGLE);
             WeaponType vspLaserType = (WeaponType) EquipmentType.get("ISMediumVSPLaser");
             WeaponMounted vspLaser = (WeaponMounted) attacker.addEquipment(vspLaserType, Mek.LOC_CENTER_TORSO);
 
             Mek target = createMek("Target", "TGT-1", "Bob");
             target.setOwnerId(player2.getId());
             target.setId(2);
+            when(target.getCrew().isActive()).thenReturn(true);
 
             game.addEntity(attacker);
             game.addEntity(target);
@@ -317,6 +319,9 @@ public class ComputeToHitTest extends GameBoardTestCase {
                   int range = testCase[0];
                   int expectedModifier = testCase[1];
                   target.setPosition(new Coords(range, 0));
+                  int targetDirection = attacker.getPosition().direction(target.getPosition());
+                  attacker.setFacing(targetDirection);
+                  attacker.setSecondaryFacing(targetDirection);
 
                   ToHitData result = ComputeToHit.toHitCalc(game, attacker.getId(), target,
                           vspLaser.getEquipmentNum(), Entity.LOC_NONE, AimingMode.NONE,

--- a/megamek/unittests/megamek/common/actions/compute/ComputeToHitTest.java
+++ b/megamek/unittests/megamek/common/actions/compute/ComputeToHitTest.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import megamek.client.ui.Messages;
 import megamek.common.GameBoardTestCase;
 import megamek.common.Player;
 import megamek.common.Team;
@@ -123,6 +124,20 @@ public class ComputeToHitTest extends GameBoardTestCase {
           hex 0305 0 "" ""
           end""";
 
+      private static final String BOARD_10_BY_01_FLAT_DATA = """
+              size 10 1
+              hex 0101 0 "" ""
+              hex 0201 0 "" ""
+              hex 0301 0 "" ""
+              hex 0401 0 "" ""
+              hex 0501 0 "" ""
+              hex 0601 0 "" ""
+              hex 0701 0 "" ""
+              hex 0801 0 "" ""
+              hex 0901 0 "" ""
+              hex 1001 0 "" ""
+              end""";
+
     private static TWGameManager mockGameManager;
     private static GameOptions mockGameOptions;
     private static Team team1;
@@ -135,6 +150,7 @@ public class ComputeToHitTest extends GameBoardTestCase {
     static {
         initializeBoard("03_BY_05_CENTER_HILLS", BOARD_03_BY_05_CENTER_HILLS_DATA);
         initializeBoard("03_BY_05_FLAT", BOARD_03_BY_05_FLAT_DATA);
+            initializeBoard("10_BY_01_FLAT", BOARD_10_BY_01_FLAT_DATA);
     }
 
     Mek createMek(String chassis, String model, String crewName) {
@@ -274,6 +290,46 @@ public class ComputeToHitTest extends GameBoardTestCase {
         game.addPlayer(0, player1);
         game.addPlayer(1, player2);
     }
+
+      @Test
+      @DisplayName("Medium VSP Laser applies its range-specific to-hit modifier")
+      void mediumVspLaserAppliesRangeSpecificToHitModifier() throws LocationFullException {
+            setBoard("10_BY_01_FLAT");
+
+            Mek attacker = createMek("Attacker", "ATK-1", "Alice");
+            attacker.setOwnerId(player1.getId());
+            attacker.setId(1);
+            attacker.setPosition(new Coords(0, 0));
+            attacker.setFacing(2);
+            WeaponType vspLaserType = (WeaponType) EquipmentType.get("ISMediumVSPLaser");
+            WeaponMounted vspLaser = (WeaponMounted) attacker.addEquipment(vspLaserType, Mek.LOC_CENTER_TORSO);
+
+            Mek target = createMek("Target", "TGT-1", "Bob");
+            target.setOwnerId(player2.getId());
+            target.setId(2);
+
+            game.addEntity(attacker);
+            game.addEntity(target);
+
+            int[][] rangeAndModifier = { { 2, -3 }, { 5, -2 }, { 9, -1 } };
+            String weaponModifierDescription = Messages.getString("WeaponAttackAction.WeaponMod");
+            for (int[] testCase : rangeAndModifier) {
+                  int range = testCase[0];
+                  int expectedModifier = testCase[1];
+                  target.setPosition(new Coords(range, 0));
+
+                  ToHitData result = ComputeToHit.toHitCalc(game, attacker.getId(), target,
+                          vspLaser.getEquipmentNum(), Entity.LOC_NONE, AimingMode.NONE,
+                          false, false, null, null, false, false, null, false,
+                          WeaponAttackAction.UNASSIGNED, WeaponAttackAction.UNASSIGNED);
+
+                  assertTrue(result.getModifiers().stream().anyMatch(modifier ->
+                                    (modifier.value() == expectedModifier)
+                                            && weaponModifierDescription.equals(modifier.description())),
+                          () -> "Expected Medium VSP Laser modifier " + expectedModifier + " at range " + range
+                                    + ", but modifiers were " + result.getModifiers());
+            }
+      }
 
     @Nested
     @DisplayName(value = "toHitCalc Tests - BuildingEntity")


### PR DESCRIPTION
This PR moves the VSP variable hit modifier into the weapon itself instead of being a being detached into ComputeToHit.
It also adds that data during export (used by MekBay)