### PR TITLE
Fix #8375: Fixed Black Out Checks Allowing Multiple Edge Re-Rolls

### DIFF
--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -18813,7 +18813,8 @@ public class TWGameManager extends AbstractGameManager {
      * @param crewPos The <code>int</code> index of the crew member for multi crew cockpits, ignored by basic
      *                <code>crew</code>
      */
-    private Vector<Report> resolveCrewDamage(Entity e, int damage, int crewPos) {
+    // package-private for testing
+    Vector<Report> resolveCrewDamage(Entity e, int damage, int crewPos) {
         Vector<Report> vDesc = new Vector<>();
         final int totalHits = e.getCrew().getHits(crewPos);
         if ((e instanceof MekWarrior) || !e.isTargetable() || !e.getCrew().isActive(crewPos) || (damage == 0)) {
@@ -18835,10 +18836,15 @@ public class TWGameManager extends AbstractGameManager {
             if (game.getOptions().booleanOption(OptionsConstants.RPG_TOUGHNESS)) {
                 rollTarget -= e.getCrew().getToughness(crewPos);
             }
-            boolean edgeUsed = false;
+            // Edge may reroll a failed consciousness roll, but only once: a single roll cannot be rerolled
+            // repeatedly even if the crew has several Edge points remaining.
+            boolean rerollWithEdge = false;
+            boolean edgeAlreadyUsed = false;
             do {
-                if (edgeUsed) {
+                if (rerollWithEdge) {
                     e.getCrew().decreaseEdge();
+                    edgeAlreadyUsed = true;
+                    rerollWithEdge = false;
                 }
                 Roll diceRoll = Compute.rollD6(2);
                 int rollValue = diceRoll.getIntValue();
@@ -18864,9 +18870,11 @@ public class TWGameManager extends AbstractGameManager {
                 } else {
                     e.getCrew().setKoThisRound(true, crewPos);
                     r.choose(false);
-                    if (e.shouldUseEdge(OptionsConstants.EDGE_WHEN_KO) ||
-                          e.shouldUseEdge(OptionsConstants.EDGE_WHEN_AERO_KO)) {
-                        edgeUsed = true;
+                    // Only offer an Edge reroll if one hasn't already been spent on this consciousness roll.
+                    if (!edgeAlreadyUsed &&
+                          (e.shouldUseEdge(OptionsConstants.EDGE_WHEN_KO) ||
+                                e.shouldUseEdge(OptionsConstants.EDGE_WHEN_AERO_KO))) {
+                        rerollWithEdge = true;
                         vDesc.add(r);
                         r = new Report(6520);
                         r.subject = e.getId();
@@ -18877,9 +18885,7 @@ public class TWGameManager extends AbstractGameManager {
                     // return true;
                 } // else
                 vDesc.add(r);
-            } while (e.getCrew().isKoThisRound(crewPos) &&
-                  (e.shouldUseEdge(OptionsConstants.EDGE_WHEN_KO) ||
-                        e.shouldUseEdge(OptionsConstants.EDGE_WHEN_AERO_KO)));
+            } while (rerollWithEdge);
             // end of do-while
             if (e.getCrew().isKoThisRound(crewPos)) {
                 boolean wasPilot = e.getCrew().getCurrentPilotIndex() == crewPos;

--- a/megamek/unittests/megamek/server/totalWarfare/CrewBlackoutEdgeTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/CrewBlackoutEdgeTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.server.totalWarfare;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import megamek.common.compute.Compute;
+import megamek.common.options.GameOptions;
+import megamek.common.options.OptionsConstants;
+import megamek.common.rolls.Roll;
+import megamek.common.units.Crew;
+import megamek.common.units.CrewType;
+import megamek.common.units.Mek;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Regression test for the Edge blackout (consciousness) reroll: a failed consciousness roll may be rerolled with Edge
+ * only once, even when the crew still has multiple Edge points remaining.
+ *
+ * @see TWGameManager#resolveCrewDamage(megamek.common.units.Entity, int, int)
+ */
+class CrewBlackoutEdgeTest {
+
+    private final TWGameManager gameManager = new TWGameManager();
+
+    @BeforeEach
+    void setUp() {
+        gameManager.getGame().setOptions(new GameOptions());
+        // Edge rerolls require the Edge game option to be enabled.
+        gameManager.getGame().getOptions().getOption(OptionsConstants.EDGE).setValue(true);
+    }
+
+    private Roll rollOf(int value) {
+        Roll roll = mock(Roll.class);
+        when(roll.getIntValue()).thenReturn(value);
+        lenient().when(roll.getReport()).thenReturn(String.valueOf(value));
+        return roll;
+    }
+
+    @Test
+    @DisplayName("A failed blackout check is rerolled with Edge at most once, even with several Edge points")
+    void blackoutCheckIsRerolledOnlyOnce() {
+        // Real crew so Edge is really decremented and hasEdgeRemaining() reflects it; five points available.
+        Crew crew = new Crew(CrewType.SINGLE);
+        crew.getOptions().getOption(OptionsConstants.EDGE).setValue(5);
+        crew.getOptions().getOption(OptionsConstants.EDGE_WHEN_KO).setValue(true);
+        crew.setHits(1, 0);
+
+        Mek mek = mock(Mek.class);
+        when(mek.getCrew()).thenReturn(crew);
+        when(mek.isTargetable()).thenReturn(true);
+        // Tie the Edge decision to the real (depleting) crew Edge state.
+        lenient().when(mek.shouldUseEdge(OptionsConstants.EDGE_WHEN_KO)).thenAnswer(inv -> crew.hasEdgeRemaining());
+        lenient().when(mek.shouldUseEdge(OptionsConstants.EDGE_WHEN_AERO_KO)).thenReturn(false);
+
+        Roll failedRoll = rollOf(2);
+
+        try (MockedStatic<Compute> mockedCompute = mockStatic(Compute.class)) {
+            // Every consciousness roll fails (2 vs. a target of 3 for a single hit)...
+            mockedCompute.when(() -> Compute.rollD6(2)).thenReturn(failedRoll);
+            // ...but keep the real consciousness-number lookup.
+            mockedCompute.when(() -> Compute.getConsciousnessNumber(1)).thenCallRealMethod();
+
+            gameManager.resolveCrewDamage(mek, 1, 0);
+        }
+
+        // Exactly one Edge point should have been spent (5 -> 4). Before the fix this drained all the way to 0.
+        assertEquals(4, crew.getOptions().intOption(OptionsConstants.EDGE),
+              "Only one Edge point should be spent rerolling a single blackout check");
+    }
+}


### PR DESCRIPTION
Fix #8375

A single event can only be re-rolled once, previously black out checks would allow the spending of multiple Edge points until all Edge were spent or the check passed. Now you can only re-roll once.

Contains AI tests.