### PR TITLE
Add Advanced Building to RAT Generator unit type list

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/randomArmy/ForceGenerationOptionsPanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/randomArmy/ForceGenerationOptionsPanel.java
@@ -97,7 +97,8 @@ public class ForceGenerationOptionsPanel extends JPanel implements ActionListene
     private static final int[] UNIT_TYPES = { UnitType.MEK, UnitType.TANK, UnitType.BATTLE_ARMOR, UnitType.INFANTRY,
                                               UnitType.PROTOMEK, UnitType.VTOL, UnitType.NAVAL, UnitType.CONV_FIGHTER,
                                               UnitType.AEROSPACE_FIGHTER, UnitType.SMALL_CRAFT, UnitType.DROPSHIP,
-                                              UnitType.JUMPSHIP, UnitType.WARSHIP, UnitType.SPACE_STATION };
+                                              UnitType.JUMPSHIP, UnitType.WARSHIP, UnitType.SPACE_STATION,
+                                              UnitType.ADVANCED_BUILDING };
     private static final int EARLIEST_YEAR = 2398;
     private static final int LATEST_YEAR = 3160;
     // endregion Variable Declarations


### PR DESCRIPTION
## Summary

The mm-data companion PR adds Gun Emplacement availability data under the Advanced Building unit type. This PR adds th
dialog so players can generate them.

## Changes Made

- **Unit type dropdown**: `UnitType.ADVANCED Generator tab's unit type list.
- **Formation Builder unaffected**: the existing `< JUMPSHIP` filter already excludes it there.
- **No other UI work needed**: the weight class panel hides by default, and role checkboxes come from `MissionRole.fitsUnitType`, which already supports Advanced Building (anti_aircraft, fire_support, command, generator, control, etc.). All role i18n strings already exist

## Files Changed

- `megamek/src/megamek/client/ui/dialogs/randomArmy/ForceGenerationOptionsPanel.java` - one constant array entry

## Testing

- `./gradlew test --tests "megamek.client.racheckstyle)
- Manual: Advanced Building appears in the RAT Generator tab only; tables generate for IS factions with the companior
- Manual: D/F rating tables exclude Siege/Blaze/Command Tower turrets as the source RATs specify; 3055+ rolls the (3050) Flak variants

Companion PR: mm-data `Implement-Advanced-Buildings-in-data` (merge first - without it this unit type generates an empty