### PR TITLE
implemented F_ANTI_MEK_GEAR

### DIFF
--- a/megamek/src/megamek/common/equipment/MiscType.java
+++ b/megamek/src/megamek/common/equipment/MiscType.java
@@ -277,6 +277,7 @@ public class MiscType extends EquipmentType {
 
     // Flag for Infantry Equipment
     public static final MiscTypeFlag F_INF_EQUIPMENT = MiscTypeFlag.F_INF_EQUIPMENT;
+    public static final MiscTypeFlag F_ANTI_MEK_GEAR = MiscTypeFlag.F_ANTI_MEK_GEAR;
     public static final MiscTypeFlag F_SCM = MiscTypeFlag.F_SCM;
     public static final MiscTypeFlag F_VIRAL_JAMMER_HOMING = MiscTypeFlag.F_VIRAL_JAMMER_HOMING;
     public static final MiscTypeFlag F_VIRAL_JAMMER_DECOY = MiscTypeFlag.F_VIRAL_JAMMER_DECOY;

--- a/megamek/src/megamek/common/equipment/MiscType.java
+++ b/megamek/src/megamek/common/equipment/MiscType.java
@@ -2403,7 +2403,7 @@ public class MiscType extends EquipmentType {
         // This is not really a single piece of equipment, it is used to
         // identify "standard" internal structure, armor, whatever.
 
-        StructureType misc = new StructureType();
+        StructureType misc = new StructureType(T_STRUCTURE_STANDARD);
 
         misc.name = EquipmentType.getStructureTypeName(T_STRUCTURE_STANDARD);
         misc.setInternalName(EquipmentType.getStructureTypeName(T_STRUCTURE_STANDARD));
@@ -9057,7 +9057,7 @@ public class MiscType extends EquipmentType {
     // Standard - See note above the Armor Standard (search for createStandard)
 
     public static StructureType createISEndoSteel() {
-        StructureType misc = new StructureType();
+        StructureType misc = new StructureType(T_STRUCTURE_ENDO_STEEL);
 
         misc.name = EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_STEEL);
         misc.setInternalName(EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_STEEL, false));
@@ -9088,7 +9088,7 @@ public class MiscType extends EquipmentType {
     }
 
     public static StructureType createISEndoSteelPrototype() {
-        StructureType misc = new StructureType();
+        StructureType misc = new StructureType(T_STRUCTURE_ENDO_PROTOTYPE);
 
         misc.name = EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_PROTOTYPE);
         misc.setInternalName(EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_PROTOTYPE, false));
@@ -9117,7 +9117,7 @@ public class MiscType extends EquipmentType {
     }
 
     public static StructureType createCLEndoSteel() {
-        StructureType misc = new StructureType();
+        StructureType misc = new StructureType(T_STRUCTURE_ENDO_STEEL);
         misc.name = EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_STEEL);
         misc.setInternalName(EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_STEEL, true));
         misc.addLookupName("Clan Endo-Steel");
@@ -9146,7 +9146,7 @@ public class MiscType extends EquipmentType {
     }
 
     public static StructureType createISCompositeStructure() {
-        StructureType misc = new StructureType();
+        StructureType misc = new StructureType(T_STRUCTURE_COMPOSITE);
 
         misc.name = EquipmentType.getStructureTypeName(T_STRUCTURE_COMPOSITE);
         misc.setInternalName(EquipmentType.getStructureTypeName(T_STRUCTURE_COMPOSITE, false));
@@ -9171,7 +9171,7 @@ public class MiscType extends EquipmentType {
     }
 
     public static StructureType createISEndoComposite() {
-        StructureType misc = new StructureType();
+        StructureType misc = new StructureType(T_STRUCTURE_ENDO_COMPOSITE);
 
         misc.name = EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_COMPOSITE);
         misc.setInternalName(EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_COMPOSITE, false));
@@ -9198,7 +9198,7 @@ public class MiscType extends EquipmentType {
     }
 
     public static StructureType createClanEndoComposite() {
-        StructureType misc = new StructureType();
+        StructureType misc = new StructureType(T_STRUCTURE_ENDO_COMPOSITE);
 
         misc.name = EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_COMPOSITE);
         misc.setInternalName(EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_COMPOSITE, true));
