### PR TITLE
Fix: Refactor linked to Autodetach linkedBy on setLinked(null)

### DIFF
--- a/megamek/src/megamek/common/equipment/Mounted.java
+++ b/megamek/src/megamek/common/equipment/Mounted.java
@@ -1116,15 +1116,15 @@ public class Mounted<T extends EquipmentType> implements Serializable, RoundUpda
         return locations;
     }
 
-    public Mounted<?> getLinked() {
+    public @Nullable Mounted<?> getLinked() {
         return linked;
     }
 
-    public Mounted<?> getLinkedBy() {
+    public @Nullable Mounted<?> getLinkedBy() {
         return linkedBy;
     }
 
-    public Mounted<?> getCrossLinkedBy() {
+    public @Nullable Mounted<?> getCrossLinkedBy() {
         return crossLinkedBy;
     }
 
@@ -1138,9 +1138,25 @@ public class Mounted<T extends EquipmentType> implements Serializable, RoundUpda
      * @see #setLinkedBy(Mounted)
      */
     public void setLinked(@Nullable Mounted<?> linked) {
+        if (linked == null && this.linked != null) {
+            this.linked.setLinkedBy(null);
+        }
+
         this.linked = linked;
+
         if (linked != null) {
             linked.setLinkedBy(this);
+        }
+    }
+
+    /**
+     * Sets the linkedBy equipment. Meaningless in case of a many-to-one relationship (ammo, etc.).
+     *
+     * @param linkedBy The inverse of linked
+     */
+    private void setLinkedBy(@Nullable Mounted<?> linkedBy) {
+        if (linkedBy == null || linkedBy.getLinked() == this) {
+            this.linkedBy = linkedBy;
         }
     }
 
@@ -1149,23 +1165,11 @@ public class Mounted<T extends EquipmentType> implements Serializable, RoundUpda
         linked.setCrossLinkedBy(this);
     }
 
-    // should only be called by setLinked(), or when dumping a DWP
-    // in the case of a many-to-one relationship (like ammo) this is meaningless
-    public void setLinkedBy(Mounted<?> linker) {
-        if ((linker != null) && (linker.getLinked() != this)) {
-            // liar
-            return;
-        }
-        linkedBy = linker;
-    }
-
     // called by setCrossLinked() when using cross-linked capacitors.
-    public void setCrossLinkedBy(Mounted<?> linker) {
-        if ((linker != null) && (linker.getLinked() != this)) {
-            // liar
-            return;
+    private void setCrossLinkedBy(Mounted<?> crossLinkedBy) {
+        if (crossLinkedBy == null || crossLinkedBy.getLinked() == this) {
+            this.crossLinkedBy = crossLinkedBy;
         }
-        crossLinkedBy = linker;
     }
 
     public int getFoundCrits() {

--- a/megamek/src/megamek/common/loaders/MekFileParser.java
+++ b/megamek/src/megamek/common/loaders/MekFileParser.java
@@ -834,7 +834,11 @@ public class MekFileParser {
               .stream()
               .filter(mounted -> mounted.is(EquipmentTypeLookup.CARGO))
               .collect(Collectors.toList());
-        cargos.forEach(cargo -> cargo.getLinkedBy().setLinked(null));
+        for (Mounted<?> cargo : cargos) {
+            if (cargo.getLinkedBy() != null) {
+                cargo.getLinkedBy().setLinked(null);
+            }
+        }
 
         for (Mounted<?> dumper : dumpers) {
             dumper.setLinked(null);

--- a/megamek/src/megamek/common/loaders/MekFileParser.java
+++ b/megamek/src/megamek/common/loaders/MekFileParser.java
@@ -834,14 +834,13 @@ public class MekFileParser {
               .stream()
               .filter(mounted -> mounted.is(EquipmentTypeLookup.CARGO))
               .collect(Collectors.toList());
-        cargos.forEach(cargo -> cargo.setLinkedBy(null));
+        cargos.forEach(cargo -> cargo.getLinkedBy().setLinked(null));
 
         for (Mounted<?> dumper : dumpers) {
             dumper.setLinked(null);
             for (Mounted<?> cargo : cargos) {
                 if ((cargo.getLinkedBy() == null) && (cargo.getLocation() == dumper.getLocation())) {
                     dumper.setLinked(cargo);
-                    cargo.setLinkedBy(dumper);
                     break;
                 }
             }

--- a/megamek/src/megamek/common/units/BaConstructionUtil.java
+++ b/megamek/src/megamek/common/units/BaConstructionUtil.java
@@ -111,7 +111,6 @@ public class BaConstructionUtil {
         }
         if (mount.getLinked() != null) {
             Mounted<?> attachedEquipment = mount.getLinked();
-            attachedEquipment.setLinkedBy(null);
             attachedEquipment.setDWPMounted(false);
             attachedEquipment.setAPMMounted(false);
             mount.setLinked(null);
@@ -137,7 +136,6 @@ public class BaConstructionUtil {
         }
         emptyDwpApm(apm);
         apm.setLinked(weapon);
-        weapon.setLinkedBy(apm);
         weapon.setAPMMounted(true);
         // A Disposable Weapon (TO:AuE p.116, Corrected Sixth Printing) mounted in an AP mount / armored glove is
         // marked so it resolves with the disposable rules. Marking is a construction property; in-game behavior is

--- a/megamek/src/megamek/common/units/ConstructionUtil.java
+++ b/megamek/src/megamek/common/units/ConstructionUtil.java
@@ -168,7 +168,7 @@ public class ConstructionUtil {
         // would be removing a linked Artemis IV FCS
         for (Mounted<?> m : unit.getEquipment()) {
             if (mount.equals(m.getLinkedBy())) {
-                m.setLinkedBy(null);
+                m.getLinkedBy().setLinked(null);
             }
         }
 
@@ -250,12 +250,10 @@ public class ConstructionUtil {
           boolean rear) {
         if ((location != eq.getLocation() && !eq.isOneShot())) {
             if (eq.getLinked() != null) {
-                eq.getLinked().setLinkedBy(null);
                 eq.setLinked(null);
             }
             if (eq.getLinkedBy() != null) {
                 eq.getLinkedBy().setLinked(null);
-                eq.setLinkedBy(null);
             }
         }
         eq.setLocation(location, rear);

--- a/megamek/src/megamek/common/units/Entity.java
+++ b/megamek/src/megamek/common/units/Entity.java
@@ -5063,7 +5063,9 @@ public abstract class Entity extends TurnOrdered
             // Make sure this ammo is in the chain, then move it to the head.
             for (Mounted<?> current = mounted; current != null; current = current.getLinked()) {
                 if (current == mountedAmmo) {
-                    current.getLinkedBy().setLinked(current.getLinked());
+                    if (current.getLinkedBy() != null) {
+                        current.getLinkedBy().setLinked(current.getLinked());
+                    }
                     current.setLinked(mounted.getLinked());
                     mounted.setLinked(current);
                     return true;


### PR DESCRIPTION
Refactor linked and linkedBy so that setLinked(null) autodetaches linkedBy to match setLinked doc

Note for Reviewer: MERGE AFTER https://github.com/MegaMek/megameklab/pull/2253

MERGE IMMEDIATELY BEFORE MML side PR: https://github.com/MegaMek/megameklab/pull/2263

MML code removes privatized MM methods