### PR TITLE
Fix: TRO Duplicate Mass Text, Fixed Equipment Table, Line Breaks, Align

### DIFF
--- a/megamek/resources/megamek/common/templates/tro/aero.ftl
+++ b/megamek/resources/megamek/common/templates/tro/aero.ftl
@@ -28,18 +28,13 @@ ${formatBasicDataRow("Armor Factor" + armorType, armorFactor, armorMass)}
      ${formatArmorRow("Wings", armorValues.RWG)}<#if patchworkByLoc??> ${patchworkByLoc.RWG}</#if>
      ${formatArmorRow("Aft", armorValues.AFT)}<#if patchworkByLoc??> ${patchworkByLoc.AFT}</#if>
 
-<#if isOmni>
-Fixed Equipment
-	<#if fixedTonnage gt 0>
-${formatBasicDataRow("Location", "Fixed", "Tonnage")}
+<#if isOmni && fixedTonnage gt 0>
+${formatBasicDataRow("Fixed Equipment", "Location", "Tonnage")}
 	<#list fixedEquipment as row>
 		<#if row.equipment != "None">
-${formatBasicDataRow(row.location, row.equipment, row.tonnage)}
+${formatBasicDataRow(row.equipment, row.location, row.tonnage)}
 		</#if>
 	</#list>
-	<#else>
-None
-	</#if>
 </#if>
 
 Weapons

--- a/megamek/resources/megamek/common/templates/tro/aero.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/aero.ftlh
@@ -56,7 +56,7 @@
 <#if isOmni && fixedTonnage gt 0>
     <br/>
     <table>
-        <tr><th align="left">Fixed Equipment</th><th>Location</th><th>Tonnage</th>
+        <tr><th align="left">Fixed Equipment</th><th>Location</th><th>Tonnage</th></tr>
         <#list fixedEquipment as row>
             <#if row.equipment != "None">
         <tr><td>${row.equipment}</td><td align="center">${row.location}</td><td align="center">${row.tonnage}</td></tr>

--- a/megamek/resources/megamek/common/templates/tro/aero.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/aero.ftlh
@@ -15,9 +15,9 @@
 	<b>Tonnage:</b> ${tonnage}<br/>
 	<b>Battle Value:</b> ${battleValue}<br/>
 	</p>
-
+	<br/>
 	<table>
-	<tr><th>Equipment</th><th/><th>Mass</th></tr>
+	<tr><th align="left">Equipment</th><th/><th>Mass</th></tr>
 	<#if !isFighterSquadron>
 	<tr><td>Engine</td><td align="center">${engineName!'(None)'}</td><td align="center">${engineMass!''}</td></tr>
 	</#if>
@@ -35,7 +35,7 @@
 	<tr><td>Armor Factor${armorType}:</td><td align="center">${armorFactor}</td><td align="center">${armorMass}</td></tr>
 	</table>
 
-	<table width="80%">
+	<table>
 		<tr><th></th><th>Armor<br/>Value</th></tr>
 		<tr>
 			<td>Nose</td>
@@ -53,23 +53,18 @@
 			<#if patchworkByLoc??><td>${patchworkByLoc.AFT}</td></#if>
 		</tr>
 	</table>
-
-	<#if isOmni>
-	<b>Fixed Equipment</b><br/>
-		<#if fixedTonnage gt 0>
-			<table>
-			<tr><td><i>Location</i></td><td align="center"><i>Fixed</i></td><td align="center"><i>Tonnage</i></td><td><i>Heat</i></i></td><th>SRV</i></td><td><i>MRV</i></td><td><i>LRV</th><td><i>ERV</i></td></td></tr>
-			<#list fixedEquipment as row>
-				<#if row.equipment != "None">
-	        		<tr><td>${row.location}</td><td align="center">${row.equipment}</td><td align="center">${row.tonnage}</td><td>${row.heat}</td><td>${row.srv}</td><td>${row.mrv}</td><td>${row.lrv}</td><td>${row.erv}</td></tr>
-				</#if>
-			</#list>
-			</table>
-		<#else>
-			None
-		</#if>
-	</#if>
-
+<#if isOmni && fixedTonnage gt 0>
+    <br/>
+    <table>
+        <tr><th align="left">Fixed Equipment</th><th>Location</th><th>Tonnage</th>
+        <#list fixedEquipment as row>
+            <#if row.equipment != "None">
+        <tr><td>${row.equipment}</td><td align="center">${row.location}</td><td align="center">${row.tonnage}</td></tr>
+            </#if>
+        </#list>
+    </table>
+</#if>
+	<br/>
 	<table>
 		<tr><th align="left">Weapons<br/>and Ammo</th><th>Location</th><th>Tonnage</th><th>Heat</th><th>SRV</th><th>MRV</th><th>LRV</th><th>ERV</th></tr>
 		<#list equipment as eq>

