### PR TITLE
Fix Aimed Shot dialog it now remembers where the player last dragged it

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/phaseDisplay/AimedShotDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/phaseDisplay/AimedShotDialog.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2003 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2003-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2003-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -47,14 +47,22 @@ import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.SwingConstants;
 
+import megamek.MegaMek;
 import megamek.client.ui.Messages;
 import megamek.client.ui.clientGUI.ClientGUI;
 import megamek.client.ui.clientGUI.tooltip.UnitToolTip;
+import megamek.client.ui.preferences.JWindowPreference;
+import megamek.client.ui.preferences.PreferencesNode;
 import megamek.client.ui.util.UIUtil;
 import megamek.client.ui.widget.IndexedRadioButton;
 import megamek.common.units.Targetable;
+import megamek.logging.MMLogger;
 
 public class AimedShotDialog extends JDialog {
+    private static final MMLogger LOGGER = MMLogger.create(AimedShotDialog.class);
+
+    private static final String DIALOG_NAME = "AimedShotDialog";
+
     @Serial
     private static final long serialVersionUID = 6527374019085650613L;
 
@@ -123,9 +131,34 @@ public class AimedShotDialog extends JDialog {
         butNoAim.requestFocus();
 
         pack();
+        // First-time default: center on the parent frame. If the player has moved the dialog
+        // before, setPreferences() below restores that remembered position over this centering.
         setLocation((parent.getLocation().x + (parent.getSize().width / 2))
               - (getSize().width / 2), (parent.getLocation().y
               + (parent.getSize().height / 2)) - (getSize().height / 2));
+
+        setPreferences();
+
+        // The dialog is rebuilt for every aimed shot and its height depends on how many locations
+        // the current target has. Re-pack after restoring preferences so the size always fits this
+        // target, while keeping the remembered location (pack() resizes but never moves the window).
+        pack();
+    }
+
+    /**
+     * Restores the position the dialog was last left at, and keeps it up to date as the player moves the dialog. A
+     * remembered position wins over the first-time centering in the constructor, so the dialog no longer snaps back
+     * over the map on every aimed shot.
+     */
+    private void setPreferences() {
+        try {
+            setName(DIALOG_NAME);
+            PreferencesNode preferences = MegaMek.getMMPreferences().forClass(AimedShotDialog.class);
+            preferences.manage(new JWindowPreference(this));
+        } catch (Exception exception) {
+            // a dialog that cannot remember where it was is still perfectly usable
+            LOGGER.error(exception, "Could not set the preferences of the aimed shot dialog");
+        }
     }
 
     public void setEnableAll(boolean enableAll) {

--- a/megamek/src/megamek/client/ui/dialogs/phaseDisplay/AimedShotDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/phaseDisplay/AimedShotDialog.java
@@ -143,6 +143,10 @@ public class AimedShotDialog extends JDialog {
         // the current target has. Re-pack after restoring preferences so the size always fits this
         // target, while keeping the remembered location (pack() resizes but never moves the window).
         pack();
+
+        // Growing the dialog at a remembered edge location (or a resolution change between sessions)
+        // could leave it partially off-screen. Clamp its bounds so it always stays fully visible.
+        UIUtil.updateWindowBounds(this);
     }
 
     /**


### PR DESCRIPTION
The Aimed Shot dialog now remembers where the player last dragged it, instead of re-centering over the map (and the just-centered active unit) on every aimed shot.

Root cause

AimedShotDialog is rebuilt from scratch for each aimed shot, and its constructor unconditionally recenters on the parent frame. No position was ever saved, so it always snapped back to center.

Fix

Applied MegaMek's standard window-persistence mechanism, JWindowPreference — the same one already used by GameMasterVoteDialog, UnitEditorDialog, and AbstractDialog:
- setName("AimedShotDialog") + preferences.manage(new JWindowPreference(this)) restores the remembered position over the first-time centering, and tracks the position as the player moves the dialog.
- A final pack() after restoring preferences — because the dialog's height depends on how many hit locations the current target has (a Mek has more than a Tank), this re-fits the size to the current target while keeping the remembered position (pack() resizes but never moves the window). Without it, restoring a smaller remembered size could clip a larger dialog.
- Wrapped in try/catch with an error log; a dialog that can't remember its spot is still fully usable.

Behavior

- First use ever → no saved preference → centers on parent, exactly as before.
- After the player moves it → reopens where they left it.

Files changed

- AimedShotDialog.java — added the setPreferences() helper, imports, an MMLogger, and the copyright-year bump to 2003-2026.

Closes https://github.com/MegaMek/megamek/issues/8460