### PR TITLE
String Comparison Optimization in Chat Processing & Equipment Type

### DIFF
--- a/megamek/src/megamek/client/bot/ChatProcessor.java
+++ b/megamek/src/megamek/client/bot/ChatProcessor.java
@@ -221,8 +221,8 @@ public class ChatProcessor {
 
     private static void processChatCommand(Princess princess, String command, String[] arguments) {
         for (ChatCommands cmd : ChatCommands.values()) {
-            if (command.toLowerCase().equalsIgnoreCase(cmd.getAbbreviation()) ||
-                  command.toLowerCase().equalsIgnoreCase(cmd.getCommand())) {
+            if (command.equalsIgnoreCase(cmd.getAbbreviation()) ||
+                  command.equalsIgnoreCase(cmd.getCommand())) {
                 try {
                     Arguments args = ArgumentsParser.parse(arguments, cmd.getChatCommand().defineArguments());
                     LOGGER.info("{}: executing chat command {} with arguments {}",

--- a/megamek/src/megamek/common/equipment/EquipmentType.java
+++ b/megamek/src/megamek/common/equipment/EquipmentType.java
@@ -772,8 +772,8 @@ public class EquipmentType implements ITechnology {
     }
 
     /**
-     * Clears lookup identity inherited from a superclass constructor. 
-     * This must only be used before the equipment type is registered.
+     * Clears lookup identity inherited from a superclass constructor. This must only be used before the equipment type
+     * is registered.
      */
     protected void clearLookupNames() {
         if (registered) {
@@ -820,6 +820,7 @@ public class EquipmentType implements ITechnology {
      *
      * @param key      The internal name, lookup name, or display name
      * @param techBase The preferred tech base for an ambiguous display name
+     *
      * @return The matching equipment type, or null if there is none
      */
     public static @Nullable EquipmentType get(String key, @Nullable TechBase techBase) {
@@ -841,7 +842,7 @@ public class EquipmentType implements ITechnology {
         if (equipmentType == null) {
             // Display names are not lookup identities. This fallback is only needed when the caller supplied one.
             for (EquipmentType type : allTypes) {
-                if (type.getName().toLowerCase().equals(normalizedKey)) {
+                if (type.getName().equalsIgnoreCase(normalizedKey)) {
                     equipmentType = type;
                     break;
                 }
@@ -864,9 +865,10 @@ public class EquipmentType implements ITechnology {
 
     /**
      * Explicit structure lookup by name
-     * 
-     * @param key   String name
-     * @return      The matching Structure-specific Equipment Type.
+     *
+     * @param key String name
+     *
+     * @return The matching Structure-specific Equipment Type.
      */
     public static @Nullable StructureType getStructureFromName(String key) {
         if (key == null) {
@@ -883,7 +885,7 @@ public class EquipmentType implements ITechnology {
         // Fallback fullscan for display name
         for (EquipmentType type : allTypes) {
             if (type instanceof StructureType structureType) {
-                if (structureType.getName().toLowerCase().equals(normalizedKey)) {
+                if (structureType.getName().equalsIgnoreCase(normalizedKey)) {
                     return structureType;
                 }
             }
@@ -895,6 +897,7 @@ public class EquipmentType implements ITechnology {
      * Explicit armor lookup by name
      *
      * @param key String name
+     *
      * @return The matching Armor-specific Equipment Type, or null when the name is unknown
      */
     public static @Nullable ArmorType getArmorFromName(String key) {
@@ -912,7 +915,7 @@ public class EquipmentType implements ITechnology {
         // Fallback fullscan for display name
         for (EquipmentType type : allTypes) {
             if (type instanceof ArmorType armorType) {
-                if (armorType.getName().toLowerCase().equals(normalizedKey)) {
+                if (armorType.getName().equalsIgnoreCase(normalizedKey)) {
                     return armorType;
                 }
             }
@@ -1398,9 +1401,9 @@ public class EquipmentType implements ITechnology {
             stats.put("explosive", true);
         }
         if (hasHitModifiersByRange()) {
-            int[] toHitModifiersByRange = {getToHitModifierAtRange(null, RangeType.RANGE_SHORT),
-                getToHitModifierAtRange(null, RangeType.RANGE_MEDIUM),
-                getToHitModifierAtRange(null, RangeType.RANGE_LONG)
+            int[] toHitModifiersByRange = { getToHitModifierAtRange(null, RangeType.RANGE_SHORT),
+                                            getToHitModifierAtRange(null, RangeType.RANGE_MEDIUM),
+                                            getToHitModifierAtRange(null, RangeType.RANGE_LONG)
             };
             stats.put("toHitModifier", toHitModifiersByRange);
         } else if (toHitModifier != 0) {
@@ -1706,7 +1709,7 @@ public class EquipmentType implements ITechnology {
 
     /**
      * @return True if this equipment counts for the size and weight of a Targeting Computer, and benefits from it in
-     * the case of weapons. TM p.238, TO:AUE p.157
+     *       the case of weapons. TM p.238, TO:AUE p.157
      */
     public boolean relevantToTargetingComputer() {
         return false;


### PR DESCRIPTION
I am armed with a profiler and you bet I'm gonna use it.

This is an optimization pass to several String comparison calls. We were converting to lower case and then comparing the string with the (presumably lowercase) other String. Now we just compare ignoring case.

In a few places we were weirdly converting to lowercase and _then_ comparing ignoring case - rendering the expensive conversion to lowercase redundant.

This took parse time from around 40k ms to just 2 during my test process.