### PR TITLE
Fixed drifting cost labels and fixed some rounding errors

### DIFF
--- a/megamek/src/megamek/client/ui/clientGUI/calculationReport/CalculationReport.java
+++ b/megamek/src/megamek/client/ui/clientGUI/calculationReport/CalculationReport.java
@@ -69,6 +69,22 @@ public interface CalculationReport {
      */
     CalculationReport addLine(@Nullable String type, @Nullable String calculation, @Nullable String result);
 
+        /**
+         * Adds a line that provides inputs or context but is not itself part of a report's running total.
+         * Display-oriented reports render this exactly like a regular line; structured report implementations may retain
+         * the semantic distinction.
+         *
+         * @param type        The first element of this line
+         * @param calculation A calculation or other info
+         * @param result      A result or other info displayed on the right side
+         *
+         * @return The CalculationReport itself
+         */
+        default CalculationReport addInformationalLine(@Nullable String type, @Nullable String calculation,
+                    @Nullable String result) {
+                return addLine(type, calculation, result);
+        }
+
     /**
      * Adds a single line to the CalculationReport. This method performs rounding to a single decimal digit on the
      * result and writes resultPrefix in front of it.

--- a/megamek/src/megamek/common/battleValue/HeatTrackingBVCalculator.java
+++ b/megamek/src/megamek/common/battleValue/HeatTrackingBVCalculator.java
@@ -188,14 +188,7 @@ public abstract class HeatTrackingBVCalculator extends BVCalculator {
         }
 
         // 1d6 extra heat; add half for heat calculations (1d3/+2 for small pulse)
-        if ((wType instanceof ISERLaserLargePrototype)
-              || (wType instanceof ISPulseLaserLargePrototype)
-              || (wType instanceof ISPulseLaserMediumPrototype)
-              || (wType instanceof ISPulseLaserMediumRecovered)) {
-            weaponHeat += 3;
-        } else if (wType instanceof ISPulseLaserSmallPrototype) {
-            weaponHeat += 2;
-        }
+        weaponHeat += wType.getHeatAdjustmentForBvCalculation();
 
         // RISC laser pulse module adds 2 heat
         if ((wType.hasFlag(WeaponType.F_LASER)) && (weapon.getLinkedBy() != null)

--- a/megamek/src/megamek/common/cost/CombatVehicleCostCalculator.java
+++ b/megamek/src/megamek/common/cost/CombatVehicleCostCalculator.java
@@ -268,7 +268,8 @@ public class CombatVehicleCostCalculator {
         ArrayList<String> left = getLeft(tank);
         String[] systemNames = left.toArray(new String[0]);
         long roundedCost = Math.round(cost);
-        CostCalculator.fillInReport(costReport, tank, ignoreAmmo, systemNames, equipmentIndex, roundedCost, costs);
+          CostCalculator.fillInReport(costReport, tank, ignoreAmmo, systemNames, equipmentIndex, structCostIdx,
+              roundedCost, costs);
         return roundedCost;
     }
 

--- a/megamek/src/megamek/common/cost/CombatVehicleCostCalculator.java
+++ b/megamek/src/megamek/common/cost/CombatVehicleCostCalculator.java
@@ -265,8 +265,9 @@ public class CombatVehicleCostCalculator {
 
         ArrayList<String> left = getLeft(tank);
         String[] systemNames = left.toArray(new String[0]);
-        CostCalculator.fillInReport(costReport, tank, ignoreAmmo, systemNames, 7, cost, costs);
-        return Math.round(cost);
+        long roundedCost = Math.round(cost);
+        CostCalculator.fillInReport(costReport, tank, ignoreAmmo, systemNames, 7, roundedCost, costs);
+        return roundedCost;
     }
 
     private static ArrayList<String> getLeft(Tank tank) {

--- a/megamek/src/megamek/common/cost/CombatVehicleCostCalculator.java
+++ b/megamek/src/megamek/common/cost/CombatVehicleCostCalculator.java
@@ -183,6 +183,7 @@ public class CombatVehicleCostCalculator {
         costs[i++] = 2000 * Math.max(0, sinks - freeHeatSinks);
         costs[i++] = turretWeight * 5000;
 
+        int equipmentIndex = i;
         costs[i++] = CostCalculator.getWeaponsAndEquipmentCost(tank, ignoreAmmo) + tank.getExtraCrewSeats() * 100L;
 
         if (!tank.isSupportVehicle()) {
@@ -255,7 +256,8 @@ public class CombatVehicleCostCalculator {
                   || tank.hasWorkingMisc(MiscType.F_ENVIRONMENTAL_SEALING)) {
                 cost *= 1.25;
                 costs[i++] = -1.25;
-
+            } else {
+                costs[i++] = 0;
             }
             if (tank.hasWorkingMisc(MiscType.F_OFF_ROAD)) {
                 cost *= 1.2;
@@ -266,7 +268,7 @@ public class CombatVehicleCostCalculator {
         ArrayList<String> left = getLeft(tank);
         String[] systemNames = left.toArray(new String[0]);
         long roundedCost = Math.round(cost);
-        CostCalculator.fillInReport(costReport, tank, ignoreAmmo, systemNames, 7, roundedCost, costs);
+        CostCalculator.fillInReport(costReport, tank, ignoreAmmo, systemNames, equipmentIndex, roundedCost, costs);
         return roundedCost;
     }
 
@@ -276,7 +278,13 @@ public class CombatVehicleCostCalculator {
             left.add("Chassis");
         }
         left.add("Engine");
-        left.add("Armor");
+        if (tank.hasPatchworkArmor()) {
+            for (int location = 0; location < tank.locations(); location++) {
+                left.add("Armor (" + tank.getLocationAbbr(location) + ")");
+            }
+        } else {
+            left.add("Armor");
+        }
         if (tank.isSupportVehicle()) {
             left.add("Final Structural Cost");
         } else {

--- a/megamek/src/megamek/common/cost/CostCalculator.java
+++ b/megamek/src/megamek/common/cost/CostCalculator.java
@@ -208,6 +208,17 @@ public class CostCalculator {
      */
     static void fillInReport(CalculationReport costReport, Entity entity, boolean ignoreAmmo,
           String[] systemNames, int equipIndex, double cost, double[] costs) {
+          fillInReport(costReport, entity, ignoreAmmo, systemNames, equipIndex, 0, cost, costs);
+        }
+
+        /**
+         * Fills in a cost report while identifying leading rows that are inputs to a later rolled-up cost rather than
+         * independently additive costs.
+         *
+         * @param costStartIndex the first system-cost index included directly in the unit's running total
+         */
+        static void fillInReport(CalculationReport costReport, Entity entity, boolean ignoreAmmo,
+            String[] systemNames, int equipIndex, int costStartIndex, double cost, double[] costs) {
         NumberFormat commaFormatter = NumberFormat.getInstance();
         commaFormatter.setMaximumFractionDigits(10);
         costReport.addHeader("Cost Calculations For " + entity.getChassis() + " " + entity.getModel());
@@ -225,7 +236,11 @@ public class CostCalculator {
                 } else if (costs[l] < 0) {
                     result = "x " + commaFormatter.format(-costs[l]);
                 }
-                costReport.addLine(systemNames[l], "", result);
+                if (l < costStartIndex) {
+                    costReport.addInformationalLine(systemNames[l], "", result);
+                } else {
+                    costReport.addLine(systemNames[l], "", result);
+                }
             }
         }
         costReport.addResultLine("Total Cost:", "", commaFormatter.format(cost));

