### PR TITLE
added flag for few equipment families

### DIFF
--- a/megamek/src/megamek/common/equipment/WeaponType.java
+++ b/megamek/src/megamek/common/equipment/WeaponType.java
@@ -569,6 +569,14 @@ public class WeaponType extends EquipmentType {
     public static final WeaponTypeFlag F_PLASMA = WeaponTypeFlag.F_PLASMA;
     public static final WeaponTypeFlag F_INCENDIARY_NEEDLES = WeaponTypeFlag.F_INCENDIARY_NEEDLES;
 
+    // families
+    public static final WeaponTypeFlag F_AC = WeaponTypeFlag.F_AC;
+    public static final WeaponTypeFlag F_HAG = WeaponTypeFlag.F_HAG;
+    public static final WeaponTypeFlag F_MML = WeaponTypeFlag.F_MML;
+    public static final WeaponTypeFlag F_MRM = WeaponTypeFlag.F_MRM;
+    public static final WeaponTypeFlag F_ATM = WeaponTypeFlag.F_ATM;
+    
+
     // War of 3039 prototypes
     public static final WeaponTypeFlag F_PROTOTYPE = WeaponTypeFlag.F_PROTOTYPE;
     // Variable heat, heat is listed in dice, not points

--- a/megamek/src/megamek/common/equipment/WeaponType.java
+++ b/megamek/src/megamek/common/equipment/WeaponType.java
@@ -571,6 +571,8 @@ public class WeaponType extends EquipmentType {
 
     // families
     public static final WeaponTypeFlag F_AC = WeaponTypeFlag.F_AC;
+    public static final WeaponTypeFlag F_SRM = WeaponTypeFlag.F_SRM;
+    public static final WeaponTypeFlag F_LRM = WeaponTypeFlag.F_LRM;
     public static final WeaponTypeFlag F_HAG = WeaponTypeFlag.F_HAG;
     public static final WeaponTypeFlag F_MML = WeaponTypeFlag.F_MML;
     public static final WeaponTypeFlag F_MRM = WeaponTypeFlag.F_MRM;

--- a/megamek/src/megamek/common/equipment/WeaponTypeFlag.java
+++ b/megamek/src/megamek/common/equipment/WeaponTypeFlag.java
@@ -72,15 +72,6 @@ public enum WeaponTypeFlag implements EquipmentFlag {
     F_INFERNO, // Inferno weapon
     F_PLASMA, // fires
 
-    // families
-    F_AC,
-    F_LRM,
-    F_SRM,
-    F_HAG,
-    F_MML,
-    F_MRM,
-    F_ATM,
-
     // Special behaviors
     F_TAG,
     F_C3M, // C3 Master with Target Acquisition gear
@@ -154,5 +145,14 @@ public enum WeaponTypeFlag implements EquipmentFlag {
     /**
      * Denotes Clan Heavy Lasers (S, M, L)
      */
-    HEAVY_LASER
+    HEAVY_LASER,
+
+    // families
+    F_AC,
+    F_LRM,
+    F_SRM,
+    F_HAG,
+    F_MML,
+    F_MRM,
+    F_ATM,
 }

--- a/megamek/src/megamek/common/equipment/WeaponTypeFlag.java
+++ b/megamek/src/megamek/common/equipment/WeaponTypeFlag.java
@@ -74,6 +74,8 @@ public enum WeaponTypeFlag implements EquipmentFlag {
 
     // families
     F_AC,
+    F_LRM,
+    F_SRM,
     F_HAG,
     F_MML,
     F_MRM,

--- a/megamek/src/megamek/common/equipment/WeaponTypeFlag.java
+++ b/megamek/src/megamek/common/equipment/WeaponTypeFlag.java
@@ -72,6 +72,13 @@ public enum WeaponTypeFlag implements EquipmentFlag {
     F_INFERNO, // Inferno weapon
     F_PLASMA, // fires
 
+    // families
+    F_AC,
+    F_HAG,
+    F_MML,
+    F_MRM,
+    F_ATM,
+
     // Special behaviors
     F_TAG,
     F_C3M, // C3 Master with Target Acquisition gear

--- a/megamek/src/megamek/common/weapons/autoCannons/ACWeapon.java
+++ b/megamek/src/megamek/common/weapons/autoCannons/ACWeapon.java
@@ -77,7 +77,7 @@ public abstract class ACWeapon extends AmmoWeapon {
 
     public ACWeapon() {
         super();
-        flags = flags.or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_MEK_WEAPON).or(F_AERO_WEAPON).or(F_TANK_WEAPON);
+        flags = flags.or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_MEK_WEAPON).or(F_AERO_WEAPON).or(F_TANK_WEAPON).or(F_AC);
         ammoType = AmmoType.AmmoTypeEnum.AC;
         explosive = true; // when firing incendiary ammo
         atClass = CLASS_AC;

--- a/megamek/src/megamek/common/weapons/autoCannons/LBXACWeapon.java
+++ b/megamek/src/megamek/common/weapons/autoCannons/LBXACWeapon.java
@@ -99,7 +99,8 @@ public abstract class LBXACWeapon extends AmmoWeapon {
               .or(F_AERO_WEAPON)
               .or(F_PROTO_WEAPON)
               .or(F_BALLISTIC)
-              .or(F_DIRECT_FIRE);
+              .or(F_DIRECT_FIRE)
+              .or(F_AC);
 
         ammoType = AmmoType.AmmoTypeEnum.AC_LBX;
         atClass = CLASS_LBX_AC;

--- a/megamek/src/megamek/common/weapons/autoCannons/UACWeapon.java
+++ b/megamek/src/megamek/common/weapons/autoCannons/UACWeapon.java
@@ -61,7 +61,7 @@ public abstract class UACWeapon extends AmmoWeapon {
     public UACWeapon() {
         super();
         flags = flags.or(F_MEK_WEAPON).or(F_TANK_WEAPON).or(F_AERO_WEAPON).or(F_PROTO_WEAPON)
-              .or(F_BALLISTIC).or(F_DIRECT_FIRE);
+              .or(F_BALLISTIC).or(F_DIRECT_FIRE).or(F_AC);
         ammoType = AmmoType.AmmoTypeEnum.AC_ULTRA;
         String[] modeStrings = { MODE_AC_SINGLE, MODE_UAC_ULTRA };
         setModes(modeStrings);

--- a/megamek/src/megamek/common/weapons/bayWeapons/LRMBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayWeapons/LRMBayWeapon.java
@@ -70,7 +70,7 @@ public class LRMBayWeapon extends AmmoBayWeapon {
         this.tonnage = 0.0;
         this.bv = 0;
         this.cost = 0;
-        this.flags = flags.or(F_MISSILE);
+        this.flags = flags.or(F_MISSILE).or(F_LRM);
         this.atClass = CLASS_LRM;
     }
 

--- a/megamek/src/megamek/common/weapons/bayWeapons/SRMBayWeapon.java
+++ b/megamek/src/megamek/common/weapons/bayWeapons/SRMBayWeapon.java
@@ -70,7 +70,7 @@ public class SRMBayWeapon extends AmmoBayWeapon {
         this.tonnage = 0.0;
         this.bv = 0;
         this.cost = 0;
-        this.flags = flags.or(F_MISSILE);
+        this.flags = flags.or(F_MISSILE).or(F_SRM);
         this.atClass = CLASS_SRM;
     }
 

--- a/megamek/src/megamek/common/weapons/capitalWeapons/naval/NavalACWeapon.java
+++ b/megamek/src/megamek/common/weapons/capitalWeapons/naval/NavalACWeapon.java
@@ -59,7 +59,7 @@ public abstract class NavalACWeapon extends AmmoWeapon {
         super();
         ammoType = AmmoType.AmmoTypeEnum.NAC;
         atClass = CLASS_CAPITAL_AC;
-        flags = flags.or(F_DIRECT_FIRE).or(F_BALLISTIC).andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
+        flags = flags.or(F_DIRECT_FIRE).or(F_BALLISTIC).andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON).or(F_AC);
         capital = true;
     }
 

--- a/megamek/src/megamek/common/weapons/gaussRifles/HAGWeapon.java
+++ b/megamek/src/megamek/common/weapons/gaussRifles/HAGWeapon.java
@@ -67,7 +67,7 @@ public abstract class HAGWeapon extends GaussWeapon {
         super();
         damage = DAMAGE_BY_CLUSTER_TABLE;
         ammoType = AmmoType.AmmoTypeEnum.HAG;
-        flags = flags.or(F_NO_AIM);
+        flags = flags.or(F_NO_AIM).or(F_HAG);
         atClass = CLASS_AC;
         infDamageClass = WEAPON_CLUSTER_BALLISTIC;
     }

--- a/megamek/src/megamek/common/weapons/infantry/support/InfantrySupportLRMInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/InfantrySupportLRMInfernoWeapon.java
@@ -76,7 +76,7 @@ public class InfantrySupportLRMInfernoWeapon extends InfantryWeapon {
         ammoWeight = 0.0083;
         ammoCost = 1500;
         shots = 1;
-        flags = flags.or(F_INFERNO).or(F_DIRECT_FIRE).or(F_MISSILE).or(F_INF_ENCUMBER).or(F_INF_SUPPORT);
+        flags = flags.or(F_INFERNO).or(F_DIRECT_FIRE).or(F_MISSILE).or(F_INF_ENCUMBER).or(F_INF_SUPPORT).or(F_LRM);
         infantryDamage = 0.19;
         infantryRange = 3;
         rulesRefs = "273, TM";

--- a/megamek/src/megamek/common/weapons/infantry/support/InfantrySupportLRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/InfantrySupportLRMWeapon.java
@@ -72,7 +72,7 @@ public class InfantrySupportLRMWeapon extends InfantryWeapon {
         cost = 2000;
         bv = 3.44;
         tonnage = .03;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_MISSILE).or(F_INF_ENCUMBER).or(F_INF_SUPPORT);
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_MISSILE).or(F_INF_ENCUMBER).or(F_INF_SUPPORT).or(F_LRM);
         infantryDamage = 0.48;
         infantryRange = 3;
         ammoWeight = 0.0083;

--- a/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMHeavyInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMHeavyInfernoWeapon.java
@@ -63,7 +63,7 @@ public class InfantrySupportSRMHeavyInfernoWeapon extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 3000;
         bv = 1.74;
-        flags = flags.or(F_DIRECT_FIRE).or(F_INFERNO).or(F_MISSILE).or(F_INF_SUPPORT);
+        flags = flags.or(F_DIRECT_FIRE).or(F_INFERNO).or(F_MISSILE).or(F_INF_SUPPORT).or(F_SRM);
         infantryDamage = 0.34;
         infantryRange = 2;
         ammoWeight = 0.018;

--- a/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMHeavyWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMHeavyWeapon.java
@@ -70,7 +70,7 @@ public class InfantrySupportSRMHeavyWeapon extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 3000;
         bv = 2.91;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_MISSILE).or(F_INF_ENCUMBER).or(F_INF_SUPPORT);
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_MISSILE).or(F_INF_ENCUMBER).or(F_INF_SUPPORT).or(F_SRM);
         infantryDamage = 0.57;
         infantryRange = 2;
         ammoWeight = 0.018;

--- a/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMLightInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMLightInfernoWeapon.java
@@ -69,7 +69,7 @@ public class InfantrySupportSRMLightInfernoWeapon extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 1500;
         bv = 1.74;
-        flags = flags.or(F_DIRECT_FIRE).or(F_INFERNO).or(F_MISSILE).or(F_INF_SUPPORT);
+        flags = flags.or(F_DIRECT_FIRE).or(F_INFERNO).or(F_MISSILE).or(F_INF_SUPPORT).or(F_SRM);
         infantryDamage = 0.34;
         infantryRange = 2;
         ammoWeight = 0.009;

--- a/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMLightWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMLightWeapon.java
@@ -70,7 +70,7 @@ public class InfantrySupportSRMLightWeapon extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 1500;
         bv = 2.91;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_MISSILE).or(F_INF_SUPPORT);
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_MISSILE).or(F_INF_SUPPORT).or(F_SRM);
         infantryDamage = 0.57;
         infantryRange = 2;
         tonnage = .010;

--- a/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMStandardInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMStandardInfernoWeapon.java
@@ -71,7 +71,7 @@ public class InfantrySupportSRMStandardInfernoWeapon extends InfantryWeapon {
         cost = 1500;
         bv = 3.48;
         tonnage = .030;
-        flags = flags.or(F_DIRECT_FIRE).or(F_INFERNO).or(F_MISSILE).or(F_INF_SUPPORT);
+        flags = flags.or(F_DIRECT_FIRE).or(F_INFERNO).or(F_MISSILE).or(F_INF_SUPPORT).or(F_SRM);
         infantryDamage = 0.68;
         infantryRange = 2;
         ammoWeight = 0.02;

--- a/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMStandardWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMStandardWeapon.java
@@ -71,7 +71,7 @@ public class InfantrySupportSRMStandardWeapon extends InfantryWeapon {
         cost = 1500;
         bv = 5.83;
         tonnage = .030;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_MISSILE).or(F_INF_ENCUMBER).or(F_INF_SUPPORT);
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_MISSILE).or(F_INF_ENCUMBER).or(F_INF_SUPPORT).or(F_SRM);
         infantryDamage = 1.14;
         infantryRange = 2;
         crew = 1;

--- a/megamek/src/megamek/common/weapons/lrms/LRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/LRMWeapon.java
@@ -69,7 +69,7 @@ public abstract class LRMWeapon extends MissileWeapon {
         longRange = 21;
         extremeRange = 28;
         atClass = CLASS_LRM;
-        flags = flags.or(F_PROTO_WEAPON).or(F_ARTEMIS_COMPATIBLE).or('F_LRM');
+        flags = flags.or(F_PROTO_WEAPON).or(F_ARTEMIS_COMPATIBLE).or(F_LRM);
     }
 
 

--- a/megamek/src/megamek/common/weapons/lrms/LRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/lrms/LRMWeapon.java
@@ -69,7 +69,7 @@ public abstract class LRMWeapon extends MissileWeapon {
         longRange = 21;
         extremeRange = 28;
         atClass = CLASS_LRM;
-        flags = flags.or(F_PROTO_WEAPON).or(F_ARTEMIS_COMPATIBLE);
+        flags = flags.or(F_PROTO_WEAPON).or(F_ARTEMIS_COMPATIBLE).or('F_LRM');
     }
 
 

--- a/megamek/src/megamek/common/weapons/missiles/ATMWeapon.java
+++ b/megamek/src/megamek/common/weapons/missiles/ATMWeapon.java
@@ -63,6 +63,7 @@ public abstract class ATMWeapon extends MissileWeapon {
         super();
         ammoType = AmmoType.AmmoTypeEnum.ATM;
         atClass = CLASS_ATM;
+        flags = flags.or(F_ATM);
     }
 
     /*

--- a/megamek/src/megamek/common/weapons/missiles/MMLWeapon.java
+++ b/megamek/src/megamek/common/weapons/missiles/MMLWeapon.java
@@ -58,7 +58,7 @@ public abstract class MMLWeapon extends MissileWeapon {
         super();
         ammoType = AmmoType.AmmoTypeEnum.MML;
         atClass = CLASS_MML;
-        flags = flags.or(F_ARTEMIS_COMPATIBLE);
+        flags = flags.or(F_ARTEMIS_COMPATIBLE).or(F_MML);
     }
 
     @Override

--- a/megamek/src/megamek/common/weapons/missiles/MRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/missiles/MRMWeapon.java
@@ -65,6 +65,7 @@ public abstract class MRMWeapon extends MissileWeapon {
         ammoType = AmmoType.AmmoTypeEnum.MRM;
         toHitModifier = 1;
         atClass = CLASS_MRM;
+        flags = flags.or(F_MRM);
     }
 
     @Override

--- a/megamek/src/megamek/common/weapons/srms/SRMWeapon.java
+++ b/megamek/src/megamek/common/weapons/srms/SRMWeapon.java
@@ -63,7 +63,7 @@ public abstract class SRMWeapon extends MissileWeapon {
         super();
         ammoType = AmmoType.AmmoTypeEnum.SRM;
         atClass = CLASS_SRM;
-        flags = flags.or(F_PROTO_WEAPON).or(F_ARTEMIS_COMPATIBLE);
+        flags = flags.or(F_PROTO_WEAPON).or(F_ARTEMIS_COMPATIBLE).or(F_SRM);
     }
 
     @Override


### PR DESCRIPTION
This PR adds few flags to identify easier some weapons families without the need to rely to their instanceof: AC, SRM, LRM, MRM, ATM, MML, HAG.
This is useful to identify them by flag and will be used in another PR.