### PR TITLE
armor_tech normalization more content aware

### DIFF
--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -1934,11 +1934,36 @@ public class BLKFile {
         normalizeAllTechBaseArmor(entity);
     }
 
+    /**
+     * Fixes the wrongly assigned armor_tech, for example a Clan armor_tech to an IS unit
+     */
     private void normalizeAllTechBaseArmor(Entity entity) {
         ArmorType armor = ArmorType.forEntity(entity);
         if (!entity.isMixedTech() && !entity.hasPatchworkArmor() && (armor != null)
               && (armor.getTechAdvancement().getTechBase() == TechBase.ALL)) {
-            entity.setArmorTechLevel(entity.getTechLevel());
+            int armorTechLevel = entity.getArmorTechLevel(entity.firstArmorIndex());
+            int normalizedTechLevel = switch (armorTechLevel) {
+                case TechConstants.T_INTRO_BOX_SET, TechConstants.T_IS_TW_NON_BOX, TechConstants.T_IS_TW_ALL ->
+                    entity.isClan() ? TechConstants.T_CLAN_TW : armorTechLevel;
+                case TechConstants.T_IS_ADVANCED ->
+                    entity.isClan() ? TechConstants.T_CLAN_ADVANCED : armorTechLevel;
+                case TechConstants.T_IS_EXPERIMENTAL ->
+                    entity.isClan() ? TechConstants.T_CLAN_EXPERIMENTAL : armorTechLevel;
+                case TechConstants.T_IS_UNOFFICIAL ->
+                    entity.isClan() ? TechConstants.T_CLAN_UNOFFICIAL : armorTechLevel;
+                case TechConstants.T_ALL_IS -> entity.isClan() ? TechConstants.T_ALL_CLAN : armorTechLevel;
+                case TechConstants.T_CLAN_TW ->
+                    entity.isClan() ? armorTechLevel : TechConstants.T_IS_TW_NON_BOX;
+                case TechConstants.T_CLAN_ADVANCED ->
+                    entity.isClan() ? armorTechLevel : TechConstants.T_IS_ADVANCED;
+                case TechConstants.T_CLAN_EXPERIMENTAL ->
+                    entity.isClan() ? armorTechLevel : TechConstants.T_IS_EXPERIMENTAL;
+                case TechConstants.T_CLAN_UNOFFICIAL ->
+                    entity.isClan() ? armorTechLevel : TechConstants.T_IS_UNOFFICIAL;
+                case TechConstants.T_ALL_CLAN -> entity.isClan() ? armorTechLevel : TechConstants.T_ALL_IS;
+                default -> armorTechLevel;
+            };
+            entity.setArmorTechLevel(normalizedTechLevel);
         }
     }
 

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -1937,7 +1937,7 @@ public class BLKFile {
     /**
      * Normalizes ALL-tech-base armor tech levels when the file specifies an IS/Clan tech base that
      * doesn't match the unit, while preserving the underlying rules level (e.g., IS Advanced -> Clan Advanced).
-    */
+     */
     private void normalizeAllTechBaseArmor(Entity entity) {
         ArmorType armor = ArmorType.forEntity(entity);
         if (!entity.isMixedTech() && !entity.hasPatchworkArmor() && (armor != null)

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -1964,7 +1964,9 @@ public class BLKFile {
                 case TechConstants.T_ALL_CLAN -> entity.isClan() ? armorTechLevel : TechConstants.T_ALL_IS;
                 default -> armorTechLevel;
             };
-            entity.setArmorTechLevel(normalizedTechLevel);
+            if (normalizedTechLevel != armorTechLevel) {
+                entity.setArmorTechLevel(normalizedTechLevel);
+            }
         }
     }
 

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -1935,8 +1935,9 @@ public class BLKFile {
     }
 
     /**
-     * Fixes the wrongly assigned armor_tech, for example a Clan armor_tech to an IS unit
-     */
+     * Normalizes ALL-tech-base armor tech levels when the file specifies an IS/Clan tech base that
+     * doesn't match the unit, while preserving the underlying rules level (e.g., IS Advanced -> Clan Advanced).
+    */
     private void normalizeAllTechBaseArmor(Entity entity) {
         ArmorType armor = ArmorType.forEntity(entity);
         if (!entity.isMixedTech() && !entity.hasPatchworkArmor() && (armor != null)

--- a/megamek/unittests/megamek/common/loaders/BLKFileTest.java
+++ b/megamek/unittests/megamek/common/loaders/BLKFileTest.java
@@ -153,6 +153,21 @@ class BLKFileTest {
     }
 
     @Test
+    void allTechbaseArmorPreservesCompatibleStrictTechLevel() {
+        BuildingBlock blk = new BuildingBlock();
+        blk.writeBlockData("armor_tech_level", TechConstants.T_IS_TW_ALL);
+        BLKFile loader = new BLKFile();
+        loader.dataFile = blk;
+        Tank tank = new Tank();
+        tank.setTechLevel(TechConstants.T_IS_TW_NON_BOX);
+        tank.setArmorType(EquipmentType.T_ARMOR_STANDARD);
+
+        loader.setArmorTechLevelFromDataFile(tank);
+
+        assertEquals(TechConstants.T_IS_TW_ALL, tank.getArmorTechLevel(tank.firstArmorIndex()));
+    }
+
+    @Test
     void allTechbaseArmorPreservesExplicitTechbaseForMixedUnit() {
         BuildingBlock blk = new BuildingBlock();
         blk.writeBlockData("armor_tech_level", TechConstants.T_IS_ADVANCED);
@@ -590,6 +605,25 @@ class BLKFileTest {
         String resaved = String.join("\n", BLKFile.getBlock(loaded).getAllDataAsString());
         assertTrue(resaved.contains("LRM 20"));
         assertFalse(resaved.contains("CLLRM20"));
+    }
+
+    @Test
+    void battleArmorRoundTripPreservesCompatibleArmorTechLevel() throws Exception {
+        BattleArmor original = loadBattleArmor("Afreet Med BA (HH) (Sqd4).blk");
+        String[] blockData = BLKFile.getBlock(original).getAllDataAsString();
+        for (int index = 0; index < blockData.length - 1; index++) {
+            if (blockData[index].equalsIgnoreCase("<type>")) {
+                blockData[index + 1] = "IS Level 2";
+            } else if (blockData[index].equalsIgnoreCase("<armor_tech>")) {
+                blockData[index + 1] = Integer.toString(TechConstants.T_IS_TW_ALL);
+            }
+        }
+
+        BattleArmor loaded = (BattleArmor) new BLKBattleArmorFile(new BuildingBlock(blockData)).getEntity();
+        BuildingBlock resaved = BLKFile.getBlock(loaded);
+
+        assertEquals(TechConstants.T_IS_TW_ALL, loaded.getArmorTechLevel(BattleArmor.LOC_SQUAD));
+        assertEquals(TechConstants.T_IS_TW_ALL, resaved.getDataAsInt("armor_tech")[0]);
     }
 
     /**


### PR DESCRIPTION
This PR builds on the normalization (autofix) of BLK files that advertise as a techbase while containing armor_tech of the opposite base (IS<->Clan).

It properly maintain the "level", so is advanced->clan advanced
