### PR TITLE
Add faction lineage aliases and era-varying logo/background to Faction2

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/FactionRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/FactionRecord.java
@@ -161,7 +161,7 @@ public class FactionRecord {
                 setName(entry.getKey(), entry.getValue());
             }
         }
-        aliases.putAll(faction2.getAliases());
+        faction2.getAliases().forEach(this::addAlias);
     }
 
     @Override
@@ -208,7 +208,17 @@ public class FactionRecord {
     }
 
     public TreeMap<Integer, String> getAliases() {
-        return aliases;
+        return new TreeMap<>(aliases);
+    }
+
+    /**
+     * Adds a historical faction-code alias effective from the given year. See {@link #getAliases()}.
+     *
+     * @param year      the year the alias code became active
+     * @param aliasCode the retired faction code that resolves to this faction
+     */
+    public void addAlias(int year, String aliasCode) {
+        aliases.put(year, aliasCode);
     }
 
     /**

--- a/megamek/src/megamek/client/ratgenerator/FactionRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/FactionRecord.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2016-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2016-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -78,6 +78,7 @@ public class FactionRecord {
     private boolean periphery;
     private String name;
     private final TreeMap<Integer, String> altNames;
+    private final TreeMap<Integer, String> aliases;
     private final ArrayList<DateRange> yearsActive;
     private final ArrayList<String> ratingLevels;
     private final HashMap<Integer, Integer> pctSalvage;
@@ -126,6 +127,7 @@ public class FactionRecord {
         minor = clan = periphery = false;
         ratingLevels = new ArrayList<>();
         altNames = new TreeMap<>();
+        aliases = new TreeMap<>();
         yearsActive = new ArrayList<>();
         pctSalvage = new HashMap<>();
         pctTech = new HashMap<>();
@@ -159,6 +161,7 @@ public class FactionRecord {
                 setName(entry.getKey(), entry.getValue());
             }
         }
+        aliases.putAll(faction2.getAliases());
     }
 
     @Override
@@ -202,6 +205,43 @@ public class FactionRecord {
 
     public TreeMap<Integer, String> getAltNames() {
         return altNames;
+    }
+
+    public TreeMap<Integer, String> getAliases() {
+        return aliases;
+    }
+
+    /**
+     * Returns the faction codes under which this faction's unit availability may be recorded, for the given year,
+     * ordered so the era-active code (per the {@link #getAliases() alias} date map) is tried first, then this
+     * faction's own key, then any remaining historical alias codes.
+     *
+     * <p>For a faction with no aliases this is simply a single-element list of {@link #getKey() the key}, so
+     * availability resolution is unchanged. For a consolidated rename lineage (for example Clan Goliath Scorpion,
+     * aliased to {@code CEI} from 3080 and {@code SE} from 3141) generating in 3100 this yields
+     * {@code [CEI, CGS, SE]} - so the era-appropriate {@code CEI} availability is preferred while units still listed
+     * only under the legacy {@code CGS} code remain reachable.</p>
+     *
+     * @param year the game year the availability is being resolved for
+     *
+     * @return the ordered, de-duplicated lineage codes to try. Never {@code null} or empty.
+     */
+    public List<String> getLineageCodesForYear(int year) {
+        if (aliases.isEmpty()) {
+            return List.of(key);
+        }
+        List<String> lineageCodes = new ArrayList<>();
+        Map.Entry<Integer, String> activeAlias = aliases.floorEntry(year);
+        lineageCodes.add((activeAlias != null) ? activeAlias.getValue() : key);
+        if (!lineageCodes.contains(key)) {
+            lineageCodes.add(key);
+        }
+        for (String aliasCode : aliases.values()) {
+            if (!lineageCodes.contains(aliasCode)) {
+                lineageCodes.add(aliasCode);
+            }
+        }
+        return lineageCodes;
     }
 
     /**

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -81,6 +81,8 @@ public class RATGenerator {
     private final HashMap<String, ModelRecord> models;
     private final HashMap<String, ChassisRecord> chassis;
     private final HashMap<String, FactionRecord> factions;
+    /** Maps a retired/aliased faction code to the surviving canonical faction key; see {@link FactionRecord#getAliases()}. */
+    private final HashMap<String, String> factionAliases;
     private final HashMap<Integer, HashMap<String, HashMap<String, AvailabilityRating>>> modelIndex;
     private final HashMap<Integer, HashMap<String, HashMap<String, AvailabilityRating>>> chassisIndex;
 