--- a/megamek/resources/megamek/common/templates/tro/aero_vessel.ftl
+++ b/megamek/resources/megamek/common/templates/tro/aero_vessel.ftl
@@ -2,13 +2,12 @@ ${fullName}
 <#if typeDesc??>
 Type: ${typeDesc}
 </#if>
-Mass: ${massDesc} tons
 <#if use??>
 Use: ${use}
 </#if>
 Technology Base: ${techBase}
 Introduced: ${year}
-Mass: ${tonnage}
+Mass: ${massDesc}
 Battle Value: ${battleValue}
 Tech Rating/Availability: ${techRating}
 Cost: ${cost} C-bills

--- a/megamek/resources/megamek/common/templates/tro/aero_vessel.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/aero_vessel.ftlh
@@ -9,13 +9,12 @@
 <#if typeDesc??>
   	<b>Type: </b>${typeDesc}<br/>
 </#if>
-  	<b>Mass: </b>${massDesc} tons<br/>
 <#if use??>
   	<b>Use:</b> ${use}<br/>
 </#if>
 	<b>Technology Base:</b> ${techBase}<br/>
   	<b>Introduced:</b> ${year}<br/>
-	<b>Mass:</b> ${tonnage}<br/>
+	<b>Mass: </b>${massDesc}<br/>
 	<b>Battle Value:</b> ${battleValue}<br/>
   	<b>Tech Rating/Availability:</b> ${techRating}<br/>
   	<b>Cost:</b> ${cost} C-bills<br/>
@@ -98,7 +97,7 @@
 	<b>Notes: </b><#if armorMass gt 0>Mounts ${armorMass} tons of ${armorType} armor.</#if><br/>
 </#if>
 	</p>
-
+	<br/>
 <#if usesWeaponBays>
 	<table>
 		<tr><th align="left">Weapons:</th><th></th><th colspan="4">Capital Attack Values (Standard)</th><th></th></tr>

--- a/megamek/resources/megamek/common/templates/tro/ba.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/ba.ftlh
@@ -17,7 +17,7 @@
 	<b>Manufacturer: </b> <#if manufacturerDesc??>${manufacturerDesc}<#else>Unknown</#if><br/>
 	<b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Primary Factory: </b> <#if factoryDesc??>${factoryDesc}<#else>Unknown</#if><br/>
         </#if>
-	</p>
+	</p>ƒ
 </#if>
 
 	<p>
@@ -31,9 +31,9 @@
 	<b>Note:</b> Leg attacks can only be made in water of depth 1+<br/>
 	</#if>
 	</p>
-
+	<br/>
 	<table>
-		<tr><th>Equipment</th><th></th><th>Slots</th><th>Mass</th></tr>
+		<tr><th align="left">Equipment</th><th></th><th>Slots</th><th>Mass</th></tr>
 		<tr><td>Chassis:</td><td></td><td></td><td align="right">${massChassis} kg</td></tr>
 		<tr><td>Motive System:</td><td></td><td></td><td></td></tr>
 		<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;Ground MP:</td><td>${groundMP}</td><td></td><td align="right">${groundMass} kg</td></tr>
@@ -53,7 +53,7 @@
 		<tr><td>Armor:</td><td>${armorType}</td><td align="center">${armorSlots}</td><td align="right">${armorMass} kg</td></tr>
 		<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;Armor Value:</td><td>${armorValue} + ${internal} (Trooper)</td><td></td><td></td></tr>
 	</table>
