### PR TITLE
Fixed Out-of-Memory Crashing and Garbage Collection Lock-Ups in Double-Blind Games

### DIFF
--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -45,15 +45,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.Vector;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -116,8 +108,8 @@ import megamek.common.planetaryConditions.PlanetaryConditions;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.turns.UnloadStrandedTurn;
 import megamek.common.units.Crew;
-import megamek.common.units.DemolitionCharge;
 import megamek.common.units.DamageEditSpec;
+import megamek.common.units.DemolitionCharge;
 import megamek.common.units.Entity;
 import megamek.common.units.EntitySelector;
 import megamek.common.units.FighterSquadron;
@@ -125,9 +117,9 @@ import megamek.common.units.IBuilding;
 import megamek.common.units.UnitLocation;
 import megamek.common.util.C3Util;
 import megamek.common.util.ImageUtil;
-import megamek.common.voting.Poll;
 import megamek.common.util.SerializationHelper;
 import megamek.common.util.StringUtil;
+import megamek.common.voting.Poll;
 import megamek.logging.MMLogger;
 import megamek.server.SmokeCloud;
 
@@ -500,8 +492,8 @@ public class Client extends AbstractClient {
 
     /**
      * Sends a gamemaster's damage editor edits for the server to apply to its own copy of the unit. Unlike
-     * {@link #sendUpdateEntity(Entity)} this carries only the edited values, so the server's unit keeps every
-     * piece of state the editor does not touch.
+     * {@link #sendUpdateEntity(Entity)} this carries only the edited values, so the server's unit keeps every piece of
+     * state the editor does not touch.
      */
     public void sendDamageEdit(DamageEditSpec spec) {
         LOGGER.debug("Sending damage edits for unit id {}", spec.entityId);
@@ -696,14 +688,32 @@ public class Client extends AbstractClient {
         Entity entity = game.getEntity(packet.getIntValue(0));
 
         if (entity != null) { // we may not have this entity due to double-blind
+            // Capture the observable state; the isVisibleToEnemy/isDetectedByEnemy getters are not plain field
+            // reads (without double-blind they always report true), so compare them before and after applying
+            // the packet rather than against the raw packet values
+            boolean oldEverSeenByEnemy = entity.isEverSeenByEnemy();
+            boolean oldVisibleToEnemy = entity.isVisibleToEnemy();
+            boolean oldDetectedByEnemy = entity.isDetectedByEnemy();
+            Vector<Player> oldWhoCanSee = entity.getWhoCanSee();
+            Vector<Player> oldWhoCanDetect = entity.getWhoCanDetect();
+
             entity.setEverSeenByEnemy(packet.getBooleanValue(1));
             entity.setVisibleToEnemy(packet.getBooleanValue(2));
             entity.setDetectedByEnemy(packet.getBooleanValue(3));
             entity.setWhoCanSee(packet.getPlayerVector(4));
             entity.setWhoCanDetect(packet.getPlayerVector(5));
 
-            // this next call is only needed sometimes, but we'll just call it everytime
-            game.processGameEvent(new GameEntityChangeEvent(this, entity));
+            // The server also sends indicators that carry no change; only notify listeners when the visibility
+            // state in fact changed, as each change event makes the UI redo entity sprites and images
+            boolean changed = (entity.isEverSeenByEnemy() != oldEverSeenByEnemy)
+                  || (entity.isVisibleToEnemy() != oldVisibleToEnemy)
+                  || (entity.isDetectedByEnemy() != oldDetectedByEnemy)
+                  || !Objects.equals(entity.getWhoCanSee(), oldWhoCanSee)
+                  || !Objects.equals(entity.getWhoCanDetect(), oldWhoCanDetect);
+
+            if (changed) {
+                game.processGameEvent(new GameEntityChangeEvent(this, entity));
+            }
         }
     }
 

--- a/megamek/src/megamek/client/ui/tileset/EntityImage.java
+++ b/megamek/src/megamek/client/ui/tileset/EntityImage.java
@@ -35,11 +35,8 @@ package megamek.client.ui.tileset;
 
 import java.awt.Component;
 import java.awt.Graphics;
-import java.awt.GraphicsConfiguration;
-import java.awt.GraphicsEnvironment;
 import java.awt.Image;
 import java.awt.Toolkit;
-import java.awt.Transparency;
 import java.awt.geom.AffineTransform;
 import java.awt.image.AffineTransformOp;
 import java.awt.image.BufferedImage;
@@ -116,9 +113,6 @@ public class EntityImage {
           new float[] { 0, 0, 0, 1 - SHADOW_INTENSITY }, null);
 
     private static final GUIPreferences GUIP = GUIPreferences.getInstance();
-
-    private static final GraphicsConfiguration GRAPHICS_CONFIGURATION = GraphicsEnvironment
-          .getLocalGraphicsEnvironment().getDefaultScreenDevice().getDefaultConfiguration();
 
     /** Facing-dependent camo overlays (add shadows and highlighting) */
     private static final int[][] pOverlays = new int[6][IMG_SIZE];
@@ -761,16 +755,15 @@ public class EntityImage {
         ConvolveOp op = new ConvolveOp(ImageUtil.getGaussKernel(2 * radius + 1, sigma), ConvolveOp.EDGE_NO_OP, null);
 
         // blurring requires a slightly bigger image
-        BufferedImage temp = GRAPHICS_CONFIGURATION.createCompatibleImage(
-              IMG_WIDTH + radius * 2, IMG_HEIGHT + radius * 2, Transparency.TRANSLUCENT);
+        BufferedImage temp = ImageUtil.createAcceleratedImage(
+              IMG_WIDTH + radius * 2, IMG_HEIGHT + radius * 2);
         Graphics g = temp.getGraphics();
         g.drawImage(blackedOut, radius, radius, null);
         g.dispose();
         BufferedImage shadow = op.filter(temp, null);
 
         // reduce back to the correct image size
-        BufferedImage result = GRAPHICS_CONFIGURATION.createCompatibleImage(IMG_WIDTH, IMG_HEIGHT,
-              Transparency.TRANSLUCENT);
+        BufferedImage result = ImageUtil.createAcceleratedImage(IMG_WIDTH, IMG_HEIGHT);
         Graphics gResult = result.getGraphics();
         int xOffset = 0;
         if (unitElevation == 0) {

--- a/megamek/src/megamek/client/ui/tileset/EntityImage.java
+++ b/megamek/src/megamek/client/ui/tileset/EntityImage.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2002-2004 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2020-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2020-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -58,14 +58,14 @@ import megamek.client.ui.clientGUI.GUIPreferences;
 import megamek.client.ui.util.PlayerColour;
 import megamek.codeUtilities.MathUtility;
 import megamek.common.Configuration;
+import megamek.common.annotations.Nullable;
+import megamek.common.equipment.GunEmplacement;
+import megamek.common.icons.Camouflage;
 import megamek.common.units.Entity;
 import megamek.common.units.FighterSquadron;
-import megamek.common.equipment.GunEmplacement;
 import megamek.common.units.Infantry;
 import megamek.common.units.Tank;
 import megamek.common.units.VTOL;
-import megamek.common.annotations.Nullable;
-import megamek.common.icons.Camouflage;
 import megamek.common.util.ImageUtil;
 import megamek.common.util.fileUtils.AbstractDirectory;
 import megamek.common.util.fileUtils.DirectoryItems;
@@ -149,6 +149,11 @@ public class EntityImage {
 
     /** The base (unit) image used for this icon. */
     protected Image base;
+    /**
+     * The unmodified tileset image this icon was created from. Unlike {@link #base}, this is never replaced by a
+     * processed (camouflaged/composited) image, so it can serve as a stable identity for image caching.
+     */
+    private final Image tilesetBase;
     /** The wreck base image used for this icon. */
     private Image wreck;
     /** The damage decal image used for this icon. */
@@ -223,6 +228,7 @@ public class EntityImage {
     public EntityImage(Image base, Image wreck, Camouflage camouflage, Component comp, Entity entity, int secondaryPos,
           boolean preview, boolean withShadows) {
         this.base = base;
+        this.tilesetBase = base;
         setCamouflage(camouflage);
         this.wreck = wreck;
         this.withShadows = withShadows;
@@ -247,7 +253,7 @@ public class EntityImage {
      * Worker function that calculates the entity's damage level for the purposes of displaying damage to avoid
      * particularly dumb-looking situations
      */
-    private int calculateDamageLevel(Entity entity) {
+    public static int calculateDamageLevel(Entity entity) {
         // gun emplacements don't show up as crippled when destroyed, which leads to
         // them looking pristine
         if ((entity.isBuildingEntityOrGunEmplacement()) && entity.isDestroyed()) {
@@ -376,6 +382,14 @@ public class EntityImage {
 
     public Image getBase() {
         return base;
+    }
+
+    /**
+     * @return The unmodified tileset image this icon was created from. Stable across {@link #loadFacings()}, unlike
+     *       {@link #getBase()}, and therefore usable as a cache identity.
+     */
+    public @Nullable Image getTilesetBase() {
+        return tilesetBase;
     }
 
     public Image getIcon() {

--- a/megamek/src/megamek/client/ui/tileset/TilesetManager.java
+++ b/megamek/src/megamek/client/ui/tileset/TilesetManager.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2002-2004 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2018-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -556,11 +556,13 @@ public class TilesetManager implements IPreferenceChangeListener {
 
         EntityImage entityImage = null;
 
-        // check if we have a duplicate image already loaded
+        // check if we have a duplicate image already loaded; compare the unmodified tileset image, as the base
+        // image gets replaced with a processed version when the facings are loaded (see EntityImage.loadFacings),
+        // and compare the damage level with the same calculation used when the EntityImage was created
         for (EntityImage onList : mekImageList) {
-            if ((onList.getBase() != null) && onList.getBase().equals(base)
+            if ((onList.getTilesetBase() != null) && onList.getTilesetBase().equals(base)
                   && onList.getCamouflage().equals(camouflage)
-                  && (onList.getDmgLvl() == entity.getDamageLevel(false))) {
+                  && (onList.getDmgLvl() == EntityImage.calculateDamageLevel(entity))) {
                 entityImage = onList;
                 break;
             }

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -43,6 +43,7 @@ import java.io.File;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -99,8 +100,6 @@ import megamek.common.net.packets.Packet;
 import megamek.common.options.IBasicOption;
 import megamek.common.options.IOption;
 import megamek.common.options.OptionsConstants;
-import megamek.common.voting.Poll;
-import megamek.common.voting.VoteThreshold;
 import megamek.common.planetaryConditions.Atmosphere;
 import megamek.common.planetaryConditions.PlanetaryConditions;
 import megamek.common.planetaryConditions.Wind;
@@ -122,6 +121,8 @@ import megamek.common.util.EmailService;
 import megamek.common.util.HazardousLiquidPoolUtil;
 import megamek.common.util.fileUtils.MegaMekFile;
 import megamek.common.verifier.TestEntity;
+import megamek.common.voting.Poll;
+import megamek.common.voting.VoteThreshold;
 import megamek.common.weapons.DamageType;
 import megamek.common.weapons.TeleMissile;
 import megamek.common.weapons.Weapon;
@@ -433,9 +434,9 @@ public class TWGameManager extends AbstractGameManager {
     }
 
     /**
-     * Opens a vote on granting the requester the gamemaster role, one request at a time. Every human player with a
-     * team may vote; the requester starts having voted yes, so a player alone in the game passes at once. There is
-     * no time limit: the vote stands until it is decided or the requester cancels it.
+     * Opens a vote on granting the requester the gamemaster role, one request at a time. Every human player with a team
+     * may vote; the requester starts having voted yes, so a player alone in the game passes at once. There is no time
+     * limit: the vote stands until it is decided or the requester cancels it.
      *
      * @param requester the player asking for the gamemaster role
      */
@@ -515,8 +516,8 @@ public class TWGameManager extends AbstractGameManager {
     }
 
     /**
-     * Brings the running vote's voters in line with who may vote now: players who joined since the vote was called
-     * are added with their ballot pending, and players who lost their eligibility are dropped from the tally.
+     * Brings the running vote's voters in line with who may vote now: players who joined since the vote was called are
+     * added with their ballot pending, and players who lost their eligibility are dropped from the tally.
      */
     private void syncGameMasterPollVoters() {
         if (gameMasterPoll == null) {
@@ -6441,6 +6442,35 @@ public class TWGameManager extends AbstractGameManager {
     }
 
     /**
+     * Waits on the CFR packet queue until a packet matching the given filter arrives and removes and returns it.
+     * Packets meant for other handlers are left in the queue untouched and in their original order. Only waits when no
+     * matching packet is present, so a leftover packet for another handler cannot cause a busy spin.
+     *
+     * @param isExpectedResponse filters for the packet this handler is waiting for
+     *
+     * @return the first matching packet, or null if interrupted while waiting
+     */
+    private @Nullable Server.ReceivedPacket pollCFRPacket(Predicate<Server.ReceivedPacket> isExpectedResponse) {
+        synchronized (cfrPacketQueue) {
+            while (true) {
+                for (Iterator<Server.ReceivedPacket> iterator = cfrPacketQueue.iterator(); iterator.hasNext(); ) {
+                    Server.ReceivedPacket rp = iterator.next();
+                    if (isExpectedResponse.test(rp)) {
+                        iterator.remove();
+                        return rp;
+                    }
+                }
+                // No packet for this handler yet; wait for a new arrival rather than re-scanning the same packets
+                try {
+                    cfrPacketQueue.wait();
+                } catch (InterruptedException e) {
+                    return null;
+                }
+            }
+        }
+    }
+
+    /**
      * Handles a pointblank shot for hidden units, which must request feedback from the client of the player who owns
      * the hidden unit.
      *
@@ -6449,117 +6479,87 @@ public class TWGameManager extends AbstractGameManager {
     Vector<Report> processPointblankShotCFR(Entity hidden, Entity target) throws InvalidPacketDataException {
         Vector<Report> reports = new Vector<>();
         sendPointBlankShotCFR(hidden, target);
-        boolean firstPacket = true;
-        // Keep processing until we get a response
-        while (true) {
-            synchronized (cfrPacketQueue) {
-                try {
-                    while (cfrPacketQueue.isEmpty()) {
-                        cfrPacketQueue.wait();
-                    }
-                } catch (InterruptedException e) {
-                    return null;
-                }
-                // Get the packet, if there's something to get
-                Server.ReceivedPacket rp;
-                rp = cfrPacketQueue.poll();
-                final PacketCommand cfrType = rp.getPacket().getPacketCommand(0);
-                if (cfrType != null) {
-                    // Make sure we got the right type of response
-                    if (!cfrType.isCFRHiddenPBS()) {
-                        // Re-queue packet for other handlers - don't discard it
-                        cfrPacketQueue.add(rp);
-                        continue;
-                    }
-                }
-                // Check packet came from right ID
-                if (rp.getConnectionId() != hidden.getOwnerId()) {
-                    // Re-queue packet for other handlers - don't discard it
-                    cfrPacketQueue.add(rp);
-                    continue;
-                }
-                // First packet indicates whether the PBS is taken or declined
-                if (firstPacket) {
-                    // Check to see if the client declined the PBS
-                    if (rp.getPacket().getObject(1) == null) {
-                        return null;
-                    } else {
-                        firstPacket = false;
-                        // Notify other clients, so they can display a message
-                        for (Player p : game.getPlayersList()) {
-                            if (p.getId() == hidden.getOwnerId()) {
-                                continue;
-                            }
-                            send(p.getId(),
-                                  new Packet(PacketCommand.CLIENT_FEEDBACK_REQUEST,
-                                        PacketCommand.CFR_HIDDEN_PBS,
-                                        Entity.NONE,
-                                        Entity.NONE));
-                        }
-                        // Update all clients with the position of the PBS
-                        entityUpdate(target.getId());
-                        continue;
-                    }
-                }
+        Predicate<Server.ReceivedPacket> isExpectedResponse = rp -> {
+            final PacketCommand cfrType = rp.getPacket().getPacketCommand(0);
+            return ((cfrType == null) || cfrType.isCFRHiddenPBS())
+                  && (rp.getConnectionId() == hidden.getOwnerId());
+        };
 
-                // The second packet contains the attacks to process _or_ signals not firing
-                if (rp.getPacket().getObject(1) == null) {
-                    return null;
-                } else {
-                    List<EntityAction> attacks = rp.getPacket().getEntityActionList(1);
-                    // Mark the hidden unit as having taken a PBS
-                    hidden.setMadePointblankShot(true);
-                    // Process the Actions
-                    for (EntityAction entityAction : attacks) {
-                        Entity entity = game.getEntity(entityAction.getEntityId());
-                        if (entity == null) {
-                            continue;
-                        }
+        // First packet indicates whether the PBS is taken or declined
+        Server.ReceivedPacket receivedPacket = pollCFRPacket(isExpectedResponse);
+        if ((receivedPacket == null) || (receivedPacket.getPacket().getObject(1) == null)) {
+            // Interrupted, or the client declined the PBS
+            return null;
+        }
+        // Notify other clients, so they can display a message
+        for (Player p : game.getPlayersList()) {
+            if (p.getId() == hidden.getOwnerId()) {
+                continue;
+            }
+            send(p.getId(),
+                  new Packet(PacketCommand.CLIENT_FEEDBACK_REQUEST,
+                        PacketCommand.CFR_HIDDEN_PBS,
+                        Entity.NONE,
+                        Entity.NONE));
+        }
+        // Update all clients with the position of the PBS
+        entityUpdate(target.getId());
 
-                        switch (entityAction) {
-                            case TorsoTwistAction tta -> {
-                                if (entity.canChangeSecondaryFacing()) {
-                                    entity.setSecondaryFacing(tta.getFacing());
-                                }
-                            }
-                            case DirectionalMountFacingAction mountFacingAction -> {
-                                if (entity instanceof Mek directionalMek) {
-                                    DirectionalTorsoMountRules.applyMountFacing(directionalMek,
-                                          mountFacingAction.getWeaponNumber(), mountFacingAction.getFacing());
-                                }
-                            }
-                            case FlipArmsAction faa -> entity.setArmsFlipped(faa.getIsFlipped());
-                            case SearchlightAttackAction saa -> {
-                                boolean hexesAdded = saa.setHexesIlluminated(game);
-                                // If we added new hexes, send them to all players.
-                                // These are spotlights at night, you know they're there.
-                                if (hexesAdded) {
-                                    send(createIlluminatedHexesPacket());
-                                }
-                                reports.addAll(saa.resolveAction(game));
-                            }
-                            case WeaponAttackAction waa -> {
-                                Entity ae = game.getEntity(waa.getEntityId());
-                                if (ae != null) {
-                                    Mounted<?> m = ae.getEquipment(waa.getWeaponId());
-                                    Weapon w = (Weapon) m.getType();
-                                    // Track attacks original target, for things like swarm LRMs
-                                    waa.setOriginalTargetId(waa.getTargetId());
-                                    waa.setOriginalTargetType(waa.getTargetType());
-                                    AttackHandler ah = w.fire(waa, game, this);
-                                    if (ah != null) {
-                                        ah.setStrafing(waa.isStrafing());
-                                        ah.setStrafingFirstShot(waa.isStrafingFirstShot());
-                                        game.addAttack(ah);
-                                    }
+        // The second packet contains the attacks to process _or_ signals not firing
+        receivedPacket = pollCFRPacket(isExpectedResponse);
+        if ((receivedPacket == null) || (receivedPacket.getPacket().getObject(1) == null)) {
+            return null;
+        }
+        List<EntityAction> attacks = receivedPacket.getPacket().getEntityActionList(1);
+        // Mark the hidden unit as having taken a PBS
+        hidden.setMadePointblankShot(true);
+        // Process the Actions
+        for (EntityAction entityAction : attacks) {
+            Entity entity = game.getEntity(entityAction.getEntityId());
+            if (entity == null) {
+                continue;
+            }
 
-                                }
-                            }
-                            default -> {
-                            }
-                        }
+            switch (entityAction) {
+                case TorsoTwistAction tta -> {
+                    if (entity.canChangeSecondaryFacing()) {
+                        entity.setSecondaryFacing(tta.getFacing());
                     }
-                    break;
+                }
+                case DirectionalMountFacingAction mountFacingAction -> {
+                    if (entity instanceof Mek directionalMek) {
+                        DirectionalTorsoMountRules.applyMountFacing(directionalMek,
+                              mountFacingAction.getWeaponNumber(), mountFacingAction.getFacing());
+                    }
+                }
+                case FlipArmsAction faa -> entity.setArmsFlipped(faa.getIsFlipped());
+                case SearchlightAttackAction saa -> {
+                    boolean hexesAdded = saa.setHexesIlluminated(game);
+                    // If we added new hexes, send them to all players.
+                    // These are spotlights at night, you know they're there.
+                    if (hexesAdded) {
+                        send(createIlluminatedHexesPacket());
+                    }
+                    reports.addAll(saa.resolveAction(game));
+                }
+                case WeaponAttackAction waa -> {
+                    Entity ae = game.getEntity(waa.getEntityId());
+                    if (ae != null) {
+                        Mounted<?> m = ae.getEquipment(waa.getWeaponId());
+                        Weapon w = (Weapon) m.getType();
+                        // Track attacks original target, for things like swarm LRMs
+                        waa.setOriginalTargetId(waa.getTargetId());
+                        waa.setOriginalTargetType(waa.getTargetType());
+                        AttackHandler ah = w.fire(waa, game, this);
+                        if (ah != null) {
+                            ah.setStrafing(waa.isStrafing());
+                            ah.setStrafingFirstShot(waa.isStrafingFirstShot());
+                            game.addAttack(ah);
+                        }
+
+                    }
+                }
+                default -> {
                 }
             }
         }
@@ -6579,78 +6579,34 @@ public class TWGameManager extends AbstractGameManager {
           throws InvalidPacketDataException {
         LOGGER.debug("processTeleguidedMissileCFR: playerId={}, targetCount={}", playerId, targetIds.size());
         sendTeleguidedMissileCFR(playerId, targetIds, toHitValues);
-        while (true) {
-            synchronized (cfrPacketQueue) {
-                try {
-                    while (cfrPacketQueue.isEmpty()) {
-                        cfrPacketQueue.wait();
-                    }
-                } catch (InterruptedException e) {
-                    LOGGER.debug("processTeleguidedMissileCFR: interrupted while waiting for response");
-                    return 0;
-                }
-
-                // Get the packet, if there's something to get
-                Server.ReceivedPacket rp = cfrPacketQueue.poll();
-                final PacketCommand cfrType = rp.getPacket().getPacketCommand(0);
-                // Make sure we got the right type of response
-                if (cfrType != null && !cfrType.isCFRTeleguidedTarget()) {
-                    // Re-queue packet for other handlers - don't discard it
-                    LOGGER.trace("processTeleguidedMissileCFR: re-queuing mismatched packet type {}", cfrType);
-                    cfrPacketQueue.add(rp);
-                    continue;
-                }
-                // Check packet came from right ID
-                if (rp.getConnectionId() != playerId) {
-                    // Re-queue packet for other handlers - don't discard it
-                    LOGGER.trace("processTeleguidedMissileCFR: re-queuing packet from wrong player {}",
-                          rp.getConnectionId());
-                    cfrPacketQueue.add(rp);
-                    continue;
-                }
-                int result = (int) rp.getPacket().data()[1];
-                LOGGER.debug("processTeleguidedMissileCFR: received response, selected target index {}", result);
-                return result;
-            }
+        Server.ReceivedPacket rp = pollCFRPacket(p -> {
+            final PacketCommand cfrType = p.getPacket().getPacketCommand(0);
+            return ((cfrType == null) || cfrType.isCFRTeleguidedTarget()) && (p.getConnectionId() == playerId);
+        });
+        if (rp == null) {
+            LOGGER.debug("processTeleguidedMissileCFR: interrupted while waiting for response");
+            return 0;
         }
+        int result = (int) rp.getPacket().data()[1];
+        LOGGER.debug("processTeleguidedMissileCFR: received response, selected target index {}", result);
+        return result;
     }
 
     public int processTAGTargetCFR(int playerId, List<Integer> targetIds, List<Integer> targetTypes)
           throws InvalidPacketDataException {
         LOGGER.debug("processTAGTargetCFR: playerId={}, targetCount={}", playerId, targetIds.size());
         sendTAGTargetCFR(playerId, targetIds, targetTypes);
-        while (true) {
-            synchronized (cfrPacketQueue) {
-                try {
-                    while (cfrPacketQueue.isEmpty()) {
-                        cfrPacketQueue.wait();
-                    }
-                } catch (InterruptedException e) {
-                    LOGGER.debug("processTAGTargetCFR: interrupted while waiting for response");
-                    return 0;
-                }
-                // Get the packet, if there's something to get
-                Server.ReceivedPacket rp = cfrPacketQueue.poll();
-                final PacketCommand cfrType = rp.getPacket().getPacketCommand(0);
-                // Make sure we got the right type of response
-                if (cfrType != null && !cfrType.isCFRTagTarget()) {
-                    // Re-queue packet for other handlers - don't discard it
-                    LOGGER.trace("processTAGTargetCFR: re-queuing mismatched packet type {}", cfrType);
-                    cfrPacketQueue.add(rp);
-                    continue;
-                }
-                // Check packet came from right ID
-                if (rp.getConnectionId() != playerId) {
-                    // Re-queue packet for other handlers - don't discard it
-                    LOGGER.trace("processTAGTargetCFR: re-queuing packet from wrong player {}", rp.getConnectionId());
-                    cfrPacketQueue.add(rp);
-                    continue;
-                }
-                int result = (int) rp.getPacket().data()[1];
-                LOGGER.debug("processTAGTargetCFR: received response, selected target index {}", result);
-                return result;
-            }
+        Server.ReceivedPacket rp = pollCFRPacket(p -> {
+            final PacketCommand cfrType = p.getPacket().getPacketCommand(0);
+            return ((cfrType == null) || cfrType.isCFRTagTarget()) && (p.getConnectionId() == playerId);
+        });
+        if (rp == null) {
+            LOGGER.debug("processTAGTargetCFR: interrupted while waiting for response");
+            return 0;
         }
+        int result = (int) rp.getPacket().data()[1];
+        LOGGER.debug("processTAGTargetCFR: received response, selected target index {}", result);
+        return result;
     }
 
     /**
@@ -26927,7 +26883,7 @@ public class TWGameManager extends AbstractGameManager {
             // does, and wins here) must not erase the pending one while it waits for the END phase.
             if ((entity.getTraitorId() == -1) && (oldEntity.getTraitorId() != -1)) {
                 LOGGER.info("[Traitor] Update for {} (unit id {}) from {} would have erased pending traitorId {}; "
-                      + "keeping it", entity.getDisplayName(), entity.getId(), sender.getName(),
+                            + "keeping it", entity.getDisplayName(), entity.getId(), sender.getName(),
                       oldEntity.getTraitorId());
                 entity.setTraitorId(oldEntity.getTraitorId());
             }
@@ -26961,9 +26917,9 @@ public class TWGameManager extends AbstractGameManager {
 
     /**
      * Applies a gamemaster's damage editor edits to the server's own copy of the unit. The edits arrive as a
-     * {@link DamageEditSpec} of plain values rather than an edited unit, so everything the editor did not touch -
-     * turn state, a pending traitor switch, anything that changed since the editor opened - keeps the server's
-     * authoritative value without having to be preserved field by field.
+     * {@link DamageEditSpec} of plain values rather than an edited unit, so everything the editor did not touch - turn
+     * state, a pending traitor switch, anything that changed since the editor opened - keeps the server's authoritative
+     * value without having to be preserved field by field.
      */
     private void receiveDamageEdit(Packet packet, int connIndex) {
         if (!(packet.getObject(0) instanceof DamageEditSpec spec)) {
@@ -27812,9 +27768,9 @@ public class TWGameManager extends AbstractGameManager {
     }
 
     /**
-     * Revokes the Game Master role when the game no longer allows one, so that turning off Allow Game Master takes
-     * the role and its tools away from whoever holds it. The player update is sent to every client, so their view of
-     * who is Game Master stays in step with the server.
+     * Revokes the Game Master role when the game no longer allows one, so that turning off Allow Game Master takes the
+     * role and its tools away from whoever holds it. The player update is sent to every client, so their view of who is
+     * Game Master stays in step with the server.
      */
     private void revokeGameMasterIfDisallowed() {
         if (game.getOptions().booleanOption(OptionsConstants.GAME_MASTER_ALLOW)) {

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -226,7 +226,8 @@ public class TWGameManager extends AbstractGameManager {
     /**
      * Special packet queue for client feedback requests.
      */
-    private final ConcurrentLinkedQueue<Server.ReceivedPacket> cfrPacketQueue = new ConcurrentLinkedQueue<>();
+    /** Package-private for test access; see TWGameManagerCFRPacketQueueTest. */
+    final ConcurrentLinkedQueue<Server.ReceivedPacket> cfrPacketQueue = new ConcurrentLinkedQueue<>();
 
     public TWGameManager() {
         EquipmentType.initializeTypes();
@@ -6444,17 +6445,27 @@ public class TWGameManager extends AbstractGameManager {
     /**
      * Waits on the CFR packet queue until a packet matching the given filter arrives and removes and returns it.
      * Packets meant for other handlers are left in the queue untouched and in their original order. Only waits when no
-     * matching packet is present, so a leftover packet for another handler cannot cause a busy spin.
+     * matching packet is present, so a leftover packet for another handler cannot cause a busy spin. Malformed packets
+     * (those without a recognizable CFR type) can never match any handler and are discarded with a warning.
      *
      * @param isExpectedResponse filters for the packet this handler is waiting for
      *
      * @return the first matching packet, or null if interrupted while waiting
      */
-    private @Nullable Server.ReceivedPacket pollCFRPacket(Predicate<Server.ReceivedPacket> isExpectedResponse) {
+    @Nullable
+    Server.ReceivedPacket pollCFRPacket(Predicate<Server.ReceivedPacket> isExpectedResponse) {
         synchronized (cfrPacketQueue) {
             while (true) {
                 for (Iterator<Server.ReceivedPacket> iterator = cfrPacketQueue.iterator(); iterator.hasNext(); ) {
                     Server.ReceivedPacket rp = iterator.next();
+                    if (rp.getPacket().getPacketCommand(0) == null) {
+                        // All CFR responses carry their CFR type as the first data element, so no handler can ever
+                        // consume this packet; keep the sender visible in the log rather than accumulating silently
+                        LOGGER.warn("Discarding CFR packet without a recognizable CFR type from connection {}",
+                              rp.getConnectionId());
+                        iterator.remove();
+                        continue;
+                    }
                     if (isExpectedResponse.test(rp)) {
                         iterator.remove();
                         return rp;
@@ -6464,6 +6475,7 @@ public class TWGameManager extends AbstractGameManager {
                 try {
                     cfrPacketQueue.wait();
                 } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
                     return null;
                 }
             }
@@ -6481,7 +6493,7 @@ public class TWGameManager extends AbstractGameManager {
         sendPointBlankShotCFR(hidden, target);
         Predicate<Server.ReceivedPacket> isExpectedResponse = rp -> {
             final PacketCommand cfrType = rp.getPacket().getPacketCommand(0);
-            return ((cfrType == null) || cfrType.isCFRHiddenPBS())
+            return (cfrType != null) && cfrType.isCFRHiddenPBS()
                   && (rp.getConnectionId() == hidden.getOwnerId());
         };
 
@@ -6581,7 +6593,7 @@ public class TWGameManager extends AbstractGameManager {
         sendTeleguidedMissileCFR(playerId, targetIds, toHitValues);
         Server.ReceivedPacket rp = pollCFRPacket(p -> {
             final PacketCommand cfrType = p.getPacket().getPacketCommand(0);
-            return ((cfrType == null) || cfrType.isCFRTeleguidedTarget()) && (p.getConnectionId() == playerId);
+            return (cfrType != null) && cfrType.isCFRTeleguidedTarget() && (p.getConnectionId() == playerId);
         });
         if (rp == null) {
             LOGGER.debug("processTeleguidedMissileCFR: interrupted while waiting for response");
@@ -6598,7 +6610,7 @@ public class TWGameManager extends AbstractGameManager {
         sendTAGTargetCFR(playerId, targetIds, targetTypes);
         Server.ReceivedPacket rp = pollCFRPacket(p -> {
             final PacketCommand cfrType = p.getPacket().getPacketCommand(0);
-            return ((cfrType == null) || cfrType.isCFRTagTarget()) && (p.getConnectionId() == playerId);
+            return (cfrType != null) && cfrType.isCFRTagTarget() && (p.getConnectionId() == playerId);
         });
         if (rp == null) {
             LOGGER.debug("processTAGTargetCFR: interrupted while waiting for response");

--- a/megamek/unittests/megamek/client/ClientVisibilityIndicatorTest.java
+++ b/megamek/unittests/megamek/client/ClientVisibilityIndicatorTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Vector;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import megamek.common.Player;
+import megamek.common.event.GameListenerAdapter;
+import megamek.common.event.entity.GameEntityChangeEvent;
+import megamek.common.net.enums.PacketCommand;
+import megamek.common.net.packets.Packet;
+import megamek.common.options.OptionsConstants;
+import megamek.common.units.BipedMek;
+import megamek.common.units.Entity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that {@code Client.receiveEntityVisibilityIndicator} only fires a {@link GameEntityChangeEvent} when the
+ * visibility state in fact changed. The server re-sends unchanged indicators wholesale in double-blind games; firing an
+ * event for each one made the UI redo entity sprites and images for every packet.
+ */
+class ClientVisibilityIndicatorTest {
+
+    private Client client;
+    private Entity entity;
+    private final AtomicInteger entityChangeEvents = new AtomicInteger();
+
+    @BeforeEach
+    void setUp() {
+        client = new Client("Test Player", "localhost", 1234);
+        // Visibility indicators matter in double-blind games; without the option, the visibility getters
+        // report true unconditionally
+        client.getGame().getOptions().getOption(OptionsConstants.ADVANCED_DOUBLE_BLIND).setValue(true);
+        entity = new BipedMek();
+        client.getGame().addEntity(entity, false);
+        client.getGame().addGameListener(new GameListenerAdapter() {
+            @Override
+            public void gameEntityChange(GameEntityChangeEvent e) {
+                entityChangeEvents.incrementAndGet();
+            }
+        });
+    }
+
+    private Packet visibilityPacket(boolean everSeen, boolean visible, boolean detected,
+          Vector<Player> whoCanSee, Vector<Player> whoCanDetect) {
+        return new Packet(PacketCommand.ENTITY_VISIBILITY_INDICATOR,
+              entity.getId(), everSeen, visible, detected, whoCanSee, whoCanDetect);
+    }
+
+    @Test
+    void firesEventWhenVisibilityChanges() throws Exception {
+        client.receiveEntityVisibilityIndicator(
+              visibilityPacket(true, true, false, new Vector<>(), new Vector<>()));
+
+        assertEquals(1, entityChangeEvents.get());
+        assertTrue(entity.isEverSeenByEnemy());
+        assertTrue(entity.isVisibleToEnemy());
+        assertFalse(entity.isDetectedByEnemy());
+    }
+
+    @Test
+    void doesNotFireEventWhenNothingChanged() throws Exception {
+        Vector<Player> whoCanSee = new Vector<>();
+        whoCanSee.add(new Player(0, "Spotter"));
+
+        client.receiveEntityVisibilityIndicator(
+              visibilityPacket(true, true, false, whoCanSee, new Vector<>()));
+        assertEquals(1, entityChangeEvents.get());
+
+        // Identical state re-sent by the server: state must be applied but no event fired
+        Vector<Player> sameWhoCanSee = new Vector<>();
+        sameWhoCanSee.add(new Player(0, "Spotter"));
+        client.receiveEntityVisibilityIndicator(
+              visibilityPacket(true, true, false, sameWhoCanSee, new Vector<>()));
+
+        assertEquals(1, entityChangeEvents.get(),
+              "An indicator that carries no change must not fire a GameEntityChangeEvent");
+    }
+
+    @Test
+    void firesEventAgainWhenAFlagChanges() throws Exception {
+        client.receiveEntityVisibilityIndicator(
+              visibilityPacket(true, true, false, new Vector<>(), new Vector<>()));
+        client.receiveEntityVisibilityIndicator(
+              visibilityPacket(true, true, false, new Vector<>(), new Vector<>()));
+        assertEquals(1, entityChangeEvents.get());
+
+        client.receiveEntityVisibilityIndicator(
+              visibilityPacket(true, true, true, new Vector<>(), new Vector<>()));
+
+        assertEquals(2, entityChangeEvents.get());
+        assertTrue(entity.isDetectedByEnemy());
+    }
+
+    @Test
+    void firesEventWhenWhoCanSeeChanges() throws Exception {
+        client.receiveEntityVisibilityIndicator(
+              visibilityPacket(true, true, false, new Vector<>(), new Vector<>()));
+        assertEquals(1, entityChangeEvents.get());
+
+        Vector<Player> whoCanSee = new Vector<>();
+        whoCanSee.add(new Player(3, "New Spotter"));
+        client.receiveEntityVisibilityIndicator(
+              visibilityPacket(true, true, false, whoCanSee, new Vector<>()));
+
+        assertEquals(2, entityChangeEvents.get());
+        assertEquals(whoCanSee, entity.getWhoCanSee());
+    }
+
+    @Test
+    void withoutDoubleBlindVisibilityFlagsAreNotObservableChanges() throws Exception {
+        // Without double-blind, isVisibleToEnemy/isDetectedByEnemy report true unconditionally, so packets
+        // that only toggle those flags change nothing a listener could observe
+        client.getGame().getOptions().getOption(OptionsConstants.ADVANCED_DOUBLE_BLIND).setValue(false);
+
+        client.receiveEntityVisibilityIndicator(
+              visibilityPacket(false, true, true, new Vector<>(), new Vector<>()));
+        assertEquals(0, entityChangeEvents.get());
+
+        client.receiveEntityVisibilityIndicator(
+              visibilityPacket(false, false, false, new Vector<>(), new Vector<>()));
+        assertEquals(0, entityChangeEvents.get());
+
+        // everSeenByEnemy is a plain field and thus observable regardless of double-blind
+        client.receiveEntityVisibilityIndicator(
+              visibilityPacket(true, false, false, new Vector<>(), new Vector<>()));
+        assertEquals(1, entityChangeEvents.get());
+    }
+}

--- a/megamek/unittests/megamek/client/ui/tileset/EntityImageTest.java
+++ b/megamek/unittests/megamek/client/ui/tileset/EntityImageTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.ui.tileset;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.awt.image.BufferedImage;
+
+import megamek.common.icons.Camouflage;
+import megamek.common.units.Crew;
+import megamek.common.units.Entity;
+import megamek.common.units.Infantry;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the two values {@code TilesetManager.loadImage} uses to deduplicate cached unit images. Both were broken for
+ * years, which made every {@code GameEntityChangeEvent} create and retain a fresh image set (roughly 0.5 GB per round
+ * in large double-blind games, ending in an OOM):
+ * <ul>
+ *     <li>{@link EntityImage#getTilesetBase()} must stay identical to the tileset image the icon was created from,
+ *     even though {@code loadFacings()} replaces the {@code base} image with a processed version.</li>
+ *     <li>{@link EntityImage#calculateDamageLevel(Entity)} is the exact calculation stored at creation time, so the
+ *     dedup check must use it too (raw {@code getDamageLevel(false)} disagrees with it, e.g. for units "crippled"
+ *     only by ammo depletion).</li>
+ * </ul>
+ */
+class EntityImageTest {
+
+    private static final int ICON_WIDTH = 84;
+    private static final int ICON_HEIGHT = 72;
+
+    @Test
+    void tilesetBaseIsStableAcrossLoadFacings() {
+        // Infantry skips damage decals and smoke, keeping this test independent of decal image files
+        Infantry entity = mock(Infantry.class);
+        BufferedImage base = new BufferedImage(ICON_WIDTH, ICON_HEIGHT, BufferedImage.TYPE_INT_ARGB);
+
+        EntityImage entityImage = EntityImage.createIcon(base, null, new Camouflage(), entity, -1, true, false);
+        entityImage.loadFacings();
+
+        assertSame(base, entityImage.getTilesetBase(),
+              "getTilesetBase() must keep returning the original tileset image after loadFacings(), "
+                    + "otherwise the TilesetManager cache dedup never matches and images leak");
+    }
+
+    @Test
+    void iconsFromTheSameTilesetImageShareTheSameTilesetBase() {
+        Infantry entity = mock(Infantry.class);
+        BufferedImage base = new BufferedImage(ICON_WIDTH, ICON_HEIGHT, BufferedImage.TYPE_INT_ARGB);
+
+        EntityImage first = EntityImage.createIcon(base, null, new Camouflage(), entity, -1, true, false);
+        first.loadFacings();
+        EntityImage second = EntityImage.createIcon(base, null, new Camouflage(), entity, -1, true, false);
+
+        assertSame(first.getTilesetBase(), second.getTilesetBase(),
+              "Icons created from the same tileset image must compare equal on their cache identity");
+    }
+
+    @Test
+    void destroyedGunEmplacementShowsCrippledDamage() {
+        Entity entity = mock(Entity.class);
+        when(entity.isBuildingEntityOrGunEmplacement()).thenReturn(true);
+        when(entity.isDestroyed()).thenReturn(true);
+
+        assertEquals(Entity.DMG_CRIPPLED, EntityImage.calculateDamageLevel(entity));
+    }
+
+    @Test
+    void ejectedAirborneUnitShowsAtLeastHeavyDamage() {
+        Entity entity = mock(Entity.class);
+        Crew crew = mock(Crew.class);
+        when(entity.isAirborne()).thenReturn(true);
+        when(entity.getCrew()).thenReturn(crew);
+        when(crew.isEjected()).thenReturn(true);
+        when(entity.getDamageLevel(false)).thenReturn(Entity.DMG_NONE);
+
+        assertEquals(Entity.DMG_HEAVY, EntityImage.calculateDamageLevel(entity));
+    }
+
+    @Test
+    void unitCrippledWithoutActualDamageShowsNoDamage() {
+        // E.g. "crippled" from weapon jams or ammo depletion while armor and structure are untouched
+        Entity entity = mock(Entity.class);
+        when(entity.getDamageLevel()).thenReturn(Entity.DMG_CRIPPLED);
+        when(entity.getArmorRemainingPercent()).thenReturn(1.0);
+        when(entity.getInternalRemainingPercent()).thenReturn(1.0);
+
+        assertEquals(Entity.DMG_NONE, EntityImage.calculateDamageLevel(entity));
+    }
+
+    @Test
+    void unitWithActualDamageShowsItsDamageLevel() {
+        Entity entity = mock(Entity.class);
+        when(entity.getDamageLevel()).thenReturn(Entity.DMG_MODERATE);
+        when(entity.getArmorRemainingPercent()).thenReturn(0.5);
+        when(entity.getInternalRemainingPercent()).thenReturn(1.0);
+
+        assertEquals(Entity.DMG_MODERATE, EntityImage.calculateDamageLevel(entity));
+    }
+}

--- a/megamek/unittests/megamek/server/totalWarfare/TWGameManagerCFRPacketQueueTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/TWGameManagerCFRPacketQueueTest.java
@@ -38,10 +38,8 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.List;
-import java.util.Queue;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 
@@ -52,30 +50,30 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
 /**
- * Tests for {@code TWGameManager.pollCFRPacket}: the CFR handlers must consume only the packet they are waiting for,
- * leave packets meant for other handlers untouched and in order, and block instead of busy-spinning when only
- * mismatched packets are queued (the busy spin caused a server livelock at 100% CPU).
+ * Tests for {@link TWGameManager#pollCFRPacket}: the CFR handlers must consume only the packet they are waiting for,
+ * leave packets meant for other handlers untouched and in order, discard malformed packets that no handler could ever
+ * consume, and block instead of busy-spinning when no matching packet is queued (the busy spin caused a server
+ * livelock at 100% CPU).
  */
 class TWGameManagerCFRPacketQueueTest {
 
     private final TWGameManager gameManager = new TWGameManager();
 
-    @SuppressWarnings("unchecked")
-    private Queue<Server.ReceivedPacket> cfrPacketQueue() throws Exception {
-        Field field = TWGameManager.class.getDeclaredField("cfrPacketQueue");
-        field.setAccessible(true);
-        return (Queue<Server.ReceivedPacket>) field.get(gameManager);
+    /** A well-formed CFR response: the CFR type is the first data element, as all client responses send it. */
+    private static Server.ReceivedPacket cfrResponse(int connectionId, PacketCommand cfrType) {
+        return new Server.ReceivedPacket(connectionId, new Packet(PacketCommand.CLIENT_FEEDBACK_REQUEST, cfrType));
     }
 
-    private Server.ReceivedPacket invokePollCFRPacket(Predicate<Server.ReceivedPacket> isExpectedResponse)
-          throws Exception {
-        Method method = TWGameManager.class.getDeclaredMethod("pollCFRPacket", Predicate.class);
-        method.setAccessible(true);
-        return (Server.ReceivedPacket) method.invoke(gameManager, isExpectedResponse);
-    }
-
-    private static Server.ReceivedPacket packetFromConnection(int connectionId) {
+    /** A malformed packet: no recognizable CFR type in the first data element. */
+    private static Server.ReceivedPacket malformedPacket(int connectionId) {
         return new Server.ReceivedPacket(connectionId, new Packet(PacketCommand.CLIENT_FEEDBACK_REQUEST));
+    }
+
+    private static Predicate<Server.ReceivedPacket> hiddenPBSResponseFrom(int connectionId) {
+        return rp -> {
+            final PacketCommand cfrType = rp.getPacket().getPacketCommand(0);
+            return (cfrType != null) && cfrType.isCFRHiddenPBS() && (rp.getConnectionId() == connectionId);
+        };
     }
 
     private static void awaitThreadState(Thread thread, Thread.State expected) throws InterruptedException {
@@ -90,32 +88,62 @@ class TWGameManagerCFRPacketQueueTest {
 
     @Test
     @Timeout(10)
-    void returnsMatchingPacketAndRemovesItFromQueue() throws Exception {
-        Server.ReceivedPacket match = packetFromConnection(42);
-        cfrPacketQueue().add(match);
+    void returnsMatchingPacketAndRemovesItFromQueue() {
+        Server.ReceivedPacket match = cfrResponse(42, PacketCommand.CFR_HIDDEN_PBS);
+        gameManager.handleCfrPacket(match);
 
-        Server.ReceivedPacket result = invokePollCFRPacket(rp -> rp.getConnectionId() == 42);
+        Server.ReceivedPacket result = gameManager.pollCFRPacket(hiddenPBSResponseFrom(42));
 
         assertSame(match, result);
-        assertTrue(cfrPacketQueue().isEmpty(), "Consumed packet must be removed from the queue");
+        assertTrue(gameManager.cfrPacketQueue.isEmpty(), "Consumed packet must be removed from the queue");
     }
 
     @Test
     @Timeout(10)
-    void leavesPacketsForOtherHandlersInQueueInOriginalOrder() throws Exception {
-        Server.ReceivedPacket other1 = packetFromConnection(1);
-        Server.ReceivedPacket other2 = packetFromConnection(2);
-        Server.ReceivedPacket match = packetFromConnection(42);
-        Queue<Server.ReceivedPacket> queue = cfrPacketQueue();
-        queue.add(other1);
-        queue.add(other2);
-        queue.add(match);
+    void leavesPacketsForOtherHandlersInQueueInOriginalOrder() {
+        Server.ReceivedPacket otherPlayer = cfrResponse(1, PacketCommand.CFR_HIDDEN_PBS);
+        Server.ReceivedPacket otherType = cfrResponse(42, PacketCommand.CFR_TAG_TARGET);
+        Server.ReceivedPacket match = cfrResponse(42, PacketCommand.CFR_HIDDEN_PBS);
+        gameManager.handleCfrPacket(otherPlayer);
+        gameManager.handleCfrPacket(otherType);
+        gameManager.handleCfrPacket(match);
 
-        Server.ReceivedPacket result = invokePollCFRPacket(rp -> rp.getConnectionId() == 42);
+        Server.ReceivedPacket result = gameManager.pollCFRPacket(hiddenPBSResponseFrom(42));
 
         assertSame(match, result);
-        assertEquals(List.of(other1, other2), List.copyOf(queue),
+        assertEquals(List.of(otherPlayer, otherType), List.copyOf(gameManager.cfrPacketQueue),
               "Packets for other handlers must remain queued in their original order");
+    }
+
+    /**
+     * Regression test for consuming malformed packets as responses: a packet from the awaited player without a
+     * recognizable CFR type must not be mistaken for their answer (it previously read as "player declined").
+     */
+    @Test
+    @Timeout(10)
+    void malformedPacketFromAwaitedPlayerIsNotConsumedAsResponse() {
+        gameManager.handleCfrPacket(malformedPacket(42));
+        Server.ReceivedPacket realResponse = cfrResponse(42, PacketCommand.CFR_HIDDEN_PBS);
+        gameManager.handleCfrPacket(realResponse);
+
+        Server.ReceivedPacket result = gameManager.pollCFRPacket(hiddenPBSResponseFrom(42));
+
+        assertSame(realResponse, result, "The real response must be returned, not the malformed packet");
+    }
+
+    /** Malformed packets can never match any handler, so they are discarded rather than accumulating forever. */
+    @Test
+    @Timeout(10)
+    void malformedPacketsAreDiscarded() {
+        gameManager.handleCfrPacket(malformedPacket(1));
+        gameManager.handleCfrPacket(malformedPacket(2));
+        Server.ReceivedPacket match = cfrResponse(42, PacketCommand.CFR_HIDDEN_PBS);
+        gameManager.handleCfrPacket(match);
+
+        Server.ReceivedPacket result = gameManager.pollCFRPacket(hiddenPBSResponseFrom(42));
+
+        assertSame(match, result);
+        assertTrue(gameManager.cfrPacketQueue.isEmpty(), "Malformed packets must be discarded, not retained");
     }
 
     /**
@@ -126,44 +154,34 @@ class TWGameManagerCFRPacketQueueTest {
     @Test
     @Timeout(10)
     void waitsInsteadOfSpinningWhenOnlyMismatchedPacketsAreQueued() throws Exception {
-        Server.ReceivedPacket other = packetFromConnection(1);
-        Queue<Server.ReceivedPacket> queue = cfrPacketQueue();
-        queue.add(other);
+        Server.ReceivedPacket other = cfrResponse(1, PacketCommand.CFR_HIDDEN_PBS);
+        gameManager.handleCfrPacket(other);
 
         AtomicReference<Server.ReceivedPacket> result = new AtomicReference<>();
-        Thread poller = new Thread(() -> {
-            try {
-                result.set(invokePollCFRPacket(rp -> rp.getConnectionId() == 42));
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }, "cfr-poller");
+        Thread poller = new Thread(() -> result.set(gameManager.pollCFRPacket(hiddenPBSResponseFrom(42))),
+              "cfr-poller");
         poller.start();
 
         // The old implementation spun forever here (RUNNABLE); the fix must park in wait()
         awaitThreadState(poller, Thread.State.WAITING);
 
-        Server.ReceivedPacket match = packetFromConnection(42);
-        synchronized (queue) {
-            queue.add(match);
-            queue.notifyAll();
-        }
+        Server.ReceivedPacket match = cfrResponse(42, PacketCommand.CFR_HIDDEN_PBS);
+        gameManager.handleCfrPacket(match);
         poller.join(5000);
 
         assertSame(match, result.get());
-        assertEquals(List.of(other), List.copyOf(queue), "The mismatched packet must still be queued");
+        assertEquals(List.of(other), List.copyOf(gameManager.cfrPacketQueue),
+              "The mismatched packet must still be queued");
     }
 
     @Test
     @Timeout(10)
-    void returnsNullWhenInterruptedWhileWaiting() throws Exception {
+    void returnsNullAndRestoresInterruptFlagWhenInterrupted() throws Exception {
         AtomicReference<Object> result = new AtomicReference<>("not yet run");
+        AtomicBoolean interruptFlagRestored = new AtomicBoolean(false);
         Thread poller = new Thread(() -> {
-            try {
-                result.set(invokePollCFRPacket(rp -> true));
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
+            result.set(gameManager.pollCFRPacket(rp -> true));
+            interruptFlagRestored.set(Thread.currentThread().isInterrupted());
         }, "cfr-poller-interrupted");
         poller.start();
 
@@ -172,5 +190,6 @@ class TWGameManagerCFRPacketQueueTest {
         poller.join(5000);
 
         assertNull(result.get(), "An interrupted wait must return null");
+        assertTrue(interruptFlagRestored.get(), "The interrupt flag must be restored after the InterruptedException");
     }
 }

--- a/megamek/unittests/megamek/server/totalWarfare/TWGameManagerCFRPacketQueueTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/TWGameManagerCFRPacketQueueTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.server.totalWarfare;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+
+import megamek.common.net.enums.PacketCommand;
+import megamek.common.net.packets.Packet;
+import megamek.server.Server;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Tests for {@code TWGameManager.pollCFRPacket}: the CFR handlers must consume only the packet they are waiting for,
+ * leave packets meant for other handlers untouched and in order, and block instead of busy-spinning when only
+ * mismatched packets are queued (the busy spin caused a server livelock at 100% CPU).
+ */
+class TWGameManagerCFRPacketQueueTest {
+
+    private final TWGameManager gameManager = new TWGameManager();
+
+    @SuppressWarnings("unchecked")
+    private Queue<Server.ReceivedPacket> cfrPacketQueue() throws Exception {
+        Field field = TWGameManager.class.getDeclaredField("cfrPacketQueue");
+        field.setAccessible(true);
+        return (Queue<Server.ReceivedPacket>) field.get(gameManager);
+    }
+
+    private Server.ReceivedPacket invokePollCFRPacket(Predicate<Server.ReceivedPacket> isExpectedResponse)
+          throws Exception {
+        Method method = TWGameManager.class.getDeclaredMethod("pollCFRPacket", Predicate.class);
+        method.setAccessible(true);
+        return (Server.ReceivedPacket) method.invoke(gameManager, isExpectedResponse);
+    }
+
+    private static Server.ReceivedPacket packetFromConnection(int connectionId) {
+        return new Server.ReceivedPacket(connectionId, new Packet(PacketCommand.CLIENT_FEEDBACK_REQUEST));
+    }
+
+    private static void awaitThreadState(Thread thread, Thread.State expected) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 5000;
+        while (thread.getState() != expected) {
+            if (System.currentTimeMillis() > deadline) {
+                fail("Timed out waiting for thread state " + expected + "; thread was " + thread.getState());
+            }
+            Thread.sleep(10);
+        }
+    }
+
+    @Test
+    @Timeout(10)
+    void returnsMatchingPacketAndRemovesItFromQueue() throws Exception {
+        Server.ReceivedPacket match = packetFromConnection(42);
+        cfrPacketQueue().add(match);
+
+        Server.ReceivedPacket result = invokePollCFRPacket(rp -> rp.getConnectionId() == 42);
+
+        assertSame(match, result);
+        assertTrue(cfrPacketQueue().isEmpty(), "Consumed packet must be removed from the queue");
+    }
+
+    @Test
+    @Timeout(10)
+    void leavesPacketsForOtherHandlersInQueueInOriginalOrder() throws Exception {
+        Server.ReceivedPacket other1 = packetFromConnection(1);
+        Server.ReceivedPacket other2 = packetFromConnection(2);
+        Server.ReceivedPacket match = packetFromConnection(42);
+        Queue<Server.ReceivedPacket> queue = cfrPacketQueue();
+        queue.add(other1);
+        queue.add(other2);
+        queue.add(match);
+
+        Server.ReceivedPacket result = invokePollCFRPacket(rp -> rp.getConnectionId() == 42);
+
+        assertSame(match, result);
+        assertEquals(List.of(other1, other2), List.copyOf(queue),
+              "Packets for other handlers must remain queued in their original order");
+    }
+
+    /**
+     * Regression test for the livelock: with only a mismatched packet in the queue, the old code re-queued it and
+     * re-polled in a hot spin (thread stayed RUNNABLE forever). The fixed code must block in wait() and complete once
+     * the matching packet arrives.
+     */
+    @Test
+    @Timeout(10)
+    void waitsInsteadOfSpinningWhenOnlyMismatchedPacketsAreQueued() throws Exception {
+        Server.ReceivedPacket other = packetFromConnection(1);
+        Queue<Server.ReceivedPacket> queue = cfrPacketQueue();
+        queue.add(other);
+
+        AtomicReference<Server.ReceivedPacket> result = new AtomicReference<>();
+        Thread poller = new Thread(() -> {
+            try {
+                result.set(invokePollCFRPacket(rp -> rp.getConnectionId() == 42));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }, "cfr-poller");
+        poller.start();
+
+        // The old implementation spun forever here (RUNNABLE); the fix must park in wait()
+        awaitThreadState(poller, Thread.State.WAITING);
+
+        Server.ReceivedPacket match = packetFromConnection(42);
+        synchronized (queue) {
+            queue.add(match);
+            queue.notifyAll();
+        }
+        poller.join(5000);
+
+        assertSame(match, result.get());
+        assertEquals(List.of(other), List.copyOf(queue), "The mismatched packet must still be queued");
+    }
+
+    @Test
+    @Timeout(10)
+    void returnsNullWhenInterruptedWhileWaiting() throws Exception {
+        AtomicReference<Object> result = new AtomicReference<>("not yet run");
+        Thread poller = new Thread(() -> {
+            try {
+                result.set(invokePollCFRPacket(rp -> true));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }, "cfr-poller-interrupted");
+        poller.start();
+
+        awaitThreadState(poller, Thread.State.WAITING);
+        poller.interrupt();
+        poller.join(5000);
+
+        assertNull(result.get(), "An interrupted wait must return null");
+    }
+}


### PR DESCRIPTION
We recently hit issues with double-blind games reliably hitting OOM errors, or freezing entirely as Garbage Collection attempted to clear the heap. Through profiling I was able to find around 400-600 MB 'leaked' per round. This resulted in significant slowdown that actually then leaked back into MekHQ.

This PR fixes both the leak, and the client-side root cause. Finally, it also fixes a lock-up in our packet handling for unrecognized packets.

# Fix 1: `TimesetManager`and `EntityImage`
`TilesetManager.mekImageList` is meant to hold one `EntityImage` (6 rotated facings +
damage decals + smoke + shadows + wreck facings + icon) per unique option (tileset image, camouflage, and damage level).

There were two bugs that made this check fail consistently, this meant that every call (via `GameEntityChangeEvent`) built a brand new fresh image set and appended it to the array forever. This array would then get increasingly chunky as the game went on, resulting in slowdown that would only be cleared by restarting the scenario. If the client ever failed to hand-off back to mhq this **potentially** could result in the array persisting in memory, leaking back to MekHQ.

This was particularly an issue in double-blind as it was being called by `Client.receiveEntityVisibilityIndicator` - which itself had issues.

I fixed this by updating the callers so that `EntityImage` so that a) we're now correctly matching existing entries so we're not rebuilding constantly, and b) storing the images more intelligently via access adjustments (statics and publics, largely).

Through the power of GitBlame I was able to track down the root cause to a 2020 refactor that adjusted tileset handling. Players should see an immediate improvement in long games.

# Fix 2: Fixing `Client.receiveEntityVisibilityIndicator` Going Crazy with Call Events

Every time we were checking visibility - which is a lot - we fire a `GameEntityChangeEvent` unconditionally. In fact the code itself happily comments that it's "only needed sometimes, but we'll just call it every time". Every time this event fired it would then cascade down the event change redrawing all entities, reloading the tileManager, updating the ECM list, and a whole other giant pile of changes.

This was particularly an issue in double-blind games, as (by merit of being double-blind) this event was being fired **constantly**. This then interacted _awfully_ with the first bug I highlighted in Fix 1. The two bugs basically feeding each other until the client ran out of memory.

The issue? The vast majority of these event calls actually didn't do anything. They were declaring "hey, something changed better update the universe", when no change actually took place.

I fixed this by simply comparing the current state against the new state and restricting the event to only firing when an actual change has taken place.

# Fix 3: Fixed a Lock-Up When Waiting on Player Feedback (CFR Packets)
So, this was actually where I originally thought the OOM issue was coming from. The profiler data pins the memory issues squarely on Fixes 1 and 2 - but while digging around I found a genuine lock-up bug, so it gets fixed too.

Some rules need a player decision mid-resolution (e.g. hidden unit point-blank shots, etc). When that happens the server sends the player a feedback request and then sits on a shared queue waiting for their answer. If the queue is empty, it idles.

Back in November we changed these loops so that packets meant for _other_ handlers get re-queued instead of discarded. Unfortunately, the "should I idle?" check is just "is the queue empty?". So the moment the queue contains a packet that isn't the one we're waiting for (i.e. a stale or duplicate response meant for another handler or player) the loop pulls it out, puts it straight back, notices the queue isn't empty, and immediately does it all again. Forever. At 100% CPU. And the packet it's so carefully preserving "for other handlers" can never actually be collected, because those handlers all run on the same server thread that's now busy spinning.

I fixed this by having each loop scan the queue for its specific packet (matching handler type and player) leaving everything else untouched and in order, and only idling when there's genuinely nothing for it. This preserves the don't-discard change from November, just without the spin.

# I Have Access to a Profiler and I'm Going to Use It

Double-blind player scenario with gif saving and roughly 8 units per side. Both sides controlled by Princess.

## Before
| Round | Heap used |
|---|---|
| 0 | 1.31 GB |
| 2 | 2.56 GB |
| 4 | 3.01 GB |
| 5 | 3.89 GB |
| 7 | 4.02 GB |
| 8 | **4.17 GB → OOM crash** |

I actually ran this multiple times, this was the only instance where I could get data from the OOM. All the others locked up Java so hard I had to force close IntelliJ. Which, lemme tell you, was an experience. No wonder testers were having trouble! :D

## After
| | Scenario 1 (28 rounds) | Scenario 2 (31 rounds, same session) |
|---|---|---|
| Baseline | 1.25 GB | 1.51 GB |
| Peak | 2.92 GB | 3.97 GB |
| Repeatedly returns to | ~1.2 GB | ~1.5–1.7 GB |
| Result | completed normally | completed normally |

# Testing
Added a bunch of tests to verify these fixes worked and that it wasn't just confirmation bias at play. These tests were AI authored.

# Why Now?
So, these problems are actually pre-existing. Some all the way back to 2020, others November last year. From personal experience, as a double-blind player, I can confirm I have definitely noticed the chug during long scenarios. However, my computer is ancient, so I figured it was a me issue.

The reason it's hitting us harder now is that the leak scales with how busy the game is. In double-blind the server sends visibility indicators for every entity, constantly. This then tripped the event bug from Fix 2, which fed the leak from Fix 1. Bigger battles, more bot-controlled units, and longer scenarios all multiply that.

Most players would see this characterized as "MegaMek gets laggy in long games and needs to be restarted". 

# Disclaimer
I don't play around much in MegaMek and I certainly don't faff with packets and other fanciness. The findings and fixes here were largely based on me intuiting the issues after running the profiler multiple times and then feeding those intuits into Claude to see if my theories held water - most didn't. I have tested these changes extensively and see a definite improvement. I added unit tests as an extra layer of insurance.