### PR TITLE
Fix improved-inferno iATM (IIW) missiles doing wrong damage to infantry

### DIFF
--- a/megamek/src/megamek/common/weapons/handlers/CLIATMHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/CLIATMHandler.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005 - Ben Mazur (bmazur@sev.org).
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -69,12 +69,15 @@ import megamek.common.units.ProtoMek;
 import megamek.common.units.Tank;
 import megamek.common.units.Targetable;
 import megamek.common.weapons.Weapon;
+import megamek.logging.MMLogger;
 import megamek.server.totalWarfare.TWGameManager;
 
 /**
  * @author Sebastian Brocks, modified by Greg
  */
 public class CLIATMHandler extends ATMHandler {
+    private static final MMLogger LOGGER = MMLogger.create(CLIATMHandler.class);
+
     @Serial
     private static final long serialVersionUID = 5476183194060709574L;
     boolean isAngelECMAffected;
@@ -149,9 +152,20 @@ public class CLIATMHandler extends ATMHandler {
         // compute amount of missiles hit - this is the same for all ATM ammo types.
         int hits = calcMissileHits(vPhaseReport);
 
-        // If we use IIW or IMP we are done.
-        if ((ammoType.getMunitionType().contains(AmmoType.Munitions.M_IATM_IIW))
-              || (ammoType.getMunitionType().contains(AmmoType.Munitions.M_IATM_IMP))) {
+        // IIW warheads resolve as standard Infernos (WoR p.202 -> TW p.141): every inferno missile
+        // that strikes conventional infantry eliminates three troopers. Against infantry,
+        // calcMissileHits() collapses the salvo into a single lump (correct for standard/HE damage,
+        // wrong for infernos), so deliver one inferno missile per missile in the rack instead - this
+        // matches the count already reported by calcMissileHits() and the standard SRM inferno rule.
+        if (ammoType.getMunitionType().contains(AmmoType.Munitions.M_IATM_IIW)) {
+            if (target.isConventionalInfantry()) {
+                return infernoMissilesVersusInfantry();
+            }
+            return hits;
+        }
+
+        // If we use IMP we are done (its infantry lump is handled with directBlowInfantryDamage).
+        if (ammoType.getMunitionType().contains(AmmoType.Munitions.M_IATM_IMP)) {
             return hits;
         }
 
@@ -181,11 +195,12 @@ public class CLIATMHandler extends ATMHandler {
 
         // conventional infantry gets hit in one lump
         // BAs do one lump of damage per BA suit
+        // The infantry hit line ends the line normally (no newlines = 0) so the following damage or
+        // destruction reports render on their own line, matching the standard SRM/LRM inferno output.
         if (target.isConventionalInfantry()) {
             if (attackingEntity instanceof BattleArmor) {
                 bSalvo = true;
                 Report report = new Report(3325);
-                report.newlines = 0;
                 report.subject = subjectId;
                 report.add(weaponType.getRackSize() * ((BattleArmor) attackingEntity).getShootingStrength());
                 report.add(sSalvoType);
@@ -195,7 +210,6 @@ public class CLIATMHandler extends ATMHandler {
             }
             Report report = new Report(3325);
             report.subject = subjectId;
-            report.newlines = 0;
             report.add(weaponType.getRackSize());
             report.add(sSalvoType);
             report.add(toHit.getTableDesc());
@@ -343,6 +357,24 @@ public class CLIATMHandler extends ATMHandler {
         vPhaseReport.addElement(r);
         bSalvo = true;
         return missilesHit;
+    }
+
+    /**
+     * Counts the inferno missiles delivered to a conventional infantry target by an IIW salvo. Per WoR p.202 and TW
+     * p.141, every inferno missile that strikes conventional infantry eliminates three troopers, so the whole rack
+     * strikes as individual inferno missiles rather than a single lumped hit (mirroring the standard SRM inferno
+     * behaviour). BattleArmor cannot mount iATMs, but the shooting-strength multiplier is kept for parity with the
+     * count reported in {@link #calcMissileHits(Vector)}.
+     *
+     * @return the number of inferno missiles to deliver to the conventional infantry target
+     */
+    private int infernoMissilesVersusInfantry() {
+        int infernoMissiles = (attackingEntity instanceof BattleArmor battleArmor)
+              ? weaponType.getRackSize() * battleArmor.getShootingStrength()
+              : weaponType.getRackSize();
+        LOGGER.debug("[iATM IIW] {} inferno missile(s) vs conventional infantry {} (3 troopers each)",
+              infernoMissiles, target.getDisplayName());
+        return infernoMissiles;
     }
 
     // I don't think I need to change anything here for iATMs. Seems just to

--- a/megamek/src/megamek/common/weapons/handlers/CLIATMHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/CLIATMHandler.java
@@ -195,8 +195,9 @@ public class CLIATMHandler extends ATMHandler {
 
         // conventional infantry gets hit in one lump
         // BAs do one lump of damage per BA suit
-        // The infantry hit line ends the line normally (no newlines = 0) so the following damage or
-        // destruction reports render on their own line, matching the standard SRM/LRM inferno output.
+        // The infantry hit line keeps the default line break (Report.newlines = 1) so the following
+        // damage or destruction reports render on their own line, matching the standard SRM/LRM
+        // inferno output.
         if (target.isConventionalInfantry()) {
             if (attackingEntity instanceof BattleArmor) {
                 bSalvo = true;

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -7465,6 +7465,17 @@ public class TWGameManager extends AbstractGameManager {
                         r.indent(3);
                         vPhaseReport.add(r);
                     } else {
+                        // The whole platoon is wiped out. Report the inferno damage (three troopers
+                        // per missile, TW p.141) before destroying it, matching the surviving-infantry
+                        // branch and normal infantry damage reporting instead of jumping straight to a
+                        // bare "DESTROYED" line.
+                        r = new Report(6065);
+                        r.addDesc(te);
+                        r.add(3 * missiles);
+                        r.indent(2);
+                        r.add(te.getLocationAbbr(hit));
+                        r.subject = te.getId();
+                        vPhaseReport.add(r);
                         vPhaseReport.addAll(destroyEntity(te, "damage", false));
                         creditKill(te, ae);
                         Report.addNewline(vPhaseReport);

--- a/megamek/unittests/megamek/common/weapons/handlers/CLIATMHandlerInfernoInfantryTest.java
+++ b/megamek/unittests/megamek/common/weapons/handlers/CLIATMHandlerInfernoInfantryTest.java
@@ -134,7 +134,7 @@ class CLIATMHandlerInfernoInfantryTest {
             attacker = createAttacker();
             launcher = addImprovedInfernoLauncher(attacker);
         } catch (Exception exception) {
-            throw new EntityLoadingException(exception.getMessage());
+            throw new EntityLoadingException(exception.getMessage(), exception);
         }
         ConvInfantry target = createInfantryTarget(7, 4);
         game.addEntity(attacker);

--- a/megamek/unittests/megamek/common/weapons/handlers/CLIATMHandlerInfernoInfantryTest.java
+++ b/megamek/unittests/megamek/common/weapons/handlers/CLIATMHandlerInfernoInfantryTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.weapons.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Vector;
+
+import megamek.common.Player;
+import megamek.common.Report;
+import megamek.common.ToHitData;
+import megamek.common.actions.WeaponAttackAction;
+import megamek.common.board.Coords;
+import megamek.common.equipment.AmmoType;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.Mounted;
+import megamek.common.equipment.WeaponMounted;
+import megamek.common.equipment.WeaponType;
+import megamek.common.game.Game;
+import megamek.common.loaders.EntityLoadingException;
+import megamek.common.units.BipedMek;
+import megamek.common.units.ConvInfantry;
+import megamek.common.units.Crew;
+import megamek.common.units.CrewType;
+import megamek.common.units.Entity;
+import megamek.common.units.EntityMovementMode;
+import megamek.common.units.Mek;
+import megamek.server.totalWarfare.TWGameManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for issue #8534: Improved Inferno (IIW) iATM missiles must deliver one inferno missile per missile in
+ * the rack against conventional infantry, so that the standard Inferno rule (WoR p.202 -> TW p.141: every inferno
+ * missile that strikes eliminates three troopers) applies to the whole salvo. Before the fix the salvo was collapsed
+ * into a single inferno missile, killing only three troopers regardless of rack size.
+ */
+class CLIATMHandlerInfernoInfantryTest {
+
+    private static final String IATM6_WEAPON = "CLiATM6";
+    private static final String IATM6_IIW_AMMO = "Clan Ammo iATM-6 IIW";
+
+    private Game game;
+    private TWGameManager gameManager;
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void setUp() {
+        gameManager = new TWGameManager();
+        game = gameManager.getGame();
+        game.addPlayer(0, new Player(0, "Attacker"));
+        game.addPlayer(1, new Player(1, "Defender"));
+    }
+
+    private WeaponMounted addImprovedInfernoLauncher(Entity attacker) throws Exception {
+        WeaponType launcherType = (WeaponType) EquipmentType.get(IATM6_WEAPON);
+        AmmoType improvedInfernoAmmo = (AmmoType) EquipmentType.get(IATM6_IIW_AMMO);
+        WeaponMounted launcher = (WeaponMounted) attacker.addEquipment(launcherType, Mek.LOC_RIGHT_TORSO);
+        Mounted<?> ammo = attacker.addEquipment(improvedInfernoAmmo, Mek.LOC_RIGHT_TORSO);
+        launcher.setLinked(ammo);
+        return launcher;
+    }
+
+    private Entity createAttacker() throws Exception {
+        BipedMek attacker = new BipedMek();
+        attacker.setGame(game);
+        attacker.setId(1);
+        attacker.setChassis("iATM Carrier");
+        attacker.setModel("Attacker");
+        attacker.setCrew(new Crew(CrewType.SINGLE));
+        attacker.setOwner(game.getPlayer(0));
+        attacker.setWeight(50.0);
+        attacker.setOriginalWalkMP(5);
+        attacker.setPosition(new Coords(1, 1));
+        attacker.setFacing(0);
+        return attacker;
+    }
+
+    private ConvInfantry createInfantryTarget(int squadSize, int squadCount) {
+        ConvInfantry infantry = new ConvInfantry();
+        infantry.setGame(game);
+        infantry.setId(2);
+        infantry.setMovementMode(EntityMovementMode.INF_LEG);
+        infantry.setSquadSize(squadSize);
+        infantry.setSquadCount(squadCount);
+        infantry.autoSetInternal();
+        infantry.setOwner(game.getPlayer(1));
+        infantry.setPosition(new Coords(1, 2));
+        return infantry;
+    }
+
+    @Test
+    @DisplayName("IIW iATM delivers one inferno missile per rack missile against conventional infantry")
+    void improvedInfernoDeliversRackSizeMissilesToInfantry() throws EntityLoadingException {
+        Entity attacker;
+        WeaponMounted launcher;
+        try {
+            attacker = createAttacker();
+            launcher = addImprovedInfernoLauncher(attacker);
+        } catch (Exception exception) {
+            throw new EntityLoadingException(exception.getMessage());
+        }
+        ConvInfantry target = createInfantryTarget(7, 4);
+        game.addEntity(attacker);
+        game.addEntity(target);
+
+        WeaponAttackAction weaponAttack = new WeaponAttackAction(attacker.getId(), target.getId(),
+              attacker.getEquipmentNum(launcher));
+        CLIATMHandler handler = new CLIATMHandler(new ToHitData(), weaponAttack, game, gameManager);
+
+        int infernoMissiles = handler.calcHits(new Vector<Report>());
+
+        assertEquals(launcher.getType().getRackSize(), infernoMissiles,
+              "IIW iATM must deliver one inferno missile per missile in the rack against conventional infantry "
+                    + "(regression for #8534, previously collapsed to a single missile)");
+        assertEquals(6, infernoMissiles,
+              "An iATM/6 firing Improved Inferno at infantry should deliver 6 inferno missiles (18 troopers)");
+    }
+}


### PR DESCRIPTION
## Root Cause
CLIATMHandler delivered IIW (Improved Inferno) missiles to conventional infantry as a single lumped inferno missile. calcMissileHits() collapses an infantry target into one lump (correct for standard/HE ATM, where the lump carries the full directBlowInfantryDamage), and calcHits() passed that 1 to deliverInfernoMissiles() for IIW. Since inferno applies 3 troopers killed per missile (WoR p.202 -> TW p.141), a full salvo eliminated only 3 troopers regardless of rack size, even though the report already claimed the whole rack had struck.

## Changes
1. CLIATMHandler.calcHits - for IIW vs conventional infantry, deliver one inferno missile per missile in the rack (new infernoMissilesVersusInfantry() helper), mirroring SRMInfernoHandler. IMP and standard/HE paths unchanged.
2. CLIATMHandler.calcMissileHits - drop newlines = 0 on the infantry hit line so the following damage/destruction reports render on their own line, matching SRM/LRM inferno output.
3. TWGameManager.deliverInfernoMissiles - when inferno wipes out a platoon, report the inferno damage (3 * missiles) before destroying it, so inferno kills read like normal infantry damage instead of a bare DESTROYED line. Applies to all inferno weapons.
4. Added [iATM IIW] diagnostic logging.

## Files Changed
- megamek/src/megamek/common/weapons/handlers/CLIATMHandler.java
- megamek/src/megamek/server/totalWarfare/TWGameManager.java
- megamek/unittests/megamek/common/weapons/handlers/CLIATMHandlerInfernoInfantryTest.java

## Testing
New CLIATMHandlerInfernoInfantryTest asserts an iATM/6 IIW salvo delivers 6 inferno missiles (rack size) to conventional infantry. Playtest confirmed an iATM/9 IIW salvo eliminates the target infantry point with the corrected reporting.

Fixes #8534