### PR TITLE
Add toast on/off and duration controls, stop report toasts repeating

### DIFF
--- a/megamek/resources/megamek/client/messages.properties
+++ b/megamek/resources/megamek/client/messages.properties
@@ -1436,6 +1436,16 @@ CommonSettingsDialog.colors.warningColor=Warning Color
 CommonSettingsDialog.colors.myUnitColor=My Unit Color
 CommonSettingsDialog.colors.allyUnitColor=Ally Unit Color
 CommonSettingsDialog.colors.enemyUnitColor=Enemy Unit Color
+# Board toast notifications (Overlays tab)
+CommonSettingsDialog.toastEnabled=Show board toast notifications
+CommonSettingsDialog.toastEnabled.tooltip=Toast notifications are the messages that slide in at the top of the board. Turning them off also hides messages that are never written to the chat log - see the warning below.
+CommonSettingsDialog.toastEnabled.warning=Warning: not every toast is repeated in the chat log. With toasts turned off you will not see Game Master actions, artillery fire missions and their target grids, effects such as Magnetic Pulse jamming wearing off, or the reason an action was refused.
+CommonSettingsDialog.toastDurationSeconds=Toast display time (seconds)
+CommonSettingsDialog.toastDurationSeconds.tooltip=How long a toast stays on screen before it fades, from 1 to 10 seconds. More urgent toasts hold longer than this: warnings add 1 second and errors add 2.
+CommonSettingsDialog.toastDripSeconds=Gap between report toasts (seconds)
+CommonSettingsDialog.toastDripSeconds.tooltip=How long to wait between report toasts when several arrive at once, so each one can be read before the next appears.
+CommonSettingsDialog.toastReportEvents=Show round report events as toasts
+CommonSettingsDialog.toastReportEvents.tooltip=Echoes each event from the round report as its own toast. Turn this off to quiet the running commentary while keeping the toasts that are not written to the report, such as Game Master actions and artillery fire missions.
 CommonSettingsDialog.darkenMapAtNight=Darken Map At Night
 CommonSettingsDialog.enableExperimentalBotFeatures=Enable experimental bot features.
 CommonSettingsDialog.enableExperimentalBotFeatures.tooltip=If enabled, Princess will have access to experimental systems. These systems may be unbalanced, broken or otherwise unfit for normal gameplay. Use at your own risk.

--- a/megamek/src/megamek/client/ui/clientGUI/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/ClientGUI.java
@@ -591,22 +591,25 @@ public class ClientGUI extends AbstractClientGUI
      * @param entity the entity whose icon to show, or {@code null} for text-only
      */
     public void addToast(ToastLevel level, String text, @Nullable Entity entity) {
-        String normalized = ReportToastFormatter.normalizeToastText(text);
         String entityLabel = (entity != null) ?
               entity.getShortName() + " [" + entity.getId() + "]" :
               "no entity";
+        // Gate before normalizing: normalizeToastText is regex-heavy and only the shown path needs the
+        // cleaned text. On the suppressed paths log the raw text so switching toasts off does not pay the
+        // normalization cost for every would-be toast.
         if (toastOverlay == null) {
             logger.debug("[Toast] suppressed [{}] ({}) - overlay not initialized yet: {}",
-                  level, entityLabel, normalized);
+                  level, entityLabel, text);
             return;
         }
         if (!GUIP.getToastEnabled()) {
             logger.debug("[Toast] suppressed [{}] ({}) - toasts switched off in client settings: {}",
-                  level, entityLabel, normalized);
+                  level, entityLabel, text);
             return;
         }
-        logger.debug("[Toast] shown [{}] ({}): {}", level, entityLabel, normalized);
-        toastOverlay.show(level, normalized, entity);
+        String normalizedText = ReportToastFormatter.normalizeToastText(text);
+        logger.debug("[Toast] shown [{}] ({}): {}", level, entityLabel, normalizedText);
+        toastOverlay.show(level, normalizedText, entity);
     }
 
     /**

--- a/megamek/src/megamek/client/ui/clientGUI/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/ClientGUI.java
@@ -395,6 +395,8 @@ public class ClientGUI extends AbstractClientGUI
 
     private final ConcurrentLinkedQueue<Runnable> toastDripQueue = new ConcurrentLinkedQueue<>();
     private javax.swing.Timer toastDripTimer;
+    /** Plain-text report entries already shown as toasts this phase; see {@link ReportToastFormatter#formatReport}. */
+    private final Set<String> toastedReportEntries = new HashSet<>();
 
 
     // some dialogs...