@@ -115,6 +117,7 @@ public class RATGenerator {
         models = new HashMap<>();
         chassis = new HashMap<>();
         factions = new HashMap<>();
+        factionAliases = new HashMap<>();
         modelIndex = new HashMap<>();
         chassisIndex = new HashMap<>();
         eraSet = new TreeSet<>();
@@ -161,8 +164,9 @@ public class RATGenerator {
     }
 
     public AvailabilityRating findChassisAvailabilityRecord(int era, String unit, String faction, int year) {
-        if (factions.containsKey(faction)) {
-            return findChassisAvailabilityRecord(era, unit, factions.get(faction), year);
+        FactionRecord factionRecord = getFaction(faction);
+        if (factionRecord != null) {
+            return findChassisAvailabilityRecord(era, unit, factionRecord, year);
         }
 
         if (chassisIndex.containsKey(era) && chassisIndex.get(era).containsKey(unit)) {
@@ -248,8 +252,9 @@ public class RATGenerator {
     }
 
     public @Nullable AvailabilityRating findModelAvailabilityRecord(int era, String unit, String faction) {
-        if (factions.containsKey(faction)) {
-            return findModelAvailabilityRecord(era, unit, factions.get(faction));
+        FactionRecord factionRecord = getFaction(faction);
+        if (factionRecord != null) {
+            return findModelAvailabilityRecord(era, unit, factionRecord);
         }
         // Normalize the unit key to the canonical MekSummary name so name_changes aliases work.
         ModelRecord modelRecord = models.get(unit);
@@ -453,7 +458,14 @@ public class RATGenerator {
     }
 
     public FactionRecord getFaction(String key) {
-        return factions.get(key);
+        FactionRecord factionRecord = factions.get(key);
+        if (factionRecord == null) {
+            String canonicalKey = factionAliases.get(key);
+            if (canonicalKey != null) {
+                factionRecord = factions.get(canonicalKey);
+            }
+        }
+        return factionRecord;
     }
 
     public void addFaction(FactionRecord rec) {
@@ -1479,22 +1491,30 @@ public class RATGenerator {
     }
 
     /**
-     * Registers each faction's historical code aliases (see {@link FactionRecord#getAliases()}) as additional keys
-     * pointing at the surviving {@link FactionRecord}, so that availability tokens still written under a retired code
-     * (for example {@code CEI:5} after Clan Goliath Scorpion absorbed the Escorpion Imperio into its {@code CGS} key)
-     * are recognized at load and resolve to the surviving faction. Runs after the real factions are indexed, so a real
-     * faction always wins over an alias claiming the same code.
+     * Registers each faction's historical code aliases (see {@link FactionRecord#getAliases()}) in a separate
+     * alias-to-canonical map, so that availability tokens still written under a retired code (for example
+     * {@code CEI:5} after Clan Goliath Scorpion absorbed the Escorpion Imperio into its {@code CGS} key) are recognized
+     * at load and resolve to the surviving faction via {@link #getFaction(String)}. The aliases are kept out of the
+     * {@code factions} map itself so that iterations over {@link #getFactionList()} and RAT export do not see the same
+     * record under multiple keys. Runs after the real factions are indexed, so a real faction always wins over an alias
+     * claiming the same code.
      */
     private void registerFactionAliases() {
-        for (FactionRecord factionRecord : new ArrayList<>(factions.values())) {
+        for (FactionRecord factionRecord : factions.values()) {
             for (String aliasCode : factionRecord.getAliases().values()) {
-                FactionRecord existing = factions.get(aliasCode);
-                if (existing == null) {
-                    factions.put(aliasCode, factionRecord);
+                if (factions.containsKey(aliasCode)) {
+                    if (factions.get(aliasCode) != factionRecord) {
+                        LOGGER.warn("[FactionAlias] Alias {} for faction {} collides with an existing faction; " +
+                                    "keeping the existing faction.", aliasCode, factionRecord.getKey());
+                    }
+                    continue;
+                }
+                String previousKey = factionAliases.putIfAbsent(aliasCode, factionRecord.getKey());
+                if (previousKey != null && !previousKey.equals(factionRecord.getKey())) {
+                    LOGGER.warn("[FactionAlias] Alias {} is claimed by both {} and {}; keeping {}.",
+                          aliasCode, previousKey, factionRecord.getKey(), previousKey);
+                } else if (previousKey == null) {
                     LOGGER.debug("[FactionAlias] {} registered as an alias of {}", aliasCode, factionRecord.getKey());
-                } else if (existing != factionRecord) {
-                    LOGGER.warn("[FactionAlias] Alias {} for faction {} collides with faction {}; keeping {}.",
-                          aliasCode, factionRecord.getKey(), existing.getKey(), existing.getKey());
                 }
             }
         }
@@ -1641,13 +1661,13 @@ public class RATGenerator {
                 for (String code : codes) {
 
                     AvailabilityRating ar = new AvailabilityRating(chassisKey, era, code);
-                    FactionRecord chassisFaction = factions.get(ar.getFaction());
+                    FactionRecord chassisFaction = getFaction(ar.getFaction());
                     if (null != chassisFaction || code.startsWith("General")) {
 
                         // If it provides availability values based on equipment ratings,
                         // generate index values in addition to letter values
                         if (ar.hasMultipleRatings()) {
-                            ar.setRatingByNumericLevel(factions.get(ar.getFaction()));
+                            ar.setRatingByNumericLevel(chassisFaction);
                         }
 
                         cr.getIncludedFactions().add(ar.getFaction());
@@ -1717,12 +1737,12 @@ public class RATGenerator {
                 for (String code : codes) {
 
                     AvailabilityRating ar = new AvailabilityRating(modelRecord.getKey(), era, code);
-                    FactionRecord modelFaction = factions.get(ar.getFaction());
+                    FactionRecord modelFaction = getFaction(ar.getFaction());
                     if (null != modelFaction || code.startsWith("General")) {
                         // If it provides availability values based on equipment ratings,
                         // generate index values in addition to letter values
                         if (ar.hasMultipleRatings()) {
-                            ar.setRatingByNumericLevel(factions.get(ar.getFaction()));
+                            ar.setRatingByNumericLevel(modelFaction);
                         }
 
                         modelRecord.getIncludedFactions().add(ar.getFaction());

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2016-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -196,9 +196,11 @@ public class RATGenerator {
 
         AvailabilityRating retVal = null;
         if (chassisIndex.containsKey(era) && chassisIndex.get(era).containsKey(unit)) {
+            Map<String, AvailabilityRating> unitAvailability = chassisIndex.get(era).get(unit);
+            AvailabilityRating lineageAvailability = findLineageAvailability(unitAvailability, factionRecord, year);
 
-            if (chassisIndex.get(era).get(unit).containsKey(factionRecord.getKey())) {
-                retVal = chassisIndex.get(era).get(unit).get(factionRecord.getKey());
+            if (lineageAvailability != null) {
+                retVal = lineageAvailability;
             } else if (factionRecord.getParentFactions().size() == 1) {
                 retVal = findChassisAvailabilityRecord(era, unit, factionRecord.getParentFactions().getFirst(), year);
             } else if (!factionRecord.getParentFactions().isEmpty()) {
@@ -212,7 +214,7 @@ public class RATGenerator {
                 retVal = mergeFactionAvailability(factionRecord.getKey(), list);
 
             } else {
-                retVal = chassisIndex.get(era).get(unit).get("General");
+                retVal = unitAvailability.get("General");
             }
         }
 
@@ -220,6 +222,28 @@ public class RATGenerator {
             return retVal;
         }
 
+        return null;
+    }
+
+    /**
+     * Looks up the availability rating for a faction within a single unit's per-code availability map, trying the
+     * faction's lineage codes - its own key plus any historical rename {@link FactionRecord#getAliases() aliases} - in
+     * era-active-first order. For a faction without aliases this checks only its own key, so behavior is unchanged.
+     *
+     * @param unitAvailability the availability ratings for a single unit in a single era, keyed by faction code
+     * @param factionRecord    the faction whose availability is sought
+     * @param year             the game year, used to pick the era-active alias first
+     *
+     * @return the first matching {@link AvailabilityRating}, or {@code null} if no lineage code is listed
+     */
+    private @Nullable AvailabilityRating findLineageAvailability(Map<String, AvailabilityRating> unitAvailability,
+          FactionRecord factionRecord, int year) {
+        for (String lineageCode : factionRecord.getLineageCodesForYear(year)) {
+            AvailabilityRating availabilityRating = unitAvailability.get(lineageCode);
+            if (availabilityRating != null) {
+                return availabilityRating;
+            }
+        }
         return null;
     }
 
@@ -267,9 +291,12 @@ public class RATGenerator {
         }
 
         if (modelIndex.containsKey(era) && modelIndex.get(era).containsKey(unit)) {
-            // If the provided faction is directly specified, return its availability
-            if (modelIndex.get(era).get(unit).containsKey(factionRecord.getKey())) {
-                return modelIndex.get(era).get(unit).get(factionRecord.getKey());
+            // If the provided faction (or one of its lineage aliases) is directly specified, return its availability.
+            // The era stands in for the year when resolving the era-active alias, since no specific year is supplied.
+            AvailabilityRating lineageAvailability =
+                  findLineageAvailability(modelIndex.get(era).get(unit), factionRecord, era);
+            if (lineageAvailability != null) {
+                return lineageAvailability;
             }
 
             // If the provided faction has a single parent, return its availability
@@ -1448,6 +1475,29 @@ public class RATGenerator {
         // Since the unification of MHQ and RatGen factions, every faction can create a FactionRecord but not every
         // FactionRecord has enough data to produce units, so remove those
         factions.values().removeIf(fr -> fr.getRatingLevelSystem().isEmpty());
+        registerFactionAliases();
+    }
+
+    /**
+     * Registers each faction's historical code aliases (see {@link FactionRecord#getAliases()}) as additional keys
+     * pointing at the surviving {@link FactionRecord}, so that availability tokens still written under a retired code
+     * (for example {@code CEI:5} after Clan Goliath Scorpion absorbed the Escorpion Imperio into its {@code CGS} key)
+     * are recognized at load and resolve to the surviving faction. Runs after the real factions are indexed, so a real
+     * faction always wins over an alias claiming the same code.
+     */
+    private void registerFactionAliases() {
+        for (FactionRecord factionRecord : new ArrayList<>(factions.values())) {
+            for (String aliasCode : factionRecord.getAliases().values()) {
+                FactionRecord existing = factions.get(aliasCode);
+                if (existing == null) {
+                    factions.put(aliasCode, factionRecord);
+                    LOGGER.debug("[FactionAlias] {} registered as an alias of {}", aliasCode, factionRecord.getKey());
+                } else if (existing != factionRecord) {
+                    LOGGER.warn("[FactionAlias] Alias {} for faction {} collides with faction {}; keeping {}.",
+                          aliasCode, factionRecord.getKey(), existing.getKey(), existing.getKey());
+                }
+            }
+        }
     }
 
     /**

--- a/megamek/src/megamek/common/universe/Faction2.java
+++ b/megamek/src/megamek/common/universe/Faction2.java
@@ -70,8 +70,8 @@ import megamek.common.annotations.Nullable;
  * avoid repetition.
  */
 @SuppressWarnings("unused") // Class fields are assigned when factions are loaded from YAML files
-@JsonPropertyOrder({ "key", "name", "sucsCodes", "nameChanges", "capital", "capitalChanges", "yearsActive", "successor",
-                     "tags", "color", "logo", "background", "camos", "camosChanges", "nameGenerator", "eraMods",
+@JsonPropertyOrder({ "key", "name", "sucsCodes", "nameChanges", "aliases", "capital", "capitalChanges", "yearsActive", "successor",
+                     "tags", "color", "logo", "logoChanges", "background", "backgroundChanges", "camos", "camosChanges", "nameGenerator", "eraMods",
                      "ratingLevels", "fallBackFactions", "preInvasionHonorRating", "postInvasionHonorRating",
                      "formationBaseSize", "formationGrouping", "rankSystem", "factionLeaders", "usesMercenaries" })
 public class Faction2 {
@@ -83,6 +83,7 @@ public class Faction2 {
     private String name;
     private final Set<String> sucsCodes = new LinkedHashSet<>();
     private final NavigableMap<Integer, String> nameChanges = new TreeMap<>();
+    private final NavigableMap<Integer, String> aliases = new TreeMap<>();
     private String capital;
     private final NavigableMap<Integer, String> capitalChanges = new TreeMap<>();
     private final ArrayList<FactionRecord.DateRange> yearsActive = new ArrayList<>();
@@ -90,7 +91,9 @@ public class Faction2 {
     private final Set<FactionTag> tags = new HashSet<>();
     private final Color color = Color.LIGHT_GRAY;
     private String logo;
+    private final NavigableMap<Integer, String> logoChanges = new TreeMap<>();
     private String background;
+    private final NavigableMap<Integer, String> backgroundChanges = new TreeMap<>();
 
     @JsonProperty("camos")
     private String camosFolder;
@@ -153,8 +156,45 @@ public class Faction2 {
         return background;
     }
 
+    /**
+     * Returns the faction's background image path for the given year, honoring any era-based
+     * {@link #getBackgroundChanges() background changes}. Falls back to the base {@link #getBackground() background}
+     * when no change applies for the year.
+     *
+     * @param year the game year to resolve the background for
+     *
+     * @return the era-appropriate background image path, or the base background when none applies
+     */
+    public String getBackground(int year) {
+        final Map.Entry<Integer, String> backgroundByYear = backgroundChanges.floorEntry(year);
+        return (backgroundByYear == null) ? background : backgroundByYear.getValue();
+    }
+
+    public NavigableMap<Integer, String> getBackgroundChanges() {
+        return backgroundChanges;
+    }
+
     public String getLogo() {
         return logo;
+    }
+
+    /**
+     * Returns the faction's logo image path for the given year, honoring any era-based
+     * {@link #getLogoChanges() logo changes}. Falls back to the base {@link #getLogo() logo} when no change applies
+     * for the year. Used to keep a consolidated rename lineage (for example Clan Goliath Scorpion becoming the
+     * Escorpion Imperio in 3080) visually era-correct after its faction files are merged into one.
+     *
+     * @param year the game year to resolve the logo for
+     *
+     * @return the era-appropriate logo image path, or the base logo when none applies
+     */
+    public String getLogo(int year) {
+        final Map.Entry<Integer, String> logoByYear = logoChanges.floorEntry(year);
+        return (logoByYear == null) ? logo : logoByYear.getValue();
+    }
+
+    public NavigableMap<Integer, String> getLogoChanges() {
+        return logoChanges;
     }
 
     public int[] getEraMods() {
@@ -262,6 +302,24 @@ public class Faction2 {
 
     public NavigableMap<Integer, String> getNameChanges() {
         return nameChanges;
+    }
+
+    /**
+     * Returns the historical faction-code aliases for this faction, keyed by the year each alias became active.
+     * When a faction is the consolidation of an earlier faction that was renamed (for example Clan Goliath Scorpion
+     * becoming the Escorpion Imperio in 3080), the retired faction code is kept here as an alias of the surviving
+     * key, so that saved games, planetary ownership and RAT availability tables that still reference the old code
+     * continue to resolve to this faction.
+     *
+     * <p>Aliases are for <em>rename lineages</em> only - a single entity renamed over time, with disjoint date
+     * ranges. They must not be used for a merger of two distinct factions (for example Clan Snow Raven and the
+     * Outworlds Alliance both becoming the Raven Alliance); those relationships belong in
+     * {@link #getFallBackFactions()} instead.</p>
+     *
+     * @return The alias codes keyed by the year each became active, in ascending year order. Never {@code null}.
+     */
+    public NavigableMap<Integer, String> getAliases() {
+        return aliases;
     }
 
     public NavigableMap<Integer, String> getCapitalChanges() {

--- a/megamek/src/megamek/common/universe/Factions2.java
+++ b/megamek/src/megamek/common/universe/Factions2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -109,6 +109,9 @@ public final class Factions2 {
 
     private final Map<String, Faction2> factions = new HashMap<>();
 
+    /** Maps a retired/aliased faction code to the surviving canonical faction key. See {@link Faction2#getAliases()}. */
+    private final Map<String, String> aliasToCanonical = new HashMap<>();
+
     private Factions2() {
         loadFactionsFromFile();
     }
@@ -138,6 +141,7 @@ public final class Factions2 {
     public Factions2(String factionsDataPath) {
         ObjectMapper mapper = getLoadMapper();
         loadFactionsFromDirectory(factionsDataPath, mapper);
+        registerAliases();
     }
 
     /**
@@ -154,7 +158,17 @@ public final class Factions2 {
      * @return The faction for the given faction code, if any.
      */
     public Optional<Faction2> getFaction(@Nullable String factionCode) {
-        return Optional.ofNullable(factionCode == null ? null : factions.get(factionCode));
+        if (factionCode == null) {
+            return Optional.empty();
+        }
+        Faction2 faction = factions.get(factionCode);
+        if (faction == null) {
+            String canonicalKey = aliasToCanonical.get(factionCode);
+            if (canonicalKey != null) {
+                faction = factions.get(canonicalKey);
+            }
+        }
+        return Optional.ofNullable(faction);
     }
 
     /**
@@ -171,6 +185,7 @@ public final class Factions2 {
             loadFactionsFromDirectory(new File(userDir, MMConstants.FACTIONS_DIR).toString(), mapper);
             loadFactionsFromDirectory(new File(userDir, MMConstants.COMMANDS_DIR).toString(), mapper);
         }
+        registerAliases();
         LOGGER.info("Loaded a total of {} factions and commands", factions.size());
     }
 
@@ -232,5 +247,33 @@ public final class Factions2 {
     private void loadFaction(InputStream source, ObjectMapper mapper) throws IOException {
         Faction2 faction = mapper.readValue(source, Faction2.class);
         factions.put(faction.getKey(), faction);
+    }
+
+    /**
+     * Registers each faction's historical code aliases (see {@link Faction2#getAliases()}) so that a lookup by a
+     * retired faction code resolves to the surviving faction. Runs once after all faction files are loaded, so that a
+     * real faction file always wins over an alias claiming the same code - this guards against a merger of two
+     * distinct factions being mis-declared as a rename alias.
+     */
+    private void registerAliases() {
+        for (Faction2 faction : factions.values()) {
+            for (String aliasCode : faction.getAliases().values()) {
+                if (factions.containsKey(aliasCode)) {
+                    if (factions.get(aliasCode) != faction) {
+                        LOGGER.warn("[FactionAlias] Alias {} for faction {} collides with an existing faction; " +
+                                    "keeping the existing faction. Remove the {}.yml faction file to complete the merge.",
+                              aliasCode, faction.getKey(), aliasCode);
+                    }
+                    continue;
+                }
+                String previousKey = aliasToCanonical.putIfAbsent(aliasCode, faction.getKey());
+                if (previousKey != null && !previousKey.equals(faction.getKey())) {
+                    LOGGER.warn("[FactionAlias] Alias {} is claimed by both {} and {}; keeping {}.",
+                          aliasCode, previousKey, faction.getKey(), previousKey);
+                } else if (previousKey == null) {
+                    LOGGER.debug("[FactionAlias] Registered alias {} -> {}", aliasCode, faction.getKey());
+                }
+            }
+        }
     }
 }

--- a/megamek/testresources/data/universe/factions/MERGED_test.yml
+++ b/megamek/testresources/data/universe/factions/MERGED_test.yml
@@ -1,0 +1,39 @@
+# MegaMek Data (C) 2025-2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+key: MRG
+name: Merged Test Faction
+# OLDCODE has no faction file of its own, so it resolves to MRG via the alias.
+# LA is a real faction, so it must win over this colliding alias.
+aliases:
+  3080: OLDCODE
+  3141: LA
+yearsActive:
+  - start: 2807
+tags:
+  - CLAN
+logo: base_logo.png
+logoChanges:
+  3080: era_logo.png
+background: base_background.png
+backgroundChanges:
+  3080: era_background.png
+ratingLevels:
+  - F
+  - D
+  - C
+  - B
+  - A

--- a/megamek/unittests/megamek/client/ratgenerator/FactionRecordTest.java
+++ b/megamek/unittests/megamek/client/ratgenerator/FactionRecordTest.java
@@ -148,8 +148,8 @@ class FactionRecordTest {
     @Test
     void lineageCodesPreferEraActiveAliasFirst() {
         FactionRecord factionRecord = new FactionRecord("CGS");
-        factionRecord.getAliases().put(3080, "CEI");
-        factionRecord.getAliases().put(3141, "SE");
+        factionRecord.addAlias(3080, "CEI");
+        factionRecord.addAlias(3141, "SE");
 
         // Before the first alias year, the faction's own key is era-active.
         assertEquals(List.of("CGS", "CEI", "SE"), factionRecord.getLineageCodesForYear(3050));

--- a/megamek/unittests/megamek/client/ratgenerator/FactionRecordTest.java
+++ b/megamek/unittests/megamek/client/ratgenerator/FactionRecordTest.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.util.HashMap;
+import java.util.List;
 import javax.xml.parsers.DocumentBuilder;
 
 import megamek.utilities.xml.MMXMLUtility;
@@ -136,5 +137,27 @@ class FactionRecordTest {
         // Assert SL/IS ASF value
         pct = fr.findPctTech(FactionRecord.TechCategory.IS_ADVANCED_AERO, 3151, 0);
         assertEquals(20, pct);
+    }
+
+    @Test
+    void lineageCodesWithoutAliasesReturnsOnlyKey() {
+        FactionRecord factionRecord = new FactionRecord("CGS");
+        assertEquals(List.of("CGS"), factionRecord.getLineageCodesForYear(3100));
+    }
+
+    @Test
+    void lineageCodesPreferEraActiveAliasFirst() {
+        FactionRecord factionRecord = new FactionRecord("CGS");
+        factionRecord.getAliases().put(3080, "CEI");
+        factionRecord.getAliases().put(3141, "SE");
+
+        // Before the first alias year, the faction's own key is era-active.
+        assertEquals(List.of("CGS", "CEI", "SE"), factionRecord.getLineageCodesForYear(3050));
+        // In the Escorpion Imperio era, CEI is preferred, then the key, then the remaining alias.
+        assertEquals(List.of("CEI", "CGS", "SE"), factionRecord.getLineageCodesForYear(3100));
+        // Exactly on a boundary year, the alias that begins that year is era-active.
+        assertEquals(List.of("CEI", "CGS", "SE"), factionRecord.getLineageCodesForYear(3080));
+        // In the Scorpion Empire era, SE is preferred.
+        assertEquals(List.of("SE", "CGS", "CEI"), factionRecord.getLineageCodesForYear(3200));
     }
 }

--- a/megamek/unittests/megamek/common/universe/Faction2Test.java
+++ b/megamek/unittests/megamek/common/universe/Faction2Test.java
@@ -32,8 +32,10 @@
  */
 package megamek.common.universe;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -103,5 +105,45 @@ class Faction2Test {
         Factions2 testFactions = getTestFactions2();
         Faction2 mercFaction = testFactions.getFaction("MERC").orElseThrow();
         assertTrue(mercFaction.getSucsCodes().isEmpty());
+    }
+
+    @Test
+    void aliasesParsedFromYaml() {
+        Factions2 testFactions = getTestFactions2();
+        Faction2 mergedFaction = testFactions.getFaction("MRG").orElseThrow();
+        assertEquals("OLDCODE", mergedFaction.getAliases().get(3080));
+        assertEquals("LA", mergedFaction.getAliases().get(3141));
+    }
+
+    @Test
+    void aliasResolvesToCanonicalFaction() {
+        Factions2 testFactions = getTestFactions2();
+        Faction2 mergedFaction = testFactions.getFaction("MRG").orElseThrow();
+        // A retired code with no faction file of its own resolves to the surviving faction via the alias.
+        assertSame(mergedFaction, testFactions.getFaction("OLDCODE").orElseThrow());
+    }
+
+    @Test
+    void realFactionWinsOverCollidingAlias() {
+        Factions2 testFactions = getTestFactions2();
+        // MRG declares LA as an alias, but LA is a real faction and must win the lookup.
+        Faction2 laFaction = testFactions.getFaction("LA").orElseThrow();
+        assertEquals("Lyran Commonwealth", laFaction.getName());
+    }
+
+    @Test
+    void logoAndBackgroundResolveByYear() {
+        Factions2 testFactions = getTestFactions2();
+        Faction2 mergedFaction = testFactions.getFaction("MRG").orElseThrow();
+        // No-arg getters return the base value.
+        assertEquals("base_logo.png", mergedFaction.getLogo());
+        assertEquals("base_background.png", mergedFaction.getBackground());
+        // Before the change year, the year-aware getters fall back to the base value.
+        assertEquals("base_logo.png", mergedFaction.getLogo(3050));
+        assertEquals("base_background.png", mergedFaction.getBackground(3050));
+        // From the change year onward, the era value applies.
+        assertEquals("era_logo.png", mergedFaction.getLogo(3080));
+        assertEquals("era_logo.png", mergedFaction.getLogo(3200));
+        assertEquals("era_background.png", mergedFaction.getBackground(3200));
     }
 }


### PR DESCRIPTION
- Faction2: add date-scoped `aliases` (retired faction codes -> surviving key) and `logoChanges`/`backgroundChanges`, with getLogo(int)/getBackground(int).

- Factions2: resolve aliases in getFaction() via a separate alias->canonical map, registered after all files load so a real faction always wins over a colliding alias.

- FactionRecord: carry aliases; add getLineageCodesForYear() (era-active-first order).

- RATGenerator: register alias codes and resolve unit availability across a faction's lineage codes, so RAT availability tokens under retired codes keep resolving.

- Tests: Faction2Test (alias resolution, collision guard, logo/background by year); FactionRecordTest (lineage-code ordering).

Additive and inert until a faction YAML declares `aliases`/`logoChanges`.