### PR TITLE
Fix weapon assignment by internal name instead of display name

### DIFF
--- a/megamek/src/megamek/common/equipment/EquipmentType.java
+++ b/megamek/src/megamek/common/equipment/EquipmentType.java
@@ -783,7 +783,12 @@ public class EquipmentType implements ITechnology {
         if (equipmentType != null) {
             return equipmentType;
         }
-        return allTypes().stream().filter(type -> type.getName().equals(key)).findFirst().orElse(null);
+        for (EquipmentType type : allTypes) {
+            if (type.getName().equals(key)) {
+                return type;
+            }
+        }
+        return null;
     }
 
     /**

--- a/megamek/src/megamek/common/equipment/EquipmentType.java
+++ b/megamek/src/megamek/common/equipment/EquipmentType.java
@@ -772,6 +772,21 @@ public class EquipmentType implements ITechnology {
     }
 
     /**
+     * Looks up equipment by internal name or lookup name, falling back to its display name for legacy serialized data.
+     *
+     * @param key The internal name, lookup name, or display name
+     *
+     * @return The matching equipment type, or null if there is none
+     */
+    public static @Nullable EquipmentType getWithFallbackToDisplayName(String key) {
+        EquipmentType equipmentType = get(key);
+        if (equipmentType != null) {
+            return equipmentType;
+        }
+        return allTypes().stream().filter(type -> type.getName().equals(key)).findFirst().orElse(null);
+    }
+
+    /**
      * Explicit structure lookup by name, to avoid armor type collisions (mainly "IS Standard")
      * Works because all structure names (q.v.) are added to the hash with " structure" appended.
      * @param key   String name, probably generated from looking up a structure type name using an index

--- a/megamek/src/megamek/common/equipment/Mounted.java
+++ b/megamek/src/megamek/common/equipment/Mounted.java
@@ -250,7 +250,7 @@ public class Mounted<T extends EquipmentType> implements Serializable, RoundUpda
     @SuppressWarnings("unchecked")
     public void restore() {
         if (typeName == null) {
-            typeName = type.getName();
+            typeName = type.getInternalName();
         } else {
             type = (T) EquipmentType.get(typeName);
         }

--- a/megamek/src/megamek/common/equipment/Mounted.java
+++ b/megamek/src/megamek/common/equipment/Mounted.java
@@ -252,7 +252,7 @@ public class Mounted<T extends EquipmentType> implements Serializable, RoundUpda
         if (typeName == null) {
             typeName = type.getInternalName();
         }
-        type = (T) EquipmentType.get(typeName);
+        type = (T) EquipmentType.getWithFallbackToDisplayName(typeName);
 
         if (type == null) {
             String message = String.format("Could not restore equipment type \"%s\"", typeName);

--- a/megamek/src/megamek/common/equipment/Mounted.java
+++ b/megamek/src/megamek/common/equipment/Mounted.java
@@ -251,13 +251,14 @@ public class Mounted<T extends EquipmentType> implements Serializable, RoundUpda
     public void restore() {
         if (typeName == null) {
             typeName = type.getInternalName();
-        } else {
-            type = (T) EquipmentType.get(typeName);
         }
+        type = (T) EquipmentType.get(typeName);
 
         if (type == null) {
             String message = String.format("Could not restore equipment type \"%s\"", typeName);
             LOGGER.error(message);
+        } else {
+            typeName = type.getInternalName();
         }
     }
 

--- a/megamek/src/megamek/common/units/ConvInfantry.java
+++ b/megamek/src/megamek/common/units/ConvInfantry.java
@@ -1074,6 +1074,7 @@ public class ConvInfantry extends Infantry {
             if ((getSecondaryWeaponsPerSquad() > 1)
                   && !hasAbility(OptionsConstants.MD_TSM_IMPLANT)
                   && !hasAbility(OptionsConstants.MD_DERMAL_ARMOR)
+                  && !hasNonEncumberingSecondaryWeaponSpecialization()
                   && (null != secondaryWeapon)
                   && secondaryWeapon.hasFlag(WeaponType.F_INF_SUPPORT)
                   && !getMovementMode().isTracked()
@@ -1400,6 +1401,10 @@ public class ConvInfantry extends Infantry {
         return secondaryWeaponsPerSquad;
     }
 
+    private boolean hasNonEncumberingSecondaryWeaponSpecialization() {
+        return hasSpecialization(PARAMEDICS | TAG_TROOPS);
+    }
+
     public double getDamagePerTrooper() {
         if (null == primaryWeapon) {
             return 0;
@@ -1592,6 +1597,7 @@ public class ConvInfantry extends Infantry {
             if ((getSecondaryWeaponsPerSquad() > 1) &&
                   !hasAbility(OptionsConstants.MD_TSM_IMPLANT) &&
                   !hasAbility(OptionsConstants.MD_DERMAL_ARMOR) &&
+                  !hasNonEncumberingSecondaryWeaponSpecialization() &&
                   !getMovementMode().isSubmarine() &&
                   (null != secondaryWeapon) &&
                   secondaryWeapon.hasFlag(WeaponType.F_INF_SUPPORT)) {

--- a/megamek/src/megamek/common/units/ConvInfantry.java
+++ b/megamek/src/megamek/common/units/ConvInfantry.java
@@ -1402,7 +1402,7 @@ public class ConvInfantry extends Infantry {
     }
 
     private boolean hasNonEncumberingSecondaryWeaponSpecialization() {
-        return hasSpecialization(PARAMEDICS | TAG_TROOPS);
+        return hasSpecialization(TAG_TROOPS);
     }
 
     public double getDamagePerTrooper() {
@@ -1521,7 +1521,7 @@ public class ConvInfantry extends Infantry {
     }
 
     private static @Nullable InfantryWeapon restoreInfantryWeapon(String weaponName) {
-        if (EquipmentType.get(weaponName) instanceof InfantryWeapon infantryWeapon) {
+        if (EquipmentType.getWithFallbackToDisplayName(weaponName) instanceof InfantryWeapon infantryWeapon) {
             return infantryWeapon;
         }
         return null;

--- a/megamek/src/megamek/common/units/ConvInfantry.java
+++ b/megamek/src/megamek/common/units/ConvInfantry.java
@@ -1507,10 +1507,16 @@ public class ConvInfantry extends Infantry {
 
         if (null != primaryName) {
             primaryWeapon = restoreInfantryWeapon(primaryName);
+            if (null != primaryWeapon) {
+                primaryName = primaryWeapon.getInternalName();
+            }
         }
 
         if (null != secondName) {
             secondaryWeapon = restoreInfantryWeapon(secondName);
+            if (null != secondaryWeapon) {
+                secondName = secondaryWeapon.getInternalName();
+            }
         }
     }
 

--- a/megamek/src/megamek/common/units/ConvInfantry.java
+++ b/megamek/src/megamek/common/units/ConvInfantry.java
@@ -1308,7 +1308,7 @@ public class ConvInfantry extends Infantry {
 
     public void setPrimaryWeapon(InfantryWeapon w) {
         primaryWeapon = w;
-        primaryName = w.getName();
+        primaryName = w.getInternalName();
     }
 
     public InfantryWeapon getPrimaryWeapon() {
@@ -1320,7 +1320,7 @@ public class ConvInfantry extends Infantry {
         if (null == w) {
             secondName = null;
         } else {
-            secondName = w.getName();
+            secondName = w.getInternalName();
         }
     }
 
@@ -1501,12 +1501,19 @@ public class ConvInfantry extends Infantry {
         super.restore();
 
         if (null != primaryName) {
-            primaryWeapon = (InfantryWeapon) EquipmentType.get(primaryName);
+            primaryWeapon = restoreInfantryWeapon(primaryName);
         }
 
         if (null != secondName) {
-            secondaryWeapon = (InfantryWeapon) EquipmentType.get(secondName);
+            secondaryWeapon = restoreInfantryWeapon(secondName);
         }
+    }
+
+    private static @Nullable InfantryWeapon restoreInfantryWeapon(String weaponName) {
+        if (EquipmentType.get(weaponName) instanceof InfantryWeapon infantryWeapon) {
+            return infantryWeapon;
+        }
+        return null;
     }
 
     @Override

--- a/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
@@ -2133,7 +2133,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
         if (typeName == null) {
             typeName = weaponType.getInternalName();
         }
-        weaponType = (WeaponType) EquipmentType.get(typeName);
+        weaponType = (WeaponType) EquipmentType.getWithFallbackToDisplayName(typeName);
 
         if (weaponType == null) {
             LOGGER.error("Could not restore equipment type \"{}\"", typeName);

--- a/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
@@ -2131,7 +2131,7 @@ public class WeaponHandler implements AttackHandler, Serializable {
      */
     public void restore() {
         if (typeName == null) {
-            typeName = weaponType.getName();
+            typeName = weaponType.getInternalName();
         } else {
             weaponType = (WeaponType) EquipmentType.get(typeName);
         }

--- a/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
@@ -2132,12 +2132,13 @@ public class WeaponHandler implements AttackHandler, Serializable {
     public void restore() {
         if (typeName == null) {
             typeName = weaponType.getInternalName();
-        } else {
-            weaponType = (WeaponType) EquipmentType.get(typeName);
         }
+        weaponType = (WeaponType) EquipmentType.get(typeName);
 
         if (weaponType == null) {
             LOGGER.error("Could not restore equipment type \"{}\"", typeName);
+        } else {
+            typeName = weaponType.getInternalName();
         }
     }
 

--- a/megamek/unittests/megamek/common/units/ConvInfantryDisposableWeaponTest.java
+++ b/megamek/unittests/megamek/common/units/ConvInfantryDisposableWeaponTest.java
@@ -143,4 +143,27 @@ class ConvInfantryDisposableWeaponTest {
         assertEquals(law, infantry.getDisposableWeapon());
         assertEquals("Rocket Launcher (LAW)", infantry.getDisposableWeapon().getInternalName());
     }
+
+    @Test
+    @DisplayName("primary and secondary weapons are reconstructed by name after client/server serialization")
+    void infantryWeaponsSurviveSerialization() throws Exception {
+        ConvInfantry infantry = createInfantry();
+        InfantryWeapon primaryWeapon = infantry.getPrimaryWeapon();
+        InfantryWeapon secondaryWeapon = (InfantryWeapon) EquipmentType.get("InfantryGrenade");
+        infantry.setSecondaryWeapon(secondaryWeapon);
+
+        clearWeaponReference(infantry, "primaryWeapon");
+        clearWeaponReference(infantry, "secondaryWeapon");
+
+        infantry.restore();
+
+        assertEquals(primaryWeapon, infantry.getPrimaryWeapon());
+        assertEquals(secondaryWeapon, infantry.getSecondaryWeapon());
+    }
+
+    private static void clearWeaponReference(ConvInfantry infantry, String fieldName) throws Exception {
+        Field weaponField = ConvInfantry.class.getDeclaredField(fieldName);
+        weaponField.setAccessible(true);
+        weaponField.set(infantry, null);
+    }
 }

--- a/megamek/unittests/megamek/common/units/ConvInfantryDisposableWeaponTest.java
+++ b/megamek/unittests/megamek/common/units/ConvInfantryDisposableWeaponTest.java
@@ -145,7 +145,7 @@ class ConvInfantryDisposableWeaponTest {
     }
 
     @Test
-    @DisplayName("primary and secondary weapons are reconstructed by name after client/server serialization")
+    @DisplayName("primary and secondary weapons are reconstructed by internal name after client/server serialization")
     void infantryWeaponsSurviveSerialization() throws Exception {
         ConvInfantry infantry = createInfantry();
         InfantryWeapon primaryWeapon = infantry.getPrimaryWeapon();

--- a/megamek/unittests/megamek/common/units/ConvInfantrySupportWeaponMovementTest.java
+++ b/megamek/unittests/megamek/common/units/ConvInfantrySupportWeaponMovementTest.java
@@ -71,17 +71,6 @@ class ConvInfantrySupportWeaponMovementTest {
         assertEquals(3, jumpInfantry.getJumpMP(MPCalculationSetting.NO_GRAVITY));
     }
 
-    @Test
-    void paramedicsDoNotReduceGroundOrJumpMovement() {
-        ConvInfantry legInfantry = createInfantry(EntityMovementMode.INF_LEG,
-              EquipmentTypeLookup.INFANTRY_MORTAR_LIGHT, ConvInfantry.PARAMEDICS);
-        ConvInfantry jumpInfantry = createInfantry(EntityMovementMode.INF_JUMP,
-              EquipmentTypeLookup.INFANTRY_MORTAR_LIGHT, ConvInfantry.PARAMEDICS);
-
-        assertEquals(1, legInfantry.getWalkMP(MPCalculationSetting.NO_GRAVITY));
-        assertEquals(3, jumpInfantry.getJumpMP(MPCalculationSetting.NO_GRAVITY));
-    }
-
     private static ConvInfantry createInfantry(EntityMovementMode movementMode, String secondaryWeapon,
           int specializations) {
         ConvInfantry infantry = new ConvInfantry();

--- a/megamek/unittests/megamek/common/units/ConvInfantrySupportWeaponMovementTest.java
+++ b/megamek/unittests/megamek/common/units/ConvInfantrySupportWeaponMovementTest.java
@@ -51,37 +51,44 @@ class ConvInfantrySupportWeaponMovementTest {
 
     @Test
     void supportWeaponsReduceGroundAndJumpMovement() {
-        ConvInfantry infantry = createJumpInfantry();
-        infantry.setSecondaryWeapon(infantryWeapon(EquipmentTypeLookup.INFANTRY_MORTAR_LIGHT));
+        ConvInfantry legInfantry = createInfantry(EntityMovementMode.INF_LEG,
+              EquipmentTypeLookup.INFANTRY_MORTAR_LIGHT, 0);
+        ConvInfantry jumpInfantry = createInfantry(EntityMovementMode.INF_JUMP,
+              EquipmentTypeLookup.INFANTRY_MORTAR_LIGHT, 0);
 
-        assertEquals(0, infantry.getWalkMP(MPCalculationSetting.NO_GRAVITY));
-        assertEquals(2, infantry.getJumpMP(MPCalculationSetting.NO_GRAVITY));
+        assertEquals(0, legInfantry.getWalkMP(MPCalculationSetting.NO_GRAVITY));
+        assertEquals(2, jumpInfantry.getJumpMP(MPCalculationSetting.NO_GRAVITY));
     }
 
     @Test
     void tagTroopsDoNotReduceGroundOrJumpMovement() {
-        ConvInfantry infantry = createJumpInfantry();
-        infantry.setSecondaryWeapon(infantryWeapon(EquipmentTypeLookup.INFANTRY_TAG));
-        infantry.setSpecializations(ConvInfantry.TAG_TROOPS);
+        ConvInfantry legInfantry = createInfantry(EntityMovementMode.INF_LEG,
+              EquipmentTypeLookup.INFANTRY_TAG, ConvInfantry.TAG_TROOPS);
+        ConvInfantry jumpInfantry = createInfantry(EntityMovementMode.INF_JUMP,
+              EquipmentTypeLookup.INFANTRY_TAG, ConvInfantry.TAG_TROOPS);
 
-        assertEquals(1, infantry.getWalkMP(MPCalculationSetting.NO_GRAVITY));
-        assertEquals(3, infantry.getJumpMP(MPCalculationSetting.NO_GRAVITY));
+        assertEquals(1, legInfantry.getWalkMP(MPCalculationSetting.NO_GRAVITY));
+        assertEquals(3, jumpInfantry.getJumpMP(MPCalculationSetting.NO_GRAVITY));
     }
 
     @Test
     void paramedicsDoNotReduceGroundOrJumpMovement() {
-        ConvInfantry infantry = createJumpInfantry();
-        infantry.setSecondaryWeapon(infantryWeapon(EquipmentTypeLookup.INFANTRY_MORTAR_LIGHT));
-        infantry.setSpecializations(ConvInfantry.PARAMEDICS);
+        ConvInfantry legInfantry = createInfantry(EntityMovementMode.INF_LEG,
+              EquipmentTypeLookup.INFANTRY_MORTAR_LIGHT, ConvInfantry.PARAMEDICS);
+        ConvInfantry jumpInfantry = createInfantry(EntityMovementMode.INF_JUMP,
+              EquipmentTypeLookup.INFANTRY_MORTAR_LIGHT, ConvInfantry.PARAMEDICS);
 
-        assertEquals(1, infantry.getWalkMP(MPCalculationSetting.NO_GRAVITY));
-        assertEquals(3, infantry.getJumpMP(MPCalculationSetting.NO_GRAVITY));
+        assertEquals(1, legInfantry.getWalkMP(MPCalculationSetting.NO_GRAVITY));
+        assertEquals(3, jumpInfantry.getJumpMP(MPCalculationSetting.NO_GRAVITY));
     }
 
-    private static ConvInfantry createJumpInfantry() {
+    private static ConvInfantry createInfantry(EntityMovementMode movementMode, String secondaryWeapon,
+          int specializations) {
         ConvInfantry infantry = new ConvInfantry();
-        infantry.setMovementMode(EntityMovementMode.INF_JUMP);
+        infantry.setMovementMode(movementMode);
         infantry.setSecondaryWeaponsPerSquad(2);
+        infantry.setSecondaryWeapon(infantryWeapon(secondaryWeapon));
+        infantry.setSpecializations(specializations);
         return infantry;
     }
 

--- a/megamek/unittests/megamek/common/units/ConvInfantrySupportWeaponMovementTest.java
+++ b/megamek/unittests/megamek/common/units/ConvInfantrySupportWeaponMovementTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.units;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import megamek.common.MPCalculationSetting;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.EquipmentTypeLookup;
+import megamek.common.weapons.infantry.InfantryWeapon;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class ConvInfantrySupportWeaponMovementTest {
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    @Test
+    void supportWeaponsReduceGroundAndJumpMovement() {
+        ConvInfantry infantry = createJumpInfantry();
+        infantry.setSecondaryWeapon(infantryWeapon(EquipmentTypeLookup.INFANTRY_MORTAR_LIGHT));
+
+        assertEquals(0, infantry.getWalkMP(MPCalculationSetting.NO_GRAVITY));
+        assertEquals(2, infantry.getJumpMP(MPCalculationSetting.NO_GRAVITY));
+    }
+
+    @Test
+    void tagTroopsDoNotReduceGroundOrJumpMovement() {
+        ConvInfantry infantry = createJumpInfantry();
+        infantry.setSecondaryWeapon(infantryWeapon(EquipmentTypeLookup.INFANTRY_TAG));
+        infantry.setSpecializations(ConvInfantry.TAG_TROOPS);
+
+        assertEquals(1, infantry.getWalkMP(MPCalculationSetting.NO_GRAVITY));
+        assertEquals(3, infantry.getJumpMP(MPCalculationSetting.NO_GRAVITY));
+    }
+
+    @Test
+    void paramedicsDoNotReduceGroundOrJumpMovement() {
+        ConvInfantry infantry = createJumpInfantry();
+        infantry.setSecondaryWeapon(infantryWeapon(EquipmentTypeLookup.INFANTRY_MORTAR_LIGHT));
+        infantry.setSpecializations(ConvInfantry.PARAMEDICS);
+
+        assertEquals(1, infantry.getWalkMP(MPCalculationSetting.NO_GRAVITY));
+        assertEquals(3, infantry.getJumpMP(MPCalculationSetting.NO_GRAVITY));
+    }
+
+    private static ConvInfantry createJumpInfantry() {
+        ConvInfantry infantry = new ConvInfantry();
+        infantry.setMovementMode(EntityMovementMode.INF_JUMP);
+        infantry.setSecondaryWeaponsPerSquad(2);
+        return infantry;
+    }
+
+    private static InfantryWeapon infantryWeapon(String internalName) {
+        return (InfantryWeapon) EquipmentType.get(internalName);
+    }
+}


### PR DESCRIPTION
This PR fixes how CI weapons  are stored/restored. They where wrongly assigned by name instead of internalName creating an issue during serialization/deserialization (loss of equipment).
This issue was also in the restore() methods for Mounted/WeaponHandler