### PR TITLE
Improve bot minefield placement

### DIFF
--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -1419,23 +1419,16 @@ public abstract class BotClient extends Client {
     		// avoid unnecessary loops and evaluations
     		if (minesToPlace <= 0) {
     			continue;
-    		}    		
+    		}
     		
     		Map<Double, List<Coords>> potentialCoords = 
-    				mdp.getBucketedCandidateCoords(minefieldType, getBoard());
-    		
-    		// this operation takes the buckets and sorts them in descending order
-    		List<Double> sortedBuckets = new ArrayList<>();
-    		sortedBuckets.addAll(potentialCoords.keySet());
-    		Collections.sort(sortedBuckets);
-    		sortedBuckets = sortedBuckets.reversed();
-    		    		
+    				mdp.getBucketedCandidateCoords(minefieldType, getBoard());    		    		
     		
     		// complicated loop:
     		// while we have mines to place (minesToPlace > 0)
     		// AND we have buckets left with coordinates in them, place mines.    		
     		bucketloop:
-    		for (double bucket : sortedBuckets) {
+    		for (double bucket : potentialCoords.keySet()) {
     			for (Coords coords : potentialCoords.get(bucket)) {
     				// it's always more advantageous to put in higher density minefields
 	    			// but hardly fair when players may be bound by scenario restrictions

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -1454,6 +1454,7 @@ public abstract class BotClient extends Client {
 	    			}
 	    			
 	    			deployedMinefields.add(minefield);
+	    			mdp.markMinePlacement(coords);
 	    			
 	    			minesToPlace--;
 	    			

--- a/megamek/src/megamek/client/bot/princess/MinefieldDeploymentPlanner.java
+++ b/megamek/src/megamek/client/bot/princess/MinefieldDeploymentPlanner.java
@@ -77,6 +77,20 @@ public class MinefieldDeploymentPlanner {
 	private double infantryProportion = 0.0;
 	private int vibrabombSetting = 50;
 	
+	private Map<Coords, Integer> placedMines = new HashMap<>();
+	
+	/**
+	 * Increment mine placement counter
+	 */
+	public void markMinePlacement(Coords coords) {
+		placedMines.putIfAbsent(coords, 0);
+		placedMines.put(coords, placedMines.get(coords) + 1);
+	}
+	
+	/**
+	 * Constructor for the minefield deployment planner.
+	 * Initializes opposition unit counts and "reasonable" vibrabomb setting
+	 */
 	public MinefieldDeploymentPlanner(Player player, Game game) {
 		// would prefer to have a map of unit type to score, but tracked, wheeled and hover
 		// vehicles have different movement rules while being the same unit type
@@ -211,10 +225,6 @@ public class MinefieldDeploymentPlanner {
 		Map<Coords, Integer> infantryScores = new HashMap<>();
 		Map<Coords, Integer> hoverVeeScores = new HashMap<>();
 		
-		if (minefieldType == Minefield.TYPE_TRIPWIRE) {
-			int alpha = 1;
-		}
-		
 		// only calculate the scores for a unit type if it's present in the opfor
 		if (mekProportion > 0) {
 			mekScores = getMinefieldScores(minefieldType, UnitType.MEK, EntityMovementMode.BIPED, board);
@@ -255,6 +265,11 @@ public class MinefieldDeploymentPlanner {
 						wheeledVeeScore * wheelProportion +
 						infantryScore * infantryProportion + 
 						hoverVeeScore * hoverProportion;
+				
+				// if we've already placed a minefield here, we discourage placing more
+				if (placedMines.containsKey(coords)) {
+					totalScore -= placedMines.get(coords);
+				}
 				
 				coalescedMap.put(coords, totalScore);
 			}

--- a/megamek/src/megamek/client/bot/princess/MinefieldDeploymentPlanner.java
+++ b/megamek/src/megamek/client/bot/princess/MinefieldDeploymentPlanner.java
@@ -39,6 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 import megamek.common.Hex;
 import megamek.common.Player;
@@ -177,7 +178,7 @@ public class MinefieldDeploymentPlanner {
 	public Map<Double, List<Coords>> getBucketedCandidateCoords(int minefieldType, Board board) {
 		Map<Coords, Double> minefieldScores = buildCoalescedMinefieldScores(minefieldType, board);
 		
-		Map<Double, List<Coords>> bucketedCoords = new HashMap<>();
+		Map<Double, List<Coords>> bucketedCoords = new TreeMap<>(Collections.reverseOrder());
 		
 		for (Coords coords : minefieldScores.keySet()) {
 			double scoreBucket = minefieldScores.get(coords);
@@ -209,6 +210,10 @@ public class MinefieldDeploymentPlanner {
 		Map<Coords, Integer> wheeledVeeScores = new HashMap<>();
 		Map<Coords, Integer> infantryScores = new HashMap<>();
 		Map<Coords, Integer> hoverVeeScores = new HashMap<>();
+		
+		if (minefieldType == Minefield.TYPE_TRIPWIRE) {
+			int alpha = 1;
+		}
 		
 		// only calculate the scores for a unit type if it's present in the opfor
 		if (mekProportion > 0) {
@@ -281,10 +286,12 @@ public class MinefieldDeploymentPlanner {
 				
 				// if we can't place the minefield, just move on
 				if (hex.containsAnyTerrainOf(DISALLOWED_TERRAIN_TYPES)) {
+					minefieldScores.put(coords, Integer.MIN_VALUE);
 					continue;
 				}
 				
 				if (!hex.canPlaceMinefield(minefieldType)) {
+					minefieldScores.put(coords, Integer.MIN_VALUE);
 					continue;
 				}
 				

--- a/megamek/src/megamek/common/Hex.java
+++ b/megamek/src/megamek/common/Hex.java
@@ -796,9 +796,9 @@ public class Hex implements Serializable {
     public boolean canPlaceMinefield(int minefieldType) {
     	switch (minefieldType) {
     	case Minefield.TYPE_TRIPWIRE:
-    		return containsAnyTerrainOf(Terrains.INVALID_TRIPWIRE_TERRAIN);
+    		return !containsAnyTerrainOf(Terrains.INVALID_TRIPWIRE_TERRAIN);
     	case Minefield.TYPE_PITFALL:
-    		return containsAnyTerrainOf(Terrains.INVALID_PITFALL_TERRAIN);
+    		return !containsAnyTerrainOf(Terrains.INVALID_PITFALL_TERRAIN);
     	}
     	
     	return true;


### PR DESCRIPTION
A couple of updates:

1) Tripwires/pitfalls were always being put into buildings if they were present
2) Mines kept getting stacked on the same spot - it might be a good spot, but it's also good to spread them out, so we discourage stacking mines
3) Use tree-map instead of after-the-fact sorting for mine placement value buckets