### PR TITLE
Issue#8362 ppc capacitors do not work in space or low altitude

### DIFF
--- a/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
@@ -822,7 +822,6 @@ public class WeaponHandler implements AttackHandler, Serializable {
                     }
                 } else {
                     bSalvo = false;
-                    nDamPerHit = attackValue;
                     nCluster = 1;
                 }
             }
@@ -1632,7 +1631,6 @@ public class WeaponHandler implements AttackHandler, Serializable {
             if (bLowProfileGlancing) {
                 hit.makeGlancingBlow();
             }
-
             vPhaseReport.addAll(gameManager.damageEntity(entityTarget, hit, nDamage, false,
                   attackingEntity.getSwarmTargetId() == entityTarget.getId() ? DamageType.IGNORE_PASSENGER : damageType,
                   false, false, throughFront, underWater, nukeS2S));

--- a/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
@@ -1631,6 +1631,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
             if (bLowProfileGlancing) {
                 hit.makeGlancingBlow();
             }
+
             vPhaseReport.addAll(gameManager.damageEntity(entityTarget, hit, nDamage, false,
                   attackingEntity.getSwarmTargetId() == entityTarget.getId() ? DamageType.IGNORE_PASSENGER : damageType,
                   false, false, throughFront, underWater, nukeS2S));


### PR DESCRIPTION
WeaponHandler.calcAeroDamage contains a line that resets the damage value of non cluster non capital weapons, which overwrites the damage PPCHandler gives for having a charged capacitor. I removed the overwriting line with this PR, I don't believe it's necessary