-
+	<br/>
 	<table>
 		<tr><th>Weapons and Equipment</th><th>Location</th><th>Slots (Capacity)</th><th>Mass</th></tr>
 		<#list equipment as row>

--- a/megamek/resources/megamek/common/templates/tro/ba.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/ba.ftlh
@@ -17,7 +17,7 @@
 	<b>Manufacturer: </b> <#if manufacturerDesc??>${manufacturerDesc}<#else>Unknown</#if><br/>
 	<b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Primary Factory: </b> <#if factoryDesc??>${factoryDesc}<#else>Unknown</#if><br/>
         </#if>
-	</p>ƒ
+	</p>
 </#if>
 
 	<p>

--- a/megamek/resources/megamek/common/templates/tro/gunemplacement.ftl
+++ b/megamek/resources/megamek/common/templates/tro/gunemplacement.ftl
@@ -25,19 +25,13 @@ ${formatBasicDataRow("Front Turret:", "", turretMass2)}
 ${formatBasicDataRow("Turret:", "", turretMass)}
 </#if>
 
-
-<#if isOmni>
-Fixed Equipment
-	<#if fixedTonnage gt 0>
-${formatBasicDataRow("Location", "Fixed", "Tonnage")}
+<#if isOmni && fixedTonnage gt 0>
+${formatBasicDataRow("Fixed Equipment", "Location", "Tonnage")}
 	<#list fixedEquipment as row>
 		<#if row.equipment != "None">
-${formatBasicDataRow(row.location, row.equipment, row.tonnage)}
+${formatBasicDataRow(row.equipment, row.location, row.tonnage)}
 		</#if>
 	</#list>
-	<#else>
-None
-	</#if>
 </#if>
 
 Weapons

--- a/megamek/resources/megamek/common/templates/tro/gunemplacement.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/gunemplacement.ftlh
@@ -34,7 +34,7 @@
 <#if isOmni && fixedTonnage gt 0>
     <br/>
     <table>
-        <tr><th align="left">Fixed Equipment</th><th>Location</th><th>Tonnage</th>
+        <tr><th align="left">Fixed Equipment</th><th>Location</th><th>Tonnage</th></tr>
         <#list fixedEquipment as row>
             <#if row.equipment != "None">
         <tr><td>${row.equipment}</td><td align="center">${row.location}</td><td align="center">${row.tonnage}</td></tr>

--- a/megamek/resources/megamek/common/templates/tro/gunemplacement.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/gunemplacement.ftlh
@@ -15,9 +15,9 @@
 	<b>Tonnage:</b> ${tonnage}<br/>
 	<b>Battle Value:</b> ${battleValue}<br/>
 	</p>
-
+	<br/>
 	<table>
-	<tr><th>Equipment</th><th/><th>Mass</th></tr>
+	<tr><th align="left">Equipment</th><th/><th>Mass</th></tr>
 	<tr><td>Heat Sinks:</td><td align="center">${hsCount}</td><td align="center">${hsMass}</td></tr>
 	<tr><td>Control Equipment:</td><td></td><td align="center">${controlMass}</td</tr>
 <#if liftMass gt 0>
@@ -31,23 +31,18 @@
 	<tr><td>Turret:</td><td></td><td align="center">${turretMass}</td</tr>
 </#if>
 	</table>
-
-	<#if isOmni>
-	<b>Fixed Equipment</b><br/>
-		<#if fixedTonnage gt 0>
-			<table>
-			<tr><td><i>Location</i></td><td align="center"><i>Fixed</i></td><td align="center"><i>Tonnage</i></td></tr>
-			<#list fixedEquipment as row>
-				<#if row.equipment != "None">
-			<tr><td>${row.location}</td><td align="center">${row.equipment}</td><td align="center">${row.tonnage}</td></tr>
-				</#if>
-			</#list>
-			</table>
-		<#else>
-			None
-		</#if>
-	</#if>
-
+<#if isOmni && fixedTonnage gt 0>
+    <br/>
+    <table>
+        <tr><th align="left">Fixed Equipment</th><th>Location</th><th>Tonnage</th>
+        <#list fixedEquipment as row>
+            <#if row.equipment != "None">
+        <tr><td>${row.equipment}</td><td align="center">${row.location}</td><td align="center">${row.tonnage}</td></tr>
+            </#if>
+        </#list>
+    </table>
+</#if>
+	<br/>
 	<table>
 		<tr><th align="left">Weapons<br/>and Ammo</th><th>Location</th><th>Critical</th><th>Tonnage</th></tr>
 		<#list equipment as eq>

