### PR TITLE
Added Tracking for Ares Convention Signatory Status

### DIFF
--- a/megamek/src/megamek/common/universe/Faction2.java
+++ b/megamek/src/megamek/common/universe/Faction2.java
@@ -73,7 +73,8 @@ import megamek.common.annotations.Nullable;
 @JsonPropertyOrder({ "key", "name", "sucsCodes", "nameChanges", "capital", "capitalChanges", "yearsActive", "successor",
                      "tags", "color", "logo", "background", "camos", "camosChanges", "nameGenerator", "eraMods",
                      "ratingLevels", "fallBackFactions", "preInvasionHonorRating", "postInvasionHonorRating",
-                     "formationBaseSize", "formationGrouping", "rankSystem", "factionLeaders", "usesMercenaries" })
+                     "formationBaseSize", "formationGrouping", "rankSystem", "factionLeaders", "usesMercenaries",
+                     "aresConventionsSignatory" })
 public class Faction2 {
     private static final int UNKNOWN = -1;
     private static final String DEFAULT_RANK_SYSTEM_INNER_SPHERE = "SLDF";
@@ -108,6 +109,7 @@ public class Faction2 {
     private String rankSystem = null;
     private List<FactionLeaderData> factionLeaders = new ArrayList<>();
     private final NavigableMap<Integer, Boolean> usesMercenaries = new TreeMap<>();
+    private final NavigableMap<Integer, Boolean> aresConventionsSignatory = new TreeMap<>();
 
     public List<String> getRatingLevels() {
         return ratingLevels;
@@ -270,6 +272,10 @@ public class Faction2 {
 
     public NavigableMap<Integer, Boolean> getUsesMercenaries() {
         return usesMercenaries;
+    }
+
+    public NavigableMap<Integer, Boolean> getAresConventionsSignatory() {
+        return aresConventionsSignatory;
     }
 
     public Set<String> getFallBackFactions() {
@@ -558,6 +564,19 @@ public class Faction2 {
     public Boolean isUsesMercenaries(int year) {
         final Map.Entry<Integer, Boolean> isUseMercenaries = usesMercenaries.floorEntry(year);
         return isUseMercenaries == null || isUseMercenaries.getValue();
+    }
+
+    /**
+     * Whether this faction was a signatory of the Ares Conventions - and thus observed their restrictions on targeting
+     * population centers - in the given year. Defaults to {@code false} for years with no recorded signatory status.
+     *
+     * @param year the year to check
+     *
+     * @return {@code true} if the faction observed the Ares Conventions in that year
+     */
+    public boolean isAresConventionsSignatory(int year) {
+        final Map.Entry<Integer, Boolean> signatory = aresConventionsSignatory.floorEntry(year);
+        return (signatory != null) && signatory.getValue();
     }
 
     @Override

--- a/megamek/unittests/megamek/common/universe/Faction2AresConventionsTest.java
+++ b/megamek/unittests/megamek/common/universe/Faction2AresConventionsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.universe;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class Faction2AresConventionsTest {
+    @Test
+    void defaultsToNonSignatory() {
+        Faction2 faction = new Faction2();
+        assertFalse(faction.isAresConventionsSignatory(2400));
+        assertFalse(faction.isAresConventionsSignatory(2500));
+        assertFalse(faction.isAresConventionsSignatory(3025));
+    }
+
+    @Test
+    void followsDateKeyedSignatoryStatus() {
+        Faction2 faction = new Faction2();
+        faction.getAresConventionsSignatory().put(2412, true);
+        faction.getAresConventionsSignatory().put(2786, false);
+
+        assertFalse(faction.isAresConventionsSignatory(2411), "before the conventions were signed");
+        assertTrue(faction.isAresConventionsSignatory(2412), "the year they were signed");
+        assertTrue(faction.isAresConventionsSignatory(2700), "still observed");
+        assertFalse(faction.isAresConventionsSignatory(2786), "renounced at the First Succession War");
+        assertFalse(faction.isAresConventionsSignatory(3025), "long after renunciation");
+    }
+}


### PR DESCRIPTION
This PR adds code to allow us to track whether (and when) a faction is an Ares Conventions signatory. This is needed for the MekHQ Contract Overhaul Project.

See also https://github.com/MegaMek/mekhq/pull/9636 && https://github.com/MegaMek/mm-data/pull/466