### PR TITLE
Fix Sandblaster SPA missing for Silver Bullet Gauss

### DIFF
--- a/megamek/src/megamek/common/units/PilotSPAHelper.java
+++ b/megamek/src/megamek/common/units/PilotSPAHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2023-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -124,13 +124,19 @@ public final class PilotSPAHelper {
      * @return True when the given EquipmentType is a valid choice for the Sandblaster SPA.
      */
     public static boolean isSandblasterValid(EquipmentType equipmentType, @Nullable GameOptions options) {
+        if (!(equipmentType instanceof WeaponType weaponType)) {
+            return false;
+        }
+
         boolean rapidFireAC = (options != null)
               && options.booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_RAPID_AC)
-              && (equipmentType instanceof ACWeapon);
+              && (weaponType instanceof ACWeapon);
 
-        return (equipmentType instanceof WeaponType)
-              && ((equipmentType instanceof UACWeapon) || (equipmentType instanceof LBXACWeapon) || rapidFireAC
-              || ((WeaponType) equipmentType).getDamage() == WeaponType.DAMAGE_BY_CLUSTER_TABLE);
+        return (weaponType instanceof UACWeapon)
+              || (weaponType instanceof LBXACWeapon)
+              || rapidFireAC
+              || (weaponType.getDamage() == WeaponType.DAMAGE_BY_CLUSTER_TABLE)
+              || (weaponType.getAtClass() == WeaponType.CLASS_LBX_AC);
     }
 
     /**

--- a/megamek/unittests/megamek/common/units/PilotSPAHelperTest.java
+++ b/megamek/unittests/megamek/common/units/PilotSPAHelperTest.java
@@ -208,4 +208,36 @@ class PilotSPAHelperTest {
 
         assertTrue(PilotSPAHelper.isWindWalkerValid(spaceStation), "Wind Walker should be valid for Space Stations");
     }
+
+    @Test
+    void testSandblasterValidForSilverBulletGauss() {
+        EquipmentType silverBulletGauss = EquipmentType.get("ISSBGR");
+
+        assertTrue(PilotSPAHelper.isSandblasterValid(silverBulletGauss, null),
+              "Sandblaster should be valid for the Silver Bullet Gauss Rifle (fires on the cluster hit table)");
+    }
+
+    @Test
+    void testSandblasterValidForLBXAutocannon() {
+        EquipmentType lb10x = EquipmentType.get("ISLBXAC10");
+
+        assertTrue(PilotSPAHelper.isSandblasterValid(lb10x, null),
+              "Sandblaster should be valid for LB-X autocannons");
+    }
+
+    @Test
+    void testSandblasterInvalidForStandardGauss() {
+        EquipmentType standardGauss = EquipmentType.get("ISGaussRifle");
+
+        assertFalse(PilotSPAHelper.isSandblasterValid(standardGauss, null),
+              "Sandblaster should NOT be valid for the standard Gauss Rifle (single-slug, direct fire)");
+    }
+
+    @Test
+    void testSandblasterInvalidForMediumLaser() {
+        EquipmentType mediumLaser = EquipmentType.get("ISMediumLaser");
+
+        assertFalse(PilotSPAHelper.isSandblasterValid(mediumLaser, null),
+              "Sandblaster should NOT be valid for the Medium Laser");
+    }
 }

--- a/megamek/unittests/megamek/common/units/PilotSPAHelperTest.java
+++ b/megamek/unittests/megamek/common/units/PilotSPAHelperTest.java
@@ -34,6 +34,7 @@
 package megamek.common.units;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import megamek.common.equipment.EquipmentType;
@@ -212,6 +213,8 @@ class PilotSPAHelperTest {
     @Test
     void testSandblasterValidForSilverBulletGauss() {
         EquipmentType silverBulletGauss = EquipmentType.get("ISSBGR");
+        assertNotNull(silverBulletGauss,
+              "Test setup: Silver Bullet Gauss Rifle (ISSBGR) missing from the equipment registry");
 
         assertTrue(PilotSPAHelper.isSandblasterValid(silverBulletGauss, null),
               "Sandblaster should be valid for the Silver Bullet Gauss Rifle (fires on the cluster hit table)");
@@ -220,6 +223,7 @@ class PilotSPAHelperTest {
     @Test
     void testSandblasterValidForLBXAutocannon() {
         EquipmentType lb10x = EquipmentType.get("ISLBXAC10");
+        assertNotNull(lb10x, "Test setup: LB 10-X AC (ISLBXAC10) missing from the equipment registry");
 
         assertTrue(PilotSPAHelper.isSandblasterValid(lb10x, null),
               "Sandblaster should be valid for LB-X autocannons");
@@ -228,6 +232,8 @@ class PilotSPAHelperTest {
     @Test
     void testSandblasterInvalidForStandardGauss() {
         EquipmentType standardGauss = EquipmentType.get("ISGaussRifle");
+        assertNotNull(standardGauss,
+              "Test setup: standard Gauss Rifle (ISGaussRifle) missing from the equipment registry");
 
         assertFalse(PilotSPAHelper.isSandblasterValid(standardGauss, null),
               "Sandblaster should NOT be valid for the standard Gauss Rifle (single-slug, direct fire)");
@@ -236,6 +242,7 @@ class PilotSPAHelperTest {
     @Test
     void testSandblasterInvalidForMediumLaser() {
         EquipmentType mediumLaser = EquipmentType.get("ISMediumLaser");
+        assertNotNull(mediumLaser, "Test setup: Medium Laser (ISMediumLaser) missing from the equipment registry");
 
         assertFalse(PilotSPAHelper.isSandblasterValid(mediumLaser, null),
               "Sandblaster should NOT be valid for the Medium Laser");


### PR DESCRIPTION
Fixes #8483

The Silver Bullet Gauss Rifle fires on the cluster hit table but did not appear in the Sandblaster SPA dropdown.

Root cause: isSandblasterValid() only matched cluster weapons by instanceof UAC/LBX-AC, rapid-fire AC, or the DAMAGE_BY_CLUSTER_TABLE damage sentinel. The SB Gauss extends GaussWeapon and declares a concrete damage of 15 (for its aero AV math), so it matched none of those checks, even though it sets atClass = CLASS_LBX_AC and always uses LBXHandler.

Fix: also accept a weapon whose atClass is CLASS_LBX_AC, the flag that marks a weapon as firing LBX-style cluster shot. LBX-ACs already match via instanceof, so this newly covers the SB Gauss (and any future variant) without changing existing behavior.