### PR TITLE
Fix Add Unit buttons staying disabled in the lobby

### DIFF
--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
@@ -594,15 +594,23 @@ public class ChatLounge extends AbstractPhaseDisplay
         activeSorter = unitSorters.getFirst();
     }
 
-    /**
-     * Enables buttons to allow adding units when the MSC has finished loading. The cache notifies its listeners
-     * from its loader thread, so the buttons must be enabled on the event dispatch thread.
-     */
-    private final transient MekSummaryCache.Listener mekSummaryCacheListener =
-          () -> SwingUtilities.invokeLater(this::enableUnitAddButtons);
+    /** Enables buttons to allow adding units when the MSC has finished loading. */
+    private final transient MekSummaryCache.Listener mekSummaryCacheListener = this::enableUnitAddButtons;
 
-    /** Enables the buttons that need a loaded unit cache to work. */
+    /**
+     * Enables the buttons that need a loaded unit cache to work.
+     * <p>
+     * Both callers can run off the event dispatch thread: the unit cache notifies its listeners from its loader
+     * thread, and the lobby is constructed from the phase change, which is dispatched on the client's connection
+     * thread. The button updates are therefore moved onto the event dispatch thread here, so that every caller is
+     * covered.
+     * </p>
+     */
     private void enableUnitAddButtons() {
+        if (!SwingUtilities.isEventDispatchThread()) {
+            SwingUtilities.invokeLater(this::enableUnitAddButtons);
+            return;
+        }
         butAdd.setEnabled(true);
         butArmy.setEnabled(true);
         butLoadList.setEnabled(true);

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
@@ -409,6 +409,12 @@ public class ChatLounge extends AbstractPhaseDisplay
         GUIP.addPreferenceChangeListener(this);
         PreferenceManager.getClientPreferences().addPreferenceChangeListener(this);
         MekSummaryCache.getInstance().addListener(mekSummaryCacheListener);
+        // The cache may have finished loading between setupUnitConfig() reading its state and the listener
+        // being registered just above. Without this check that notification is missed and the buttons that
+        // need the cache stay disabled for the rest of the lobby.
+        if (MekSummaryCache.getInstance().isInitialized()) {
+            enableUnitAddButtons();
+        }
         clientgui.getClient().getGame().addGameListener(this);
         clientgui.boardViews().forEach(bv -> bv.addBoardViewListener(this));
 
@@ -588,12 +594,19 @@ public class ChatLounge extends AbstractPhaseDisplay
         activeSorter = unitSorters.getFirst();
     }
 
-    /** Enables buttons to allow adding units when the MSC has finished loading. */
-    private final transient MekSummaryCache.Listener mekSummaryCacheListener = () -> {
+    /**
+     * Enables buttons to allow adding units when the MSC has finished loading. The cache notifies its listeners
+     * from its loader thread, so the buttons must be enabled on the event dispatch thread.
+     */
+    private final transient MekSummaryCache.Listener mekSummaryCacheListener =
+          () -> SwingUtilities.invokeLater(this::enableUnitAddButtons);
+
+    /** Enables the buttons that need a loaded unit cache to work. */
+    private void enableUnitAddButtons() {
         butAdd.setEnabled(true);
         butArmy.setEnabled(true);
         butLoadList.setEnabled(true);
-    };
+    }
 
     /** Sets up the Mek Table and Mek Tree. */
     private void setupEntities() {


### PR DESCRIPTION
## Summary

The lobby sometimes opened with Add Unit, Add Army, and Load Unit List greyed out, with no way to get them back. This fixes the startup race that caused it.

## Bug Fixed

- **Buttons stuck disabled**: the `ChatLounge` constructor calls `setupUnitConfig()`, which enables those three buttons only if the unit cache has already finished loading. The done-loading listener that would enable them later is not registered until `setupListeners()`, four calls afterwards. If the cache finished loading in that window, the notification went nowhere and the buttons stayed disabled for the rest of the lobby. That timing is why the bug came and went.
- **Off-thread Swing calls**: `MekSummaryCache` notifies its listeners from its own loader thread, so the listener was calling `setEnabled` on Swing components off the event dispatch thread. It now hops to the EDT.

## Changes

1. **ChatLounge.java** - re-check the cache state after registering the listener; enable the buttons on the EDT.

## Files Changed

- `megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java` - fix the startup race and the off-thread button updates

## Testing

- Manual testing: launched the lobby repeatedly on a warm cache and on a cold cache (deleted `units.cache` to force a rebuild). Add Unit, Add Army, and Load Unit List were enabled every time.
- No unit test: reproducing this needs a constructed `ChatLounge`, which needs a full `ClientGUI`. There are no lobby tests in the repo for that reason, and a test that mocked its way past the constructor would not exercise the race.

Fixes #8497