### PR TITLE
Teach Princess to cross water and close to melee

### DIFF
--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2011 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2011-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2011-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -1686,9 +1686,12 @@ public class BasicPathRanker extends PathRanker {
         Coords facingTarget = (standoffArtillery && (highValueClusterPosition != null))
               ? highValueClusterPosition
               : null;
-        // A melee unit that is closing to contact must square up on its target so it can strike next turn (a
-        // hatchet/kick cannot be delivered through a torso twist); it faces the closest enemy exactly rather
-        // than settling for any facing within the usual tolerance (issue #7627).
+        // Square up exactly on the closest enemy (facing it dead-on rather than settling for any facing within
+        // the usual tolerance) when the unit both benefits from closing (closeRangeIncentive > 0) and can still
+        // deliver a point-blank physical attack this move (estimatedMeleeDamage > 0). The latter is true for any
+        // upright, mobile Mek, not only dedicated hatchet units - that breadth is deliberate ("damage peaks at
+        // close range"): a kick or hatchet cannot be thrown through a torso twist, and facing dead-on also keeps
+        // the strongest forward arc on the target it is charging (issue #7627).
         boolean squareUpOnClosestEnemy = (facingTarget == null) && (closeRangeIncentive > 0)
               && (estimatedMeleeDamage(movingUnit) > 0);
         double facingMod = calculateFacingMod(movingUnit,

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -2400,12 +2400,12 @@ public class BasicPathRanker extends PathRanker {
         // Locations that submerge only when the unit is prone - notably the head and center torso in Depth 1
         // water - drown it only if it falls, so that catastrophic risk is weighted by the chance of failing
         // the water-entry piloting roll.
-        Set<Integer> submergedWhileUpright = submergedLocations(movingUnit, hex, step.isProne());
+        Set<Integer> submergedInCurrentPose = submergedLocations(movingUnit, hex, step.isProne());
         Set<Integer> submergedWhileProne = submergedLocations(movingUnit, hex, true);
 
         double hazardValue = 0;
         // Certain breaches: unarmored locations already submerged in the unit's current pose.
-        for (int location : submergedWhileUpright) {
+        for (int location : submergedInCurrentPose) {
             if (movingUnit.getArmor(location) > 0) {
                 continue;
             }
@@ -2421,7 +2421,7 @@ public class BasicPathRanker extends PathRanker {
         // the fall probability lazily so a fully-armored unit never triggers it.
         double fallProbability = -1;
         for (int location : submergedWhileProne) {
-            if (submergedWhileUpright.contains(location) || (movingUnit.getArmor(location) > 0)) {
+            if (submergedInCurrentPose.contains(location) || (movingUnit.getArmor(location) > 0)) {
                 continue;
             }
             double breachWeight = breachConsequence(movingUnit, location);
@@ -2470,19 +2470,24 @@ public class BasicPathRanker extends PathRanker {
      * @param movingUnit the wading unit
      * @param location   the location index
      *
-     * @return the hazard weight of breaching {@code location}: {@link #UNIT_DESTRUCTION_FACTOR} for a head or
-     *       center-torso breach (or any breach on a non-Mek/ProtoMek, which drowns), otherwise a fixed
-     *       per-location cost
+     * @return the hazard weight of breaching {@code location}: {@link #UNIT_DESTRUCTION_FACTOR} for a
+     *       life-critical breach (head or center torso on a Mek, head or torso on a ProtoMek, or any breach on
+     *       a non-Mek/ProtoMek, which drowns), otherwise a fixed per-location cost
      */
     private double breachConsequence(Entity movingUnit, int location) {
-        if ((Mek.LOC_HEAD == location) ||
-              (Mek.LOC_CENTER_TORSO == location) ||
-              (ProtoMek.LOC_HEAD == location) ||
-              (ProtoMek.LOC_TORSO == location) ||
-              (!movingUnit.isMek() && !movingUnit.isProtoMek())) {
-            return UNIT_DESTRUCTION_FACTOR;
+        // The Mek and ProtoMek location numbering overlaps (e.g. Mek right torso and ProtoMek torso are both
+        // index 2), so the critical-location test must be chosen by the unit's actual type rather than testing
+        // all four constants against one index.
+        if (movingUnit.isProtoMek()) {
+            boolean isCriticalProtoMekLocation = (ProtoMek.LOC_HEAD == location) || (ProtoMek.LOC_TORSO == location);
+            return isCriticalProtoMekLocation ? UNIT_DESTRUCTION_FACTOR : 50;
         }
-        return 50;
+        if (movingUnit.isMek()) {
+            boolean isCriticalMekLocation = (Mek.LOC_HEAD == location) || (Mek.LOC_CENTER_TORSO == location);
+            return isCriticalMekLocation ? UNIT_DESTRUCTION_FACTOR : 50;
+        }
+        // Anything else that submerges a location while wading simply drowns.
+        return UNIT_DESTRUCTION_FACTOR;
     }
 
     /**

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -113,6 +113,14 @@ public class BasicPathRanker extends PathRanker {
     // so this must outweigh the aggression/bravery incentives that would otherwise favor closing distance
     private final int SPRINT_INTO_THREAT_PENALTY = 250;
 
+    // Closing incentive (issue #7627): a unit whose damage is higher at point-blank range than at its current
+    // range - short-range gunners and, above all, melee brawlers whose hatchet/kick damage is invisible to the
+    // ranged damage estimate until they are adjacent - gets a reward for advancing that grows as it nears
+    // contact. CLOSE_RANGE_BAND is how far out (hexes) the pull begins; CLOSE_RANGE_INCENTIVE_WEIGHT scales its
+    // magnitude against the other rank terms.
+    private static final double CLOSE_RANGE_BAND = 12.0;
+    private static final double CLOSE_RANGE_INCENTIVE_WEIGHT = 1.0;
+
     private final FacingDiffCalculator facingDiffCalculator;
     private final UnitsMedianCoordinateCalculator unitsMedianCoordinateCalculator;
     protected final DecimalFormat LOG_DECIMAL = new DecimalFormat("0.00", new DecimalFormatSymbols(Locale.US));
@@ -688,6 +696,59 @@ public class BasicPathRanker extends PathRanker {
         double aggressionMod = distToEnemy * aggression;
         logger.trace("aggression mod [ -{} = {} * {}]", aggressionMod, distToEnemy, aggression);
         return aggressionMod;
+    }
+
+    /**
+     * A reward for advancing toward point-blank range, for units that do more damage up close than they do at
+     * their current range - short-range gunners and, most importantly, melee brawlers. The ranged damage
+     * estimate credits a unit's hatchet, sword or kick only on the turn it ends adjacent to an enemy, so a
+     * brawler otherwise sees no reason to close and will pace at range (issue #7627: an Axman would not wade a
+     * river to reach hatchet range). This incentive is the unit's point-blank damage premium scaled by how far
+     * it has closed toward contact, so it grows smoothly as the unit advances and is zero for units that
+     * already deliver their best damage at range.
+     *
+     * @param movingUnit  the unit being moved
+     * @param distToEnemy the path's ending distance to the closest enemy
+     *
+     * @return the closing incentive to add to the path's utility (never negative)
+     */
+    protected double calculateCloseRangeIncentive(Entity movingUnit, double distToEnemy) {
+        if ((distToEnemy <= 1) || (distToEnemy >= CLOSE_RANGE_BAND)) {
+            // Already at contact (aggression/bravery take over), or too far out for the pull to apply yet.
+            return 0;
+        }
+        int currentRange = (int) Math.ceil(distToEnemy);
+        double pointBlankDamage = getMaxDamageAtRange(movingUnit, 1, false, false)
+              + estimatedMeleeDamage(movingUnit);
+        double currentRangeDamage = getMaxDamageAtRange(movingUnit, currentRange, false, false);
+        double pointBlankPremium = pointBlankDamage - currentRangeDamage;
+        if (pointBlankPremium <= 0) {
+            // This unit does not gain by closing - it already does its best damage at the current range.
+            return 0;
+        }
+        // Fraction of the way from the engagement band in to contact: 0 at CLOSE_RANGE_BAND, ~1 at range 1.
+        double proximity = (CLOSE_RANGE_BAND - distToEnemy) / (CLOSE_RANGE_BAND - 1);
+        double incentive = pointBlankPremium * proximity * CLOSE_RANGE_INCENTIVE_WEIGHT;
+        logger.trace("close range incentive [ +{} = premium {} * proximity {} * weight {}]",
+              incentive, pointBlankPremium, proximity, CLOSE_RANGE_INCENTIVE_WEIGHT);
+        return incentive;
+    }
+
+    /**
+     * A cheap, distance-independent estimate of a unit's best physical (melee) attack damage, used only to
+     * value closing to contact. Every upright walking Mek can kick for roughly {@code tonnage / 5}, which also
+     * approximates a hatchet or sword on the same chassis; units that cannot make a meaningful physical attack
+     * contribute nothing.
+     *
+     * @param movingUnit the unit being moved
+     *
+     * @return the estimated melee damage, or {@code 0} for units without a useful physical attack
+     */
+    private static double estimatedMeleeDamage(Entity movingUnit) {
+        if (!(movingUnit instanceof Mek) || movingUnit.isProne() || (movingUnit.getWalkMP() <= 0)) {
+            return 0;
+        }
+        return Math.floor(movingUnit.getWeight() / 5.0);
     }
 
     // Indirect artillery (targeting phase) is impossible at one mapsheet or closer - TooShortForIndirectArty,
@@ -1573,6 +1634,13 @@ public class BasicPathRanker extends PathRanker {
         scores.put("aggressionIndex", (double) getOwner().getBehaviorSettings().getHyperAggressionIndex());
         scores.put("aggressionMod", aggressionMod);
 
+        // Pull short-range gunners and melee brawlers toward contact. Standoff units (artillery tubes, TAG
+        // spotters) want to keep their distance, and a unit told to ignore its damage output has no reason to
+        // close, so neither gets the incentive.
+        boolean wantsToClose = (standoffDistance == 0) && !getOwner().getBehaviorSettings().isIgnoreDamageOutput();
+        double closeRangeIncentive = wantsToClose ? calculateCloseRangeIncentive(movingUnit, distToEnemy) : 0;
+        scores.put("closeRangeIncentive", closeRangeIncentive);
+
         // The further I am from my teammates, the lower this path
         // ranks (weighted by Herd Mentality).
         // Standoff artillery (whether holding at range or falling back when the enemy breaches its standoff) ignores the
@@ -1640,6 +1708,7 @@ public class BasicPathRanker extends PathRanker {
         double utility = -fallMod;
         utility += braveryMod;
         utility -= aggressionMod;
+        utility += closeRangeIncentive;
         utility -= herdingMod;
         utility += movementMod;
         utility -= crowdingTolerance;
@@ -1693,6 +1762,9 @@ public class BasicPathRanker extends PathRanker {
             formula.append("0 no friends");
         }
         formula.append("]");
+        if (closeRangeIncentive != 0.0) {
+            formula.append(" + closeRangeIncentive [").append(LOG_DECIMAL.format(closeRangeIncentive)).append("]");
+        }
         if (movementMod != 0.0) {
             formula.append(" + ").append(movementModFormula);
         }

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -2405,33 +2405,33 @@ public class BasicPathRanker extends PathRanker {
 
         double hazardValue = 0;
         // Certain breaches: unarmored locations already submerged in the unit's current pose.
-        for (int loc : submergedWhileUpright) {
-            if (movingUnit.getArmor(loc) > 0) {
+        for (int location : submergedWhileUpright) {
+            if (movingUnit.getArmor(location) > 0) {
                 continue;
             }
-            double breachConsequence = breachConsequence(movingUnit, loc);
-            if (breachConsequence == UNIT_DESTRUCTION_FACTOR) {
-                logger.trace("Location {} breached and critical (destruction).", loc);
+            double breachWeight = breachConsequence(movingUnit, location);
+            if (breachWeight == UNIT_DESTRUCTION_FACTOR) {
+                logger.trace("Location {} breached and critical (destruction).", location);
                 return UNIT_DESTRUCTION_FACTOR;
             }
-            hazardValue += breachConsequence;
+            hazardValue += breachWeight;
         }
 
         // Fall-contingent breaches: unarmored locations that submerge only if the unit falls prone. Compute
         // the fall probability lazily so a fully-armored unit never triggers it.
         double fallProbability = -1;
-        for (int loc : submergedWhileProne) {
-            if (submergedWhileUpright.contains(loc) || (movingUnit.getArmor(loc) > 0)) {
+        for (int location : submergedWhileProne) {
+            if (submergedWhileUpright.contains(location) || (movingUnit.getArmor(location) > 0)) {
                 continue;
             }
-            double breachConsequence = breachConsequence(movingUnit, loc);
-            if (breachConsequence == 0) {
+            double breachWeight = breachConsequence(movingUnit, location);
+            if (breachWeight == 0) {
                 continue;
             }
             if (fallProbability < 0) {
                 fallProbability = waterEntryFallProbability(movingUnit, hex, movePath);
             }
-            hazardValue += fallProbability * breachConsequence;
+            hazardValue += fallProbability * breachWeight;
         }
 
         logger.trace("Water breach hazard {}.", hazardValue);
@@ -2448,20 +2448,22 @@ public class BasicPathRanker extends PathRanker {
      */
     private static Set<Integer> submergedLocations(Entity movingUnit, Hex hex, boolean prone) {
         Set<Integer> submerged = new HashSet<>();
-        for (int loc = 0; loc < movingUnit.locations(); loc++) {
-            if ((Mek.LOC_CENTER_LEG == loc) && !(movingUnit instanceof TripodMek)) {
+        for (int location = 0; location < movingUnit.locations(); location++) {
+            if ((Mek.LOC_CENTER_LEG == location) && !(movingUnit instanceof TripodMek)) {
                 continue;
             }
             if ((hex.depth() >= 2) || prone || !(movingUnit instanceof Mek)) {
-                submerged.add(loc);
+                submerged.add(location);
                 continue;
             }
-            if ((Mek.LOC_RIGHT_LEG == loc) || (Mek.LOC_LEFT_LEG == loc) || (Mek.LOC_CENTER_LEG == loc)) {
-                submerged.add(loc);
+            if ((Mek.LOC_RIGHT_LEG == location) || (Mek.LOC_LEFT_LEG == location)
+                  || (Mek.LOC_CENTER_LEG == location)) {
+                submerged.add(location);
                 continue;
             }
-            if ((movingUnit instanceof QuadMek) && ((Mek.LOC_RIGHT_ARM == loc) || (Mek.LOC_LEFT_ARM == loc))) {
-                submerged.add(loc);
+            if ((movingUnit instanceof QuadMek)
+                  && ((Mek.LOC_RIGHT_ARM == location) || (Mek.LOC_LEFT_ARM == location))) {
+                submerged.add(location);
             }
         }
         return submerged;
@@ -2469,17 +2471,17 @@ public class BasicPathRanker extends PathRanker {
 
     /**
      * @param movingUnit the wading unit
-     * @param loc        the location index
+     * @param location   the location index
      *
-     * @return the hazard weight of breaching {@code loc}: {@link #UNIT_DESTRUCTION_FACTOR} for a head or
+     * @return the hazard weight of breaching {@code location}: {@link #UNIT_DESTRUCTION_FACTOR} for a head or
      *       center-torso breach (or any breach on a non-Mek/ProtoMek, which drowns), otherwise a fixed
      *       per-location cost
      */
-    private double breachConsequence(Entity movingUnit, int loc) {
-        if ((Mek.LOC_HEAD == loc) ||
-              (Mek.LOC_CENTER_TORSO == loc) ||
-              (ProtoMek.LOC_HEAD == loc) ||
-              (ProtoMek.LOC_TORSO == loc) ||
+    private double breachConsequence(Entity movingUnit, int location) {
+        if ((Mek.LOC_HEAD == location) ||
+              (Mek.LOC_CENTER_TORSO == location) ||
+              (ProtoMek.LOC_HEAD == location) ||
+              (ProtoMek.LOC_TORSO == location) ||
               (!movingUnit.isMek() && !movingUnit.isProtoMek())) {
             return UNIT_DESTRUCTION_FACTOR;
         }

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -2425,9 +2425,6 @@ public class BasicPathRanker extends PathRanker {
                 continue;
             }
             double breachWeight = breachConsequence(movingUnit, location);
-            if (breachWeight == 0) {
-                continue;
-            }
             if (fallProbability < 0) {
                 fallProbability = waterEntryFallProbability(movingUnit, hex, movePath);
             }
@@ -2498,7 +2495,14 @@ public class BasicPathRanker extends PathRanker {
      *       elevation-gated check would skip the roll
      */
     private double waterEntryFallProbability(Entity movingUnit, Hex hex, MovePath movePath) {
-        PilotingRollData waterRoll = movingUnit.checkWaterMove(hex.depth(), movePath.getLastStepMovementType());
+        // The RAW water-entry roll keys off the intended movement mode (walk/run/jump), not end-position
+        // legality; getLastStepMovementType() can report MOVE_ILLEGAL for a path that is illegal only at its
+        // end (e.g. a leveling candidate), which would skew the roll, so fall back to a plain walk in that case.
+        EntityMovementType movementType = movePath.getLastStepMovementType();
+        if (movementType == EntityMovementType.MOVE_ILLEGAL) {
+            movementType = EntityMovementType.MOVE_WALK;
+        }
+        PilotingRollData waterRoll = movingUnit.checkWaterMove(hex.depth(), movementType);
         if (waterRoll.getValue() == TargetRoll.CHECK_FALSE) {
             return 0.0;
         }

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -70,6 +70,7 @@ import megamek.common.moves.MovePath;
 import megamek.common.moves.MoveStep;
 import megamek.common.options.OptionsConstants;
 import megamek.common.planetaryConditions.PlanetaryConditions;
+import megamek.common.rolls.PilotingRollData;
 import megamek.common.rolls.TargetRoll;
 import megamek.common.units.*;
 import megamek.common.util.HazardousLiquidPoolUtil;
@@ -2311,55 +2312,114 @@ public class BasicPathRanker extends PathRanker {
 
         // TODO: implement crush depth calcs (TO:AR pg. 40)
 
-        // Find the submerged locations.
-        Set<Integer> submergedLocations = new HashSet<>();
-        for (int loc = 0; loc < movingUnit.locations(); loc++) {
-            if (Mek.LOC_CENTER_LEG == loc && !(movingUnit instanceof TripodMek)) {
-                continue;
-            }
+        // Breach risk. A submerged location with no armor breaches automatically once it is underwater
+        // (TW p.65). Armored locations are treated as safe for a unit that is merely crossing (they would only
+        // breach on a hull-breach check if the fall's damage happened to hit them, which is negligible).
+        // Locations that submerge only when the unit is prone - notably the head and center torso in Depth 1
+        // water - drown it only if it falls, so that catastrophic risk is weighted by the chance of failing
+        // the water-entry piloting roll.
+        Set<Integer> submergedWhileUpright = submergedLocations(movingUnit, hex, step.isProne());
+        Set<Integer> submergedWhileProne = submergedLocations(movingUnit, hex, true);
 
-            if ((hex.depth() >= 2) || step.isProne() || !(movingUnit instanceof Mek)) {
-                submergedLocations.add(loc);
-                continue;
-            }
-
-            if (Mek.LOC_RIGHT_LEG == loc || Mek.LOC_LEFT_LEG == loc || Mek.LOC_CENTER_LEG == loc) {
-                submergedLocations.add(loc);
-                continue;
-            }
-
-            if ((movingUnit instanceof QuadMek) && (Mek.LOC_RIGHT_ARM == loc || Mek.LOC_LEFT_ARM == loc)) {
-                submergedLocations.add(loc);
-            }
-        }
-        logger.trace("Submerged locations: {}", submergedLocations);
-
-        int hazardValue = 0;
-        for (int loc : submergedLocations) {
-            // Only locations without armor can breach in the movement phase.
+        double hazardValue = 0;
+        // Certain breaches: unarmored locations already submerged in the unit's current pose.
+        for (int loc : submergedWhileUpright) {
             if (movingUnit.getArmor(loc) > 0) {
-                logger.trace("Location {} is not breached (0).", loc);
                 continue;
             }
-
-            // Meks or ProtoMeks having a head or torso breach is deadly.
-            // For other units, any breach is deadly.
-            // noinspection ConstantConditions
-            if ((Mek.LOC_HEAD == loc) ||
-                  (Mek.LOC_CENTER_TORSO == loc) ||
-                  (ProtoMek.LOC_HEAD == loc) ||
-                  (ProtoMek.LOC_TORSO == loc) ||
-                  (!movingUnit.isMek() && !movingUnit.isProtoMek())) {
-                logger.trace("Location {} breached and critical (1000).", loc);
+            double breachConsequence = breachConsequence(movingUnit, loc);
+            if (breachConsequence == UNIT_DESTRUCTION_FACTOR) {
+                logger.trace("Location {} breached and critical (destruction).", loc);
                 return UNIT_DESTRUCTION_FACTOR;
             }
-
-            // Add 50 points per potential breach location.
-            logger.trace("Location {} breached (50).", loc);
-            hazardValue += 50;
+            hazardValue += breachConsequence;
         }
 
+        // Fall-contingent breaches: unarmored locations that submerge only if the unit falls prone. Compute
+        // the fall probability lazily so a fully-armored unit never triggers it.
+        double fallProbability = -1;
+        for (int loc : submergedWhileProne) {
+            if (submergedWhileUpright.contains(loc) || (movingUnit.getArmor(loc) > 0)) {
+                continue;
+            }
+            double breachConsequence = breachConsequence(movingUnit, loc);
+            if (breachConsequence == 0) {
+                continue;
+            }
+            if (fallProbability < 0) {
+                fallProbability = waterEntryFallProbability(movingUnit, hex, movePath);
+            }
+            hazardValue += fallProbability * breachConsequence;
+        }
+
+        logger.trace("Water breach hazard {}.", hazardValue);
         return hazardValue;
+    }
+
+    /**
+     * @param movingUnit the wading unit
+     * @param hex        the water hex
+     * @param prone      {@code true} to report the locations submerged when the unit is prone, {@code false}
+     *                   for its standing pose
+     *
+     * @return the set of location indices submerged for the given pose in this water hex
+     */
+    private static Set<Integer> submergedLocations(Entity movingUnit, Hex hex, boolean prone) {
+        Set<Integer> submerged = new HashSet<>();
+        for (int loc = 0; loc < movingUnit.locations(); loc++) {
+            if ((Mek.LOC_CENTER_LEG == loc) && !(movingUnit instanceof TripodMek)) {
+                continue;
+            }
+            if ((hex.depth() >= 2) || prone || !(movingUnit instanceof Mek)) {
+                submerged.add(loc);
+                continue;
+            }
+            if ((Mek.LOC_RIGHT_LEG == loc) || (Mek.LOC_LEFT_LEG == loc) || (Mek.LOC_CENTER_LEG == loc)) {
+                submerged.add(loc);
+                continue;
+            }
+            if ((movingUnit instanceof QuadMek) && ((Mek.LOC_RIGHT_ARM == loc) || (Mek.LOC_LEFT_ARM == loc))) {
+                submerged.add(loc);
+            }
+        }
+        return submerged;
+    }
+
+    /**
+     * @param movingUnit the wading unit
+     * @param loc        the location index
+     *
+     * @return the hazard weight of breaching {@code loc}: {@link #UNIT_DESTRUCTION_FACTOR} for a head or
+     *       center-torso breach (or any breach on a non-Mek/ProtoMek, which drowns), otherwise a fixed
+     *       per-location cost
+     */
+    private double breachConsequence(Entity movingUnit, int loc) {
+        if ((Mek.LOC_HEAD == loc) ||
+              (Mek.LOC_CENTER_TORSO == loc) ||
+              (ProtoMek.LOC_HEAD == loc) ||
+              (ProtoMek.LOC_TORSO == loc) ||
+              (!movingUnit.isMek() && !movingUnit.isProtoMek())) {
+            return UNIT_DESTRUCTION_FACTOR;
+        }
+        return 50;
+    }
+
+    /**
+     * @param movingUnit the wading unit
+     * @param hex        the water hex being entered
+     * @param movePath   the path being evaluated
+     *
+     * @return the probability (0.0 - 1.0) that {@code movingUnit} fails the water-entry piloting roll (and so
+     *       falls). Uses the RAW depth-based roll (TW p.49) so the estimate holds even where the engine's
+     *       elevation-gated check would skip the roll
+     */
+    private double waterEntryFallProbability(Entity movingUnit, Hex hex, MovePath movePath) {
+        PilotingRollData waterRoll = movingUnit.checkWaterMove(hex.depth(), movePath.getLastStepMovementType());
+        if (waterRoll.getValue() == TargetRoll.CHECK_FALSE) {
+            return 0.0;
+        }
+        boolean naturalAptPilot = movingUnit.hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING);
+        return 1.0 - (Compute.oddsAbove(waterRoll.getValue(), naturalAptPilot) / 100.0);
     }
 
     private double calcFireHazard(Entity movingUnit, boolean endHex) {

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -1323,12 +1323,14 @@ public class BasicPathRanker extends PathRanker {
      * @return A facing modifier value (higher is worse) to be used in path ranking
      */
     protected double calculateFacingMod(Entity movingUnit, Game game, final MovePath path,
-          @Nullable Coords enemyMedianPosition, @Nullable Coords closestEnemyPosition) {
+          @Nullable Coords enemyMedianPosition, @Nullable Coords closestEnemyPosition,
+          boolean squareUpOnClosestEnemy) {
         int facingDiff = facingDiffCalculator.getFacingDiff(movingUnit,
               path,
               game.getBoard(movingUnit).getCenter(),
               enemyMedianPosition,
-              closestEnemyPosition);
+              closestEnemyPosition,
+              squareUpOnClosestEnemy);
         double facingMod = FACING_MOD_MULTIPLIER * facingDiff;
 
         logger.trace("facing mod [(-){} = {} * {}]", facingMod, FACING_MOD_MULTIPLIER, facingDiff);
@@ -1682,11 +1684,17 @@ public class BasicPathRanker extends PathRanker {
         Coords facingTarget = (standoffArtillery && (highValueClusterPosition != null))
               ? highValueClusterPosition
               : null;
+        // A melee unit that is closing to contact must square up on its target so it can strike next turn (a
+        // hatchet/kick cannot be delivered through a torso twist); it faces the closest enemy exactly rather
+        // than settling for any facing within the usual tolerance (issue #7627).
+        boolean squareUpOnClosestEnemy = (facingTarget == null) && (closeRangeIncentive > 0)
+              && (estimatedMeleeDamage(movingUnit) > 0);
         double facingMod = calculateFacingMod(movingUnit,
               game,
               pathCopy,
               (facingTarget != null) ? facingTarget : medianEnemyPosition,
-              (facingTarget != null) ? facingTarget : closestEnemyPositionNotZeroDistance);
+              (facingTarget != null) ? facingTarget : closestEnemyPositionNotZeroDistance,
+              squareUpOnClosestEnemy);
         scores.put("finalFacing", (double) pathCopy.getFinalFacing());
         scores.put("facingDiff", facingMod / FACING_MOD_MULTIPLIER);
         scores.put("facingMod", facingMod);

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -713,8 +713,10 @@ public class BasicPathRanker extends PathRanker {
      * @return the closing incentive to add to the path's utility (never negative)
      */
     protected double calculateCloseRangeIncentive(Entity movingUnit, double distToEnemy) {
-        if ((distToEnemy <= 1) || (distToEnemy >= CLOSE_RANGE_BAND)) {
-            // Already at contact (aggression/bravery take over), or too far out for the pull to apply yet.
+        if ((distToEnemy < 1) || (distToEnemy >= CLOSE_RANGE_BAND)) {
+            // Too far out for the pull to apply yet (or a degenerate zero distance). The incentive is left to
+            // peak at contact (distToEnemy == 1) so that taking the final hex into melee is rewarded rather
+            // than penalized - zeroing it at contact would stall a brawler one hex short of its target.
             return 0;
         }
         int currentRange = (int) Math.ceil(distToEnemy);

--- a/megamek/src/megamek/client/bot/princess/FacingDiffCalculator.java
+++ b/megamek/src/megamek/client/bot/princess/FacingDiffCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/src/megamek/client/bot/princess/FacingDiffCalculator.java
+++ b/megamek/src/megamek/client/bot/princess/FacingDiffCalculator.java
@@ -73,10 +73,43 @@ record FacingDiffCalculator(int allowFacingTolerance) {
      */
     int getFacingDiff(final Entity unit, final MovePath path, final Coords secondaryTargetPosition,
           @Nullable final Coords enemyMedianPosition, @Nullable final Coords closestEnemyPosition) {
-        Coords toFace = selectOneCoordsToFace(path, secondaryTargetPosition, enemyMedianPosition, closestEnemyPosition);
-        int desiredFacing = getDesiredFacing(unit, path, toFace);
+        return getFacingDiff(unit, path, secondaryTargetPosition, enemyMedianPosition, closestEnemyPosition, false);
+    }
+
+    /**
+     * As {@link #getFacingDiff(Entity, MovePath, Coords, Coords, Coords)}, but with the option to square up
+     * precisely on the closest enemy. A unit closing to melee must end the turn facing its target - a hatchet,
+     * sword or kick cannot be delivered through a torso twist - so when {@code squareUpOnClosestEnemy} is
+     * {@code true} the unit faces the closest enemy directly, with no armor-angling bias and no facing
+     * tolerance, instead of settling for any facing within a hex side of the enemy cluster (issue #7627).
+     *
+     * @param unit                    The entity making the movement
+     * @param path                    The movement path being evaluated
+     * @param secondaryTargetPosition Fallback position to face if no enemies are present (typically board center)
+     * @param enemyMedianPosition     The median position of nearby enemies (maybe {@code null} if no enemies)
+     * @param closestEnemyPosition    The position of the closest enemy (maybe {@code null} if no enemies)
+     * @param squareUpOnClosestEnemy  {@code true} to face the closest enemy exactly (for a unit closing to melee)
+     *
+     * @return The facing difference, from 0 (optimal) to 3 (opposite direction)
+     */
+    int getFacingDiff(final Entity unit, final MovePath path, final Coords secondaryTargetPosition,
+          @Nullable final Coords enemyMedianPosition, @Nullable final Coords closestEnemyPosition,
+          final boolean squareUpOnClosestEnemy) {
+        Coords toFace;
+        int bias;
+        int tolerance;
+        if (squareUpOnClosestEnemy && (closestEnemyPosition != null)) {
+            toFace = closestEnemyPosition;
+            bias = 0;
+            tolerance = 0;
+        } else {
+            toFace = selectOneCoordsToFace(path, secondaryTargetPosition, enemyMedianPosition, closestEnemyPosition);
+            bias = getBiasTowardsFacing(unit);
+            tolerance = allowFacingTolerance;
+        }
+        int desiredFacing = getDesiredFacing(path, toFace, bias);
         int currentFacing = path.getFinalFacing();
-        return getFacingDiff(currentFacing, desiredFacing);
+        return getFacingDiff(currentFacing, desiredFacing, tolerance);
     }
 
     /**
@@ -86,17 +119,17 @@ record FacingDiffCalculator(int allowFacingTolerance) {
      * the target.
      * </p>
      *
-     * @param unit   The entity making the movement
-     * @param path   The movement path being evaluated
+     * @param path The movement path being evaluated
      * @param toFace The target coordinates to face toward
+     * @param bias The armor-angling bias to apply ({@code -1} right, {@code 1} left, {@code 0} none)
      *
      * @return The desired facing direction (0-5)
      */
-    private int getDesiredFacing(Entity unit, MovePath path, Coords toFace) {
+    private int getDesiredFacing(MovePath path, Coords toFace, int bias) {
         int desiredFacing = path.getFinalCoords().direction(toFace);
 
         // -1 is bias towards facing left, 1 is bias towards facing right
-        desiredFacing += getBiasTowardsFacing(unit);
+        desiredFacing += bias;
         if (desiredFacing < 0) {
             desiredFacing += 6;
         }
@@ -148,10 +181,11 @@ record FacingDiffCalculator(int allowFacingTolerance) {
      *
      * @param currentFacing The unit's current facing (0-5)
      * @param desiredFacing The desired facing direction (0-5)
+     * @param tolerance     The number of hex sides of deviation forgiven with no penalty
      *
-     * @return The facing difference (0-2) (there is a built-in tolerance for 1 turn click)
+     * @return The facing difference after tolerance (0 to 3)
      */
-    private int getFacingDiff(int currentFacing, int desiredFacing) {
+    private int getFacingDiff(int currentFacing, int desiredFacing, int tolerance) {
         int facingDiff;
         if (currentFacing == desiredFacing) {
             facingDiff = 0;
@@ -162,7 +196,7 @@ record FacingDiffCalculator(int allowFacingTolerance) {
         } else {
             facingDiff = 3;
         }
-        return Math.max(0, facingDiff - allowFacingTolerance);
+        return Math.max(0, facingDiff - tolerance);
     }
 
     /**

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -542,7 +542,13 @@ public abstract class PathRanker implements IPathRanker {
     private static int waterEntryDepth(String rollDescription) {
         Matcher matcher = WATER_ENTRY_DEPTH_PATTERN.matcher(rollDescription);
         if (matcher.find()) {
-            return Integer.parseInt(matcher.group(1));
+            try {
+                return Integer.parseInt(matcher.group(1));
+            } catch (NumberFormatException numberFormatException) {
+                // The capture is all digits, so this only happens on an implausibly large value that overflows
+                // an int; treat it as the shallowest depth rather than failing.
+                return 1;
+            }
         }
         return 1;
     }

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -71,6 +71,12 @@ import org.apache.logging.log4j.Level;
 public abstract class PathRanker implements IPathRanker {
     private final static MMLogger logger = MMLogger.create(PathRanker.class);
     private static final BotLogger botLogger = new BotLogger();
+
+    // Fraction of a failed water-entry piloting roll treated as an acceptable (non-damaging) outcome: falling
+    // when wading into water just drops the unit prone in the water (minor damage, stand next turn) rather
+    // than a real fall. Softens the fall penalty so Princess will ford deep water instead of pacing at the
+    // bank when there is no shallower crossing (issue #7627).
+    private static final double WATER_FALL_FORGIVENESS = 0.75;
     // TODO: Introduce PathRankerCacheHelper class that contains "global" path
     // ranker state
     // TODO: Introduce FireControlCacheHelper class that contains "global" Fire
@@ -465,6 +471,12 @@ public abstract class PathRanker implements IPathRanker {
             }
 
             double odds = Compute.oddsAbove(roll.getValue(), naturalAptPilot) / 100d;
+            // A failed water-entry roll only drops the unit prone in the water rather than causing a damaging
+            // fall, so treat most of that chance as an acceptable outcome. Otherwise an 8% wet-fall reads as a
+            // catastrophe (fall chance x fallShame) and Princess refuses to ford deep water (issue #7627).
+            if (roll.getDesc().toLowerCase().contains("entering depth")) {
+                odds += (1.0 - odds) * WATER_FALL_FORGIVENESS;
+            }
             logger.trace("Odds above {} = {}", roll.getValue(), odds);
             successProbability *= odds;
         }

--- a/megamek/src/megamek/client/bot/princess/PathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/PathRanker.java
@@ -47,6 +47,8 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import megamek.client.bot.BotLogger;
 import megamek.client.bot.princess.UnitBehavior.BehaviorType;
@@ -73,10 +75,16 @@ public abstract class PathRanker implements IPathRanker {
     private static final BotLogger botLogger = new BotLogger();
 
     // Fraction of a failed water-entry piloting roll treated as an acceptable (non-damaging) outcome: falling
-    // when wading into water just drops the unit prone in the water (minor damage, stand next turn) rather
-    // than a real fall. Softens the fall penalty so Princess will ford deep water instead of pacing at the
-    // bank when there is no shallower crossing (issue #7627).
-    private static final double WATER_FALL_FORGIVENESS = 0.75;
+    // when wading only drops the unit prone in the water (minor damage, stand next turn) rather than a real
+    // fall. The forgiveness is scaled by water depth - a fall in a shallow ford is nearly harmless, but is
+    // progressively worse in deeper water (where the separately-scored submerged-location breach hazard also
+    // applies). This keeps Princess willing to wade a shallow river to engage instead of pacing at the bank
+    // (issue #7627) without making her reckless in deep water.
+    private static final double WATER_FALL_FORGIVENESS_DEPTH_1 = 0.95;
+    private static final double WATER_FALL_FORGIVENESS_PER_DEPTH = 0.20;
+    private static final double WATER_FALL_FORGIVENESS_FLOOR = 0.30;
+    // Matches the "entering Depth N Water" piloting-roll description built in Entity.checkWaterMove.
+    private static final Pattern WATER_ENTRY_DEPTH_PATTERN = Pattern.compile("entering depth (\\d+)");
     // TODO: Introduce PathRankerCacheHelper class that contains "global" path
     // ranker state
     // TODO: Introduce FireControlCacheHelper class that contains "global" Fire
@@ -459,10 +467,11 @@ public abstract class PathRanker implements IPathRanker {
         logger.trace("Calculating Move Path Success for {}", pathCopy);
 
         for (TargetRoll roll : pilotingRolls) {
+            String rollDescription = roll.getDesc().toLowerCase();
             // Skip the getting up check. That's handled when checking for being immobile.
-            if (roll.getDesc().toLowerCase().contains("getting up")) {
+            if (rollDescription.contains("getting up")) {
                 continue;
-            } else if (roll.getDesc().toLowerCase().contains("careful stand")) {
+            } else if (rollDescription.contains("careful stand")) {
                 continue;
             }
             boolean naturalAptPilot = movePath.getEntity().hasAbility(OptionsConstants.PILOT_APTITUDE_PILOTING);
@@ -472,10 +481,12 @@ public abstract class PathRanker implements IPathRanker {
 
             double odds = Compute.oddsAbove(roll.getValue(), naturalAptPilot) / 100d;
             // A failed water-entry roll only drops the unit prone in the water rather than causing a damaging
-            // fall, so treat most of that chance as an acceptable outcome. Otherwise an 8% wet-fall reads as a
-            // catastrophe (fall chance x fallShame) and Princess refuses to ford deep water (issue #7627).
-            if (roll.getDesc().toLowerCase().contains("entering depth")) {
-                odds += (1.0 - odds) * WATER_FALL_FORGIVENESS;
+            // fall, so treat most of that chance as an acceptable outcome - more so the shallower the water.
+            // Otherwise an 8% wet-fall reads as a catastrophe (fall chance x fallShame) and Princess refuses to
+            // wade even a shallow river (issue #7627).
+            if (rollDescription.contains("entering depth")) {
+                double forgiveness = waterFallForgiveness(waterEntryDepth(rollDescription));
+                odds += (1.0 - odds) * forgiveness;
             }
             logger.trace("Odds above {} = {}", roll.getValue(), odds);
             successProbability *= odds;
@@ -501,6 +512,39 @@ public abstract class PathRanker implements IPathRanker {
         getPathRankerState().getPathSuccessProbabilities().put(movePath.getKey(), successProbability);
 
         return successProbability;
+    }
+
+    /**
+     * The fraction of a failed water-entry piloting roll treated as an acceptable (non-damaging) outcome,
+     * scaled by water depth. A fall while wading only drops the unit prone in the water, which is nearly
+     * harmless in a shallow ford but progressively worse in deeper water; the forgiveness therefore shrinks
+     * as depth grows and never drops below {@link #WATER_FALL_FORGIVENESS_FLOOR}.
+     *
+     * @param waterDepth the depth (in levels) of the water being entered
+     *
+     * @return the forgiveness fraction, between {@link #WATER_FALL_FORGIVENESS_FLOOR} and
+     *       {@link #WATER_FALL_FORGIVENESS_DEPTH_1}
+     */
+    private static double waterFallForgiveness(int waterDepth) {
+        int depthBeyondFirst = Math.max(0, waterDepth - 1);
+        double forgiveness = WATER_FALL_FORGIVENESS_DEPTH_1 - (depthBeyondFirst * WATER_FALL_FORGIVENESS_PER_DEPTH);
+        return Math.max(WATER_FALL_FORGIVENESS_FLOOR, forgiveness);
+    }
+
+    /**
+     * Extracts the water depth from a water-entry piloting-roll description of the form
+     * {@code "entering Depth N Water"} (see {@code Entity.checkWaterMove}).
+     *
+     * @param rollDescription the lower-cased roll description
+     *
+     * @return the parsed depth, or {@code 1} (shallowest) if the description cannot be parsed
+     */
+    private static int waterEntryDepth(String rollDescription) {
+        Matcher matcher = WATER_ENTRY_DEPTH_PATTERN.matcher(rollDescription);
+        if (matcher.find()) {
+            return Integer.parseInt(matcher.group(1));
+        }
+        return 1;
     }
 
     /**

--- a/megamek/src/megamek/common/BulldozerMovePath.java
+++ b/megamek/src/megamek/common/BulldozerMovePath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/src/megamek/common/BulldozerMovePath.java
+++ b/megamek/src/megamek/common/BulldozerMovePath.java
@@ -42,13 +42,11 @@ import java.util.List;
 import java.util.Map;
 
 import megamek.client.bot.princess.FireControl;
-import megamek.client.bot.princess.MinefieldUtil;
 import megamek.common.board.Board;
 import megamek.common.board.Coords;
 import megamek.common.enums.MoveStepType;
 import megamek.common.game.Game;
 import megamek.common.moves.MovePath;
-import megamek.common.pathfinder.MovementType;
 import megamek.common.units.Entity;
 import megamek.common.units.EntityMovementMode;
 import megamek.common.units.Terrains;
@@ -103,69 +101,23 @@ public class BulldozerMovePath extends MovePath {
     }
 
     /**
-     * Override of the MovePath.addStep method, calculates leveling and other extra costs associated with this bulldozer
-     * move path
+     * Override of the MovePath.addStep method that records the leveling and other extra costs associated with
+     * this bulldozer move path. The cost computation itself lives in {@link MovePathTerrainCost}.
      */
     @Override
     public MovePath addStep(final MoveStepType type) {
-        BulldozerMovePath mp = (BulldozerMovePath) super.addStep(type);
-        Hex hex = mp.getGame().getBoard(mp.getFinalBoardId()).getHex(mp.getFinalCoords());
-        int hexWaterDepth = ((hex != null) && hex.containsTerrain(Terrains.WATER)) ? hex.depth() : Integer.MIN_VALUE;
+        BulldozerMovePath bulldozerMovePath = (BulldozerMovePath) super.addStep(type);
 
-        if (!mp.isMoveLegal() && !mp.isJumping()) {
-            // here, we will check if the step is illegal because the unit in question
-            // is attempting to move through illegal terrain for its movement type, but
-            // would be able to get through if the terrain was "reduced"
-            // don't bother to do this for jumping paths
-            int levelingCost = calculateLevelingCost(mp.getFinalCoords(), getEntity());
-            if (levelingCost > CANNOT_LEVEL) {
-                coordLevelingCosts.put(mp.getFinalCoords(), levelingCost);
-                coordsToLevel.add(mp.getFinalCoords());
-            }
-
-            // we want to make note of when we're going into water (if we are capable of it)
-            // it may look cheaper, but it slows you down to max walking speed or worse,
-            // and we should flag it as costing extra, that extra being the difference
-            // between walking and running speed
-            if (hexWaterDepth > 0) {
-                MovementType mType = MovementType.getMovementType(mp.getEntity());
-                if (mType == MovementType.Walker || mType == MovementType.WheeledAmphibious
-                      || mType == MovementType.TrackedAmphibious) {
-                    additionalCosts.put(mp.getFinalCoords(), 1);
-                }
-            }
+        MovePathTerrainCost stepCost = MovePathTerrainCost.forFinalStep(bulldozerMovePath);
+        if (stepCost.requiresLeveling()) {
+            bulldozerMovePath.coordLevelingCosts.put(bulldozerMovePath.getFinalCoords(), stepCost.levelingCost());
+            bulldozerMovePath.coordsToLevel.add(bulldozerMovePath.getFinalCoords());
+        }
+        if (stepCost.additionalCost() > 0) {
+            bulldozerMovePath.additionalCosts.put(bulldozerMovePath.getFinalCoords(), stepCost.additionalCost());
         }
 
-        if (mp.isJumping()) {
-            // if we are jumping, but not on top of a bridge (because jumping always goes to
-            // the top of a bridge)
-            // and are jumping into terrain that would impede jump jet functionality (aka
-            // water)
-            // then we are impeding future jump movement and should add an extra cost to
-            // this step
-            if ((hex != null) && !hex.containsTerrain(Terrains.BRIDGE)) {
-                // special case - mek jumping into depth 1 water might not be all that bad, jump
-                // mp cost wise
-                if (hexWaterDepth == 1) {
-                    additionalCosts.put(mp.getFinalCoords(),
-                          mp.getCachedEntityState().getJumpMP() - mp.getCachedEntityState().getTorsoJumpJets());
-                    // jumping into water that submerges you entirely pretty much ruins jump MP for
-                    // at least a turn while you clamber out
-                } else if (hexWaterDepth > 1) {
-                    additionalCosts.put(mp.getFinalCoords(), mp.getCachedEntityState().getJumpMP());
-                }
-            }
-        }
-
-        // we want to discourage running over minefields
-        double minefieldFactor = MinefieldUtil.calcMinefieldHazardForHex(mp.getLastStep(), mp.getEntity(),
-              mp.isJumping(), false);
-
-        if (minefieldFactor > 0) {
-            additionalCosts.put(mp.getFinalCoords(), (int) Math.ceil(minefieldFactor));
-        }
-
-        return mp;
+        return bulldozerMovePath;
     }
 
     /**

--- a/megamek/src/megamek/common/MovePathTerrainCost.java
+++ b/megamek/src/megamek/common/MovePathTerrainCost.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common;
+
+import megamek.client.bot.princess.MinefieldUtil;
+import megamek.common.annotations.Nullable;
+import megamek.common.board.Coords;
+import megamek.common.pathfinder.MovementType;
+import megamek.common.units.Terrains;
+
+/**
+ * The extra pathfinding costs a single {@link BulldozerMovePath} step incurs beyond its raw MP: the cost to
+ * "level" impassable-but-destructible terrain in the way, plus additional costs that slow the unit without
+ * raising its MP total (wading into deep water, jumping into water, or crossing a minefield). This logic used
+ * to be inlined in {@link BulldozerMovePath#addStep}; it is pulled out here so it is cohesive and
+ * unit-testable, and so the (previously dead) deep-water cost can be exercised in isolation.
+ *
+ * @param levelingCost   MP-equivalent cost to level destructible terrain at the step's hex, or
+ *                       {@link BulldozerMovePath#CANNOT_LEVEL} when no leveling is needed or possible
+ * @param additionalCost extra cost that slows the move without raising MP (deep water, minefield),
+ *                       {@code 0} if none
+ */
+public record MovePathTerrainCost(int levelingCost, int additionalCost) {
+
+    /**
+     * Computes the leveling and additional costs incurred by the most recently added step of the given path.
+     *
+     * @param path the bulldozer path whose final step is being costed
+     *
+     * @return the {@link MovePathTerrainCost} for that step
+     */
+    public static MovePathTerrainCost forFinalStep(BulldozerMovePath path) {
+        Coords finalCoords = path.getFinalCoords();
+        Hex hex = path.getGame().getBoard(path.getFinalBoardId()).getHex(finalCoords);
+        int waterDepth = ((hex != null) && hex.containsTerrain(Terrains.WATER)) ? hex.depth() : Integer.MIN_VALUE;
+
+        int levelingCost = BulldozerMovePath.CANNOT_LEVEL;
+        if (!path.isMoveLegal() && !path.isJumping()) {
+            // The step is illegal only because the terrain would need to be "reduced"; record what leveling
+            // it would take to get through. Not relevant for jumping paths.
+            levelingCost = BulldozerMovePath.calculateLevelingCost(finalCoords, path.getEntity());
+        }
+
+        int additionalCost;
+        if (path.isJumping()) {
+            additionalCost = jumpIntoWaterCost(hex, waterDepth, path);
+        } else {
+            additionalCost = wadingCost(MovementType.getMovementType(path.getEntity()), waterDepth,
+                  path.getCachedEntityState().getRunMP(), path.getCachedEntityState().getWalkMP());
+        }
+
+        // A minefield in the hex overrides the water cost for this step, preserving the original
+        // put-overwrite ordering of BulldozerMovePath.addStep.
+        double minefieldFactor = MinefieldUtil.calcMinefieldHazardForHex(path.getLastStep(), path.getEntity(),
+              path.isJumping(), false);
+        if (minefieldFactor > 0) {
+            additionalCost = (int) Math.ceil(minefieldFactor);
+        }
+
+        return new MovePathTerrainCost(levelingCost, additionalCost);
+    }
+
+    /**
+     * Cost of a ground Mek or amphibious vehicle wading into a Depth 1+ water hex. Entering deep water costs
+     * extra MP (1 for Depth 1, 3 for Depth 2 or deeper), forbids running, and forces a Piloting Skill Roll
+     * (TW p.49), none of which the raw MP total captures. Charge the forfeited running speed plus a per-depth
+     * penalty so the A* prefers a Depth 0 ford or a land route over wading straight across (issue #7627).
+     *
+     * @param movementType the unit's {@link MovementType}
+     * @param waterDepth   the destination hex's water depth ({@code <= 0} means no deep water)
+     * @param runMP        the unit's running MP
+     * @param walkMP       the unit's walking MP
+     *
+     * @return the extra cost, or {@code 0} if this unit type is not slowed by wading
+     */
+    static int wadingCost(MovementType movementType, int waterDepth, int runMP, int walkMP) {
+        if (waterDepth <= 0) {
+            return 0;
+        }
+        if ((movementType != MovementType.Walker) && (movementType != MovementType.WheeledAmphibious)
+              && (movementType != MovementType.TrackedAmphibious)) {
+            return 0;
+        }
+        int forfeitedRunningSpeed = Math.max(0, runMP - walkMP);
+        int depthPenalty = (waterDepth >= 2) ? 3 : 1;
+        return forfeitedRunningSpeed + depthPenalty;
+    }
+
+    /**
+     * Cost of jumping into a water hex: jump jets are impeded, so future jump movement suffers. Depth 1 costs
+     * the jump MP not provided by torso jets; Depth 2 or deeper (full submersion) effectively costs a turn's
+     * worth of jump MP while the unit clambers out. Landing on a bridge is free.
+     */
+    private static int jumpIntoWaterCost(@Nullable Hex hex, int waterDepth, BulldozerMovePath path) {
+        if ((hex == null) || hex.containsTerrain(Terrains.BRIDGE)) {
+            return 0;
+        }
+        if (waterDepth == 1) {
+            return path.getCachedEntityState().getJumpMP() - path.getCachedEntityState().getTorsoJumpJets();
+        } else if (waterDepth > 1) {
+            return path.getCachedEntityState().getJumpMP();
+        }
+        return 0;
+    }
+
+    /**
+     * @return {@code true} if the step needs (and is able to perform) terrain leveling to be traversable
+     */
+    public boolean requiresLeveling() {
+        return levelingCost > BulldozerMovePath.CANNOT_LEVEL;
+    }
+}

--- a/megamek/src/megamek/common/MovePathTerrainCost.java
+++ b/megamek/src/megamek/common/MovePathTerrainCost.java
@@ -117,18 +117,38 @@ public record MovePathTerrainCost(int levelingCost, int additionalCost) {
     }
 
     /**
+     * Extracts the jump-cost inputs from the path's cached entity state and delegates to
+     * {@link #jumpIntoWaterCost(int, int, int, boolean)}.
+     */
+    private static int jumpIntoWaterCost(@Nullable Hex hex, int waterDepth, BulldozerMovePath path) {
+        boolean landingOnBridge = (hex != null) && hex.containsTerrain(Terrains.BRIDGE);
+        return jumpIntoWaterCost(waterDepth, path.getCachedEntityState().getJumpMP(),
+              path.getCachedEntityState().getTorsoJumpJets(), landingOnBridge);
+    }
+
+    /**
      * Cost of jumping into a water hex: jump jets are impeded, so future jump movement suffers. Depth 1 costs
      * the jump MP not provided by torso jets; Depth 2 or deeper (full submersion) effectively costs a turn's
      * worth of jump MP while the unit clambers out. Landing on a bridge is free.
+     *
+     * @param waterDepth      the destination hex's water depth ({@code <= 0} means no deep water)
+     * @param jumpMP          the unit's current jump MP (already reduced by heat or damage)
+     * @param torsoJumpJets   the number of the unit's jump jets mounted in the torso
+     * @param landingOnBridge {@code true} if the step lands on a bridge, which negates the water cost
+     *
+     * @return the extra cost, never negative
      */
-    private static int jumpIntoWaterCost(@Nullable Hex hex, int waterDepth, BulldozerMovePath path) {
-        if ((hex == null) || hex.containsTerrain(Terrains.BRIDGE)) {
+    static int jumpIntoWaterCost(int waterDepth, int jumpMP, int torsoJumpJets, boolean landingOnBridge) {
+        if (landingOnBridge) {
             return 0;
         }
         if (waterDepth == 1) {
-            return path.getCachedEntityState().getJumpMP() - path.getCachedEntityState().getTorsoJumpJets();
-        } else if (waterDepth > 1) {
-            return path.getCachedEntityState().getJumpMP();
+            // Clamp at 0: heat or jump-jet damage can pull current jump MP below the torso-jet count, and a
+            // negative "additional cost" would wrongly make jumping into water look cheaper than staying dry.
+            return Math.max(0, jumpMP - torsoJumpJets);
+        }
+        if (waterDepth > 1) {
+            return jumpMP;
         }
         return 0;
     }

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -75,6 +75,7 @@ import megamek.common.options.OptionsConstants;
 import megamek.common.options.PilotOptions;
 import megamek.common.planetaryConditions.PlanetaryConditions;
 import megamek.common.planetaryConditions.Weather;
+import megamek.common.rolls.PilotingRollData;
 import megamek.common.rolls.TargetRoll;
 import megamek.common.units.*;
 import megamek.utils.MockGenerators;
@@ -202,6 +203,27 @@ class BasicPathRankerTest {
 
         double actual = testRanker.getMovePathSuccessProbability(mockPath);
         assertEquals(0.346, actual, TOLERANCE);
+    }
+
+    @Test
+    void testWaterEntryFallIsForgivenInSuccessProbability() {
+        final Entity mockMek = MockGenerators.generateMockBipedMek(0, 0);
+        final MovePath mockPath = MockGenerators.generateMockPath(0, 0, mockMek);
+        when(mockPath.hasActiveMASC()).thenReturn(false);
+
+        final TargetRoll waterRoll = mock(TargetRoll.class);
+        when(waterRoll.getValue()).thenReturn(4);
+        when(waterRoll.getDesc()).thenReturn("entering Depth 1 Water");
+        final List<TargetRoll> testRollList = List.of(waterRoll);
+
+        final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
+        doReturn(testRollList).when(testRanker).getPSRList(eq(mockPath));
+
+        // oddsAbove(4) = 33/36 = ~0.917 pass. A failed water entry is 75% forgiven, so the effective success
+        // probability is 0.917 + (1 - 0.917) * 0.75 = ~0.979, not the raw 0.917 - keeping Princess willing to
+        // ford deep water instead of treating an ~8% wet-fall as catastrophic (issue #7627).
+        double actual = testRanker.getMovePathSuccessProbability(mockPath);
+        assertEquals(0.979, actual, TOLERANCE);
     }
 
     @Test
@@ -1721,6 +1743,12 @@ class BasicPathRankerTest {
         when(mockHexThree.getTerrainTypesSet()).thenReturn(new HashSet<>(Set.of(Terrains.BUILDING)));
         assertEquals(1.285, testRanker.checkPathForHazards(mockPath, mockUnit, mockGame), TOLERANCE);
         when(mockHexThree.getTerrainTypes()).thenReturn(new int[0]);
+
+        // The water-breach hazard looks up the water-entry piloting roll; stub it to a check-false roll so the
+        // fall-probability path does not touch real board state (the water hazard is discarded on ice hexes).
+        final PilotingRollData mockWaterRoll = mock(PilotingRollData.class);
+        when(mockWaterRoll.getValue()).thenReturn(TargetRoll.CHECK_FALSE);
+        when(mockUnit.checkWaterMove(anyInt(), any())).thenReturn(mockWaterRoll);
 
         // Test walking over 3 hexes of ice.
         when(mockPath.isJumping()).thenReturn(false);

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -248,6 +248,43 @@ class BasicPathRankerTest {
     }
 
     @Test
+    void testCloseRangeIncentiveRewardsMeleeBrawlerForClosing() {
+        final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
+        final Entity mockBrawler = MockGenerators.generateMockBipedMek(0, 0); // 50 tons -> kick proxy 10
+        when(mockBrawler.getWalkMP()).thenReturn(4);
+        when(mockBrawler.isProne()).thenReturn(false);
+        // Point-blank ranged damage 6 (+ melee 10 = 16); at range 7 only 4 -> premium 12.
+        doReturn(6.0).when(testRanker).getMaxDamageAtRange(eq(mockBrawler), eq(1), anyBoolean(), anyBoolean());
+        doReturn(4.0).when(testRanker).getMaxDamageAtRange(eq(mockBrawler), eq(7), anyBoolean(), anyBoolean());
+
+        // proximity = (12 - 7) / (12 - 1) = 0.4545; incentive = 12 * 0.4545 * 1.0 = ~5.45.
+        assertEquals(5.45, testRanker.calculateCloseRangeIncentive(mockBrawler, 7), 0.01);
+    }
+
+    @Test
+    void testCloseRangeIncentiveIsZeroBeyondTheBand() {
+        final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
+        final Entity mockBrawler = MockGenerators.generateMockBipedMek(0, 0);
+        when(mockBrawler.getWalkMP()).thenReturn(4);
+
+        // At or beyond CLOSE_RANGE_BAND (12) the pull has not engaged yet - no incentive, no damage lookups.
+        assertEquals(0.0, testRanker.calculateCloseRangeIncentive(mockBrawler, 12), TOLERANCE);
+    }
+
+    @Test
+    void testCloseRangeIncentiveIsZeroWithoutAPointBlankPremium() {
+        final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
+        final Entity mockGunner = MockGenerators.generateMockBipedMek(0, 0);
+        when(mockGunner.getWalkMP()).thenReturn(4);
+        // A unit that already does more damage at range than it would up close (even counting the melee proxy)
+        // gets no closing incentive.
+        doReturn(2.0).when(testRanker).getMaxDamageAtRange(eq(mockGunner), eq(1), anyBoolean(), anyBoolean());
+        doReturn(20.0).when(testRanker).getMaxDamageAtRange(eq(mockGunner), eq(5), anyBoolean(), anyBoolean());
+
+        assertEquals(0.0, testRanker.calculateCloseRangeIncentive(mockGunner, 5), TOLERANCE);
+    }
+
+    @Test
     void testEvaluateUnmovedAeroEnemy() {
         final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
         doReturn(mockPrincess).when(testRanker).getOwner();

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -285,6 +285,23 @@ class BasicPathRankerTest {
     }
 
     @Test
+    void testCloseRangeIncentivePeaksAtMeleeContact() {
+        final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
+        final Entity mockBrawler = MockGenerators.generateMockBipedMek(0, 0); // 50 tons -> melee proxy 10
+        when(mockBrawler.getWalkMP()).thenReturn(4);
+        // Melee-only unit: no ranged damage at any range, so the premium is just the melee proxy (10).
+        doReturn(0.0).when(testRanker).getMaxDamageAtRange(eq(mockBrawler), anyInt(), anyBoolean(), anyBoolean());
+
+        // The incentive must be maximal at melee contact (distance 1) so closing the final hex is rewarded, not
+        // penalized (issue #7627: it previously cliffed to 0 at distance <= 1 and stalled the brawler one hex
+        // short). proximity at distance 1 = (12 - 1) / (12 - 1) = 1.0 -> full premium 10.
+        double atContact = testRanker.calculateCloseRangeIncentive(mockBrawler, 1);
+        double atRangeTwo = testRanker.calculateCloseRangeIncentive(mockBrawler, 2);
+        assertEquals(10.0, atContact, 0.01);
+        assertTrue(atContact > atRangeTwo);
+    }
+
+    @Test
     void testEvaluateUnmovedAeroEnemy() {
         final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
         doReturn(mockPrincess).when(testRanker).getOwner();

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -206,7 +206,7 @@ class BasicPathRankerTest {
     }
 
     @Test
-    void testWaterEntryFallIsForgivenInSuccessProbability() {
+    void testShallowWaterEntryFallIsForgivenInSuccessProbability() {
         final Entity mockMek = MockGenerators.generateMockBipedMek(0, 0);
         final MovePath mockPath = MockGenerators.generateMockPath(0, 0, mockMek);
         when(mockPath.hasActiveMASC()).thenReturn(false);
@@ -219,11 +219,32 @@ class BasicPathRankerTest {
         final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
         doReturn(testRollList).when(testRanker).getPSRList(eq(mockPath));
 
-        // oddsAbove(4) = 33/36 = ~0.917 pass. A failed water entry is 75% forgiven, so the effective success
-        // probability is 0.917 + (1 - 0.917) * 0.75 = ~0.979, not the raw 0.917 - keeping Princess willing to
-        // ford deep water instead of treating an ~8% wet-fall as catastrophic (issue #7627).
+        // oddsAbove(4) = 33/36 = ~0.917 pass. A failed Depth 1 water entry is 95% forgiven (a shallow-ford fall
+        // is nearly harmless), so the effective success probability is 0.917 + (1 - 0.917) * 0.95 = ~0.996, not
+        // the raw 0.917 - keeping Princess willing to wade a shallow river instead of pacing at the bank
+        // (issue #7627).
         double actual = testRanker.getMovePathSuccessProbability(mockPath);
-        assertEquals(0.979, actual, TOLERANCE);
+        assertEquals(0.996, actual, TOLERANCE);
+    }
+
+    @Test
+    void testDeepWaterEntryFallIsForgivenLessThanShallow() {
+        final Entity mockMek = MockGenerators.generateMockBipedMek(0, 0);
+        final MovePath mockPath = MockGenerators.generateMockPath(0, 0, mockMek);
+        when(mockPath.hasActiveMASC()).thenReturn(false);
+
+        final TargetRoll waterRoll = mock(TargetRoll.class);
+        when(waterRoll.getValue()).thenReturn(4);
+        when(waterRoll.getDesc()).thenReturn("entering Depth 3 Water");
+        final List<TargetRoll> testRollList = List.of(waterRoll);
+
+        final BasicPathRanker testRanker = spy(new BasicPathRanker(mockPrincess));
+        doReturn(testRollList).when(testRanker).getPSRList(eq(mockPath));
+
+        // Depth 3 forgiveness = 0.95 - 2 * 0.20 = 0.55 (a fall in deep water is worse than in a shallow ford),
+        // so 0.917 + (1 - 0.917) * 0.55 = ~0.962 - forgiven, but less than the Depth 1 case above.
+        double actual = testRanker.getMovePathSuccessProbability(mockPath);
+        assertEquals(0.962, actual, TOLERANCE);
     }
 
     @Test

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000-2011 - Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/unittests/megamek/client/bot/princess/FacingDiffCalculatorTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FacingDiffCalculatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/unittests/megamek/client/bot/princess/FacingDiffCalculatorTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FacingDiffCalculatorTest.java
@@ -159,4 +159,43 @@ class FacingDiffCalculatorTest {
         assertEquals(0, facingDiff);
     }
 
+    @Test
+    void testSquareUpOnClosestEnemyIgnoresBiasAndTolerance() {
+        Mek mek = mock(BipedMek.class);
+        // Right side more heavily armored than the left, so the normal armor bias is -1 (angle to show the
+        // stronger right side). This is what makes a closing unit end up facing off-target.
+        when(mek.getArmor(Mek.LOC_LEFT_ARM)).thenReturn(2);
+        when(mek.getArmor(Mek.LOC_LEFT_LEG)).thenReturn(2);
+        when(mek.getArmor(Mek.LOC_LEFT_TORSO)).thenReturn(2);
+        when(mek.getArmor(Mek.LOC_RIGHT_ARM)).thenReturn(10);
+        when(mek.getArmor(Mek.LOC_RIGHT_LEG)).thenReturn(10);
+        when(mek.getArmor(Mek.LOC_RIGHT_TORSO)).thenReturn(10);
+        when(mek.isMek()).thenReturn(true);
+        // Tolerance 1, matching Princess's default.
+        FacingDiffCalculator facingDiffCalculator = new FacingDiffCalculator(1);
+        MovePath path = mock(MovePath.class);
+        when(path.getFinalCoords()).thenReturn(new Coords(5, 5));
+
+        // Direction from 0606 (5,5) to the closest enemy 1111 (10,10) is 2 (SE). The unit is facing NE (1).
+        when(path.getFinalFacing()).thenReturn(1);
+
+        // Normal mode: the -1 armor bias makes NE the "desired" facing, so facing NE reads as optimal (diff 0).
+        // This is why a closing brawler ends up angled off the enemy instead of squared on it.
+        int tolerant = facingDiffCalculator.getFacingDiff(mek, path, new Coords(0, 0),
+              new Coords(10, 10), new Coords(10, 10), false);
+        assertEquals(0, tolerant);
+
+        // Square-up mode: no bias and no tolerance, so facing NE while the target is SE is a real one-hex-side
+        // miss (diff 1) - the unit is pushed to turn toward the enemy.
+        int squaredOff = facingDiffCalculator.getFacingDiff(mek, path, new Coords(0, 0),
+              new Coords(10, 10), new Coords(10, 10), true);
+        assertEquals(1, squaredOff);
+
+        // Facing the target exactly (SE = 2) is optimal in square-up mode.
+        when(path.getFinalFacing()).thenReturn(2);
+        int squaredOn = facingDiffCalculator.getFacingDiff(mek, path, new Coords(0, 0),
+              new Coords(10, 10), new Coords(10, 10), true);
+        assertEquals(0, squaredOn);
+    }
+
 }

--- a/megamek/unittests/megamek/common/MovePathTerrainCostTest.java
+++ b/megamek/unittests/megamek/common/MovePathTerrainCostTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import megamek.common.pathfinder.MovementType;
+import org.junit.jupiter.api.Test;
+
+class MovePathTerrainCostTest {
+
+    @Test
+    void wadingCostIsZeroForAFordAndDryLand() {
+        // Depth 0 (a ford) and hexes with no water carry no wading cost, so the A* treats a ford like clear
+        // terrain instead of pacing at the bank (issue #7627).
+        assertEquals(0, MovePathTerrainCost.wadingCost(MovementType.Walker, 0, 6, 4));
+        assertEquals(0, MovePathTerrainCost.wadingCost(MovementType.Walker, Integer.MIN_VALUE, 6, 4));
+    }
+
+    @Test
+    void wadingCostScalesWithDepthAndForfeitedRunningSpeed() {
+        // Depth 1: forfeited running (run 6 - walk 4 = 2) + depth penalty 1 = 3.
+        assertEquals(3, MovePathTerrainCost.wadingCost(MovementType.Walker, 1, 6, 4));
+        // Depth 2: forfeited running 2 + depth penalty 3 = 5.
+        assertEquals(5, MovePathTerrainCost.wadingCost(MovementType.Walker, 2, 6, 4));
+        // Depth 3 uses the same Depth 2+ penalty; forfeited running (8 - 5 = 3) + 3 = 6.
+        assertEquals(6, MovePathTerrainCost.wadingCost(MovementType.Walker, 3, 8, 5));
+    }
+
+    @Test
+    void wadingCostWithNoForfeitedSpeedIsJustTheDepthPenalty() {
+        assertEquals(1, MovePathTerrainCost.wadingCost(MovementType.Walker, 1, 4, 4));
+        assertEquals(3, MovePathTerrainCost.wadingCost(MovementType.Walker, 2, 4, 4));
+    }
+
+    @Test
+    void amphibiousGroundUnitsAreChargedForWading() {
+        assertEquals(3, MovePathTerrainCost.wadingCost(MovementType.WheeledAmphibious, 1, 6, 4));
+        assertEquals(3, MovePathTerrainCost.wadingCost(MovementType.TrackedAmphibious, 1, 6, 4));
+    }
+
+    @Test
+    void unitsNotSlowedByWadingAreNotCharged() {
+        // Hover units skim the surface, so they take no wading cost regardless of depth.
+        assertEquals(0, MovePathTerrainCost.wadingCost(MovementType.Hover, 2, 6, 4));
+    }
+}

--- a/megamek/unittests/megamek/common/MovePathTerrainCostTest.java
+++ b/megamek/unittests/megamek/common/MovePathTerrainCostTest.java
@@ -42,9 +42,10 @@ class MovePathTerrainCostTest {
     @Test
     void wadingCostIsZeroForAFordAndDryLand() {
         // Depth 0 (a ford) and hexes with no water carry no wading cost, so the A* treats a ford like clear
-        // terrain instead of pacing at the bank (issue #7627).
+        // terrain instead of pacing at the bank (issue #7627). Any non-positive depth is the "no deep water"
+        // case per the wadingCost contract.
         assertEquals(0, MovePathTerrainCost.wadingCost(MovementType.Walker, 0, 6, 4));
-        assertEquals(0, MovePathTerrainCost.wadingCost(MovementType.Walker, Integer.MIN_VALUE, 6, 4));
+        assertEquals(0, MovePathTerrainCost.wadingCost(MovementType.Walker, -1, 6, 4));
     }
 
     @Test
@@ -73,5 +74,30 @@ class MovePathTerrainCostTest {
     void unitsNotSlowedByWadingAreNotCharged() {
         // Hover units skim the surface, so they take no wading cost regardless of depth.
         assertEquals(0, MovePathTerrainCost.wadingCost(MovementType.Hover, 2, 6, 4));
+    }
+
+    @Test
+    void jumpIntoDepthOneWaterCostsTheJumpMpNotProvidedByTorsoJets() {
+        // Depth 1: 4 jump MP total, 1 torso jet -> 3 MP of leg/other jets are impeded.
+        assertEquals(3, MovePathTerrainCost.jumpIntoWaterCost(1, 4, 1, false));
+    }
+
+    @Test
+    void jumpIntoDepthOneWaterCostNeverGoesNegative() {
+        // Heat or jump-jet damage can drop current jump MP below the torso-jet count; the extra cost must
+        // clamp at 0 rather than making a jump into water look cheaper than staying on dry land.
+        assertEquals(0, MovePathTerrainCost.jumpIntoWaterCost(1, 2, 4, false));
+    }
+
+    @Test
+    void jumpIntoDeepWaterCostsAFullJumpAllotment() {
+        // Depth 2+ (full submersion) costs a turn's worth of jump MP while the unit clambers out.
+        assertEquals(5, MovePathTerrainCost.jumpIntoWaterCost(2, 5, 2, false));
+    }
+
+    @Test
+    void jumpOntoABridgeOverWaterIsFree() {
+        // Landing on a bridge keeps the unit out of the water, so no jump cost applies.
+        assertEquals(0, MovePathTerrainCost.jumpIntoWaterCost(2, 5, 2, true));
     }
 }


### PR DESCRIPTION
## Summary

Princess would refuse to cross a river to engage — she'd march up to the bank and just stop, even when the water was a shallow, wadeable stream and the enemy was right across it. This PR makes her value water crossings realistically and gives melee units a reason to close the distance, so she now wades across, advances on the enemy, faces her target, and closes into hatchet range instead of stalling.

## The story (worked example)

On the River Valley 2 map, a hatchet-armed Axman (a dedicated melee brawler) deployed across a shallow river from its target. Before this PR it walked to its own bank and stalled there for the entire game. Digging into why turned up four separate reasons, each fixed here:

1. She treated a shallow wade like a deadly fall. Failing the piloting roll entering knee-deep water just drops you prone in the water — minor — but the bot scored it as a catastrophe. Now that risk is discounted, and more so the shallower the water (a Depth-1 ford is nearly free; deep water still gets respect).
2. Her pathfinder ignored the cost of wading. It didn't charge anything for slogging through deep water, so a shallow ford and a dry road looked identical. Now wading costs extra (forfeited running speed plus a per-depth penalty), so she prefers a real ford or a land route when one exists — and knows what a crossing actually costs when it doesn't.
3. A melee brawler had no reason to close. The bot only credits a hatchet/kick on the exact turn you end up next to the enemy — so while closing, a 13-damage hatchet was worth nothing to it. Now any unit that hits harder up close (short-range gunners, and especially melee units) gets a pull toward contact that grows as it approaches, peaking when it reaches melee range.
4. She advanced while angled away from the enemy. Facing is normally chosen with some slack (and a bias to show your stronger armor side), which is fine for a gunner who can torso-twist to fire — but a hatchet can't twist, so she'd close while facing off to the side. Now a melee unit closing to contact squares up directly on its target.

Net effect: she crosses the shallow river, advances on the enemy, faces it, and closes all the way into melee.

## Changes

1. Depth-scaled water-fall forgiveness (PathRanker) — a failed water-entry roll is discounted by depth (Depth 1 ~95%, tapering to a floor for deep water).
2. Water-movement cost (MovePathTerrainCost, new; BulldozerMovePath) — extracted the bulldozer path's cost logic into a small, unit-tested class, and
made wading into deep water actually cost extra in the long-r
3. Close-range / melee closing incentive (BasicPathRanker) — units that do more damage up close get a reward for advancing that peaks at melee contact; standoff units (artillery/TAG) and units told to ignore damage are excluded.
4. Square-up-on-target facing (FacingDiffCalculator, BasicPatng to contact faces its target exactly, dropping the armor bias and facing tolerance.
5. Depth-aware breach hazard (BasicPathRanker) — reworked the water-breach risk so an unarmored location that only submerges if she falls is weighted by
the chance of actually failing the roll, rather than counted

## Files Changed

- PathRanker.java — depth-scaled water-fall forgiveness.
- MovePathTerrainCost.java (new) — extracted, testable terrain-cost logic incl. wading cost.
- BulldozerMovePath.java — addStep delegates to MovePathTerra
- BasicPathRanker.java — closing incentive, melee square-up wiring, depth-aware breach hazard.
- FacingDiffCalculator.java — square-up-on-closest-enemy option.
- Tests: BasicPathRankerTest, MovePathTerrainCostTest, Facing

## Testing

- Unit tests (39 across the three classes): water-fall forgiveness (shallow vs deep), wading cost, depth-aware breach, closing incentive (rewards closing, peaks at contact, zero beyond band / with no premium), and facing square-up.
- Headless playtests on River Valley 2 through the whole fix es the river, closes to the enemy, faces it (SE), and stepsinto melee contact — each behavior verified in bot_path_ranker.log.

## What is NOT proven yet

- Melee closing with ranged weapons enabled. The closing playtests were run with the brawler's guns disabled (hatchet only). With weapons on, point-blank return fire adds a real "bravery" penalty for the final step; the incentive peak should still carry her into contact, but that exact case hasn't been playtested yet.
- Over-aggression tuning. The closing incentive's strength (C 1.0) and reach (CLOSE_RANGE_BAND = 12) are first-pass values.A brawler could over-commit into a gunline; if playtests show that, these are one-line dials.
- Sheer-cliff terrain is unchanged and correct. On canyon maps where the bank is a 3-4 level drop into the water, crossing is genuinely illegal per the rules (a Mek can only descend 2 levels), and Princess correctepositioning along a bank to find a legal ford is separate,larger behavioral work, deliberately not in this PR.

Fixes #7627