@@ -575,29 +577,36 @@ public class ClientGUI extends AbstractClientGUI
      * @param text  the message text to display
      */
     public void addToast(ToastLevel level, String text) {
-        if (toastOverlay != null) {
-            String normalized = ReportToastFormatter.normalizeToastText(text);
-            logger.debug("Toast [{}] (no entity): {}", level, normalized);
-            toastOverlay.show(level, normalized);
-        }
+        addToast(level, text, null);
     }
 
     /**
      * Shows a toast notification with the given entity's sprite icon on the board view.
      *
+     * <p>This is the single entry point for every toast in the client, server-raised ones included, so the player's
+     * {@link GUIPreferences#TOAST_ENABLED} setting is enforced here and nowhere else.</p>
+     *
      * @param level  the severity level determining color and default duration
      * @param text   the message text to display
-     * @param entity the entity whose icon to show, or null for text-only
+     * @param entity the entity whose icon to show, or {@code null} for text-only
      */
     public void addToast(ToastLevel level, String text, @Nullable Entity entity) {
-        if (toastOverlay != null) {
-            String normalized = ReportToastFormatter.normalizeToastText(text);
-            String entityLabel = (entity != null) ?
-                  entity.getShortName() + " [" + entity.getId() + "]" :
-                  "no entity";
-            logger.debug("Toast [{}] ({}): {}", level, entityLabel, normalized);
-            toastOverlay.show(level, normalized, entity);
+        String normalized = ReportToastFormatter.normalizeToastText(text);
+        String entityLabel = (entity != null) ?
+              entity.getShortName() + " [" + entity.getId() + "]" :
+              "no entity";
+        if (toastOverlay == null) {
+            logger.debug("[Toast] suppressed [{}] ({}) - overlay not initialized yet: {}",
+                  level, entityLabel, normalized);
+            return;
         }
+        if (!GUIP.getToastEnabled()) {
+            logger.debug("[Toast] suppressed [{}] ({}) - toasts switched off in client settings: {}",
+                  level, entityLabel, normalized);
+            return;
+        }
+        logger.debug("[Toast] shown [{}] ({}): {}", level, entityLabel, normalized);
+        toastOverlay.show(level, normalized, entity);
     }
 
     /**
@@ -652,9 +661,21 @@ public class ClientGUI extends AbstractClientGUI
      * Splits a server-side report HTML stream into per-event toasts via {@link ReportToastFormatter} and drip-feeds
      * them to the overlay on the {@link GUIPreferences#TOAST_DRIP_SECONDS} cadence so each one has time to scroll past
      * before the next appears.
+     *
+     * <p>Entries already toasted earlier in the same phase are skipped, because a mid-phase report packet can carry
+     * events that an earlier packet already delivered. Does nothing at all when the player has switched
+     * {@link GUIPreferences#TOAST_REPORT_EVENTS} off; toasts that carry information the report log does not hold are
+     * unaffected by that setting.</p>
      */
     private void showReportAsToasts(String defaultPrefix, String report) {
-        for (String body : ReportToastFormatter.formatReport(defaultPrefix, report)) {
+        if (!GUIP.getToastReportEvents()) {
+            logger.debug("[Toast] report burst suppressed - round report events are switched off in client settings");
+            return;
+        }
+        List<String> bodies = ReportToastFormatter.formatReport(defaultPrefix, report, toastedReportEntries);
+        logger.debug("[Toast] report burst queued {} new event(s); {} entries seen this phase",
+              bodies.size(), toastedReportEntries.size());
+        for (String body : bodies) {
             toastDripQueue.offer(() -> addToast(ToastLevel.INFO, body));
         }
         startToastDripIfIdle();
@@ -3168,6 +3189,11 @@ public class ClientGUI extends AbstractClientGUI
             if (roundsInAirDialog != null) {
                 roundsInAirDialog.refresh();
             }
+
+            // Special-report packets replay the whole phase report each time they are sent, so the "already toasted"
+            // history only has to span a single phase. Clearing it here also lets a line that genuinely recurs in a
+            // later phase toast again.
+            toastedReportEntries.clear();
 
             // Once per round, remind the player of own platoons busy raising bridges (TO:AUE); building
             // platoons are ineligible for all phases, so no phase display ever selects them

--- a/megamek/src/megamek/client/ui/clientGUI/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/ClientGUI.java
@@ -395,7 +395,7 @@ public class ClientGUI extends AbstractClientGUI
 
     private final ConcurrentLinkedQueue<Runnable> toastDripQueue = new ConcurrentLinkedQueue<>();
     private javax.swing.Timer toastDripTimer;
-    /** Plain-text report entries already shown as toasts this phase; see {@link ReportToastFormatter#formatReport}. */
+    /** Normalized report entries already shown as toasts this phase; see {@link ReportToastFormatter#formatReport}. */
     private final Set<String> toastedReportEntries = new HashSet<>();
 
 
@@ -666,8 +666,20 @@ public class ClientGUI extends AbstractClientGUI
      * events that an earlier packet already delivered. Does nothing at all when the player has switched
      * {@link GUIPreferences#TOAST_REPORT_EVENTS} off; toasts that carry information the report log does not hold are
      * unaffected by that setting.</p>
+     *
+     * <p>Every reason to skip is checked before the report is formatted, because formatting is what records entries
+     * as already toasted. Recording an entry that was never shown would suppress it later, when the player turns
+     * toasts back on part way through the same phase.</p>
      */
     private void showReportAsToasts(String defaultPrefix, String report) {
+        if (toastOverlay == null) {
+            logger.debug("[Toast] report burst suppressed - overlay not initialized yet");
+            return;
+        }
+        if (!GUIP.getToastEnabled()) {
+            logger.debug("[Toast] report burst suppressed - toasts are switched off in client settings");
+            return;
+        }
         if (!GUIP.getToastReportEvents()) {
             logger.debug("[Toast] report burst suppressed - round report events are switched off in client settings");
             return;

--- a/megamek/src/megamek/client/ui/clientGUI/GUIPreferences.java
+++ b/megamek/src/megamek/client/ui/clientGUI/GUIPreferences.java
@@ -155,6 +155,9 @@ public class GUIPreferences extends PreferenceStoreProxy {
     public static final String TRACE_OVERLAY_ORIGIN_Y = "TraceOverlayOriginY";
     public static final String TRACE_OVERLAY_IMAGE_FILE = "TraceOverlayImageFile";
 
+    public static final String TOAST_ENABLED = "ToastEnabled";
+    public static final String TOAST_DURATION_SECONDS = "ToastDurationSeconds";
+    public static final String TOAST_REPORT_EVENTS = "ToastReportEvents";
     public static final String TOAST_DRIP_SECONDS = "ToastDripSeconds";
 
     public static final String PLAYERS_REMAINING_TO_SHOW = "PlayersRemainingToShow";
@@ -574,6 +577,9 @@ public class GUIPreferences extends PreferenceStoreProxy {
         setDefault(TRACE_OVERLAY_ORIGIN_Y, 0);
         setDefault(TRACE_OVERLAY_IMAGE_FILE, "");
 
+        setDefault(TOAST_ENABLED, true);
+        setDefault(TOAST_DURATION_SECONDS, 3);
+        setDefault(TOAST_REPORT_EVENTS, true);
         setDefault(TOAST_DRIP_SECONDS, 2);
 
         setDefault(WARNING_COLOR, DEFAULT_RED);
@@ -3439,6 +3445,43 @@ public class GUIPreferences extends PreferenceStoreProxy {
 
     public void setTraceOverlayScale(int i) {
         store.setValue(TRACE_OVERLAY_SCALE, i);
+    }
+
+    /**
+     * @return {@code true} if board toast notifications are shown at all. When {@code false}, every toast is
+     *       suppressed, including those whose content never reaches the report or chat log (Game Master actions,
+     *       artillery fire missions, effects wearing off, and the reasons an action was refused).
+     */
+    public boolean getToastEnabled() {
+        return getBoolean(TOAST_ENABLED);
+    }
+
+    public void setToastEnabled(boolean state) {
+        store.setValue(TOAST_ENABLED, state);
+    }
+
+    /**
+     * @return the base display time in seconds for a board toast. Each {@code ToastLevel} adds its own offset on top
+     *       of this, so more urgent levels always linger longer than the base.
+     */
+    public int getToastDurationSeconds() {
+        return getInt(TOAST_DURATION_SECONDS);
+    }
+
+    public void setToastDurationSeconds(int seconds) {
+        store.setValue(TOAST_DURATION_SECONDS, seconds);
+    }
+
+    /**
+     * @return {@code true} if round-report events are echoed as toasts. When {@code false}, only toasts that carry
+     *       information the report log does not already hold are shown.
+     */
+    public boolean getToastReportEvents() {
+        return getBoolean(TOAST_REPORT_EVENTS);
+    }
+
+    public void setToastReportEvents(boolean state) {
+        store.setValue(TOAST_REPORT_EVENTS, state);
     }
 
     public int getToastDripSeconds() {

--- a/megamek/src/megamek/client/ui/clientGUI/ReportToastFormatter.java
+++ b/megamek/src/megamek/client/ui/clientGUI/ReportToastFormatter.java
@@ -136,7 +136,7 @@ public final class ReportToastFormatter {
      * <p>This overload keeps no history, so every call treats the report as unseen. Callers that receive overlapping
      * reports should use {@link #formatReport(String, String, Set)} instead.</p>
      *
-     * @return ordered list of toast bodies; empty if the report is null/empty or fully filtered out
+     * @return ordered list of toast bodies; empty if the report is {@code null}/empty or fully filtered out
      */
     public static List<String> formatReport(String defaultPrefix, String report) {
         return formatReport(defaultPrefix, report, new HashSet<>());
@@ -162,7 +162,7 @@ public final class ReportToastFormatter {
      * @param alreadyToasted  plain-text bodies already shown; accepted entries are added to it. The caller owns this
      *                        set and should clear it when the reports stop overlapping, i.e. on a phase change.
      *
-     * @return ordered list of toast bodies; empty if the report is null/empty or fully filtered out
+     * @return ordered list of toast bodies; empty if the report is {@code null}/empty or fully filtered out
      */
     public static List<String> formatReport(String defaultPrefix, String report, Set<String> alreadyToasted) {
         List<String> toasts = new ArrayList<>();

--- a/megamek/src/megamek/client/ui/clientGUI/ReportToastFormatter.java
+++ b/megamek/src/megamek/client/ui/clientGUI/ReportToastFormatter.java
@@ -34,7 +34,9 @@ package megamek.client.ui.clientGUI;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -131,9 +133,38 @@ public final class ReportToastFormatter {
      *       final overflow toast like {@code "+N more events - see report panel"}.</li>
      * </ul>
      *
+     * <p>This overload keeps no history, so every call treats the report as unseen. Callers that receive overlapping
+     * reports should use {@link #formatReport(String, String, Set)} instead.</p>
+     *
      * @return ordered list of toast bodies; empty if the report is null/empty or fully filtered out
      */
     public static List<String> formatReport(String defaultPrefix, String report) {
+        return formatReport(defaultPrefix, report, new HashSet<>());
+    }
+
+    /**
+     * As {@link #formatReport(String, String)}, but skips entries that have already been turned into toasts.
+     *
+     * <p>This matters because the server's special-report packet carries the <em>entire</em> phase report accumulated
+     * so far, not just what is new. Several of those packets go out during a single movement phase (a hidden unit
+     * being revealed, a point-blank shot, an interrupted turn), so without a history every one of them would replay
+     * every event already shown - piloting-roll lines and all. Entries are matched on their plain-text content and
+     * recorded in {@code alreadyToasted} as they are accepted.</p>
+     *
+     * <p>Filtering happens <em>before</em> the {@link #MAX_TOASTS_PER_BURST} cap is applied, so a report full of
+     * already-seen entries does not exhaust the burst budget or inflate the overflow count.</p>
+     *
+     * <p>Two genuinely distinct events with byte-identical report text within the same history window collapse into
+     * one toast. Report text names the acting unit, so this is rare, and the report panel still lists both.</p>
+     *
+     * @param defaultPrefix   label for the first toast when the report carries no phase header
+     * @param report          the raw report HTML from the server
+     * @param alreadyToasted  plain-text bodies already shown; accepted entries are added to it. The caller owns this
+     *                        set and should clear it when the reports stop overlapping, i.e. on a phase change.
+     *
+     * @return ordered list of toast bodies; empty if the report is null/empty or fully filtered out
+     */
+    public static List<String> formatReport(String defaultPrefix, String report, Set<String> alreadyToasted) {
         List<String> toasts = new ArrayList<>();
         if (report == null || report.isEmpty()) {
             return toasts;
@@ -180,6 +211,11 @@ public final class ReportToastFormatter {
             // Drop empty "Team N:" / "Player (Team N):" labels - they precede BV detail lines that we already filter,
             // so the label on its own conveys nothing.
             if (TEAM_SUMMARY_LABEL.matcher(preview).matches()) {
+                continue;
+            }
+            // Drop entries this client has already toasted. The server re-sends the whole accumulated phase report
+            // with each special-report packet, so without this every packet replays the events before it.
+            if (!alreadyToasted.add(preview)) {
                 continue;
             }
             // Cap toasts per burst. Once full, count remaining qualifying entries so we can summarize them in a single

--- a/megamek/src/megamek/client/ui/clientGUI/ReportToastFormatter.java
+++ b/megamek/src/megamek/client/ui/clientGUI/ReportToastFormatter.java
@@ -148,8 +148,9 @@ public final class ReportToastFormatter {
      * <p>This matters because the server's special-report packet carries the <em>entire</em> phase report accumulated
      * so far, not just what is new. Several of those packets go out during a single movement phase (a hidden unit
      * being revealed, a point-blank shot, an interrupted turn), so without a history every one of them would replay
-     * every event already shown - piloting-roll lines and all. Entries are matched on their plain-text content and
-     * recorded in {@code alreadyToasted} as they are accepted.</p>
+     * every event already shown - piloting-roll lines and all. Entries are matched on their normalized text, as
+     * produced by {@link #normalizeToastText}, so the history keys on the line the player actually saw rather than
+     * on its markup; they are recorded in {@code alreadyToasted} as they are accepted.</p>
      *
      * <p>Filtering happens <em>before</em> the {@link #MAX_TOASTS_PER_BURST} cap is applied, so a report full of
      * already-seen entries does not exhaust the burst budget or inflate the overflow count.</p>
@@ -159,7 +160,7 @@ public final class ReportToastFormatter {
      *
      * @param defaultPrefix   label for the first toast when the report carries no phase header
      * @param report          the raw report HTML from the server
-     * @param alreadyToasted  plain-text bodies already shown; accepted entries are added to it. The caller owns this
+     * @param alreadyToasted  normalized bodies already shown; accepted entries are added to it. The caller owns this
      *                        set and should clear it when the reports stop overlapping, i.e. on a phase change.
      *
      * @return ordered list of toast bodies; empty if the report is {@code null}/empty or fully filtered out
@@ -214,8 +215,11 @@ public final class ReportToastFormatter {
                 continue;
             }
             // Drop entries this client has already toasted. The server re-sends the whole accumulated phase report
-            // with each special-report packet, so without this every packet replays the events before it.
-            if (!alreadyToasted.add(preview)) {
+            // with each special-report packet, so without this every packet replays the events before it. The key is
+            // the fully normalized text rather than the coarser preview above, so that it matches the line the player
+            // actually saw: preview leaves entities encoded, keeps runs of whitespace, and drops <br> instead of
+            // turning it into a space, so two entries that render identically can have different previews.
+            if (!alreadyToasted.add(normalizeToastText(entry))) {
                 continue;
             }
             // Cap toasts per burst. Once full, count remaining qualifying entries so we can summarize them in a single

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/overlay/ToastLevel.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/overlay/ToastLevel.java
@@ -34,31 +34,44 @@ package megamek.client.ui.clientGUI.boardview.overlay;
 
 import java.awt.Color;
 
+import megamek.client.ui.clientGUI.GUIPreferences;
+
 /**
- * Severity levels for board toast notifications. Each level defines a background color and default display duration
- * appropriate for the urgency of the message. Callers may override the duration for specific toasts.
+ * Severity levels for board toast notifications. Each level defines a background color and how much longer than the
+ * player's base display time its messages linger, so a more urgent level always outlasts a less urgent one no matter
+ * where the player sets the base. Callers may override the duration outright for specific toasts.
  */
 public enum ToastLevel {
-    INFO(new Color(41, 98, 168), 3000),
-    SUCCESS(new Color(46, 125, 50), 3000),
-    WARNING(new Color(183, 134, 11), 4000),
-    ERROR(new Color(176, 42, 42), 5000),
+    INFO(new Color(41, 98, 168), 0),
+    SUCCESS(new Color(46, 125, 50), 0),
+    WARNING(new Color(183, 134, 11), 1),
+    ERROR(new Color(176, 42, 42), 2),
     /** A Game Master's action - purple, so it reads as the GM's hand rather than a game outcome. */
-    GAMEMASTER(new Color(106, 61, 154), 4000);
+    GAMEMASTER(new Color(106, 61, 154), 1);
+
+    private static final int MILLIS_PER_SECOND = 1000;
 
     private final Color backgroundColor;
-    private final int defaultDurationMs;
+    private final int durationOffsetSeconds;
 
-    ToastLevel(Color backgroundColor, int defaultDurationMs) {
+    ToastLevel(Color backgroundColor, int durationOffsetSeconds) {
         this.backgroundColor = backgroundColor;
-        this.defaultDurationMs = defaultDurationMs;
+        this.durationOffsetSeconds = durationOffsetSeconds;
     }
 
     public Color getBackgroundColor() {
         return backgroundColor;
     }
 
+    /**
+     * Returns this level's display time, being the player's configured base duration plus this level's urgency
+     * offset. At the default base of 3 seconds this yields the long-standing 3s INFO/SUCCESS, 4s WARNING/GAMEMASTER
+     * and 5s ERROR timings.
+     *
+     * @return the display time in milliseconds
+     */
     public int getDefaultDurationMs() {
-        return defaultDurationMs;
+        int baseSeconds = GUIPreferences.getInstance().getToastDurationSeconds();
+        return (baseSeconds + durationOffsetSeconds) * MILLIS_PER_SECOND;
     }
 }

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/overlay/ToastLevel.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/overlay/ToastLevel.java
@@ -50,6 +50,8 @@ public enum ToastLevel {
     GAMEMASTER(new Color(106, 61, 154), 1);
 
     private static final int MILLIS_PER_SECOND = 1000;
+    /** Floor for the stored base duration, in case the preferences file holds a zero or negative value. */
+    private static final int MIN_BASE_DURATION_SECONDS = 1;
 
     private final Color backgroundColor;
     private final int durationOffsetSeconds;
@@ -68,10 +70,14 @@ public enum ToastLevel {
      * offset. At the default base of 3 seconds this yields the long-standing 3s INFO/SUCCESS, 4s WARNING/GAMEMASTER
      * and 5s ERROR timings.
      *
+     * <p>The settings spinner cannot go below {@link #MIN_BASE_DURATION_SECONDS}, but the stored value is clamped
+     * here as well so a hand-edited or corrupted preferences file cannot produce toasts that fade instantly.</p>
+     *
      * @return the display time in milliseconds
      */
     public int getDefaultDurationMs() {
-        int baseSeconds = GUIPreferences.getInstance().getToastDurationSeconds();
+        int baseSeconds = Math.max(MIN_BASE_DURATION_SECONDS,
+              GUIPreferences.getInstance().getToastDurationSeconds());
         return (baseSeconds + durationOffsetSeconds) * MILLIS_PER_SECOND;
     }
 }

--- a/megamek/src/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialog.java
@@ -578,6 +578,20 @@ public class CommonSettingsDialog extends AbstractButtonDialog
     /** Wrap width for the multi-line warning under the toast on/off checkbox, before GUI scaling. */
     private static final int TOAST_WARNING_WIDTH_PX = 480;
 
+    /**
+     * Clamps a persisted toast-timing value into the range the toast spinners allow. Guards against a
+     * hand-edited or corrupted preferences file: {@link SpinnerNumberModel}'s constructor throws an
+     * {@link IllegalArgumentException} when its initial value falls outside {@code [minimum, maximum]},
+     * which would crash the Overlays tab as it is built.
+     *
+     * @param seconds the stored timing value in seconds, possibly out of range
+     *
+     * @return the value clamped to {@code [MIN_TOAST_SECONDS, MAX_TOAST_SECONDS]}
+     */
+    private static int clampToastSeconds(int seconds) {
+        return Math.min(MAX_TOAST_SECONDS, Math.max(MIN_TOAST_SECONDS, seconds));
+    }
+
     // Save some values to restore them when the dialog is canceled
     private boolean savedFovHighlight;
     private boolean savedFovDarken;
@@ -1780,7 +1794,8 @@ public class CommonSettingsDialog extends AbstractButtonDialog
 
         addSpacer(comps, 3);
 
-        SpinnerNumberModel toastDurationModel = new SpinnerNumberModel(GUIP.getToastDurationSeconds(),
+        SpinnerNumberModel toastDurationModel = new SpinnerNumberModel(
+              clampToastSeconds(GUIP.getToastDurationSeconds()),
               MIN_TOAST_SECONDS,
               MAX_TOAST_SECONDS,
               1);
@@ -1795,7 +1810,8 @@ public class CommonSettingsDialog extends AbstractButtonDialog
         row.add(toastDurationLabel);
         comps.add(row);
 
-        SpinnerNumberModel toastDripModel = new SpinnerNumberModel(GUIP.getToastDripSeconds(),
+        SpinnerNumberModel toastDripModel = new SpinnerNumberModel(
+              clampToastSeconds(GUIP.getToastDripSeconds()),
               MIN_TOAST_SECONDS,
               MAX_TOAST_SECONDS,
               1);
@@ -2766,8 +2782,8 @@ public class CommonSettingsDialog extends AbstractButtonDialog
         planetaryConditionsBackgroundTransparency.setValue(GUIP.getPlanetaryConditionsBackgroundTransparency());
 
         toastEnabled.setSelected(GUIP.getToastEnabled());
-        toastDurationSpinner.setValue(GUIP.getToastDurationSeconds());
-        toastDripSpinner.setValue(GUIP.getToastDripSeconds());
+        toastDurationSpinner.setValue(clampToastSeconds(GUIP.getToastDurationSeconds()));
+        toastDripSpinner.setValue(clampToastSeconds(GUIP.getToastDripSeconds()));
         toastReportEvents.setSelected(GUIP.getToastReportEvents());
         setToastControlsEnabled(toastEnabled.isSelected());
 

--- a/megamek/src/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialog.java
@@ -532,6 +532,15 @@ public class CommonSettingsDialog extends AbstractButtonDialog
     private final JCheckBox planetaryConditionsShowIndicators = new JCheckBox(Messages.getString(
           "CommonSettingsDialog.planetaryConditionsShowIndicators"));
     private JSpinner planetaryConditionsBackgroundTransparency;
+
+    private final JCheckBox toastEnabled = new JCheckBox(Messages.getString("CommonSettingsDialog.toastEnabled"));
+    private final JCheckBox toastReportEvents = new JCheckBox(Messages.getString(
+          "CommonSettingsDialog.toastReportEvents"));
+    private JSpinner toastDurationSpinner;
+    private JLabel toastDurationLabel;
+    private JSpinner toastDripSpinner;
+    private JLabel toastDripLabel;
+
     private JSlider traceOverlayTransparencySlider;
     private JSlider traceOverlayScaleSlider;
     private JSlider traceOverlayOriginXSlider;
@@ -562,6 +571,12 @@ public class CommonSettingsDialog extends AbstractButtonDialog
 
     private static final Dimension LABEL_SPACER = new Dimension(5, 0);
     private static final Dimension DEPENDENT_INSET = new Dimension(25, 0);
+
+    /** Shortest and longest display/spacing time the toast spinners allow, in seconds. */
+    private static final int MIN_TOAST_SECONDS = 1;
+    private static final int MAX_TOAST_SECONDS = 10;
+    /** Wrap width for the multi-line warning under the toast on/off checkbox, before GUI scaling. */
+    private static final int TOAST_WARNING_WIDTH_PX = 480;
 
     // Save some values to restore them when the dialog is canceled
     private boolean savedFovHighlight;
@@ -1747,6 +1762,63 @@ public class CommonSettingsDialog extends AbstractButtonDialog
 
         addLineSpacer(comps);
 
+        comps.add(checkboxEntry(toastEnabled, Messages.getString("CommonSettingsDialog.toastEnabled.tooltip")));
+        toastEnabled.setSelected(GUIP.getToastEnabled());
+
+        // The warning stays visible whether or not toasts are on: a player deciding whether to switch them off needs
+        // to read it before clicking, not after.
+        JLabel toastDisabledWarning = new JLabel("<html><body style='width: "
+              + UIUtil.scaleForGUI(TOAST_WARNING_WIDTH_PX) + "px'>"
+              + Messages.getString("CommonSettingsDialog.toastEnabled.warning") + "</body></html>");
+        toastDisabledWarning.setToolTipText(Messages.getString("CommonSettingsDialog.toastEnabled.tooltip"));
+        row = new ArrayList<>();
+        row.add(Box.createRigidArea(DEPENDENT_INSET));
+        row.add(toastDisabledWarning);
+        comps.add(row);
+
+        addSpacer(comps, 3);
+
+        SpinnerNumberModel toastDurationModel = new SpinnerNumberModel(GUIP.getToastDurationSeconds(),
+              MIN_TOAST_SECONDS,
+              MAX_TOAST_SECONDS,
+              1);
+        toastDurationSpinner = new JSpinner(toastDurationModel);
+        toastDurationSpinner.setMaximumSize(new Dimension(150, 40));
+        toastDurationSpinner.setToolTipText(Messages.getString("CommonSettingsDialog.toastDurationSeconds.tooltip"));
+        toastDurationLabel = new JLabel(Messages.getString("CommonSettingsDialog.toastDurationSeconds"));
+        toastDurationLabel.setToolTipText(Messages.getString("CommonSettingsDialog.toastDurationSeconds.tooltip"));
+        row = new ArrayList<>();
+        row.add(Box.createRigidArea(DEPENDENT_INSET));
+        row.add(toastDurationSpinner);
+        row.add(toastDurationLabel);
+        comps.add(row);
+
+        SpinnerNumberModel toastDripModel = new SpinnerNumberModel(GUIP.getToastDripSeconds(),
+              MIN_TOAST_SECONDS,
+              MAX_TOAST_SECONDS,
+              1);
+        toastDripSpinner = new JSpinner(toastDripModel);
+        toastDripSpinner.setMaximumSize(new Dimension(150, 40));
+        toastDripSpinner.setToolTipText(Messages.getString("CommonSettingsDialog.toastDripSeconds.tooltip"));
+        toastDripLabel = new JLabel(Messages.getString("CommonSettingsDialog.toastDripSeconds"));
+        toastDripLabel.setToolTipText(Messages.getString("CommonSettingsDialog.toastDripSeconds.tooltip"));
+        row = new ArrayList<>();
+        row.add(Box.createRigidArea(DEPENDENT_INSET));
+        row.add(toastDripSpinner);
+        row.add(toastDripLabel);
+        comps.add(row);
+
+        row = new ArrayList<>();
+        row.add(Box.createRigidArea(DEPENDENT_INSET));
+        row.addAll(checkboxEntry(toastReportEvents,
+              Messages.getString("CommonSettingsDialog.toastReportEvents.tooltip")));
+        comps.add(row);
+        toastReportEvents.setSelected(GUIP.getToastReportEvents());
+
+        setToastControlsEnabled(toastEnabled.isSelected());
+
+        addLineSpacer(comps);
+
         addSpacer(comps, 1);
 
         JLabel traceOverlayTransparencyLabel = new JLabel(Messages.getString(
@@ -2232,6 +2304,20 @@ public class CommonSettingsDialog extends AbstractButtonDialog
         return row;
     }
 
+    /**
+     * Greys out the toast timing and report-echo controls when toasts are switched off entirely, since none of them
+     * have any effect in that state.
+     *
+     * @param enabled {@code true} when board toasts are switched on
+     */
+    private void setToastControlsEnabled(boolean enabled) {
+        toastDurationSpinner.setEnabled(enabled);
+        toastDurationLabel.setEnabled(enabled);
+        toastDripSpinner.setEnabled(enabled);
+        toastDripLabel.setEnabled(enabled);
+        toastReportEvents.setEnabled(enabled);
+    }
+
     private void addLineSpacer(List<List<Component>> comps) {
         List<Component> row = new ArrayList<>();
         row.add(Box.createRigidArea(new Dimension(0, 10)));
@@ -2676,6 +2762,12 @@ public class CommonSettingsDialog extends AbstractButtonDialog
         planetaryConditionsShowValues.setSelected(GUIP.getPlanetaryConditionsShowValues());
         planetaryConditionsShowIndicators.setSelected(GUIP.getPlanetaryConditionsShowIndicators());
         planetaryConditionsBackgroundTransparency.setValue(GUIP.getPlanetaryConditionsBackgroundTransparency());
+
+        toastEnabled.setSelected(GUIP.getToastEnabled());
+        toastDurationSpinner.setValue(GUIP.getToastDurationSeconds());
+        toastDripSpinner.setValue(GUIP.getToastDripSeconds());
+        toastReportEvents.setSelected(GUIP.getToastReportEvents());
+        setToastControlsEnabled(toastEnabled.isSelected());
 
         traceOverlayTransparencySlider.setValue(GUIP.getTraceOverlayTransparency());
         traceOverlayScaleSlider.setValue(GUIP.getTraceOverlayScale());
@@ -3167,6 +3259,11 @@ public class CommonSettingsDialog extends AbstractButtonDialog
         GUIP.setPlanetaryConditionsBackgroundTransparency(
               (Integer) planetaryConditionsBackgroundTransparency.getValue());
 
+        GUIP.setToastEnabled(toastEnabled.isSelected());
+        GUIP.setToastDurationSeconds((Integer) toastDurationSpinner.getValue());
+        GUIP.setToastDripSeconds((Integer) toastDripSpinner.getValue());
+        GUIP.setToastReportEvents(toastReportEvents.isSelected());
+
         GUIP.setTraceOverlayTransparency(traceOverlayTransparencySlider.getValue());
         GUIP.setTraceOverlayScale(traceOverlayScaleSlider.getValue());
         GUIP.setTraceOverlayOriginX(traceOverlayOriginXSlider.getValue());
@@ -3188,6 +3285,8 @@ public class CommonSettingsDialog extends AbstractButtonDialog
         } else if (source.equals(stampFilenames)) {
             stampFormat.setEnabled(stampFilenames.isSelected());
             stampFormatLabel.setEnabled(stampFilenames.isSelected());
+        } else if (source.equals(toastEnabled)) {
+            setToastControlsEnabled(toastEnabled.isSelected());
         } else if (source.equals(fovInsideEnabled)) {
             GUIP.setFovHighlight(fovInsideEnabled.isSelected());
             fovHighlightAlpha.setEnabled(fovInsideEnabled.isSelected());

--- a/megamek/src/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialog.java
@@ -1762,8 +1762,10 @@ public class CommonSettingsDialog extends AbstractButtonDialog
 
         addLineSpacer(comps);
 
-        comps.add(checkboxEntry(toastEnabled, Messages.getString("CommonSettingsDialog.toastEnabled.tooltip")));
+        // Set the state before checkboxEntry() attaches the item listener: the listener drives the dependent
+        // controls, which are not built until further down this method.
         toastEnabled.setSelected(GUIP.getToastEnabled());
+        comps.add(checkboxEntry(toastEnabled, Messages.getString("CommonSettingsDialog.toastEnabled.tooltip")));
 
         // The warning stays visible whether or not toasts are on: a player deciding whether to switch them off needs
         // to read it before clicking, not after.
@@ -1808,12 +1810,12 @@ public class CommonSettingsDialog extends AbstractButtonDialog
         row.add(toastDripLabel);
         comps.add(row);
 
+        toastReportEvents.setSelected(GUIP.getToastReportEvents());
         row = new ArrayList<>();
         row.add(Box.createRigidArea(DEPENDENT_INSET));
         row.addAll(checkboxEntry(toastReportEvents,
               Messages.getString("CommonSettingsDialog.toastReportEvents.tooltip")));
         comps.add(row);
-        toastReportEvents.setSelected(GUIP.getToastReportEvents());
 
         setToastControlsEnabled(toastEnabled.isSelected());
 

--- a/megamek/src/megamek/server/ServerHelper.java
+++ b/megamek/src/megamek/server/ServerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2018-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/src/megamek/server/ServerHelper.java
+++ b/megamek/src/megamek/server/ServerHelper.java
@@ -390,11 +390,9 @@ public class ServerHelper {
             }
         }
 
-        if (!vPhaseReport.isEmpty() && game.getPhase().isMovement()
+        if (hiddenUnitFound && game.getPhase().isMovement()
               && ((game.getTurnIndex() + 1) < game.getTurnsList().size())) {
-            for (Integer playerId : reportPlayers) {
-                gameManager.send(playerId, gameManager.createSpecialReportPacket());
-            }
+            gameManager.sendNewSpecialReportsTo(reportPlayers);
         }
 
         return hiddenUnitFound;

--- a/megamek/src/megamek/server/totalWarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalWarfare/MovePathHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/src/megamek/server/totalWarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalWarfare/MovePathHandler.java
@@ -1683,7 +1683,7 @@ class MovePathHandler extends AbstractTWRuleHandler {
             // let everyone know about what just happened
             // Skip if we already sent an EMP popup this move (avoid duplicate popups)
             if ((gameManager.getMainPhaseReport().size() > 1) && !sentEMPPopupThisMove) {
-                gameManager.send(entity.getOwner().getId(), gameManager.createSpecialReportPacket());
+                gameManager.sendNewSpecialReportsTo(entity.getOwner().getId());
             }
         } else {
             if (entity.getMovementMode() == EntityMovementMode.WIGE) {
@@ -2091,8 +2091,8 @@ class MovePathHandler extends AbstractTWRuleHandler {
 
                         // If we aren't at the end, send a special report
                         if ((getGame().getTurnIndex() + 1) < getGame().getTurnsList().size()) {
-                            gameManager.send(hiddenEntity.getOwner().getId(), gameManager.createSpecialReportPacket());
-                            gameManager.send(this.entity.getOwner().getId(), gameManager.createSpecialReportPacket());
+                            gameManager.sendNewSpecialReportsTo(hiddenEntity.getOwner().getId());
+                            gameManager.sendNewSpecialReportsTo(this.entity.getOwner().getId());
                         }
 
                         // End this entity's turn _without_ updating its position to the current step, because the
@@ -2129,8 +2129,8 @@ class MovePathHandler extends AbstractTWRuleHandler {
 
                         // If we aren't at the end, send a special report
                         if ((getGame().getTurnIndex() + 1) < getGame().getTurnsList().size()) {
-                            gameManager.send(hiddenEntity.getOwner().getId(), gameManager.createSpecialReportPacket());
-                            gameManager.send(this.entity.getOwner().getId(), gameManager.createSpecialReportPacket());
+                            gameManager.sendNewSpecialReportsTo(hiddenEntity.getOwner().getId());
+                            gameManager.sendNewSpecialReportsTo(this.entity.getOwner().getId());
                         }
 
                         curFacing = this.entity.getFacing();

--- a/megamek/src/megamek/server/totalWarfare/SpecialReportDispatcher.java
+++ b/megamek/src/megamek/server/totalWarfare/SpecialReportDispatcher.java
@@ -75,9 +75,13 @@ class SpecialReportDispatcher extends AbstractTWRuleHandler {
         int alreadySent = sentReportCountByPlayer.getOrDefault(playerId, 0);
         if (alreadySent > phaseReport.size()) {
             // The phase report was cleared since this player's last send, so the mark no longer means anything.
+            // Correct the stored mark now (not just the local copy) so that if we bail out at the "nothing new"
+            // check below - which happens when the report is currently empty - a later call self-heals instead
+            // of re-detecting and re-logging the same stale mark every time.
             LOGGER.debug("[SpecialReport] player {}: mark {} exceeds report size {}, resending from the start",
                   playerId, alreadySent, phaseReport.size());
             alreadySent = 0;
+            sentReportCountByPlayer.put(playerId, 0);
         }
         if (alreadySent == phaseReport.size()) {
             LOGGER.debug("[SpecialReport] player {}: nothing new since last send, skipping packet", playerId);

--- a/megamek/src/megamek/server/totalWarfare/SpecialReportDispatcher.java
+++ b/megamek/src/megamek/server/totalWarfare/SpecialReportDispatcher.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.server.totalWarfare;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Vector;
+
+import megamek.common.Report;
+import megamek.logging.MMLogger;
+
+/**
+ * Sends mid-phase "special report" packets containing only the reports a given player has not received yet.
+ *
+ * <p>Several rules paths interrupt a movement phase to show the player what just happened rather than making them
+ * wait for the end-of-phase report: a hidden unit being revealed, a point-blank shot, an interrupted turn. Each of
+ * those used to send the <em>entire</em> phase report accumulated so far, so the second interruption in a phase
+ * re-sent everything the first one had already delivered, the third re-sent both, and so on. Clients that append
+ * what they receive - the toast overlay and the accessibility log - showed those events again each time.</p>
+ *
+ * <p>This class keeps a per-player high-water mark into {@link TWGameManager#getMainPhaseReport()} and sends only
+ * the tail past it. The mark has to be per player because a single interruption can report to two players at once
+ * (the unit that was revealed and the unit that spotted it), and those two are generally not up to date with each
+ * other.</p>
+ */
+class SpecialReportDispatcher extends AbstractTWRuleHandler {
+
+    private static final MMLogger LOGGER = MMLogger.create(SpecialReportDispatcher.class);
+
+    /** Number of phase-report entries each player has already been sent, keyed by player id. */
+    private final Map<Integer, Integer> sentReportCountByPlayer = new HashMap<>();
+
+    SpecialReportDispatcher(TWGameManager gameManager) {
+        super(gameManager);
+    }
+
+    /**
+     * Sends the given player every phase report added since they last received one. Does nothing when there is
+     * nothing new for them, which spares the client a redundant packet and a repeated notification.
+     *
+     * @param playerId the player to bring up to date
+     */
+    void sendNewReportsTo(int playerId) {
+        Vector<Report> phaseReport = gameManager.getMainPhaseReport();
+        int alreadySent = sentReportCountByPlayer.getOrDefault(playerId, 0);
+        if (alreadySent > phaseReport.size()) {
+            // The phase report was cleared since this player's last send, so the mark no longer means anything.
+            LOGGER.debug("[SpecialReport] player {}: mark {} exceeds report size {}, resending from the start",
+                  playerId, alreadySent, phaseReport.size());
+            alreadySent = 0;
+        }
+        if (alreadySent == phaseReport.size()) {
+            LOGGER.debug("[SpecialReport] player {}: nothing new since last send, skipping packet", playerId);
+            return;
+        }
+        Vector<Report> newReports = new Vector<>(phaseReport.subList(alreadySent, phaseReport.size()));
+        sentReportCountByPlayer.put(playerId, phaseReport.size());
+        LOGGER.debug("[SpecialReport] player {}: sending {} new report(s) of {} in the phase",
+              playerId, newReports.size(), phaseReport.size());
+        gameManager.send(playerId, gameManager.createSpecialReportPacket(newReports));
+    }
+
+    /**
+     * Brings each of the given players up to date. A player listed twice receives one packet, because the second
+     * visit finds nothing new left to send.
+     *
+     * @param playerIds the player ids to bring up to date; repeats are harmless
+     */
+    void sendNewReportsTo(Iterable<Integer> playerIds) {
+        for (Integer playerId : playerIds) {
+            sendNewReportsTo(playerId);
+        }
+    }
+
+    /** Forgets every player's mark. Called when the phase report itself is cleared. */
+    void reset() {
+        sentReportCountByPlayer.clear();
+    }
+}

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -27919,7 +27919,7 @@ public class TWGameManager extends AbstractGameManager {
      *       everything the first one already delivered. Use {@link #sendNewSpecialReportsTo(int)} to send a player
      *       only what is new, or {@link #createSpecialReportPacket(Vector)} to send an explicit set of reports.
      */
-    @Deprecated(since = "0.51.1", forRemoval = true)
+    @Deprecated(since = "0.51.01", forRemoval = true)
     public Packet createSpecialReportPacket() {
         return new Packet(PacketCommand.SENDING_REPORTS_SPECIAL, mainPhaseReport.clone());
     }

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -155,8 +155,29 @@ public class TWGameManager extends AbstractGameManager {
 
     private final Vector<Report> mainPhaseReport = new Vector<>();
 
+    private final SpecialReportDispatcher specialReportDispatcher = new SpecialReportDispatcher(this);
+
     public Vector<Report> getMainPhaseReport() {
         return mainPhaseReport;
+    }
+
+    /**
+     * Sends the given player the phase reports added since they last received a mid-phase special report, so an
+     * interruption shows only what is new rather than replaying the phase so far.
+     *
+     * @param playerId the player to bring up to date
+     */
+    public void sendNewSpecialReportsTo(int playerId) {
+        specialReportDispatcher.sendNewReportsTo(playerId);
+    }
+
+    /**
+     * Sends each of the given players the phase reports they have not received yet.
+     *
+     * @param playerIds the player ids to bring up to date; repeats are harmless
+     */
+    public void sendNewSpecialReportsTo(Iterable<Integer> playerIds) {
+        specialReportDispatcher.sendNewReportsTo(playerIds);
     }
 
     // Track buildings that are affected by an entity's movement.
@@ -27893,7 +27914,12 @@ public class TWGameManager extends AbstractGameManager {
     /**
      * Creates a packet containing a Vector of special Reports which needs to be sent during a phase that is not a
      * report phase.
+     *
+     * @deprecated this sends the whole phase report accumulated so far, so a second mid-phase interruption re-sends
+     *       everything the first one already delivered. Use {@link #sendNewSpecialReportsTo(int)} to send a player
+     *       only what is new, or {@link #createSpecialReportPacket(Vector)} to send an explicit set of reports.
      */
+    @Deprecated(since = "0.51.1", forRemoval = true)
     public Packet createSpecialReportPacket() {
         return new Packet(PacketCommand.SENDING_REPORTS_SPECIAL, mainPhaseReport.clone());
     }
@@ -31618,6 +31644,7 @@ public class TWGameManager extends AbstractGameManager {
      */
     void clearReports() {
         mainPhaseReport.removeAllElements();
+        specialReportDispatcher.reset();
     }
 
     /**

--- a/megamek/unittests/megamek/client/ui/clientGUI/ReportToastFormatterTest.java
+++ b/megamek/unittests/megamek/client/ui/clientGUI/ReportToastFormatterTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.ui.clientGUI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ReportToastFormatter}, with emphasis on the already-toasted history that stops the server's
+ * whole-phase special reports from replaying events the player has already seen.
+ */
+class ReportToastFormatterTest {
+
+    private static final String DEFAULT_PREFIX = "Movement Report";
+
+    /**
+     * Builds report HTML in the shape the server sends: one {@code <span class='report-entry'>} block per event.
+     *
+     * @param entries the plain-text event lines to wrap
+     *
+     * @return the assembled report HTML
+     */
+    private static String reportOf(String... entries) {
+        StringBuilder report = new StringBuilder();
+        for (String entry : entries) {
+            report.append("<span class='report-entry'>").append(entry).append("</span>");
+        }
+        return report.toString();
+    }
+
+    @Test
+    @DisplayName("Each report entry becomes its own toast, with the first one labelled")
+    void splitsEntriesAndPrefixesTheFirst() {
+        List<String> toasts = ReportToastFormatter.formatReport(DEFAULT_PREFIX,
+              reportOf("Fenrir FNR-4 must make a piloting skill roll.", "Fenrir FNR-4 rolls 7, needs 5: succeeds."));
+
+        assertEquals(2, toasts.size());
+        assertTrue(toasts.getFirst().startsWith(DEFAULT_PREFIX + ": "),
+              "first toast should carry the report label, was: " + toasts.getFirst());
+        assertFalse(toasts.getLast().startsWith(DEFAULT_PREFIX),
+              "later toasts should not repeat the label, was: " + toasts.getLast());
+    }
+
+    @Test
+    @DisplayName("Re-sending the same report produces no further toasts")
+    void suppressesEntriesAlreadyToasted() {
+        Set<String> alreadyToasted = new HashSet<>();
+        String report = reportOf("Fenrir FNR-4 must make a piloting skill roll.",
+              "Fenrir FNR-4 rolls 7, needs 5: succeeds.");
+
+        List<String> firstBurst = ReportToastFormatter.formatReport(DEFAULT_PREFIX, report, alreadyToasted);
+        List<String> secondBurst = ReportToastFormatter.formatReport(DEFAULT_PREFIX, report, alreadyToasted);
+
+        assertEquals(2, firstBurst.size());
+        assertTrue(secondBurst.isEmpty(), "a repeated report should produce no toasts, was: " + secondBurst);
+    }
+
+    @Test
+    @DisplayName("A growing report only toasts the entries added since the last burst")
+    void toastsOnlyTheNewTailOfAGrowingReport() {
+        Set<String> alreadyToasted = new HashSet<>();
+        ReportToastFormatter.formatReport(DEFAULT_PREFIX,
+              reportOf("Fenrir FNR-4 must make a piloting skill roll."), alreadyToasted);
+
+        // The server re-sends the whole accumulated phase report, first entry included.
+        List<String> secondBurst = ReportToastFormatter.formatReport(DEFAULT_PREFIX,
+              reportOf("Fenrir FNR-4 must make a piloting skill roll.", "Hidden unit revealed at 0304."),
+              alreadyToasted);
+
+        assertEquals(1, secondBurst.size());
+        assertTrue(secondBurst.getFirst().contains("Hidden unit revealed at 0304."),
+              "only the newly added event should toast, was: " + secondBurst.getFirst());
+    }
+
+    @Test
+    @DisplayName("Already-seen entries do not consume the per-burst cap or inflate the overflow count")
+    void seenEntriesDoNotConsumeTheBurstCap() {
+        Set<String> alreadyToasted = new HashSet<>();
+        String[] firstEntries = new String[ReportToastFormatter.MAX_TOASTS_PER_BURST];
+        for (int entryIndex = 0; entryIndex < firstEntries.length; entryIndex++) {
+            firstEntries[entryIndex] = "Old event " + entryIndex + " resolves.";
+        }
+        ReportToastFormatter.formatReport(DEFAULT_PREFIX, reportOf(firstEntries), alreadyToasted);
+
+        // Re-send those capped entries plus one genuinely new event.
+        String[] secondEntries = new String[firstEntries.length + 1];
+        System.arraycopy(firstEntries, 0, secondEntries, 0, firstEntries.length);
+        secondEntries[firstEntries.length] = "New event resolves.";
+        List<String> secondBurst = ReportToastFormatter.formatReport(DEFAULT_PREFIX, reportOf(secondEntries),
+              alreadyToasted);
+
+        assertEquals(1, secondBurst.size(),
+              "the new event should toast rather than be summarised as overflow, was: " + secondBurst);
+        assertTrue(secondBurst.getFirst().contains("New event resolves."));
+    }
+
+    @Test
+    @DisplayName("Bursts beyond the cap collapse the surplus into a single overflow toast")
+    void collapsesSurplusIntoOneOverflowToast() {
+        int overflowCount = 3;
+        String[] entries = new String[ReportToastFormatter.MAX_TOASTS_PER_BURST + overflowCount];
+        for (int entryIndex = 0; entryIndex < entries.length; entryIndex++) {
+            entries[entryIndex] = "Event " + entryIndex + " resolves.";
+        }
+
+        List<String> toasts = ReportToastFormatter.formatReport(DEFAULT_PREFIX, reportOf(entries));
+
+        assertEquals(ReportToastFormatter.MAX_TOASTS_PER_BURST + 1, toasts.size());
+        assertTrue(toasts.getLast().startsWith("+" + overflowCount + " more events"),
+              "last toast should summarise the surplus, was: " + toasts.getLast());
+    }
+
+    @Test
+    @DisplayName("The two-argument overload keeps no history between calls")
+    void historyFreeOverloadRepeatsEveryCall() {
+        String report = reportOf("Fenrir FNR-4 must make a piloting skill roll.");
+
+        assertEquals(1, ReportToastFormatter.formatReport(DEFAULT_PREFIX, report).size());
+        assertEquals(1, ReportToastFormatter.formatReport(DEFAULT_PREFIX, report).size());
+    }
+
+    @Test
+    @DisplayName("Report markup and embedded newlines are flattened to a single plain-text line")
+    void normalizesMarkupToPlainText() {
+        String normalized = ReportToastFormatter.normalizeToastText(
+              "<B>Fenrir FNR-4</B><br>falls&nbsp;&amp; takes\n  damage");
+
+        assertEquals("Fenrir FNR-4 falls & takes damage", normalized);
+    }
+}

--- a/megamek/unittests/megamek/client/ui/clientGUI/ReportToastFormatterTest.java
+++ b/megamek/unittests/megamek/client/ui/clientGUI/ReportToastFormatterTest.java
@@ -149,6 +149,22 @@ class ReportToastFormatterTest {
     }
 
     @Test
+    @DisplayName("Entries that render identically are deduplicated despite differing markup")
+    void deduplicatesOnRenderedTextNotMarkup() {
+        Set<String> alreadyToasted = new HashSet<>();
+        // Same sentence, different markup: a line break versus a space, an encoded ampersand versus a bare one,
+        // and a doubled space. All three render as the same toast, so the player must only see it once.
+        ReportToastFormatter.formatReport(DEFAULT_PREFIX,
+              reportOf("Fenrir FNR-4 falls<br>&amp; takes damage"), alreadyToasted);
+
+        List<String> secondBurst = ReportToastFormatter.formatReport(DEFAULT_PREFIX,
+              reportOf("Fenrir FNR-4 falls &amp;  takes damage"), alreadyToasted);
+
+        assertTrue(secondBurst.isEmpty(),
+              "an entry that renders the same should not toast twice, was: " + secondBurst);
+    }
+
+    @Test
     @DisplayName("The two-argument overload keeps no history between calls")
     void historyFreeOverloadRepeatsEveryCall() {
         String report = reportOf("Fenrir FNR-4 must make a piloting skill roll.");


### PR DESCRIPTION
## Summary

Players asked for two things: the toast display-time setting back, and a way to turn toasts off altogether. This adds both, plus a fix for the real reason toasts have felt excessive - the same events were being shown over and over.

**What a player sees.** Client Settings now has a toast block on the Overlays tab:

- **Show board toast notifications** - the master switch, on by default.
- **Toast display time** - 1 to 10 seconds, default 3.
- **Gap between report toasts** - how long to wait between messages wh
- **Show round report events as toasts** - turns off just the running commentary from the round
  report, and leaves everything else alone.

**A worked example of the repeat problem.** A Mek walks past a hidden revealed, so the server sends the player the events so far. Later in the same movement phase somebody's turn is interrupted, so the server sends the events so far *again* - including the reveal, and every piloting-roll line that has happened since. Do that three times in a phase and the player watches the same lines scroll past three times. That is what "it plays every line" was.

## The toast duration setting, and why it comes back differently

PR #8156 removed the old duration spinner in favour of per-level durations, so that a warning naturally outlasts a routine message. That was the right call and this PR keeps it.

Rather than going back to one flat number for everything, the setting is now a **base** that each severity adds to:

| Level | Display time |
|---|---|
| Info, Success | base |
| Warning, Game Master | base + 1s |
| Error | base + 2s |

At the default base of 3 seconds this produces exactly the timings in use today - 3 / 3 / 4 / 5 / 4
- so nothing changes for a player who never touches the setting. Move the base to 6 and everything
scales while keeping its relative urgency.

## Turning toasts off loses information, and the dialog says so

This is worth reviewer attention, because it is not obvious. Some things reach the player **only**
as a toast, with nothing written to the report or chat log:

- **Every Game Master command, and GM damage edits.** There is deliberately no report entry; the toast is the announcement that an intervention happened.
- **Magnetic Pulse / iATM jamming wearing off.** The effect being *applied* is reported. The effect *ending* has no report at all.
- **Artillery fire missions and their target grids.** These are struct- the target grid travels in a team-scoped toast so the other team cannot read it from the shared report.
- **Every client-side refusal reason** ("you cannot dig in here", "cannot spot while jammed"). These used to be modal pop-ups.

So the setting carries a permanent warning naming what is lost, rather than a vague caution. The separate "round report events" switch exists precisely so a player who just wants less noise can have it without giving up any of the above.

## Changes

1. **Four client settings** on the Overlays tab, in the slot the removed spinner occupied.
   `TOAST_DRIP_SECONDS` already existed but had never been exposed - its setter had no callers, so
   the only way to change it was editing the settings file by hand.
2. **`ToastLevel`** stores a per-level offset instead of a fixed duration, and adds it to the
   player's base.
3. **`ClientGUI.addToast`** enforces the on/off setting. It is the single entry point for all 98
   toast call sites, server-raised ones included, so there is exactly one gate.
4. **`ReportToastFormatter`** gains a `formatReport` overload that skips entries already toasted.
   The filter runs *before* the per-burst cap, so a report full of already-seen entries cannot
   exhaust the budget or inflate the "+N more events" summary. `ClientGUI` owns the history and
   clears it on phase change.
5. **New `SpecialReportDispatcher`** keeps a per-player high-water mar
   sends only what is new. The mark has to be per player because one interruption can report to two
   players at once - the unit revealed and the unit that spotted it - and they are rarely at the
   same point. `TWGameManager` gets only thin delegators; the no-argument
   `createSpecialReportPacket()` is deprecated rather than removed, si

This also fixes a smaller bug in passing: `AccessibilityDialog` appends every report it receives to
its log, so it was duplicating the whole phase report on each interruption.

## Files Changed

- `GUIPreferences.java` - four toast preferences and accessors
- `CommonSettingsDialog.java` - the Overlays tab controls, warning, and dependent grey-out
- `messages.properties` - labels, tooltips and the warning text
- `ToastLevel.java` - per-level offsets on top of the player's base duration
- `ClientGUI.java` - on/off gate, report-events gate, de-duplication history
- `ReportToastFormatter.java` - the history-aware `formatReport` overl
- `SpecialReportDispatcher.java` (new) - per-player incremental special reports
- `TWGameManager.java` - delegators, dispatcher reset, deprecation
- `MovePathHandler.java`, `ServerHelper.java` - use the incremental send
- `ReportToastFormatterTest.java` (new) - 7 tests

## Testing

- `./gradlew :megamek:test` green.
- New `ReportToastFormatterTest` covers de-duplication across repeated and growing reports, the
  interaction with the per-burst cap, the history-free overload, and text normalisation.
- Settings dialog opened and the Overlays tab exercised in game; toast behaviour confirmed working.

Fixes #8560
Fixes #8561