@@ -9224,7 +9224,7 @@ public class MiscType extends EquipmentType {
     }
 
     public static StructureType createReinforcedStructure() {
-        StructureType misc = new StructureType();
+        StructureType misc = new StructureType(T_STRUCTURE_REINFORCED);
 
         misc.name = EquipmentType.getStructureTypeName(T_STRUCTURE_REINFORCED);
         misc.setInternalName(EquipmentType.getStructureTypeName(T_STRUCTURE_REINFORCED));
@@ -9254,7 +9254,7 @@ public class MiscType extends EquipmentType {
     }
 
     public static StructureType createIndustrialStructure() {
-        StructureType misc = new StructureType();
+        StructureType misc = new StructureType(T_STRUCTURE_INDUSTRIAL);
 
         misc.name = EquipmentType.getStructureTypeName(T_STRUCTURE_INDUSTRIAL);
         misc.setInternalName(EquipmentType.getStructureTypeName(T_STRUCTURE_INDUSTRIAL));

--- a/megamek/src/megamek/common/equipment/MiscType.java
+++ b/megamek/src/megamek/common/equipment/MiscType.java
@@ -2399,11 +2399,11 @@ public class MiscType extends EquipmentType {
     // TODO - At some point the "Standard" below needs to be broken out as they
     // all have Separate Tech Advancement information.
 
-    public static MiscType createStandard() {
+    public static StructureType createStandard() {
         // This is not really a single piece of equipment, it is used to
         // identify "standard" internal structure, armor, whatever.
 
-        MiscType misc = new MiscType();
+        StructureType misc = new StructureType();
 
         misc.name = EquipmentType.getStructureTypeName(T_STRUCTURE_STANDARD);
         misc.setInternalName(EquipmentType.getStructureTypeName(T_STRUCTURE_STANDARD));
@@ -9056,8 +9056,8 @@ public class MiscType extends EquipmentType {
     // Structural Components (Mek)
     // Standard - See note above the Armor Standard (search for createStandard)
 
-    public static MiscType createISEndoSteel() {
-        MiscType misc = new MiscType();
+    public static StructureType createISEndoSteel() {
+        StructureType misc = new StructureType();
 
         misc.name = EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_STEEL);
         misc.setInternalName(EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_STEEL, false));
@@ -9087,8 +9087,8 @@ public class MiscType extends EquipmentType {
         return misc;
     }
 
-    public static MiscType createISEndoSteelPrototype() {
-        MiscType misc = new MiscType();
+    public static StructureType createISEndoSteelPrototype() {
+        StructureType misc = new StructureType();
 
         misc.name = EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_PROTOTYPE);
         misc.setInternalName(EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_PROTOTYPE, false));
@@ -9116,8 +9116,8 @@ public class MiscType extends EquipmentType {
         return misc;
     }
 
-    public static MiscType createCLEndoSteel() {
-        MiscType misc = new MiscType();
+    public static StructureType createCLEndoSteel() {
+        StructureType misc = new StructureType();
         misc.name = EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_STEEL);
         misc.setInternalName(EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_STEEL, true));
         misc.addLookupName("Clan Endo-Steel");
@@ -9145,8 +9145,8 @@ public class MiscType extends EquipmentType {
         return misc;
     }
 
-    public static MiscType createISCompositeStructure() {
-        MiscType misc = new MiscType();
+    public static StructureType createISCompositeStructure() {
+        StructureType misc = new StructureType();
 
         misc.name = EquipmentType.getStructureTypeName(T_STRUCTURE_COMPOSITE);
         misc.setInternalName(EquipmentType.getStructureTypeName(T_STRUCTURE_COMPOSITE, false));
@@ -9170,8 +9170,8 @@ public class MiscType extends EquipmentType {
         return misc;
     }
 
-    public static MiscType createISEndoComposite() {
-        MiscType misc = new MiscType();
+    public static StructureType createISEndoComposite() {
+        StructureType misc = new StructureType();
 
         misc.name = EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_COMPOSITE);
         misc.setInternalName(EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_COMPOSITE, false));
@@ -9197,8 +9197,8 @@ public class MiscType extends EquipmentType {
         return misc;
     }
 
-    public static MiscType createClanEndoComposite() {
-        MiscType misc = new MiscType();
+    public static StructureType createClanEndoComposite() {
+        StructureType misc = new StructureType();
 
         misc.name = EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_COMPOSITE);
         misc.setInternalName(EquipmentType.getStructureTypeName(T_STRUCTURE_ENDO_COMPOSITE, true));
@@ -9223,8 +9223,8 @@ public class MiscType extends EquipmentType {
         return misc;
     }
 
-    public static MiscType createReinforcedStructure() {
-        MiscType misc = new MiscType();
+    public static StructureType createReinforcedStructure() {
+        StructureType misc = new StructureType();
 
         misc.name = EquipmentType.getStructureTypeName(T_STRUCTURE_REINFORCED);
         misc.setInternalName(EquipmentType.getStructureTypeName(T_STRUCTURE_REINFORCED));
@@ -9253,8 +9253,8 @@ public class MiscType extends EquipmentType {
         return misc;
     }
 
-    public static MiscType createIndustrialStructure() {
-        MiscType misc = new MiscType();
+    public static StructureType createIndustrialStructure() {
+        StructureType misc = new StructureType();
 
         misc.name = EquipmentType.getStructureTypeName(T_STRUCTURE_INDUSTRIAL);
         misc.setInternalName(EquipmentType.getStructureTypeName(T_STRUCTURE_INDUSTRIAL));

--- a/megamek/src/megamek/common/equipment/StructureType.java
+++ b/megamek/src/megamek/common/equipment/StructureType.java
@@ -1,0 +1,12 @@
+package megamek.common.equipment;
+
+/**
+ * Equipment definition for an internal structure system.
+ */
+public class StructureType extends MiscType {
+
+    @Override
+    protected String getYamlTypeName() {
+        return "structure";
+    }
+}

--- a/megamek/src/megamek/common/equipment/StructureType.java
+++ b/megamek/src/megamek/common/equipment/StructureType.java
@@ -1,3 +1,36 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
 package megamek.common.equipment;
 
 /**

--- a/megamek/src/megamek/common/equipment/StructureType.java
+++ b/megamek/src/megamek/common/equipment/StructureType.java
@@ -33,13 +33,31 @@
 
 package megamek.common.equipment;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /**
  * Equipment definition for an internal structure system.
  */
 public class StructureType extends MiscType {
 
+    private final int structureTypeId;
+
+    public StructureType(int structureTypeId) {
+        this.structureTypeId = structureTypeId;
+    }
+
     @Override
     protected String getYamlTypeName() {
         return "structure";
+    }
+
+    @Override
+    public Map<String, Object> getYamlData() {
+        Map<String, Object> data = super.getYamlData();
+        Map<String, Object> structureDetails = new LinkedHashMap<>();
+        structureDetails.put("typeId", structureTypeId);
+        data.put("structure", structureDetails);
+        return data;
     }
 }

--- a/megamek/src/megamek/common/equipment/enums/MiscTypeFlag.java
+++ b/megamek/src/megamek/common/equipment/enums/MiscTypeFlag.java
@@ -273,6 +273,7 @@ public enum MiscTypeFlag implements EquipmentFlag {
 
     F_BA_MEA, // Flag for BattleArmor Modular Equipment Adaptor
     F_INF_EQUIPMENT, // Flag for Infantry Equipment
+    F_ANTI_MEK_GEAR,
 
     F_SCM,
 

--- a/megamek/src/megamek/common/miscGear/AntiMekGear.java
+++ b/megamek/src/megamek/common/miscGear/AntiMekGear.java
@@ -47,7 +47,7 @@ public class AntiMekGear extends MiscType {
         name = "Anti-Mek Gear";
         setInternalName(EquipmentTypeLookup.ANTI_MEK_GEAR);
         tonnage = 0.015;
-        flags = flags.or(F_INF_EQUIPMENT);
+        flags = flags.or(F_INF_EQUIPMENT).or(F_ANTI_MEK_GEAR);
         cost = COST_VARIABLE;
         rulesRefs = "155, TM";
         techAdvancement.setTechBase(TechBase.ALL).setAdvancement(2456, 2460, 2500)

--- a/megamek/src/megamek/common/units/ConvInfantry.java
+++ b/megamek/src/megamek/common/units/ConvInfantry.java
@@ -266,7 +266,7 @@ public class ConvInfantry extends Infantry {
      * @return True when this infantry carries anti-mek gear
      */
     public boolean hasAntiMekGear() {
-        return hasWorkingMisc(EquipmentTypeLookup.ANTI_MEK_GEAR);
+        return hasWorkingMisc(MiscType.F_ANTI_MEK_GEAR);
     }
 
     @Override

--- a/megamek/src/megamek/common/verifier/TestInfantry.java
+++ b/megamek/src/megamek/common/verifier/TestInfantry.java
@@ -231,7 +231,7 @@ public class TestInfantry extends TestEntity {
             correct = false;
         }
 
-        if (inf.isMechanized() && inf.countEquipment(EquipmentTypeLookup.ANTI_MEK_GEAR) > 0) {
+        if (inf.isMechanized() && inf.hasMisc(MiscType.F_ANTI_MEK_GEAR)) {
             buff.append("Mechanized infantry may not have anti-mek gear!\n");
             correct = false;
         }

--- a/megamek/src/megamek/common/verifier/TestInfantry.java
+++ b/megamek/src/megamek/common/verifier/TestInfantry.java
@@ -41,7 +41,6 @@ import megamek.client.ui.clientGUI.calculationReport.DummyCalculationReport;
 import megamek.client.ui.clientGUI.calculationReport.TextCalculationReport;
 import megamek.common.annotations.Nullable;
 import megamek.common.equipment.EquipmentType;
-import megamek.common.equipment.EquipmentTypeLookup;
 import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
 import megamek.common.exceptions.LocationFullException;


### PR DESCRIPTION
This PR moves the check for antimek gear from the brittle string id to a F_ANTI_MEK_GEAR flag and matches all other equipment checks.
This is also used in MekBay.