### PR TITLE
Carry copyright years forward when resaving units

### DIFF
--- a/megamek/src/megamek/utilities/UnitFileResaver.java
+++ b/megamek/src/megamek/utilities/UnitFileResaver.java
@@ -44,10 +44,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Year;
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import megamek.codeUtilities.MathUtility;
 import megamek.common.Configuration;
 import megamek.common.annotations.Nullable;
 import megamek.common.loaders.BLKFile;
@@ -255,12 +257,15 @@ public class UnitFileResaver {
     /**
      * Reads the first copyright year out of a source file's existing license header.
      *
+     * <p>Only the plain-text unit formats are opened. A unit stored in an archive reports the archive as its source
+     * file, and reading that as text would scan a large binary file for a header it cannot contain.</p>
+     *
      * @param sourceFile The file to read, or {@code null} when the source is unknown
      *
      * @return The first copyright year in the header, or 0 if the file has no readable header
      */
     private static int readCopyrightStartYear(@Nullable File sourceFile) {
-        if ((sourceFile == null) || !sourceFile.isFile()) {
+        if ((sourceFile == null) || !sourceFile.isFile() || !hasPlainTextUnitExtension(sourceFile)) {
             return 0;
         }
 
@@ -272,7 +277,7 @@ public class UnitFileResaver {
                 }
                 Matcher matcher = COPYRIGHT_YEARS_PATTERN.matcher(line);
                 if (matcher.find()) {
-                    return Integer.parseInt(matcher.group(1));
+                    return MathUtility.parseInt(matcher.group(1), 0);
                 }
             }
         } catch (IOException exception) {
@@ -281,6 +286,18 @@ public class UnitFileResaver {
         }
 
         return 0;
+    }
+
+    /**
+     * Checks whether a file is one of the plain-text unit formats that carry a license header.
+     *
+     * @param sourceFile The file to check
+     *
+     * @return {@code true} if the file is a format whose header can be read as text
+     */
+    private static boolean hasPlainTextUnitExtension(File sourceFile) {
+        String fileName = sourceFile.getName().toLowerCase(Locale.ROOT);
+        return fileName.endsWith(".mtf") || fileName.endsWith(".blk");
     }
 
     /**

--- a/megamek/src/megamek/utilities/UnitFileResaver.java
+++ b/megamek/src/megamek/utilities/UnitFileResaver.java
@@ -32,6 +32,7 @@
  */
 package megamek.utilities;
 
+import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -41,9 +42,11 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Calendar;
+import java.time.Year;
 import java.util.Comparator;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import megamek.common.Configuration;
 import megamek.common.annotations.Nullable;
@@ -71,7 +74,7 @@ import megamek.logging.MMLogger;
 public class UnitFileResaver {
     private static final MMLogger logger = MMLogger.create(UnitFileResaver.class);
 
-    private static final String LICENSE_HEADER = """
+    private static final String LICENSE_HEADER_TEMPLATE = """
           # MegaMek Data (C) %s by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
           # To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
           #
@@ -88,7 +91,16 @@ public class UnitFileResaver {
           # Microsoft's "Game Content Usage Rules"
           # <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
           # affiliated with Microsoft.
-          """.formatted(Calendar.getInstance().get(Calendar.YEAR));
+          """;
+
+    /** Matches the year, or the first year of a year range, in an existing license header. */
+    private static final Pattern COPYRIGHT_YEARS_PATTERN =
+          Pattern.compile("MegaMek Data \\(C\\) (\\d{4})(?:-(\\d{4}))? by");
+
+    /** How far into a source file to look for the license header before giving up. */
+    private static final int HEADER_SEARCH_LINE_LIMIT = 20;
+
+    private static final int CURRENT_YEAR = Year.now().getValue();
 
     public static void main(String... args) {
         Path outputDir;
@@ -174,7 +186,7 @@ public class UnitFileResaver {
             }
 
             try {
-                saveUnit(outputFile, entity);
+                saveUnit(outputFile, summary.getSourceFile(), entity);
                 saved.incrementAndGet();
             } catch (Exception e) {
                 logger.error("Failed to save {}: {}", summary.getName(), e.getMessage());
@@ -187,28 +199,88 @@ public class UnitFileResaver {
 
     /**
      * Saves an entity to a file with the license header prepended.
+     *
+     * @param outputFile The file to write the unit to
+     * @param sourceFile The file the unit was loaded from, used to carry its copyright years forward, or
+     *                   {@code null} when the source is unknown
+     * @param entity     The unit to save
      */
-    private static void saveUnit(File outputFile, Entity entity) throws IOException, EntitySavingException {
+    private static void saveUnit(File outputFile, @Nullable File sourceFile, Entity entity)
+          throws IOException, EntitySavingException {
+        String licenseHeader = LICENSE_HEADER_TEMPLATE.formatted(copyrightYears(sourceFile));
+
         if (entity instanceof Mek mek) {
-            try (FileOutputStream fos = new FileOutputStream(outputFile);
-                  PrintStream ps = new PrintStream(fos, false, StandardCharsets.UTF_8)) {
-                ps.println(LICENSE_HEADER);
-                ps.print(mek.getMtf());
+            try (FileOutputStream outputStream = new FileOutputStream(outputFile);
+                  PrintStream printStream = new PrintStream(outputStream, false, StandardCharsets.UTF_8)) {
+                printStream.println(licenseHeader);
+                printStream.print(mek.getMtf());
             }
         } else {
-            BuildingBlock blk = BLKFile.getBlock(entity);
-            try (FileOutputStream fos = new FileOutputStream(outputFile);
-                  OutputStreamWriter osw = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
-                  BufferedWriter bw = new BufferedWriter(osw)) {
-                bw.write(LICENSE_HEADER);
-                bw.newLine();
-                for (String line : blk.getAllDataAsString()) {
-                    bw.write(line);
-                    bw.newLine();
+            BuildingBlock buildingBlock = BLKFile.getBlock(entity);
+            try (FileOutputStream outputStream = new FileOutputStream(outputFile);
+                  OutputStreamWriter streamWriter = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8);
+                  BufferedWriter bufferedWriter = new BufferedWriter(streamWriter)) {
+                bufferedWriter.write(licenseHeader);
+                bufferedWriter.newLine();
+                for (String line : buildingBlock.getAllDataAsString()) {
+                    bufferedWriter.write(line);
+                    bufferedWriter.newLine();
                 }
-                bw.flush();
+                bufferedWriter.flush();
             }
         }
+    }
+
+    /**
+     * Works out the copyright years for a resaved file. A file that already carries an earlier year keeps it as the
+     * start of a range, so resaving an existing unit does not erase the year its content was first published. A file
+     * with no readable header, or one already stamped with the current year, gets the current year on its own.
+     *
+     * <p>Units loaded from inside an archive have no readable plain-text header, so they fall back to the current
+     * year.</p>
+     *
+     * @param sourceFile The file the unit was loaded from, or {@code null} when the source is unknown
+     *
+     * @return The year, or year range, to write into the license header
+     */
+    // Package-private so the year-carrying behavior can be tested directly.
+    static String copyrightYears(@Nullable File sourceFile) {
+        int startYear = readCopyrightStartYear(sourceFile);
+        if ((startYear > 0) && (startYear < CURRENT_YEAR)) {
+            return startYear + "-" + CURRENT_YEAR;
+        }
+        return String.valueOf(CURRENT_YEAR);
+    }
+
+    /**
+     * Reads the first copyright year out of a source file's existing license header.
+     *
+     * @param sourceFile The file to read, or {@code null} when the source is unknown
+     *
+     * @return The first copyright year in the header, or 0 if the file has no readable header
+     */
+    private static int readCopyrightStartYear(@Nullable File sourceFile) {
+        if ((sourceFile == null) || !sourceFile.isFile()) {
+            return 0;
+        }
+
+        try (BufferedReader reader = Files.newBufferedReader(sourceFile.toPath(), StandardCharsets.UTF_8)) {
+            for (int lineNumber = 0; lineNumber < HEADER_SEARCH_LINE_LIMIT; lineNumber++) {
+                String line = reader.readLine();
+                if (line == null) {
+                    break;
+                }
+                Matcher matcher = COPYRIGHT_YEARS_PATTERN.matcher(line);
+                if (matcher.find()) {
+                    return Integer.parseInt(matcher.group(1));
+                }
+            }
+        } catch (IOException exception) {
+            // A file that cannot be read as UTF-8 text simply has no header to carry forward
+            logger.debug("Could not read copyright year from {}: {}", sourceFile.getPath(), exception.getMessage());
+        }
+
+        return 0;
     }
 
     /**

--- a/megamek/unittests/megamek/utilities/UnitFileResaverTest.java
+++ b/megamek/unittests/megamek/utilities/UnitFileResaverTest.java
@@ -97,6 +97,18 @@ class UnitFileResaverTest {
     }
 
     @Test
+    void archiveSourceGetsCurrentYearWithoutBeingRead() throws IOException {
+        // A unit stored in an archive reports the archive as its source file. Even when the archive's bytes happen to
+        // contain something that looks like a header, it must not be scanned as text.
+        int earlierYear = CURRENT_YEAR - 1;
+        Path archiveFile = tempDir.resolve("units.zip");
+        Files.writeString(archiveFile, "# MegaMek Data (C) " + earlierYear + " by The MegaMek Team is licensed"
+              + " under CC BY-NC-SA 4.0.\n", StandardCharsets.UTF_8);
+
+        assertEquals(String.valueOf(CURRENT_YEAR), UnitFileResaver.copyrightYears(archiveFile.toFile()));
+    }
+
+    @Test
     void missingSourceGetsCurrentYear() {
         assertEquals(String.valueOf(CURRENT_YEAR), UnitFileResaver.copyrightYears(null));
         assertEquals(String.valueOf(CURRENT_YEAR),

--- a/megamek/unittests/megamek/utilities/UnitFileResaverTest.java
+++ b/megamek/unittests/megamek/utilities/UnitFileResaverTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.utilities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Year;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests that resaving a unit carries its existing copyright year forward instead of overwriting it with the current
+ * year. A resave that drops the earlier year erases the year the unit's content was first published, which happened
+ * across the whole unit catalog once already.
+ */
+class UnitFileResaverTest {
+
+    private static final int CURRENT_YEAR = Year.now().getValue();
+
+    @TempDir
+    private Path tempDir;
+
+    private File writeUnitFile(String headerLine) throws IOException {
+        Path unitFile = tempDir.resolve("TestUnit.mtf");
+        Files.writeString(unitFile, headerLine + "\nchassis:Marauder\nmodel:MAD-3R\n", StandardCharsets.UTF_8);
+        return unitFile.toFile();
+    }
+
+    @Test
+    void earlierSingleYearBecomesRange() throws IOException {
+        int earlierYear = CURRENT_YEAR - 1;
+        File sourceFile = writeUnitFile("# MegaMek Data (C) " + earlierYear + " by The MegaMek Team is licensed"
+              + " under CC BY-NC-SA 4.0.");
+
+        assertEquals(earlierYear + "-" + CURRENT_YEAR, UnitFileResaver.copyrightYears(sourceFile));
+    }
+
+    @Test
+    void existingRangeKeepsItsStartYear() throws IOException {
+        int earlierYear = CURRENT_YEAR - 1;
+        File sourceFile = writeUnitFile("# MegaMek Data (C) " + earlierYear + "-" + CURRENT_YEAR
+              + " by The MegaMek Team is licensed under CC BY-NC-SA 4.0.");
+
+        assertEquals(earlierYear + "-" + CURRENT_YEAR, UnitFileResaver.copyrightYears(sourceFile));
+    }
+
+    @Test
+    void currentYearStaysASingleYear() throws IOException {
+        File sourceFile = writeUnitFile("# MegaMek Data (C) " + CURRENT_YEAR + " by The MegaMek Team is licensed"
+              + " under CC BY-NC-SA 4.0.");
+
+        assertEquals(String.valueOf(CURRENT_YEAR), UnitFileResaver.copyrightYears(sourceFile));
+    }
+
+    @Test
+    void fileWithoutHeaderGetsCurrentYear() throws IOException {
+        File sourceFile = writeUnitFile("chassis:Archer");
+
+        assertEquals(String.valueOf(CURRENT_YEAR), UnitFileResaver.copyrightYears(sourceFile));
+    }
+
+    @Test
+    void missingSourceGetsCurrentYear() {
+        assertEquals(String.valueOf(CURRENT_YEAR), UnitFileResaver.copyrightYears(null));
+        assertEquals(String.valueOf(CURRENT_YEAR),
+              UnitFileResaver.copyrightYears(tempDir.resolve("DoesNotExist.mtf").toFile()));
+    }
+}


### PR DESCRIPTION
The resaver stamped every file with the current year alone, throwing away whatever year the file already had. A full resave in July 2026 flattened 10,884 files from 2025-2026 back to 2026, undoing an earlier deliberate fix. Any future resave would do it again.

Root cause: LICENSE_HEADER was a static final constant built once from Calendar.getInstance().get(Calendar.YEAR), so the header written to every file was fixed at class-load time and never looked at the source.

Fix: build the header per file. Read the first copyright year out of the source file and emit a start-end range when that year is earlier than the current one. Files with no readable header, and units loaded from inside an archive, still get the current year on its own.