--- a/megamek/resources/megamek/common/templates/tro/mek.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/mek.ftlh
@@ -14,9 +14,9 @@
 	<b>Tonnage:</b> ${tonnage}<br/>
 	<b>Battle Value:</b> ${battleValue}<br/>
 	</p>
-
+	<br/>
 	<table>
-	<tr><th>Equipment</th><th/><th>Mass</th></tr>
+	<tr><th align="left">Equipment</th><th/><th>Mass</th></tr>
 	<tr><td>Internal Structure</td><td align="center">${structureName}</td><td align="center">${isMass}</td></tr>
 	<#if lamConversionMass??>
 	<tr><td>LAM Conversion Equipment</td><td></td><td align="center">${lamConversionMass}</td></tr>
@@ -39,10 +39,10 @@
 	<tr><td>${hsType}:</td><td align="center">${hsCount}</td><td align="center">${hsMass}</td><#if riscKit??><td>w/ RISC Heat Sink Override Kit</td></#if></tr>
 	<tr><td>${gyroType}:</td><td></td><td align="center">${gyroMass}</td></tr>
 	<tr><td>${cockpitType}:</td><td></td><td align="center">${cockpitMass}</td></tr>
-	<tr><td>Armor Factor${armorType}:</td><td>${armorFactor}</td><td align="center">${armorMass}</td></tr>
+	<tr><td>Armor Factor${armorType}:</td><td align="center">${armorFactor}</td><td align="center">${armorMass}</td></tr>
 	</table>
 
-	<table width="80%">
+	<table>
 		<tr><th></th><th>Internal<br/>Structure</th><th>Armor<br/>Value</th></tr>
 		<tr>
 			<td>Head</td>
@@ -112,7 +112,7 @@
 	</table>
 
 	<#if isOmni>
-	<b>Weight and Space Allocation</b>
+	<p><b>Weight and Space Allocation</b></p>
 	<table>
 	<tr><td><i>Location</i></td><td align="center"><i>Fixed</i></td><td align="center"><i>Space Remaining</i></td></tr>
 	<#list fixedEquipment as row>
@@ -120,7 +120,7 @@
 	</#list>
 	</table>
 	</#if>
-
+	<br/>
 	<table>
 		<tr><th align="left">Weapons<br/>and Ammo</th><th>Location</th><th>Critical</th><th>Tonnage</th></tr>
 		<#list equipment as eq>

--- a/megamek/resources/megamek/common/templates/tro/protomek.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/protomek.ftlh
@@ -14,9 +14,9 @@
 	<b>Tonnage:</b> ${tonnage}<br/>
 	<b>Battle Value:</b> ${battleValue}<br/>
 	</p>
-
+	<br/>
 	<table>
-	<tr><th>Equipment</th><th/><th>Mass (kg)</th></tr>
+	<tr><th align="left">Equipment</th><th/><th>Mass (kg)</th></tr>
 	<tr><td>Internal Structure</td><td></td><td align="center">${isMass}</td></tr>
 	<tr><td>Engine</td><td align="center">${engineRating}</td><td align="center">${engineMass}</td></tr>
 	<#if isGlider>
@@ -35,10 +35,10 @@
 	</#if>
 	<tr><td>Heat Sinks:</td><td align="center">${hsCount}</td><td align="center">${hsMass}</td></tr>
 	<tr><td>Cockpit:</td><td></td><td align="center">${cockpitMass}</td></tr>