--- a/megamek/src/megamek/common/cost/CostCalculator.java
+++ b/megamek/src/megamek/common/cost/CostCalculator.java
@@ -47,6 +47,7 @@ import megamek.common.equipment.ArmorType;
 import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
 import megamek.common.units.Entity;
+import megamek.common.units.Tank;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
 public class CostCalculator {
@@ -208,10 +209,15 @@ public class CostCalculator {
     static void fillInReport(CalculationReport costReport, Entity entity, boolean ignoreAmmo,
           String[] systemNames, int equipIndex, double cost, double[] costs) {
         NumberFormat commaFormatter = NumberFormat.getInstance();
+        commaFormatter.setMaximumFractionDigits(10);
         costReport.addHeader("Cost Calculations For " + entity.getChassis() + " " + entity.getModel());
         for (int l = 0; l < systemNames.length; l++) {
             if (l == equipIndex) {
                 CostCalculator.getWeaponsAndEquipmentCost(entity, costReport, ignoreAmmo);
+                if ((entity instanceof Tank tank) && (tank.getExtraCrewSeats() > 0)) {
+                    costReport.addLine("Extra Crew Seats", "",
+                          commaFormatter.format(tank.getExtraCrewSeats() * 100L));
+                }
             } else {
                 String result = commaFormatter.format(costs[l]);
                 if (costs[l] == 0) {

--- a/megamek/src/megamek/common/cost/DropShipCostCalculator.java
+++ b/megamek/src/megamek/common/cost/DropShipCostCalculator.java
@@ -47,10 +47,12 @@ public class DropShipCostCalculator {
 
         // Docking Collar
         if (dropShip.getCollarType() == Dropship.COLLAR_STANDARD) {
-            costs[idx++] = 10000;
+            costs[idx] = 10000;
         } else if (dropShip.getCollarType() == Dropship.COLLAR_PROTOTYPE) {
-            costs[idx++] = 1010000;
+            costs[idx] = 1010000;
         }
+        // Keep the fixed report columns aligned when no docking collar is installed.
+        idx++;
 
         // Transport Bays
         int bayDoors = 0;
@@ -80,7 +82,8 @@ public class DropShipCostCalculator {
                                  "Engine", "Drive Unit", "Fuel Tanks", "Armor", "Heat Sinks", "Weapons/Equipment",
                                  "Docking Collar",
                                  "Bays", "Quarters", "Life Boats/Escape Pods", "Final Multiplier" };
-        CostCalculator.fillInReport(costReport, dropShip, ignoreAmmo, systemNames, 14, cost, costs);
-        return Math.round(cost);
+        long roundedCost = Math.round(cost);
+        CostCalculator.fillInReport(costReport, dropShip, ignoreAmmo, systemNames, 14, roundedCost, costs);
+        return roundedCost;
     }
 }

--- a/megamek/src/megamek/common/cost/FixedWingSupportCostCalculator.java
+++ b/megamek/src/megamek/common/cost/FixedWingSupportCostCalculator.java
@@ -129,6 +129,7 @@ public class FixedWingSupportCostCalculator {
         costs[i++] = 20000 * paWeight;
         costs[i++] = 2000 * Math.max(0, sinks - freeHeatSinks);
 
+        int equipmentIndex = i;
         costs[i++] = CostCalculator.getWeaponsAndEquipmentCost(fixedWingSupport, ignoreAmmo);
 
         double cost = 0; // calculate the total
@@ -163,7 +164,7 @@ public class FixedWingSupportCostCalculator {
         systemNames.add("Tonnage Multiplier");
         long roundedCost = Math.round(cost);
         CostCalculator.fillInReport(costReport, fixedWingSupport, ignoreAmmo,
-              systemNames.toArray(new String[0]), structCostIdx + 3, roundedCost, costs);
+              systemNames.toArray(new String[0]), equipmentIndex, structCostIdx, roundedCost, costs);
         return roundedCost;
     }
 }

--- a/megamek/src/megamek/common/cost/FixedWingSupportCostCalculator.java
+++ b/megamek/src/megamek/common/cost/FixedWingSupportCostCalculator.java
@@ -33,6 +33,8 @@
 
 package megamek.common.cost;
 
+import java.util.ArrayList;
+
 import megamek.client.ui.clientGUI.calculationReport.CalculationReport;
 import megamek.common.equipment.Engine;
 import megamek.common.units.EntityWeightClass;
@@ -143,10 +145,25 @@ public class FixedWingSupportCostCalculator {
         cost *= fixedWingSupport.getPriceMultiplier();
         costs[i] = -fixedWingSupport.getPriceMultiplier();
 
-        String[] systemNames = { "Chassis", "Engine", "Armor", "Final Structural Cost", "Power Amplifiers",
-                                 "Heat Sinks", "Equipment", "Omni Multiplier", "Tonnage Multiplier" };
+        ArrayList<String> systemNames = new ArrayList<>();
+        systemNames.add("Chassis");
+        systemNames.add("Engine");
+        if (fixedWingSupport.hasPatchworkArmor()) {
+            for (int location = 0; location < fixedWingSupport.locations(); location++) {
+                systemNames.add("Armor (" + fixedWingSupport.getLocationAbbr(location) + ")");
+            }
+        } else {
+            systemNames.add("Armor");
+        }
+        systemNames.add("Final Structural Cost");
+        systemNames.add("Power Amplifiers");
+        systemNames.add("Heat Sinks");
+        systemNames.add("Equipment");
+        systemNames.add("Omni Multiplier");
+        systemNames.add("Tonnage Multiplier");
         long roundedCost = Math.round(cost);
-        CostCalculator.fillInReport(costReport, fixedWingSupport, ignoreAmmo, systemNames, 6, roundedCost, costs);
+        CostCalculator.fillInReport(costReport, fixedWingSupport, ignoreAmmo,
+              systemNames.toArray(new String[0]), structCostIdx + 3, roundedCost, costs);
         return roundedCost;
     }
 }

--- a/megamek/src/megamek/common/cost/FixedWingSupportCostCalculator.java
+++ b/megamek/src/megamek/common/cost/FixedWingSupportCostCalculator.java
@@ -145,7 +145,8 @@ public class FixedWingSupportCostCalculator {
 
         String[] systemNames = { "Chassis", "Engine", "Armor", "Final Structural Cost", "Power Amplifiers",
                                  "Heat Sinks", "Equipment", "Omni Multiplier", "Tonnage Multiplier" };
-        CostCalculator.fillInReport(costReport, fixedWingSupport, ignoreAmmo, systemNames, 6, cost, costs);
-        return Math.round(cost);
+        long roundedCost = Math.round(cost);
+        CostCalculator.fillInReport(costReport, fixedWingSupport, ignoreAmmo, systemNames, 6, roundedCost, costs);
+        return roundedCost;
     }
 }

--- a/megamek/src/megamek/common/equipment/MiscType.java
+++ b/megamek/src/megamek/common/equipment/MiscType.java
@@ -908,24 +908,24 @@ public class MiscType extends EquipmentType {
             } else if (hasFlag(F_FLOTATION_HULL) || hasFlag(F_ENVIRONMENTAL_SEALING) || hasFlag(F_OFF_ROAD)) {
                 costValue = 0;
             } else if (hasFlag(F_LIMITED_AMPHIBIOUS) || hasFlag((F_FULLY_AMPHIBIOUS))) {
-                costValue = getTonnage(entity, loc) * 10000;
+                costValue = getTonnage(entity, loc, size) * 10000;
             } else if (hasFlag(F_DUNE_BUGGY)) {
-                double totalTons = getTonnage(entity, loc);
+                double totalTons = getTonnage(entity, loc, size);
                 costValue = 10 * totalTons * totalTons;
             } else if (hasFlag(F_MASC) && hasFlag(F_BA_EQUIPMENT)) {
                 costValue = entity.getRunMP() * 75000;
             } else if (hasFlag(F_HEAD_TURRET) || hasFlag(F_SHOULDER_TURRET) || hasFlag(F_QUAD_TURRET)) {
-                costValue = getTonnage(entity, loc) * 10000;
+                costValue = getTonnage(entity, loc, size) * 10000;
             } else if (hasFlag(F_SPONSON_TURRET)) {
-                costValue = getTonnage(entity, loc) * 4000;
+                costValue = getTonnage(entity, loc, size) * 4000;
             } else if (hasFlag(F_PINTLE_TURRET)) {
-                costValue = getTonnage(entity, loc) * 1000;
+                costValue = getTonnage(entity, loc, size) * 1000;
             } else if (hasFlag(F_ARMORED_MOTIVE_SYSTEM)) {
-                costValue = getTonnage(entity, loc) * 100000;
+                costValue = getTonnage(entity, loc, size) * 100000;
             } else if (is(EquipmentTypeLookup.BA_MANIPULATOR_CARGO_LIFTER)) {
                 return 250 * Math.ceil(size * 2);
             } else if (hasFlag(F_DRONE_OPERATING_SYSTEM)) {
-                costValue = (getTonnage(entity, loc) * 10000) + 5000;
+                costValue = (getTonnage(entity, loc, size) * 10000) + 5000;
             } else if (hasFlag(MiscType.F_MASC)) {
                 if (entity instanceof ProtoMek) {
                     costValue = Math.round((entity.hasEngine() ? entity.getEngine().getRating() : 0) *
@@ -984,30 +984,30 @@ public class MiscType extends EquipmentType {
                       (entity.hasEngine() ? entity.getEngine().getRating() : 0) *
                       entity.getWeight()) / 75);
             } else if (hasFlag(MiscType.F_TALON)) {
-                costValue = (int) Math.ceil(getTonnage(entity, loc) * 300);
+                costValue = (int) Math.ceil(getTonnage(entity, loc, size) * 300);
             } else if (hasFlag(MiscType.F_SPIKES)) {
                 costValue = (int) Math.ceil(entity.getWeight() * 50);
             } else if (hasFlag(MiscType.F_PARTIAL_WING)) {
-                costValue = (int) Math.ceil(getTonnage(entity, loc) * 50000);
+                costValue = (int) Math.ceil(getTonnage(entity, loc, size) * 50000);
             } else if (hasFlag(MiscType.F_ACTUATOR_ENHANCEMENT_SYSTEM)) {
                 int multiplier = entity.locationIsLeg(loc) ? 700 : 500;
                 costValue = (int) Math.ceil(entity.getWeight() * multiplier);
             } else if (hasFlag(MiscType.F_HAND_WEAPON) && (hasFlag(MiscTypeFlag.S_CLAW))) {
                 costValue = (int) Math.ceil(entity.getWeight() * 200);
             } else if (hasFlag(F_LIGHT_SAIL)) {
-                costValue = getTonnage(entity, loc) * 10000;
+                costValue = getTonnage(entity, loc, size) * 10000;
             } else if (hasFlag(F_NAVAL_C3)) {
-                costValue = getTonnage(entity, loc) * 100000;
+                costValue = getTonnage(entity, loc, size) * 100000;
 
                 // TODO NEO- Not sure how to add in the base control weights see IO pg 187
             } else if (hasFlag(MiscType.F_SRCS)) {
-                costValue = (getTonnage(entity, loc) * 10000) + 5000;
+                costValue = (getTonnage(entity, loc, size) * 10000) + 5000;
             } else if (hasFlag(MiscType.F_SASRCS)) {
-                costValue = (getTonnage(entity, loc) * 12500) + 6250;
+                costValue = (getTonnage(entity, loc, size) * 12500) + 6250;
             } else if (hasFlag(MiscType.F_CASPAR)) {
-                costValue = (getTonnage(entity, loc) * 50000) + 500000;
+                costValue = (getTonnage(entity, loc, size) * 50000) + 500000;
             } else if (hasFlag(MiscType.F_CASPAR_II)) {
-                costValue = (getTonnage(entity, loc) * 20000) + 50000;
+                costValue = (getTonnage(entity, loc, size) * 20000) + 50000;
             } else if (hasFlag(MiscType.F_ATAC)) {
                 costValue = (getTonnage(entity, loc, size) * 100000);
             } else if (hasFlag(MiscType.F_DTAC)) {
@@ -1041,7 +1041,7 @@ public class MiscType extends EquipmentType {
             } else if (hasFlag(F_COMMUNICATIONS)) {
                 costValue = size * 10000;
             } else if (hasFlag(F_RAM_PLATE)) {
-                costValue = getTonnage(entity, loc) * 10000;
+                costValue = getTonnage(entity, loc, size) * 10000;
             } else if (hasFlag(F_DAMAGE_INTERRUPT_CIRCUIT)) {
                 // DIC costs 150 C-bills per pilot seat (IO p.39)
                 if (entity.getCrew() != null) {

--- a/megamek/src/megamek/common/equipment/WeaponType.java
+++ b/megamek/src/megamek/common/equipment/WeaponType.java
@@ -577,6 +577,7 @@ public class WeaponType extends EquipmentType {
     public static final WeaponTypeFlag F_MML = WeaponTypeFlag.F_MML;
     public static final WeaponTypeFlag F_MRM = WeaponTypeFlag.F_MRM;
     public static final WeaponTypeFlag F_ATM = WeaponTypeFlag.F_ATM;
+    public static final WeaponTypeFlag F_NARC = WeaponTypeFlag.F_NARC;
     
 
     // War of 3039 prototypes

--- a/megamek/src/megamek/common/equipment/WeaponType.java
+++ b/megamek/src/megamek/common/equipment/WeaponType.java
@@ -753,6 +753,7 @@ public class WeaponType extends EquipmentType {
 
     // protected RangeType rangeL;
     protected int heat;
+    protected int heatAdjustmentForBvCalculation = 0; // This is added/subtracted to the heat calculation for BV (used by Prototype IS Pulse Lasers)
     protected int damage;
     protected int damageShort;
     protected int damageMedium;
@@ -833,6 +834,11 @@ public class WeaponType extends EquipmentType {
     public int getHeat() {
         return heat;
     }
+
+    /**
+     * Returns the adjustement of heat used for BV calculation
+     */
+    public int getHeatAdjustmentForBvCalculation() { return  heatAdjustmentForBvCalculation; }
 
     @Override
     public boolean hasFlag(EquipmentFlag flag) {
@@ -2560,6 +2566,7 @@ public class WeaponType extends EquipmentType {
         Map<String, Object> data = super.getYamlData();
         Map<String, Object> weapon = new LinkedHashMap<>();
 
+
         weapon.put("damage", formatDamage());
         if (explosionDamage > 0) {
             weapon.put("explosionDamage", explosionDamage);
@@ -2571,6 +2578,9 @@ public class WeaponType extends EquipmentType {
         weapon.put("ammoType", ammoType.name());
         if (heat > 0) {
             weapon.put("heat", this.heat);
+        }
+        if (heatAdjustmentForBvCalculation != 0) {
+            weapon.put("heatAdjustmentForBvCalculation", this.heatAdjustmentForBvCalculation);
         }
 
         // Export ranges (trimmed of trailing zeros)

--- a/megamek/src/megamek/common/equipment/WeaponTypeFlag.java
+++ b/megamek/src/megamek/common/equipment/WeaponTypeFlag.java
@@ -155,4 +155,5 @@ public enum WeaponTypeFlag implements EquipmentFlag {
     F_MML,
     F_MRM,
     F_ATM,
+    F_NARC
 }

--- a/megamek/src/megamek/common/weapons/other/NarcWeapon.java
+++ b/megamek/src/megamek/common/weapons/other/NarcWeapon.java
@@ -68,7 +68,7 @@ public abstract class NarcWeapon extends MissileWeapon {
      */
     public NarcWeapon() {
         super();
-        flags = flags.or(F_NO_FIRES).or(F_PROTO_WEAPON);
+        flags = flags.or(F_NO_FIRES).or(F_PROTO_WEAPON).or(F_NARC);
         ammoType = AmmoType.AmmoTypeEnum.NARC;
     }
 

--- a/megamek/src/megamek/common/weapons/prototypes/innerSphere/ISERLaserLargePrototype.java
+++ b/megamek/src/megamek/common/weapons/prototypes/innerSphere/ISERLaserLargePrototype.java
@@ -70,6 +70,7 @@ public class ISERLaserLargePrototype extends LaserWeapon {
         toHitModifier = 1;
         flags = flags.or(F_PROTOTYPE);
         heat = 12;
+        heatAdjustmentForBvCalculation = 3;
         damage = 8;
         shortRange = 7;
         mediumRange = 14;

--- a/megamek/src/megamek/common/weapons/prototypes/innerSphere/ISPulseLaserLargePrototype.java
+++ b/megamek/src/megamek/common/weapons/prototypes/innerSphere/ISPulseLaserLargePrototype.java
@@ -70,6 +70,7 @@ public class ISPulseLaserLargePrototype extends PulseLaserWeapon {
         shortName = "Large Pulse Laser (P)";
         flags = flags.or(F_PROTOTYPE);
         heat = 10;
+        heatAdjustmentForBvCalculation = 3;
         damage = 9;
         toHitModifier = -1;
         shortRange = 3;

--- a/megamek/src/megamek/common/weapons/prototypes/innerSphere/ISPulseLaserMediumPrototype.java
+++ b/megamek/src/megamek/common/weapons/prototypes/innerSphere/ISPulseLaserMediumPrototype.java
@@ -79,6 +79,7 @@ public class ISPulseLaserMediumPrototype extends PulseLaserWeapon {
         shortName = "Medium Pulse Laser (P)";
         flags = flags.or(F_PROTOTYPE);
         heat = 4;
+        heatAdjustmentForBvCalculation = 3;
         damage = 6;
         toHitModifier = -1;
         shortRange = 2;

--- a/megamek/src/megamek/common/weapons/prototypes/innerSphere/ISPulseLaserMediumRecovered.java
+++ b/megamek/src/megamek/common/weapons/prototypes/innerSphere/ISPulseLaserMediumRecovered.java
@@ -78,6 +78,7 @@ public class ISPulseLaserMediumRecovered extends PulseLaserWeapon {
         shortName = "Medium Pulse Laser (P)";
         flags = flags.or(F_PROTOTYPE);
         heat = 4;
+        heatAdjustmentForBvCalculation = 3;
         damage = 6;
         toHitModifier = -2;
         shortRange = 2;

--- a/megamek/src/megamek/common/weapons/prototypes/innerSphere/ISPulseLaserSmallPrototype.java
+++ b/megamek/src/megamek/common/weapons/prototypes/innerSphere/ISPulseLaserSmallPrototype.java
@@ -70,6 +70,7 @@ public class ISPulseLaserSmallPrototype extends PulseLaserWeapon {
         this.addLookupName("ISSmall Pulse Laser Prototype");
         shortName = "Small Pulse Laser (P)";
         this.heat = 2;
+        this.heatAdjustmentForBvCalculation = 2;
         this.damage = 3;
         this.infDamageClass = WeaponType.WEAPON_BURST_2D6;
         this.toHitModifier = -1;

--- a/megamek/unittests/megamek/common/cost/CostCalculatorReportTest.java
+++ b/megamek/unittests/megamek/common/cost/CostCalculatorReportTest.java
@@ -13,7 +13,6 @@ package megamek.common.cost;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.File;
 import java.text.NumberFormat;
@@ -23,9 +22,12 @@ import java.util.Map;
 import megamek.client.ui.clientGUI.calculationReport.CalculationReport;
 import megamek.client.ui.clientGUI.calculationReport.DummyCalculationReport;
 import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.MiscType;
+import megamek.common.equipment.Mounted;
 import megamek.common.loaders.MekFileParser;
 import megamek.common.units.Dropship;
 import megamek.common.units.Entity;
+import megamek.common.units.Mek;
 import megamek.common.units.Tank;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -50,6 +52,46 @@ class CostCalculatorReportTest {
         assertNotNull(report.result("Engine"));
         assertNotNull(report.result("Armor"));
         assertEquals(NumberFormat.getInstance().format(returnedCost), report.total());
+    }
+
+    @Test
+    void combatVehicleReportKeepsOffRoadMultiplierInItsOwnColumn() throws Exception {
+        Tank tank = assertInstanceOf(Tank.class, loadUnit("Bulldog Medium Tank.blk"));
+        tank.addEquipment(EquipmentType.get("ISOffRoadChassis"), Tank.LOC_BODY);
+        RecordingCalculationReport report = new RecordingCalculationReport();
+
+        double returnedCost = CombatVehicleCostCalculator.calculateCost(tank, report, true);
+
+        assertEquals("N/A", report.result("Flotation Hull/Environmental Sealing multiplier"));
+        assertEquals("x 1.2", report.result("Off-Road Multiplier"));
+        assertReportTotalMatchesReturnedCost(returnedCost, report);
+    }
+
+    @Test
+    void combatVehicleReportExplainsExtraCrewSeatCost() throws Exception {
+        Tank tank = assertInstanceOf(Tank.class, loadUnit("Bulldog Medium Tank.blk"));
+        tank.setExtraCrewSeats(3);
+        RecordingCalculationReport report = new RecordingCalculationReport();
+
+        double returnedCost = CombatVehicleCostCalculator.calculateCost(tank, report, true);
+
+        assertEquals("300", report.result("Extra Crew Seats"));
+        assertReportTotalMatchesReturnedCost(returnedCost, report);
+    }
+
+    @Test
+    void variableTurretCostUsesTheMountedLocation() throws Exception {
+        Mek mek = assertInstanceOf(Mek.class, loadUnit("Quickdraw QKD-8X.mtf"));
+        RecordingCalculationReport report = new RecordingCalculationReport();
+
+        double returnedCost = MekCostCalculator.calculateCost(mek, report, true);
+
+        Mounted<?> headTurret = mek.getMisc().stream()
+              .filter(mount -> mount.getType().hasFlag(MiscType.F_HEAD_TURRET))
+              .findFirst()
+              .orElseThrow();
+        assertEquals(10000, headTurret.getCost());
+        assertReportTotalMatchesReturnedCost(returnedCost, report);
     }
 
     @Test
@@ -85,6 +127,10 @@ class CostCalculatorReportTest {
 
     private static void assertReportTotalMatchesReturnedCost(CostRun run) {
         assertEquals(NumberFormat.getInstance().format(run.cost()), run.report().total());
+    }
+
+    private static void assertReportTotalMatchesReturnedCost(double cost, RecordingCalculationReport report) {
+        assertEquals(NumberFormat.getInstance().format(cost), report.total());
     }
 
     private static Entity loadUnit(String filename) throws Exception {

--- a/megamek/unittests/megamek/common/cost/CostCalculatorReportTest.java
+++ b/megamek/unittests/megamek/common/cost/CostCalculatorReportTest.java
@@ -49,9 +49,6 @@ class CostCalculatorReportTest {
         assertNotNull(report.result("Chassis"));
         assertNotNull(report.result("Engine"));
         assertNotNull(report.result("Armor"));
-        assertNull(report.result("Chassis"));
-        assertNull(report.result("Engine"));
-        assertNull(report.result("Armor"));
         assertEquals(NumberFormat.getInstance().format(returnedCost), report.total());
     }
 

--- a/megamek/unittests/megamek/common/cost/CostCalculatorReportTest.java
+++ b/megamek/unittests/megamek/common/cost/CostCalculatorReportTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ */
+package megamek.common.cost;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.File;
+import java.text.NumberFormat;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import megamek.client.ui.clientGUI.calculationReport.CalculationReport;
+import megamek.client.ui.clientGUI.calculationReport.DummyCalculationReport;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.loaders.MekFileParser;
+import megamek.common.units.Dropship;
+import megamek.common.units.Entity;
+import megamek.common.units.Tank;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class CostCalculatorReportTest {
+    private static final String UNIT_PATH = "testresources/megamek/common/units/";
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    @Test
+    void supportVehicleReportIdentifiesStructuralInputsAndUsesRoundedTotal() throws Exception {
+        Tank supportVehicle = assertInstanceOf(Tank.class, loadUnit("Dromedary Water Transport.blk"));
+        RecordingCalculationReport report = new RecordingCalculationReport();
+
+        double returnedCost = CombatVehicleCostCalculator.calculateCost(supportVehicle, report, true);
+
+        assertNotNull(report.result("Final Structural Cost"));
+        assertNotNull(report.result("Chassis"));
+        assertNotNull(report.result("Engine"));
+        assertNotNull(report.result("Armor"));
+        assertNull(report.result("Chassis"));
+        assertNull(report.result("Engine"));
+        assertNull(report.result("Armor"));
+        assertEquals(NumberFormat.getInstance().format(returnedCost), report.total());
+    }
+
+    @Test
+    void dropShipReportColumnsRemainAlignedForEveryDockingCollarType() throws Exception {
+        CostRun noCollar = calculateDropShipCost(Dropship.COLLAR_NO_BOOM);
+        CostRun standard = calculateDropShipCost(Dropship.COLLAR_STANDARD);
+        CostRun prototype = calculateDropShipCost(Dropship.COLLAR_PROTOTYPE);
+
+        assertEquals("N/A", noCollar.report().result("Docking Collar"));
+        assertEquals(NumberFormat.getInstance().format(10000), standard.report().result("Docking Collar"));
+        assertEquals(NumberFormat.getInstance().format(1010000), prototype.report().result("Docking Collar"));
+        assertEquals(noCollar.report().result("Bays"), standard.report().result("Bays"));
+        assertEquals(noCollar.report().result("Bays"), prototype.report().result("Bays"));
+        assertEquals(noCollar.report().result("Quarters"), standard.report().result("Quarters"));
+        assertEquals(noCollar.report().result("Life Boats/Escape Pods"),
+              standard.report().result("Life Boats/Escape Pods"));
+        assertEquals("x 28", noCollar.report().result("Final Multiplier"));
+        assertEquals("x 28", standard.report().result("Final Multiplier"));
+        assertEquals("x 28", prototype.report().result("Final Multiplier"));
+        assertEquals(280000, standard.cost() - noCollar.cost());
+        assertEquals(28280000, prototype.cost() - noCollar.cost());
+        assertReportTotalMatchesReturnedCost(noCollar);
+        assertReportTotalMatchesReturnedCost(standard);
+        assertReportTotalMatchesReturnedCost(prototype);
+    }
+
+    private static CostRun calculateDropShipCost(int collarType) throws Exception {
+        Dropship dropShip = assertInstanceOf(Dropship.class, loadUnit("Union (3055).blk"));
+        dropShip.setCollarType(collarType);
+        RecordingCalculationReport report = new RecordingCalculationReport();
+        return new CostRun(DropShipCostCalculator.calculateCost(dropShip, report, true), report);
+    }
+
+    private static void assertReportTotalMatchesReturnedCost(CostRun run) {
+        assertEquals(NumberFormat.getInstance().format(run.cost()), run.report().total());
+    }
+
+    private static Entity loadUnit(String filename) throws Exception {
+        return new MekFileParser(new File(UNIT_PATH + filename)).getEntity();
+    }
+
+    private record CostRun(double cost, RecordingCalculationReport report) {}
+
+    private static final class RecordingCalculationReport extends DummyCalculationReport {
+        private final Map<String, String> results = new LinkedHashMap<>();
+        private String total;
+
+        @Override
+        public CalculationReport addLine(String type, String calculation, String result) {
+            results.put(type, result);
+            return this;
+        }
+
+        @Override
+        public CalculationReport addResultLine(String type, String calculation, String result) {
+            if ("Total Cost:".equals(type)) {
+                total = result;
+            }
+            return this;
+        }
+
+        String result(String type) {
+            return results.get(type);
+        }
+
+        String total() {
+            return total;
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes a label drift for costs visualized in the Cost Report (f.e. in dropships) and also some rounding mismatches between effective values used and report-displayed values.

extra sub PR for MekBay: added F_NARC family flag and exported the heatAdjustmentForBvCalculation (Prototype IS Pulse Lasers) 