### PR TITLE
Teach Princess to account for weather, evasion, and gravity in movement estimates

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -998,12 +998,6 @@ public class FireControl {
                   AmmoType.Munitions.M_FAE);
             EnumSet<AmmoType.Munitions> homingMunitions = EnumSet.of(
                   AmmoType.Munitions.M_HOMING);
-            // Autocannon families that take armor-piercing ammunition
-            EnumSet<AmmoType.AmmoTypeEnum> autocannonAmmoTypes = EnumSet.of(
-                  AmmoType.AmmoTypeEnum.AC,
-                  AmmoType.AmmoTypeEnum.LAC,
-                  AmmoType.AmmoTypeEnum.AC_IMP,
-                  AmmoType.AmmoTypeEnum.PAC);
             if (0 != ammoType.getToHitModifier()) {
                 toHit.addModifier(ammoType.getToHitModifier(), TH_AMMO_MOD);
             }
@@ -1021,7 +1015,10 @@ public class FireControl {
                 toHit.addModifier(TH_APOLLO);
             }
             // Armor-piercing autocannon ammo is a flat +1 to-hit (removed under PLAYTEST 3 rules).
-            boolean isAutocannonAmmo = autocannonAmmoTypes.contains(ammoType.getAmmoType());
+            boolean isAutocannonAmmo = switch (ammoType.getAmmoType()) {
+                case AC, LAC, AC_IMP, PAC -> true;
+                case null, default -> false;
+            };
             boolean isArmorPiercingMunition =
                   ammoType.getMunitionType().contains(AmmoType.Munitions.M_ARMOR_PIERCING)
                         || ammoType.getMunitionType().contains(AmmoType.Munitions.M_ARMOR_PIERCING_PLAYTEST);

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1163,7 +1163,7 @@ public class FireControl {
         // conditions. The committed firing plan already accounts for these via the real engine
         // calculation; this brings the movement-ranking estimate in line with it.
         final AmmoType environmentalAmmoType =
-              (ammo != null && ammo.getType() instanceof AmmoType firedAmmoType) ? firedAmmoType : null;
+              (firingAmmo != null && firingAmmo.getType() instanceof AmmoType firedAmmoType) ? firedAmmoType : null;
         toHit.append(ComputeEnvironmentalToHitMods.compileEnvironmentalToHitMods(
               game, shooter, target, weaponType, environmentalAmmoType, null, false));
 

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -998,6 +998,9 @@ public class FireControl {
                   AmmoType.Munitions.M_FAE);
             EnumSet<AmmoType.Munitions> homingMunitions = EnumSet.of(
                   AmmoType.Munitions.M_HOMING);
+            // getMunitionType() returns a fresh EnumSet copy on every call; cache it once and reuse
+            // it for the membership checks below to avoid repeated allocations on this hot path.
+            EnumSet<AmmoType.Munitions> munitionTypes = ammoType.getMunitionType();
             if (0 != ammoType.getToHitModifier()) {
                 toHit.addModifier(ammoType.getToHitModifier(), TH_AMMO_MOD);
             }
@@ -1020,15 +1023,15 @@ public class FireControl {
                 case null, default -> false;
             };
             boolean isArmorPiercingMunition =
-                  ammoType.getMunitionType().contains(AmmoType.Munitions.M_ARMOR_PIERCING)
-                        || ammoType.getMunitionType().contains(AmmoType.Munitions.M_ARMOR_PIERCING_PLAYTEST);
+                  munitionTypes.contains(AmmoType.Munitions.M_ARMOR_PIERCING)
+                        || munitionTypes.contains(AmmoType.Munitions.M_ARMOR_PIERCING_PLAYTEST);
             boolean isArmorPiercingPenaltyInEffect =
                   !game.getOptions().booleanOption(OptionsConstants.PLAYTEST_3);
             if (isAutocannonAmmo && isArmorPiercingMunition && isArmorPiercingPenaltyInEffect) {
                 toHit.addModifier(TH_AP_AMMO);
             }
             // Air-defense Arrow IV handling; can only fire at airborne targets
-            if (ammoType.getMunitionType().contains(AmmoType.Munitions.M_ADA)) {
+            if (munitionTypes.contains(AmmoType.Munitions.M_ADA)) {
                 if (target.isAirborne() || target.isAirborneVTOLorWIGE()) {
                     toHit.addModifier(TH_WEAPON_ADA);
                 } else {
@@ -1037,19 +1040,19 @@ public class FireControl {
             }
             // Handle cluster, flak, AAA vs Airborne, Arty-only vs Airborne
             if (target.isAirborne() || target.isAirborneVTOLorWIGE()) {
-                if (ammoType.getMunitionType().stream().anyMatch(aaMunitions::contains)
+                if (munitionTypes.stream().anyMatch(aaMunitions::contains)
                       || ammoType.countsAsFlak()) {
                     if (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.HAG) {
                         toHit.addModifier(TH_WEAPON_FLAK_HAG);
                     } else {
                         toHit.addModifier(TH_WEAPON_FLAK);
                     }
-                } else if (ammoType.getMunitionType().stream().anyMatch(ArtyOnlyMunitions::contains)) {
+                } else if (munitionTypes.stream().anyMatch(ArtyOnlyMunitions::contains)) {
                     toHit.addModifier(TH_WEAPON_CANNOT_FIRE);
                 }
             }
             // Handle homing munitions
-            if (ammoType.getMunitionType().stream().anyMatch(homingMunitions::contains)) {
+            if (munitionTypes.stream().anyMatch(homingMunitions::contains)) {
                 if (game.getPhase().isOffboard()) {
                     final StringBuilder msg = new StringBuilder("Estimating to-hit for Homing artillery fire by ")
                           .append(shooter.getDisplayName());
@@ -1074,7 +1077,7 @@ public class FireControl {
             }
 
             // Guesstimate Heat-Seeking Ammo mods
-            if (ammoType.getMunitionType().contains(AmmoType.Munitions.M_HEAT_SEEKING)) {
+            if (munitionTypes.contains(AmmoType.Munitions.M_HEAT_SEEKING)) {
                 if (targetState.getHeat() > 0) {
                     // Hot target good
                     toHit.addModifier(-targetState.getHeat() / 5, TH_AMMO_MOD);

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -53,6 +53,7 @@ import megamek.common.actions.SearchlightAttackAction;
 import megamek.common.actions.SpotAction;
 import megamek.common.actions.UnjamTurretAction;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.actions.compute.ComputeEnvironmentalToHitMods;
 import megamek.common.annotations.Nullable;
 import megamek.common.annotations.StaticWrapper;
 import megamek.common.battleArmor.BattleArmor;
@@ -126,6 +127,7 @@ public class FireControl {
     static final String TH_HEAT = "heat";
     static final String TH_WEAPON_MOD = "weapon to-hit";
     static final String TH_AMMO_MOD = "ammunition to-hit modifier";
+    static final String TH_TAR_EVADING = "target evading";
     static final TargetRollModifier TH_ATT_PRONE = new TargetRollModifier(2, "attacker prone");
     static final TargetRollModifier TH_TAR_IMMOBILE = new TargetRollModifier(-4, "target immobile");
     static final TargetRollModifier TH_TAR_SKID = new TargetRollModifier(2, "target skidded");
@@ -196,7 +198,11 @@ public class FireControl {
           "prone leg weapon");
     static final TargetRollModifier TH_WEAPON_ADA = new TargetRollModifier(-2,
           "Air-Defense Arrow IV vs airborne target");
-    static final TargetRollModifier TH_WEAPON_FLAK = new TargetRollModifier(-1, "Flak vs airborne target");
+    static final TargetRollModifier TH_WEAPON_FLAK = new TargetRollModifier(-2, "Flak vs airborne target");
+    static final TargetRollModifier TH_WEAPON_FLAK_HAG = new TargetRollModifier(-3,
+          "HAG Flak vs airborne target");
+    static final TargetRollModifier TH_APOLLO = new TargetRollModifier(-1, "Apollo FCS");
+    static final TargetRollModifier TH_AP_AMMO = new TargetRollModifier(1, "armor-piercing ammo");
     static final TargetRollModifier TH_WEAPON_NO_ARC = new TargetRollModifier(TargetRoll.IMPOSSIBLE, "not in arc");
     static final TargetRollModifier TH_INF_ZERO_RNG = new TargetRollModifier(TargetRoll.AUTOMATIC_FAIL,
           "non-infantry shooting with zero range");
@@ -469,6 +475,12 @@ public class FireControl {
 
         if ((target instanceof Dropship) && !target.isAirborne()) {
             toHitData.addModifier(TH_TAR_GROUND_DS);
+        }
+
+        // Evading targets are harder to hit (TW p.111). Evasion is a property of the target, so it
+        // is independent of where the shooter moves.
+        if ((target instanceof Entity targetEntity) && targetEntity.isEvading()) {
+            toHitData.addModifier(targetEntity.getEvasionBonus(), TH_TAR_EVADING);
         }
 
         return toHitData;
@@ -988,6 +1000,28 @@ public class FireControl {
             if (0 != ammoType.getToHitModifier()) {
                 toHit.addModifier(ammoType.getToHitModifier(), TH_AMMO_MOD);
             }
+            // Apollo FCS gives MRMs -1 to-hit (TO:AR). Apollo is not negated by ECM.
+            Mounted<?> ammoLinker = weapon.getLinkedBy();
+            boolean hasApolloFcs = (ammoLinker != null)
+                  && (ammoLinker.getType() instanceof MiscType)
+                  && !ammoLinker.isDestroyed() && !ammoLinker.isMissing() && !ammoLinker.isBreached()
+                  && ammoLinker.getType().hasFlag(MiscType.F_APOLLO)
+                  && (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.MRM);
+            if (hasApolloFcs) {
+                toHit.addModifier(TH_APOLLO);
+            }
+            // Armor-piercing autocannon ammo is a flat +1 to-hit (removed under PLAYTEST 3 rules).
+            boolean isArmorPiercingAutocannon =
+                  ((ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.AC)
+                        || (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.LAC)
+                        || (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.AC_IMP)
+                        || (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.PAC))
+                        && (ammoType.getMunitionType().contains(AmmoType.Munitions.M_ARMOR_PIERCING)
+                        || ammoType.getMunitionType().contains(AmmoType.Munitions.M_ARMOR_PIERCING_PLAYTEST));
+            if (isArmorPiercingAutocannon
+                  && !game.getOptions().booleanOption(OptionsConstants.PLAYTEST_3)) {
+                toHit.addModifier(TH_AP_AMMO);
+            }
             // Air-defense Arrow IV handling; can only fire at airborne targets
             if (ammoType.getMunitionType().contains(AmmoType.Munitions.M_ADA)) {
                 if (target.isAirborne() || target.isAirborneVTOLorWIGE()) {
@@ -1000,7 +1034,11 @@ public class FireControl {
             if (target.isAirborne() || target.isAirborneVTOLorWIGE()) {
                 if (ammoType.getMunitionType().stream().anyMatch(aaMunitions::contains)
                       || ammoType.countsAsFlak()) {
-                    toHit.addModifier(TH_WEAPON_FLAK);
+                    if (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.HAG) {
+                        toHit.addModifier(TH_WEAPON_FLAK_HAG);
+                    } else {
+                        toHit.addModifier(TH_WEAPON_FLAK);
+                    }
                 } else if (ammoType.getMunitionType().stream().anyMatch(ArtyOnlyMunitions::contains)) {
                     toHit.addModifier(TH_WEAPON_CANNOT_FIRE);
                 }
@@ -1118,6 +1156,16 @@ public class FireControl {
               && (EntityMovementType.MOVE_RUN == shooter.moved)) {
             toHit.addModifier(TH_STABLE_WEAPON);
         }
+
+        // Board-global environmental effects: weather, wind, gravity, fog, blowing sand, and
+        // night/illumination. These apply equally at every candidate position, but folding them in
+        // keeps the guessed to-hit honest so Princess does not over-value shots taken in poor
+        // conditions. The committed firing plan already accounts for these via the real engine
+        // calculation; this brings the movement-ranking estimate in line with it.
+        final AmmoType environmentalAmmoType =
+              (ammo != null && ammo.getType() instanceof AmmoType firedAmmoType) ? firedAmmoType : null;
+        toHit.append(ComputeEnvironmentalToHitMods.compileEnvironmentalToHitMods(
+              game, shooter, target, weaponType, environmentalAmmoType, null, false));
 
         return toHit;
     }

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -76,6 +76,7 @@ import megamek.common.rolls.TargetRoll;
 import megamek.common.units.*;
 import megamek.common.weapons.Weapon;
 import megamek.common.weapons.attacks.StopSwarmAttack;
+import megamek.common.weapons.capitalWeapons.CapitalMissileWeapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
 import megamek.common.weapons.missiles.MMLWeapon;
 import megamek.logging.MMLogger;
@@ -1171,11 +1172,20 @@ public class FireControl {
         // calculation; this brings the movement-ranking estimate in line with it.
         final AmmoType environmentalAmmoType =
               (firingAmmo != null && firingAmmo.getType() instanceof AmmoType firedAmmoType) ? firedAmmoType : null;
+        // Indirect artillery (Targeting/Offboard phases) intentionally skips the night modifiers in
+        // the real engine calculation, so mirror the engine's own isArtilleryIndirect determination
+        // here rather than hardcoding false; otherwise the guessed to-hit for planned indirect
+        // artillery fire would diverge from the real to-hit under night/illumination rules.
+        boolean isGroundToGroundCapitalMissile =
+              (weaponType instanceof CapitalMissileWeapon) && Compute.isGroundToGround(shooter, target);
+        boolean isArtilleryWeapon = weaponType.hasFlag(WeaponType.F_ARTILLERY) || isGroundToGroundCapitalMissile;
+        boolean isArtilleryIndirect = isArtilleryWeapon
+              && (game.getPhase().isTargeting() || game.getPhase().isOffboard());
         // Pass the running toHit as the accumulator so the environmental mods are appended in place,
         // avoiding a throwaway ToHitData allocation on this movement-ranking hot path. The method
         // mutates and returns the same instance when the accumulator is non-null.
         ComputeEnvironmentalToHitMods.compileEnvironmentalToHitMods(
-              game, shooter, target, weaponType, environmentalAmmoType, toHit, false);
+              game, shooter, target, weaponType, environmentalAmmoType, toHit, isArtilleryIndirect);
 
         return toHit;
     }

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1171,8 +1171,11 @@ public class FireControl {
         // calculation; this brings the movement-ranking estimate in line with it.
         final AmmoType environmentalAmmoType =
               (firingAmmo != null && firingAmmo.getType() instanceof AmmoType firedAmmoType) ? firedAmmoType : null;
-        toHit.append(ComputeEnvironmentalToHitMods.compileEnvironmentalToHitMods(
-              game, shooter, target, weaponType, environmentalAmmoType, null, false));
+        // Pass the running toHit as the accumulator so the environmental mods are appended in place,
+        // avoiding a throwaway ToHitData allocation on this movement-ranking hot path. The method
+        // mutates and returns the same instance when the accumulator is non-null.
+        ComputeEnvironmentalToHitMods.compileEnvironmentalToHitMods(
+              game, shooter, target, weaponType, environmentalAmmoType, toHit, false);
 
         return toHit;
     }

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -997,29 +997,36 @@ public class FireControl {
                   AmmoType.Munitions.M_FAE);
             EnumSet<AmmoType.Munitions> homingMunitions = EnumSet.of(
                   AmmoType.Munitions.M_HOMING);
+            // Autocannon families that take armor-piercing ammunition
+            EnumSet<AmmoType.AmmoTypeEnum> autocannonAmmoTypes = EnumSet.of(
+                  AmmoType.AmmoTypeEnum.AC,
+                  AmmoType.AmmoTypeEnum.LAC,
+                  AmmoType.AmmoTypeEnum.AC_IMP,
+                  AmmoType.AmmoTypeEnum.PAC);
             if (0 != ammoType.getToHitModifier()) {
                 toHit.addModifier(ammoType.getToHitModifier(), TH_AMMO_MOD);
             }
             // Apollo FCS gives MRMs -1 to-hit (TO:AR). Apollo is not negated by ECM.
             Mounted<?> ammoLinker = weapon.getLinkedBy();
-            boolean hasApolloFcs = (ammoLinker != null)
+            boolean isApolloFcs = (ammoLinker != null)
                   && (ammoLinker.getType() instanceof MiscType)
-                  && !ammoLinker.isDestroyed() && !ammoLinker.isMissing() && !ammoLinker.isBreached()
-                  && ammoLinker.getType().hasFlag(MiscType.F_APOLLO)
-                  && (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.MRM);
-            if (hasApolloFcs) {
+                  && ammoLinker.getType().hasFlag(MiscType.F_APOLLO);
+            boolean isApolloFcsOperational = isApolloFcs
+                  && !ammoLinker.isDestroyed()
+                  && !ammoLinker.isMissing()
+                  && !ammoLinker.isBreached();
+            boolean isMrmAmmo = (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.MRM);
+            if (isApolloFcsOperational && isMrmAmmo) {
                 toHit.addModifier(TH_APOLLO);
             }
             // Armor-piercing autocannon ammo is a flat +1 to-hit (removed under PLAYTEST 3 rules).
-            boolean isArmorPiercingAutocannon =
-                  ((ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.AC)
-                        || (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.LAC)
-                        || (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.AC_IMP)
-                        || (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.PAC))
-                        && (ammoType.getMunitionType().contains(AmmoType.Munitions.M_ARMOR_PIERCING)
-                        || ammoType.getMunitionType().contains(AmmoType.Munitions.M_ARMOR_PIERCING_PLAYTEST));
-            if (isArmorPiercingAutocannon
-                  && !game.getOptions().booleanOption(OptionsConstants.PLAYTEST_3)) {
+            boolean isAutocannonAmmo = autocannonAmmoTypes.contains(ammoType.getAmmoType());
+            boolean isArmorPiercingMunition =
+                  ammoType.getMunitionType().contains(AmmoType.Munitions.M_ARMOR_PIERCING)
+                        || ammoType.getMunitionType().contains(AmmoType.Munitions.M_ARMOR_PIERCING_PLAYTEST);
+            boolean isArmorPiercingPenaltyInEffect =
+                  !game.getOptions().booleanOption(OptionsConstants.PLAYTEST_3);
+            if (isAutocannonAmmo && isArmorPiercingMunition && isArmorPiercingPenaltyInEffect) {
                 toHit.addModifier(TH_AP_AMMO);
             }
             // Air-defense Arrow IV handling; can only fire at airborne targets

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2011 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2011-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2011-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -53,6 +53,7 @@ import megamek.common.actions.SearchlightAttackAction;
 import megamek.common.actions.SpotAction;
 import megamek.common.actions.UnjamTurretAction;
 import megamek.common.actions.WeaponAttackAction;
+import megamek.common.actions.compute.ComputeEnvironmentalToHitMods;
 import megamek.common.annotations.Nullable;
 import megamek.common.annotations.StaticWrapper;
 import megamek.common.battleArmor.BattleArmor;
@@ -126,6 +127,7 @@ public class FireControl {
     static final String TH_HEAT = "heat";
     static final String TH_WEAPON_MOD = "weapon to-hit";
     static final String TH_AMMO_MOD = "ammunition to-hit modifier";
+    static final String TH_TAR_EVADING = "target evading";
     static final TargetRollModifier TH_ATT_PRONE = new TargetRollModifier(2, "attacker prone");
     static final TargetRollModifier TH_TAR_IMMOBILE = new TargetRollModifier(-4, "target immobile");
     static final TargetRollModifier TH_TAR_SKID = new TargetRollModifier(2, "target skidded");
@@ -196,7 +198,11 @@ public class FireControl {
           "prone leg weapon");
     static final TargetRollModifier TH_WEAPON_ADA = new TargetRollModifier(-2,
           "Air-Defense Arrow IV vs airborne target");
-    static final TargetRollModifier TH_WEAPON_FLAK = new TargetRollModifier(-1, "Flak vs airborne target");
+    static final TargetRollModifier TH_WEAPON_FLAK = new TargetRollModifier(-2, "Flak vs airborne target");
+    static final TargetRollModifier TH_WEAPON_FLAK_HAG = new TargetRollModifier(-3,
+          "HAG Flak vs airborne target");
+    static final TargetRollModifier TH_APOLLO = new TargetRollModifier(-1, "Apollo FCS");
+    static final TargetRollModifier TH_AP_AMMO = new TargetRollModifier(1, "armor-piercing ammo");
     static final TargetRollModifier TH_WEAPON_NO_ARC = new TargetRollModifier(TargetRoll.IMPOSSIBLE, "not in arc");
     static final TargetRollModifier TH_INF_ZERO_RNG = new TargetRollModifier(TargetRoll.AUTOMATIC_FAIL,
           "non-infantry shooting with zero range");
@@ -469,6 +475,12 @@ public class FireControl {
 
         if ((target instanceof Dropship) && !target.isAirborne()) {
             toHitData.addModifier(TH_TAR_GROUND_DS);
+        }
+
+        // Evading targets are harder to hit (TW p.111). Evasion is a property of the target, so it
+        // is independent of where the shooter moves.
+        if ((target instanceof Entity targetEntity) && targetEntity.isEvading()) {
+            toHitData.addModifier(targetEntity.getEvasionBonus(), TH_TAR_EVADING);
         }
 
         return toHitData;
@@ -988,6 +1000,28 @@ public class FireControl {
             if (0 != ammoType.getToHitModifier()) {
                 toHit.addModifier(ammoType.getToHitModifier(), TH_AMMO_MOD);
             }
+            // Apollo FCS gives MRMs -1 to-hit (TO:AR). Apollo is not negated by ECM.
+            Mounted<?> ammoLinker = weapon.getLinkedBy();
+            boolean hasApolloFcs = (ammoLinker != null)
+                  && (ammoLinker.getType() instanceof MiscType)
+                  && !ammoLinker.isDestroyed() && !ammoLinker.isMissing() && !ammoLinker.isBreached()
+                  && ammoLinker.getType().hasFlag(MiscType.F_APOLLO)
+                  && (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.MRM);
+            if (hasApolloFcs) {
+                toHit.addModifier(TH_APOLLO);
+            }
+            // Armor-piercing autocannon ammo is a flat +1 to-hit (removed under PLAYTEST 3 rules).
+            boolean isArmorPiercingAutocannon =
+                  ((ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.AC)
+                        || (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.LAC)
+                        || (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.AC_IMP)
+                        || (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.PAC))
+                        && (ammoType.getMunitionType().contains(AmmoType.Munitions.M_ARMOR_PIERCING)
+                        || ammoType.getMunitionType().contains(AmmoType.Munitions.M_ARMOR_PIERCING_PLAYTEST));
+            if (isArmorPiercingAutocannon
+                  && !game.getOptions().booleanOption(OptionsConstants.PLAYTEST_3)) {
+                toHit.addModifier(TH_AP_AMMO);
+            }
             // Air-defense Arrow IV handling; can only fire at airborne targets
             if (ammoType.getMunitionType().contains(AmmoType.Munitions.M_ADA)) {
                 if (target.isAirborne() || target.isAirborneVTOLorWIGE()) {
@@ -1000,7 +1034,11 @@ public class FireControl {
             if (target.isAirborne() || target.isAirborneVTOLorWIGE()) {
                 if (ammoType.getMunitionType().stream().anyMatch(aaMunitions::contains)
                       || ammoType.countsAsFlak()) {
-                    toHit.addModifier(TH_WEAPON_FLAK);
+                    if (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.HAG) {
+                        toHit.addModifier(TH_WEAPON_FLAK_HAG);
+                    } else {
+                        toHit.addModifier(TH_WEAPON_FLAK);
+                    }
                 } else if (ammoType.getMunitionType().stream().anyMatch(ArtyOnlyMunitions::contains)) {
                     toHit.addModifier(TH_WEAPON_CANNOT_FIRE);
                 }
@@ -1118,6 +1156,16 @@ public class FireControl {
               && (EntityMovementType.MOVE_RUN == shooter.moved)) {
             toHit.addModifier(TH_STABLE_WEAPON);
         }
+
+        // Board-global environmental effects: weather, wind, gravity, fog, blowing sand, and
+        // night/illumination. These apply equally at every candidate position, but folding them in
+        // keeps the guessed to-hit honest so Princess does not over-value shots taken in poor
+        // conditions. The committed firing plan already accounts for these via the real engine
+        // calculation; this brings the movement-ranking estimate in line with it.
+        final AmmoType environmentalAmmoType =
+              (ammo != null && ammo.getType() instanceof AmmoType firedAmmoType) ? firedAmmoType : null;
+        toHit.append(ComputeEnvironmentalToHitMods.compileEnvironmentalToHitMods(
+              game, shooter, target, weaponType, environmentalAmmoType, null, false));
 
         return toHit;
     }

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -560,15 +560,16 @@ public abstract class PathRanker implements IPathRanker {
             // High-gravity jump: half the walk MP lost to gravity (TO:AR gravity rules).
             overspeedMP = (movingEntity.getWalkMP(MPCalculationSetting.NO_GRAVITY) - movingEntity.getWalkMP()) / 2;
         } else if (path.isJumping()) {
-            // Low-gravity jump overspeed: MP used beyond the 1G jump rating.
-            overspeedMP = lastStep.getMpUsed() - movingEntity.getJumpMP(MPCalculationSetting.NO_GRAVITY);
+            // Low-gravity jump overspeed: MP used beyond the 1G jump rating. A mechanical jump booster uses
+            // its own no-gravity rating, matching the server extreme-gravity damage calculation.
+            int noGravityJumpMP = lastStep.isUsingMekJumpBooster()
+                  ? movingEntity.getMechanicalJumpBoosterMP(MPCalculationSetting.NO_GRAVITY)
+                  : movingEntity.getJumpMP(MPCalculationSetting.NO_GRAVITY);
+            overspeedMP = lastStep.getMpUsed() - noGravityJumpMP;
         } else {
-            // Low-gravity ground overspeed: MP used beyond the 1G running limit (+1 for a pavement/road bonus).
-            int gravityLimit = movingEntity.getRunningGravityLimit();
-            if (lastStep.isOnlyPavementOrRoad() && movingEntity.isEligibleForPavementOrRoadBonus()) {
-                gravityLimit++;
-            }
-            overspeedMP = lastStep.getMpUsed() - gravityLimit;
+            // Low-gravity ground overspeed: MP used beyond the 1G running limit. The server's extreme-gravity
+            // damage uses getRunningGravityLimit() directly (no pavement/road adjustment), so mirror it.
+            overspeedMP = lastStep.getMpUsed() - movingEntity.getRunningGravityLimit();
         }
 
         if (overspeedMP <= 0) {

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -52,6 +52,7 @@ import megamek.client.bot.BotLogger;
 import megamek.client.bot.princess.UnitBehavior.BehaviorType;
 import megamek.client.ui.Messages;
 import megamek.client.ui.SharedUtility;
+import megamek.common.MPCalculationSetting;
 import megamek.common.annotations.Nullable;
 import megamek.common.board.Board;
 import megamek.common.board.Coords;
@@ -71,6 +72,12 @@ import org.apache.logging.log4j.Level;
 public abstract class PathRanker implements IPathRanker {
     private final static MMLogger logger = MMLogger.create(PathRanker.class);
     private static final BotLogger botLogger = new BotLogger();
+
+    // Piloting-roll descriptions emitted for gravity overspeed (see Entity.checkMovedTooFast and
+    // SharedUtility.getPSRList). Matched lower-cased to add the self-inflicted leg damage into a path's
+    // expected damage taken. Kept as literals because the engine emits them as raw strings, not i18n keys.
+    private static final String PSR_DESC_GRAVITY_TOO_FAST = "used more mps than at 1g possible";
+    private static final String PSR_DESC_GRAVITY_HIGH_JUMP = "jumped in high gravity";
     // TODO: Introduce PathRankerCacheHelper class that contains "global" path
     // ranker state
     // TODO: Introduce FireControlCacheHelper class that contains "global" Fire
@@ -495,7 +502,8 @@ public abstract class PathRanker implements IPathRanker {
      * Estimates the most expected damage that a path could cause, given the pilot skill of the path ranker and various
      * conditions.
      * <p>
-     * XXX Sleet01: add fall pilot damage, skid damage, and low-gravity overspeed damage calcs
+     * XXX Sleet01: add fall pilot damage and skid damage calcs (low-/high-gravity overspeed leg damage is
+     * handled below via {@link #predictGravityOverspeedDamage}).
      */
     protected double calculateMovePathPSRDamage(Entity movingEntity, MovePath path) {
         double damage = 0.0;
@@ -512,10 +520,64 @@ public abstract class PathRanker implements IPathRanker {
                   description.contains(Messages.getString("TacOps.leaping.fall_damage"))
             ) {
                 damage += predictLeapFallDamage(movingEntity, roll);
+            } else if (
+                  description.contains(PSR_DESC_GRAVITY_TOO_FAST)
+                        || description.contains(PSR_DESC_GRAVITY_HIGH_JUMP)
+            ) {
+                damage += predictGravityOverspeedDamage(movingEntity, path, roll);
             }
         }
 
         return damage;
+    }
+
+    /**
+     * Predicts the self-inflicted leg internal-structure damage Princess would take if she failed the gravity
+     * "overspeed" piloting roll on this path. On low-gravity worlds a unit can run or jump farther than its 1G
+     * rating allows, and on high-gravity worlds a jump that costs it walk MP triggers a roll; failing either
+     * deals extreme-gravity damage to the legs (1 point per MP over the 1G limit for ground or low-gravity
+     * jumps, or {@code (1G walk MP - gravity walk MP) / 2} for a high-gravity jump).
+     *
+     * <p>Unlike the leaping rolls, the gravity roll does not encode the damage magnitude in its value (see
+     * {@link Entity#checkMovedTooFast}), so it is recomputed from the path's final step. The result is
+     * weighted by the chance of failing the roll, matching {@code predictLeapDamage}.</p>
+     *
+     * @param movingEntity the unit whose path is being ranked
+     * @param path         the candidate path
+     * @param roll         the gravity overspeed piloting roll from {@link #getPSRList(MovePath)}
+     *
+     * @return the odds-weighted expected leg damage, or {@code 0} if the path does not actually overspeed
+     */
+    private double predictGravityOverspeedDamage(Entity movingEntity, MovePath path, TargetRoll roll) {
+        MoveStep lastStep = path.getLastStep();
+        if (lastStep == null) {
+            return 0.0;
+        }
+
+        String description = roll.getLastPlainDesc().toLowerCase();
+        int overspeedMP;
+        if (description.contains(PSR_DESC_GRAVITY_HIGH_JUMP)) {
+            // High-gravity jump: half the walk MP lost to gravity (TO:AR gravity rules).
+            overspeedMP = (movingEntity.getWalkMP(MPCalculationSetting.NO_GRAVITY) - movingEntity.getWalkMP()) / 2;
+        } else if (path.isJumping()) {
+            // Low-gravity jump overspeed: MP used beyond the 1G jump rating.
+            overspeedMP = lastStep.getMpUsed() - movingEntity.getJumpMP(MPCalculationSetting.NO_GRAVITY);
+        } else {
+            // Low-gravity ground overspeed: MP used beyond the 1G running limit (+1 for a pavement/road bonus).
+            int gravityLimit = movingEntity.getRunningGravityLimit();
+            if (lastStep.isOnlyPavementOrRoad() && movingEntity.isEligibleForPavementOrRoadBonus()) {
+                gravityLimit++;
+            }
+            overspeedMP = lastStep.getMpUsed() - gravityLimit;
+        }
+
+        if (overspeedMP <= 0) {
+            return 0.0;
+        }
+
+        // Each excess MP costs 1 point of leg internal structure on a failed roll; weight by failure chance.
+        double failureProbability = 1.0 - (Compute.oddsAbove(roll.getValue(), false) / 100.0);
+        return overspeedMP * failureProbability;
     }
 
     protected List<TargetRoll> getPSRList(MovePath path) {

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -257,6 +257,35 @@ class BasicPathRankerTest {
     }
 
     @Test
+    void testCalculateMovePathPSRDamageLowGravityJumpOverspeedWithBooster() {
+        final Entity mockMek = MockGenerators.generateMockBipedMek(0, 0);
+        // The plain jump rating is deliberately different from the booster rating so the test fails if the
+        // wrong branch (getJumpMP instead of getMechanicalJumpBoosterMP) is taken.
+        when(mockMek.getJumpMP(MPCalculationSetting.NO_GRAVITY)).thenReturn(3);
+        when(mockMek.getMechanicalJumpBoosterMP(MPCalculationSetting.NO_GRAVITY)).thenReturn(5);
+
+        final MovePath mockPath = MockGenerators.generateMockPath(0, 0, mockMek);
+        when(mockPath.isJumping()).thenReturn(true);
+
+        final MoveStep mockLastStep = mock(MoveStep.class);
+        when(mockLastStep.getMpUsed()).thenReturn(7); // 2 MP beyond the 1G booster rating of 5
+        when(mockLastStep.isUsingMekJumpBooster()).thenReturn(true);
+        when(mockPath.getLastStep()).thenReturn(mockLastStep);
+
+        final TargetRoll gravityRoll = MockGenerators.mockTargetRoll(8);
+        when(gravityRoll.getLastPlainDesc()).thenReturn("used more MPs than at 1G possible");
+
+        final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
+        doReturn(List.of(gravityRoll)).when(testRanker).getPSRList(eq(mockPath));
+
+        // Overspeed is measured against the booster's no-gravity rating: 7 - 5 = 2 excess MP.
+        final double failureProbability = 1.0 - (Compute.oddsAbove(8, false) / 100.0);
+        final double expected = 2 * failureProbability;
+
+        assertEquals(expected, testRanker.calculateMovePathPSRDamage(mockMek, mockPath), TOLERANCE);
+    }
+
+    @Test
     void testCalculateMovePathPSRDamageHighGravityJump() {
         final Entity mockMek = MockGenerators.generateMockBipedMek(0, 0);
         when(mockMek.getWalkMP(MPCalculationSetting.NO_GRAVITY)).thenReturn(6);

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -61,9 +61,11 @@ import megamek.client.bot.princess.UnitBehavior.BehaviorType;
 import megamek.client.bot.princess.geometry.HexLine;
 import megamek.codeUtilities.StringUtility;
 import megamek.common.Hex;
+import megamek.common.MPCalculationSetting;
 import megamek.common.battleArmor.BattleArmor;
 import megamek.common.board.Board;
 import megamek.common.board.Coords;
+import megamek.common.compute.Compute;
 import megamek.common.equipment.ArmorType;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.game.Game;
@@ -202,6 +204,69 @@ class BasicPathRankerTest {
 
         double actual = testRanker.getMovePathSuccessProbability(mockPath);
         assertEquals(0.346, actual, TOLERANCE);
+    }
+
+    @Test
+    void testCalculateMovePathPSRDamageLowGravityGroundOverspeed() {
+        final Entity mockMek = MockGenerators.generateMockBipedMek(0, 0);
+        when(mockMek.getRunningGravityLimit()).thenReturn(6);
+
+        final MovePath mockPath = MockGenerators.generateMockPath(0, 0, mockMek);
+        when(mockPath.isJumping()).thenReturn(false);
+
+        final MoveStep mockLastStep = mock(MoveStep.class);
+        when(mockLastStep.getMpUsed()).thenReturn(8); // 2 MP beyond the 1G run limit of 6
+        when(mockLastStep.isOnlyPavementOrRoad()).thenReturn(false);
+        when(mockPath.getLastStep()).thenReturn(mockLastStep);
+
+        final TargetRoll gravityRoll = MockGenerators.mockTargetRoll(8);
+        when(gravityRoll.getLastPlainDesc()).thenReturn("used more MPs than at 1G possible");
+
+        final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
+        doReturn(List.of(gravityRoll)).when(testRanker).getPSRList(eq(mockPath));
+
+        // 2 excess MP -> 2 points of leg internal structure, weighted by the chance of failing the roll.
+        final double failureProbability = 1.0 - (Compute.oddsAbove(8, false) / 100.0);
+        final double expected = 2 * failureProbability;
+
+        assertEquals(expected, testRanker.calculateMovePathPSRDamage(mockMek, mockPath), TOLERANCE);
+    }
+
+    @Test
+    void testCalculateMovePathPSRDamageHighGravityJump() {
+        final Entity mockMek = MockGenerators.generateMockBipedMek(0, 0);
+        when(mockMek.getWalkMP(MPCalculationSetting.NO_GRAVITY)).thenReturn(6);
+        when(mockMek.getWalkMP()).thenReturn(4); // lost 2 walk MP to high gravity -> (6 - 4) / 2 = 1 point
+
+        final MovePath mockPath = MockGenerators.generateMockPath(0, 0, mockMek);
+        when(mockPath.isJumping()).thenReturn(true);
+        when(mockPath.getLastStep()).thenReturn(mock(MoveStep.class));
+
+        final TargetRoll gravityRoll = MockGenerators.mockTargetRoll(9);
+        when(gravityRoll.getLastPlainDesc()).thenReturn("jumped in high gravity");
+
+        final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
+        doReturn(List.of(gravityRoll)).when(testRanker).getPSRList(eq(mockPath));
+
+        final double failureProbability = 1.0 - (Compute.oddsAbove(9, false) / 100.0);
+        final double expected = 1 * failureProbability;
+
+        assertEquals(expected, testRanker.calculateMovePathPSRDamage(mockMek, mockPath), TOLERANCE);
+    }
+
+    @Test
+    void testCalculateMovePathPSRDamageIgnoresNonGravityRolls() {
+        // A normal (non-gravity, non-leaping) piloting roll must contribute no self-damage, so behavior on
+        // 1G worlds is unchanged.
+        final Entity mockMek = MockGenerators.generateMockBipedMek(0, 0);
+        final MovePath mockPath = MockGenerators.generateMockPath(0, 0, mockMek);
+
+        final TargetRoll unrelatedRoll = MockGenerators.mockTargetRoll(8); // getLastPlainDesc() == "mock"
+
+        final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
+        doReturn(List.of(unrelatedRoll)).when(testRanker).getPSRList(eq(mockPath));
+
+        assertEquals(0.0, testRanker.calculateMovePathPSRDamage(mockMek, mockPath), TOLERANCE);
     }
 
     @Test

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -216,7 +216,6 @@ class BasicPathRankerTest {
 
         final MoveStep mockLastStep = mock(MoveStep.class);
         when(mockLastStep.getMpUsed()).thenReturn(8); // 2 MP beyond the 1G run limit of 6
-        when(mockLastStep.isOnlyPavementOrRoad()).thenReturn(false);
         when(mockPath.getLastStep()).thenReturn(mockLastStep);
 
         final TargetRoll gravityRoll = MockGenerators.mockTargetRoll(8);
@@ -226,6 +225,31 @@ class BasicPathRankerTest {
         doReturn(List.of(gravityRoll)).when(testRanker).getPSRList(eq(mockPath));
 
         // 2 excess MP -> 2 points of leg internal structure, weighted by the chance of failing the roll.
+        final double failureProbability = 1.0 - (Compute.oddsAbove(8, false) / 100.0);
+        final double expected = 2 * failureProbability;
+
+        assertEquals(expected, testRanker.calculateMovePathPSRDamage(mockMek, mockPath), TOLERANCE);
+    }
+
+    @Test
+    void testCalculateMovePathPSRDamageLowGravityJumpOverspeed() {
+        final Entity mockMek = MockGenerators.generateMockBipedMek(0, 0);
+        when(mockMek.getJumpMP(MPCalculationSetting.NO_GRAVITY)).thenReturn(5);
+
+        final MovePath mockPath = MockGenerators.generateMockPath(0, 0, mockMek);
+        when(mockPath.isJumping()).thenReturn(true);
+
+        final MoveStep mockLastStep = mock(MoveStep.class);
+        when(mockLastStep.getMpUsed()).thenReturn(7); // 2 MP beyond the 1G jump rating of 5
+        when(mockLastStep.isUsingMekJumpBooster()).thenReturn(false);
+        when(mockPath.getLastStep()).thenReturn(mockLastStep);
+
+        final TargetRoll gravityRoll = MockGenerators.mockTargetRoll(8);
+        when(gravityRoll.getLastPlainDesc()).thenReturn("used more MPs than at 1G possible");
+
+        final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
+        doReturn(List.of(gravityRoll)).when(testRanker).getPSRList(eq(mockPath));
+
         final double failureProbability = 1.0 - (Compute.oddsAbove(8, false) / 100.0);
         final double expected = 2 * failureProbability;
 

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -73,6 +73,7 @@ import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.EquipmentFlag;
 import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.equipment.WeaponType;
@@ -2749,6 +2750,179 @@ class FireControlTest {
         ToHitData expectedNoPenalty = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
         expectedNoPenalty.addModifier(FireControl.TH_MEDIUM_RANGE);
         assertToHitDataEquals(expectedNoPenalty,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
+    }
+
+    @Test
+    void testGuessToHitApolloFcsForMrm() {
+        when(mockGameOptions.booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_RANGE)).thenReturn(false);
+        when(mockTarget.hasQuirk(eq(OptionsConstants.QUIRK_POS_LOW_PROFILE))).thenReturn(false);
+        when(mockShooterState.getFacing()).thenReturn(1);
+        doReturn(true).when(testFireControl).isInArc(any(Coords.class), anyInt(), any(Coords.class), anyInt());
+        doReturn(new ToHitData()).when(testFireControl)
+              .guessToHitModifierHelperForAnyAttack(any(Entity.class),
+                    any(EntityState.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    anyInt(),
+                    any(Game.class));
+        final LosEffects spyLosEffects = spy(new LosEffects());
+        doReturn(spyLosEffects).when(testFireControl)
+              .getLosEffects(any(Game.class),
+                    any(Entity.class),
+                    any(Targetable.class),
+                    any(Coords.class),
+                    any(Coords.class),
+                    anyBoolean());
+        doReturn(new ToHitData()).when(spyLosEffects).losModifiers(eq(mockGame));
+
+        final Hex mockTargetHex = mock(Hex.class);
+        when(mockBoard.getHex(eq(mockTargetCoords))).thenReturn(mockTargetHex);
+        when(mockTargetHex.containsTerrain(Terrains.WATER)).thenReturn(false);
+        when(mockTargetState.getPosition()).thenReturn(mockTargetCoords);
+        when(mockTarget.isAirborne()).thenReturn(false);
+        when(mockTarget.isAirborneVTOLorWIGE()).thenReturn(false);
+
+        final int mockWeaponId = 1;
+        final WeaponMounted mockWeapon = mock(WeaponMounted.class);
+        when(mockWeapon.canFire()).thenReturn(true);
+        when(mockWeapon.getLocation()).thenReturn(Mek.LOC_RIGHT_ARM);
+        when(mockShooter.getEquipmentNum(eq(mockWeapon))).thenReturn(mockWeaponId);
+        when(mockShooter.isSecondaryArcWeapon(mockWeaponId)).thenReturn(false);
+
+        final WeaponType mockWeaponType = mock(WeaponType.class);
+        when(mockWeapon.getType()).thenReturn(mockWeaponType);
+        when(mockWeaponType.getAmmoType()).thenReturn(AmmoType.AmmoTypeEnum.MRM);
+        when(mockWeaponType.getRanges(eq(mockWeapon), any(Mounted.class))).thenReturn(new int[] { 3, 6, 12, 18, 24 });
+        when(mockWeaponType.getMinimumRange()).thenReturn(3);
+        when(mockWeaponType.hasFlag(eq(WeaponType.F_DIRECT_FIRE))).thenReturn(true);
+
+        final AmmoMounted mockAmmo = mock(AmmoMounted.class);
+        when(mockWeapon.getLinked()).thenReturn((Mounted) mockAmmo);
+        when(mockAmmo.getUsableShotsLeft()).thenReturn(10);
+        final AmmoType mockAmmoType = mock(AmmoType.class);
+        when(mockAmmo.getType()).thenReturn(mockAmmoType);
+        when(mockAmmoType.getAmmoType()).thenReturn(AmmoType.AmmoTypeEnum.MRM);
+        when(mockAmmoType.getToHitModifier()).thenReturn(0);
+        when(mockAmmoType.countsAsFlak()).thenReturn(false);
+        when(mockAmmoType.getMunitionType()).thenReturn(EnumSet.of(AmmoType.Munitions.M_STANDARD));
+
+        // An operational Apollo FCS linked to the MRM launcher gives -1 to-hit.
+        final MiscType mockApolloType = mock(MiscType.class);
+        when(mockApolloType.hasFlag(MiscType.F_APOLLO)).thenReturn(true);
+        final Mounted<?> mockApollo = mock(Mounted.class);
+        when(mockApollo.getType()).thenReturn(mockApolloType);
+        when(mockApollo.isDestroyed()).thenReturn(false);
+        when(mockApollo.isMissing()).thenReturn(false);
+        when(mockApollo.isBreached()).thenReturn(false);
+        doReturn(mockApollo).when(mockWeapon).getLinkedBy();
+
+        ToHitData expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
+        expected.addModifier(FireControl.TH_MEDIUM_RANGE);
+        expected.addModifier(FireControl.TH_APOLLO);
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
+
+        // A non-operational Apollo (destroyed) contributes no modifier.
+        when(mockApollo.isDestroyed()).thenReturn(true);
+        ToHitData expectedNoApollo = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
+        expectedNoApollo.addModifier(FireControl.TH_MEDIUM_RANGE);
+        assertToHitDataEquals(expectedNoApollo,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
+    }
+
+    @Test
+    void testGuessToHitFlakVsAirborneHagVersusOther() {
+        when(mockGameOptions.booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_RANGE)).thenReturn(false);
+        when(mockTarget.hasQuirk(eq(OptionsConstants.QUIRK_POS_LOW_PROFILE))).thenReturn(false);
+        when(mockShooterState.getFacing()).thenReturn(1);
+        doReturn(true).when(testFireControl).isInArc(any(Coords.class), anyInt(), any(Coords.class), anyInt());
+        doReturn(new ToHitData()).when(testFireControl)
+              .guessToHitModifierHelperForAnyAttack(any(Entity.class),
+                    any(EntityState.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    anyInt(),
+                    any(Game.class));
+        final LosEffects spyLosEffects = spy(new LosEffects());
+        doReturn(spyLosEffects).when(testFireControl)
+              .getLosEffects(any(Game.class),
+                    any(Entity.class),
+                    any(Targetable.class),
+                    any(Coords.class),
+                    any(Coords.class),
+                    anyBoolean());
+        doReturn(new ToHitData()).when(spyLosEffects).losModifiers(eq(mockGame));
+
+        final Hex mockTargetHex = mock(Hex.class);
+        when(mockBoard.getHex(eq(mockTargetCoords))).thenReturn(mockTargetHex);
+        when(mockTargetHex.containsTerrain(Terrains.WATER)).thenReturn(false);
+        when(mockTargetState.getPosition()).thenReturn(mockTargetCoords);
+        // Flak modifiers only apply against airborne targets.
+        when(mockTarget.isAirborne()).thenReturn(true);
+        when(mockTarget.isAirborneVTOLorWIGE()).thenReturn(false);
+
+        final int mockWeaponId = 1;
+        final WeaponMounted mockWeapon = mock(WeaponMounted.class);
+        when(mockWeapon.canFire()).thenReturn(true);
+        when(mockWeapon.getLocation()).thenReturn(Mek.LOC_RIGHT_ARM);
+        when(mockShooter.getEquipmentNum(eq(mockWeapon))).thenReturn(mockWeaponId);
+        when(mockShooter.isSecondaryArcWeapon(mockWeaponId)).thenReturn(false);
+
+        final WeaponType mockWeaponType = mock(WeaponType.class);
+        when(mockWeapon.getType()).thenReturn(mockWeaponType);
+        when(mockWeaponType.getAmmoType()).thenReturn(AmmoType.AmmoTypeEnum.HAG);
+        when(mockWeaponType.getRanges(eq(mockWeapon), any(Mounted.class))).thenReturn(new int[] { 3, 6, 12, 18, 24 });
+        when(mockWeaponType.getMinimumRange()).thenReturn(3);
+        when(mockWeaponType.hasFlag(eq(WeaponType.F_DIRECT_FIRE))).thenReturn(true);
+
+        final AmmoMounted mockAmmo = mock(AmmoMounted.class);
+        when(mockWeapon.getLinked()).thenReturn((Mounted) mockAmmo);
+        when(mockAmmo.getUsableShotsLeft()).thenReturn(10);
+        final AmmoType mockAmmoType = mock(AmmoType.class);
+        when(mockAmmo.getType()).thenReturn(mockAmmoType);
+        when(mockAmmoType.getToHitModifier()).thenReturn(0);
+        when(mockAmmoType.countsAsFlak()).thenReturn(false);
+        when(mockAmmoType.getMunitionType()).thenReturn(EnumSet.of(AmmoType.Munitions.M_FLAK));
+
+        // HAG flak against an airborne target is -3.
+        when(mockAmmoType.getAmmoType()).thenReturn(AmmoType.AmmoTypeEnum.HAG);
+        ToHitData expectedHag = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
+        expectedHag.addModifier(FireControl.TH_MEDIUM_RANGE);
+        expectedHag.addModifier(FireControl.TH_WEAPON_FLAK_HAG);
+        assertToHitDataEquals(expectedHag,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
+
+        // Non-HAG flak against an airborne target is -2.
+        when(mockAmmoType.getAmmoType()).thenReturn(AmmoType.AmmoTypeEnum.AC);
+        ToHitData expectedFlak = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
+        expectedFlak.addModifier(FireControl.TH_MEDIUM_RANGE);
+        expectedFlak.addModifier(FireControl.TH_WEAPON_FLAK);
+        assertToHitDataEquals(expectedFlak,
               testFireControl.guessToHitModifierForWeapon(mockShooter,
                     mockShooterState,
                     mockTarget,

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -2646,6 +2646,119 @@ class FireControlTest {
     }
 
     @Test
+    void testGuessToHitEvadingTarget() {
+        // Mirror the vanilla helper case, then mark the target as evading.
+        when(mockShooterState.isProne()).thenReturn(false);
+        when(mockShooter.hasQuirk(eq(OptionsConstants.QUIRK_POS_ANTI_AIR))).thenReturn(false);
+        when(((Mek) mockShooter).hasAdvancedFireControl()).thenReturn(true);
+        when(mockTargetState.isImmobile()).thenReturn(false);
+        when(mockTargetState.getMovementType()).thenReturn(EntityMovementType.MOVE_NONE);
+        when(mockTargetState.getPosition()).thenReturn(new Coords(10, 0));
+        when(mockTargetState.isProne()).thenReturn(false);
+        when(mockTarget.isAirborne()).thenReturn(false);
+        when(mockTarget.isAirborneVTOLorWIGE()).thenReturn(false);
+        when(mockGameOptions.booleanOption(eq(OptionsConstants.ADVANCED_GROUND_MOVEMENT_TAC_OPS_STANDING_STILL)))
+              .thenReturn(false);
+        when(mockHex.terrainLevel(Terrains.WOODS)).thenReturn(Terrain.LEVEL_NONE);
+        when(mockHex.terrainLevel(Terrains.JUNGLE)).thenReturn(Terrain.LEVEL_NONE);
+        when(mockHex.terrainLevel(Terrains.SMOKE)).thenReturn(Terrain.LEVEL_NONE);
+        when(mockPrincess.getMaxWeaponRange(any(Entity.class), anyBoolean())).thenReturn(21);
+
+        when(mockTarget.isEvading()).thenReturn(true);
+        when(mockTarget.getEvasionBonus()).thenReturn(2);
+        ToHitData expected = new ToHitData();
+        expected.addModifier(2, FireControl.TH_TAR_EVADING);
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierHelperForAnyAttack(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    10,
+                    mockGame));
+    }
+
+    @Test
+    void testGuessToHitArmorPiercingAmmo() {
+        when(mockGameOptions.booleanOption(OptionsConstants.ADVANCED_COMBAT_TAC_OPS_RANGE)).thenReturn(false);
+        when(mockTarget.hasQuirk(eq(OptionsConstants.QUIRK_POS_LOW_PROFILE))).thenReturn(false);
+        when(mockShooterState.getFacing()).thenReturn(1);
+        doReturn(true).when(testFireControl).isInArc(any(Coords.class), anyInt(), any(Coords.class), anyInt());
+        doReturn(new ToHitData()).when(testFireControl)
+              .guessToHitModifierHelperForAnyAttack(any(Entity.class),
+                    any(EntityState.class),
+                    any(Targetable.class),
+                    any(EntityState.class),
+                    anyInt(),
+                    any(Game.class));
+        final LosEffects spyLosEffects = spy(new LosEffects());
+        doReturn(spyLosEffects).when(testFireControl)
+              .getLosEffects(any(Game.class),
+                    any(Entity.class),
+                    any(Targetable.class),
+                    any(Coords.class),
+                    any(Coords.class),
+                    anyBoolean());
+        doReturn(new ToHitData()).when(spyLosEffects).losModifiers(eq(mockGame));
+
+        final Hex mockTargetHex = mock(Hex.class);
+        when(mockBoard.getHex(eq(mockTargetCoords))).thenReturn(mockTargetHex);
+        when(mockTargetHex.containsTerrain(Terrains.WATER)).thenReturn(false);
+        when(mockTargetState.getPosition()).thenReturn(mockTargetCoords);
+        when(mockTarget.isAirborne()).thenReturn(false);
+        when(mockTarget.isAirborneVTOLorWIGE()).thenReturn(false);
+
+        final int mockWeaponId = 1;
+        final WeaponMounted mockWeapon = mock(WeaponMounted.class);
+        when(mockWeapon.canFire()).thenReturn(true);
+        when(mockWeapon.getLocation()).thenReturn(Mek.LOC_RIGHT_ARM);
+        when(mockShooter.getEquipmentNum(eq(mockWeapon))).thenReturn(mockWeaponId);
+        when(mockShooter.isSecondaryArcWeapon(mockWeaponId)).thenReturn(false);
+
+        final WeaponType mockWeaponType = mock(WeaponType.class);
+        when(mockWeapon.getType()).thenReturn(mockWeaponType);
+        when(mockWeaponType.getAmmoType()).thenReturn(AmmoType.AmmoTypeEnum.AC);
+        when(mockWeaponType.getRanges(eq(mockWeapon), any(Mounted.class))).thenReturn(new int[] { 3, 6, 12, 18, 24 });
+        when(mockWeaponType.getMinimumRange()).thenReturn(3);
+        when(mockWeaponType.hasFlag(eq(WeaponType.F_DIRECT_FIRE))).thenReturn(true);
+
+        final AmmoMounted mockAmmo = mock(AmmoMounted.class);
+        when(mockWeapon.getLinked()).thenReturn((Mounted) mockAmmo);
+        when(mockAmmo.getUsableShotsLeft()).thenReturn(10);
+        final AmmoType mockAmmoType = mock(AmmoType.class);
+        when(mockAmmo.getType()).thenReturn(mockAmmoType);
+        when(mockAmmoType.getAmmoType()).thenReturn(AmmoType.AmmoTypeEnum.AC);
+        when(mockAmmoType.getToHitModifier()).thenReturn(0);
+        when(mockAmmoType.countsAsFlak()).thenReturn(false);
+        when(mockAmmoType.getMunitionType()).thenReturn(EnumSet.of(AmmoType.Munitions.M_ARMOR_PIERCING));
+
+        // Armor-piercing autocannon ammo adds +1 to-hit.
+        ToHitData expected = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
+        expected.addModifier(FireControl.TH_MEDIUM_RANGE);
+        expected.addModifier(FireControl.TH_AP_AMMO);
+        assertToHitDataEquals(expected,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
+
+        // Under PLAYTEST 3 rules the AP penalty is removed.
+        when(mockGameOptions.booleanOption(OptionsConstants.PLAYTEST_3)).thenReturn(true);
+        ToHitData expectedNoPenalty = new ToHitData(mockShooter.getCrew().getGunnery(), FireControl.TH_GUNNERY);
+        expectedNoPenalty.addModifier(FireControl.TH_MEDIUM_RANGE);
+        assertToHitDataEquals(expectedNoPenalty,
+              testFireControl.guessToHitModifierForWeapon(mockShooter,
+                    mockShooterState,
+                    mockTarget,
+                    mockTargetState,
+                    mockWeapon,
+                    mockAmmo,
+                    mockGame));
+    }
+
+    @Test
     void testGuessAirToGroundStrikeToHitModifier() {
         final MovePath mockFlightPathGood = mock(MovePath.class);
         final MovePath mockFlightPathBad = mock(MovePath.class);


### PR DESCRIPTION
## Summary

Princess (and CASPAR, which inherits her logic) plans movement with a fast "guess" estimate that was ignoring effects the real combat math applies. That led to two visible mistakes:

1. She over-valued shots she can't really make in bad conditions. When choosing where to move she did not account for weather, wind, fog, blowing sand, gravity, night, an evading target, or a few ammo types. So on a stormy night she would advance into the open expecting hits that the rules make far harder. (Her actual weapon fire was always computed correctly — only the movement estimate was blind.)
2. She would break her own legs on low-gravity worlds. Moving faster than your 1G rating — which low gravity lets you do — risks a piloting roll that, on failure, deals internal-structure damage to your legs. Princess weighed the chance of that roll but not the damage, so under pressure she would knowingly overspeed and cripple herself.

This PR folds both into her movement-ranking estimate. It changes only how she positions; her committed weapon fire is unchanged (it was already correct).

## What changes for players

- Princess positions more sensibly in weather/night/low-gravity: she stops advancing for shots the conditions make impossible, and stops needlessly breaking her own legs running/jumping in low gravity.
- Worked example (gravity): on a 0.5G world, before this change her planner rated autocannon/LRM shots ~2 easier than they really are (it ignored gravity) and never counted the leg damage from over-jumping. In a low-gravity bot-vs-bot battery she triggered roughly two-thirds fewer overspeed events after the fix.

## Changes

1. FireControl (the guessed to-hit used for movement ranking): fold in environmental effects (one call to the existing ComputeEnvironmentalToHitMods), an evading-target modifier, and a few munition modifiers (Apollo FCS −1, armor-piercing autocannon ammo +1, corrected Flak −2 / HAG-Flak −3).
2. PathRanker: cost the self-inflicted leg damage from a failng roll (new predictGravityOverspeedDamage helper incalculateMovePathPSRDamage), mirroring the existing leap-damage handling.

Both land in shared Princess classes, so CASPAR inherits them.

## Files Changed

- FireControl.java — environmental / evading / munition modifiers in the guessed to-hit
- PathRanker.java — gravity-overspeed leg-damage cost in calc
- FireControlTest.java — evading-target and AP-ammo (incl. PLAYTEST 3) tests
- BasicPathRankerTest.java — low-gravity ground overspeed, hiavity regression

## Testing

- Unit tests above; full megamek.client.bot.princess package green.
- Headless bot-vs-bot batteries (ScenarioGameRunner, 4v4 Princess vs Princess):
  - Environmental: a guess-vs-real to-hit cross-check at gravt guess never included gravity (0 of 164 shots); after, itmatches (219 vs 217). Zero exceptions across clear / rain+gale / snow+fog / night / low-gravity+EMI conditions.
  - Gravity: a low-gravity (0.5) jumper-heavy battery — roughly 12 overspeed events/game before the fix vs ~3–4 after (about two-thirds fewer), zero exceptions.
  
  Fixes (or at least improves) https://github.com/MegaMek/megamek/issues/1006