-	<tr><td>Armor Factor${armorType}:</td><td>${armorFactor}</td><td align="center">${armorMass}</td></tr>
+	<tr><td>Armor Factor${armorType}:</td><td align="center">${armorFactor}</td><td align="center">${armorMass}</td></tr>
 	</table>
 
-	<table width="80%">
+	<table>
 		<tr><th></th><th>Internal<br/>Structure</th><th>Armor<br/>Value</th></tr>
 		<tr>
 			<td>Head</td>
@@ -73,7 +73,7 @@
 			</#if>
 		</tr>
 	</table>
-
+	<br/>
 	<table>
 		<tr><th align="left">Weapons<br/>and Ammo</th><th>Location</th><th>Mass (kg)</th></tr>
 		<#list equipment as eq>

--- a/megamek/resources/megamek/common/templates/tro/support.ftl
+++ b/megamek/resources/megamek/common/templates/tro/support.ftl
@@ -47,18 +47,13 @@ ${formatBasicDataRow("Armor Factor (" + barRating + ")", armorFactor, armorMass)
      ${formatArmorRow("Rotor", structureValues.RO, armorValues.RO)}<#if patchworkByLoc??> ${patchworkByLoc.RO}</#if>
 </#if>
 
-<#if isOmni>
-Fixed Equipment
-	<#if fixedTonnage gt 0>
-${formatBasicDataRow("Location", "Fixed", "Tonnage")}
+<#if isOmni && fixedTonnage gt 0>
+${formatBasicDataRow("Fixed Equipment", "Location", "Tonnage")}
 	<#list fixedEquipment as row>
 		<#if row.equipment != "None">
-${formatBasicDataRow(row.location, row.equipment, row.tonnage)}
+${formatBasicDataRow(row.equipment, row.location, row.tonnage)}
 		</#if>
 	</#list>
-	<#else>
-None
-	</#if>
 </#if>
 
 Weapons

--- a/megamek/resources/megamek/common/templates/tro/support.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/support.ftlh
@@ -106,7 +106,7 @@
 <#if isOmni && fixedTonnage gt 0>
     <br/>
     <table>
-        <tr><th align="left">Fixed Equipment</th><th>Location</th><th>Tonnage</th>
+        <tr><th align="left">Fixed Equipment</th><th>Location</th><th>Tonnage</th></tr>
         <#list fixedEquipment as row>
             <#if row.equipment != "None">
         <tr><td>${row.equipment}</td><td align="center">${row.location}</td><td align="center">${row.tonnage}</td></tr>

--- a/megamek/resources/megamek/common/templates/tro/support.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/support.ftlh
@@ -16,9 +16,9 @@
 	<b>Mass:</b> ${mass} ${weightStandard}<br/>
 	<b>Battle Value:</b> ${battleValue}<br/>
 	</p>
-
+	<br/>
 	<table>
-	<tr><th>Equipment</th><th/><th>Mass (${weightStandard})</th></tr>
+	<tr><th align="left">Equipment</th><th/><th>Mass (${weightStandard})</th></tr>
 	<tr><td>Chassis/Controls</td><td></td><td align="center">${chassisControlMass}</td></tr>
 	<tr><td>Engine/Trans.</td><td align="center">${engineName}</td><td align="center">${engineMass}</td></tr>
 	<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Cruise MP:</td><td align="center">${walkMP}</td><td></td></tr>
@@ -34,10 +34,11 @@
 <#elseif hasTurret>
 	<tr><td>Turret:</td><td></td><td align="center">${turretMass}</td</tr>
 </#if>
-	<tr><td>Armor Factor (${barRating}):</td><td>${armorFactor}</td><td align="center">${armorMass}</td></tr>
+	<tr><td>Armor Factor (${barRating}):</td><td align="center">${armorFactor}</td><td
+	align="center">${armorMass}</td></tr>
 	</table>
 
-	<table width="80%">
+	<table>
 		<tr><th></th><th>Internal<br/>Structure</th><th>Armor<br/>Value</th></tr>
 		<tr>
 			<td>Front</td>
@@ -102,23 +103,18 @@
 		</tr>
 </#if>
 	</table>
-
-	<#if isOmni>
-	<b>Fixed Equipment</b><br/>
-		<#if fixedTonnage gt 0>
-			<table>
-			<tr><td><i>Location</i></td><td align="center"><i>Fixed</i></td><td align="center"><i>Mass (${weightStandard})</i></td></tr>
-			<#list fixedEquipment as row>
-				<#if row.equipment != "None">
-			<tr><td>${row.location}</td><td align="center">${row.equipment}</td><td align="center">${row.tonnage}</td></tr>
-				</#if>
-			</#list>
-			</table>
-		<#else>
-			None
-		</#if>
-	</#if>
-
+<#if isOmni && fixedTonnage gt 0>
+    <br/>
+    <table>
+        <tr><th align="left">Fixed Equipment</th><th>Location</th><th>Tonnage</th>
+        <#list fixedEquipment as row>
+            <#if row.equipment != "None">
+        <tr><td>${row.equipment}</td><td align="center">${row.location}</td><td align="center">${row.tonnage}</td></tr>
+            </#if>
+        </#list>
+    </table>
+</#if>
+	<br/>
 	<table>
 		<tr><th align="left">Weapons<br/>and Ammo</th><th>Location</th><th>Critical</th><th>Mass (${weightStandard})</th></tr>
 		<#list weaponList as eq>

--- a/megamek/resources/megamek/common/templates/tro/vehicle.ftl
+++ b/megamek/resources/megamek/common/templates/tro/vehicle.ftl
@@ -52,18 +52,13 @@ ${formatBasicDataRow("Armor Factor" + armorType, armorFactor, armorMass)}
      ${formatArmorRow("Rotor", structureValues.RO, armorValues.RO)}<#if patchworkByLoc??> ${patchworkByLoc.RO}</#if>
 </#if>
 
-<#if isOmni>
-Fixed Equipment
-	<#if fixedTonnage gt 0>
-${formatBasicDataRow("Location", "Fixed", "Tonnage")}
+<#if isOmni && fixedTonnage gt 0>
+${formatBasicDataRow("Fixed Equipment", "Location", "Tonnage")}
 	<#list fixedEquipment as row>
 		<#if row.equipment != "None">
-${formatBasicDataRow(row.location, row.equipment, row.tonnage)}
+${formatBasicDataRow(row.equipment, row.location, row.tonnage)}
 		</#if>
 	</#list>
-	<#else>
-None
-	</#if>
 </#if>
 
 Weapons

--- a/megamek/resources/megamek/common/templates/tro/vehicle.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/vehicle.ftlh
@@ -15,9 +15,9 @@
 	<b>Tonnage:</b> ${tonnage}<br/>
 	<b>Battle Value:</b> ${battleValue}<br/>
 	</p>
-
+	<br/>
 	<table>
-	<tr><th>Equipment</th><th/><th>Mass</th></tr>
+	<tr><th align="left">Equipment</th><th/><th>Mass</th></tr>
 	<tr><td>Internal Structure</td><td></td><td align="center">${isMass}</td></tr>
 	<tr><td>Engine</td><td align="center">${engineName}</td><td align="center">${engineMass}</td></tr>
 	<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Cruising MP:</td><td align="center">${walkMP}</td><td></td></tr>
@@ -37,10 +37,9 @@
 <#elseif hasTurret>
 	<tr><td>Turret:</td><td></td><td align="center">${turretMass}</td</tr>
 </#if>
-	<tr><td>Armor Factor${armorType}:</td><td>${armorFactor}</td><td align="center">${armorMass}</td></tr>
+	<tr><td>Armor Factor${armorType}:</td><td align="center">${armorFactor}</td><td align="center">${armorMass}</td></tr>
 	</table>
-
-	<table width="80%">
+	<table>
 		<tr><th></th><th>Internal<br/>Structure</th><th>Armor<br/>Value</th></tr>
 		<tr>
 			<td>Front</td>
@@ -105,23 +104,18 @@
 		</tr>
 </#if>
 	</table>
-
-	<#if isOmni>
-	<b>Fixed Equipment</b><br/>
-		<#if fixedTonnage gt 0>
-			<table>
-			<tr><td><i>Location</i></td><td align="center"><i>Fixed</i></td><td align="center"><i>Tonnage</i></td></tr>
-			<#list fixedEquipment as row>
-				<#if row.equipment != "None">
-			<tr><td>${row.location}</td><td align="center">${row.equipment}</td><td align="center">${row.tonnage}</td></tr>
-				</#if>
-			</#list>
-			</table>
-		<#else>
-			None
-		</#if>
-	</#if>
-
+<#if isOmni && fixedTonnage gt 0>
+    <br/>
+    <table>
+        <tr><th align="left">Fixed Equipment</th><th>Location</th><th>Tonnage</th>
+        <#list fixedEquipment as row>
+            <#if row.equipment != "None">
+        <tr><td>${row.equipment}</td><td align="center">${row.location}</td><td align="center">${row.tonnage}</td></tr>
+            </#if>
+        </#list>
+    </table>
+</#if>
+	<br/>
 	<table>
 		<tr><th align="left">Weapons<br/>and Ammo</th><th>Location</th><th>Critical</th><th>Tonnage</th></tr>
 		<#list equipment as eq>

--- a/megamek/resources/megamek/common/templates/tro/vehicle.ftlh
+++ b/megamek/resources/megamek/common/templates/tro/vehicle.ftlh
@@ -107,7 +107,7 @@
 <#if isOmni && fixedTonnage gt 0>
     <br/>
     <table>
-        <tr><th align="left">Fixed Equipment</th><th>Location</th><th>Tonnage</th>
+        <tr><th align="left">Fixed Equipment</th><th>Location</th><th>Tonnage</th></tr>
         <#list fixedEquipment as row>
             <#if row.equipment != "None">
         <tr><td>${row.equipment}</td><td align="center">${row.location}</td><td align="center">${row.tonnage}</td></tr>

--- a/megamek/src/megamek/common/templates/CapitalShipTROView.java
+++ b/megamek/src/megamek/common/templates/CapitalShipTROView.java
@@ -33,6 +33,7 @@
 
 package megamek.common.templates;
 
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -88,7 +89,8 @@ public class CapitalShipTROView extends AeroTROView {
         addFluff();
         final TestAdvancedAerospace testAero = new TestAdvancedAerospace(aero, verifier.aeroOption, null);
 
-        setModelData("massDesc", aero.getWeight());
+        setModelData("massDesc", NumberFormat.getInstance().format(aero.getWeight())
+              + Messages.getString(aero.getWeight() == 1.0 ? "TROView.ton" : "TROView.tons"));
         setModelData("fuelMass", aero.getFuelTonnage());
         setModelData("fuelPoints", aero.getFuel());
         setModelData("safeThrust", aero.getWalkMP());

--- a/megamek/src/megamek/common/templates/SmallCraftDropshipTROView.java
+++ b/megamek/src/megamek/common/templates/SmallCraftDropshipTROView.java
@@ -33,6 +33,7 @@
 
 package megamek.common.templates;
 
+import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -89,7 +90,8 @@ public class SmallCraftDropshipTROView extends AeroTROView {
         final TestSmallCraft testAero = new TestSmallCraft(aero, verifier.aeroOption, null);
 
         setModelData("typeDesc", formatVesselType());
-        setModelData("massDesc", aero.getWeight());
+        setModelData("massDesc", NumberFormat.getInstance().format(aero.getWeight())
+              + Messages.getString(aero.getWeight() == 1.0 ? "TROView.ton" : "TROView.tons"));
         setModelData("fuelMass", aero.getFuelTonnage());
         setModelData("fuelPoints", aero.getFuel());
         setModelData("safeThrust", aero.getWalkMP());
@@ -109,7 +111,6 @@ public class SmallCraftDropshipTROView extends AeroTROView {
     }
 
     private void addFluff() {
-        addEntityFluff(aero);
         addEntityFluff(aero);
         final Map<String, String> dimensions = new HashMap<>();
         if (!aero.getFluff().getLength().isEmpty()) {


### PR DESCRIPTION
Fix TRO duplicate Mass text for Small Craft/Dropship/Advanced Aerospace, Fixed Equipment table, line breaks before table, and table cell alignments