### PR TITLE
fix: player team name retrieval normalization (MM #8569)

### DIFF
--- a/megamek/src/megamek/client/ui/clientGUI/MapMenu.java
+++ b/megamek/src/megamek/client/ui/clientGUI/MapMenu.java
@@ -423,7 +423,7 @@ public class MapMenu extends JPopupMenu {
     }
 
     private JMenu createBotCommands(Player bot) {
-        JMenu menu = new JMenu(bot.getName() + " (" + Player.TEAM_NAMES[bot.getTeam()] + ")");
+        JMenu menu = new JMenu(bot.getName() + " (" + bot.getTeamName() + ")");
 
         JMenu prioritizeTargetUnitMenu = new JMenu(Messages.getString("Bot.commands.priority"));
         JMenu ignoreTargetMenu = new JMenu(Messages.getString("Bot.commands.ignore"));

--- a/megamek/src/megamek/client/ui/dialogs/RoundsInAirDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/RoundsInAirDialog.java
@@ -129,6 +129,10 @@ public class RoundsInAirDialog extends JDialog {
      * landing time, with the target hex and warhead listed as "Unknown". Safe to call repeatedly (e.g. on phase change).
      */
     public void refresh() {
+        // if we're not actually showing this control, there's no need to actually do a refresh
+        if (!isVisible()) {
+            return;
+        }
         tableModel.setRowCount(0);
         Game game = client.getGame();
         List<RoundRow> rows = new ArrayList<>();
@@ -181,8 +185,8 @@ public class RoundsInAirDialog extends JDialog {
         if (player == null) {
             return Messages.getString("RoundsInAirDialog.unknownPlayer");
         }
-        int team = player.getTeam();
-        return ((team >= 0) && (team < Player.TEAM_NAMES.length)) ? Player.TEAM_NAMES[team] : String.valueOf(team);
+        
+        return player.getTeamName();
     }
 
     private static String firingUnitName(Game game, int firingEntityId) {

--- a/megamek/src/megamek/client/ui/dialogs/unitDisplay/ExtraPanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitDisplay/ExtraPanel.java
@@ -385,14 +385,14 @@ class ExtraPanel extends PicMap implements ActionListener, ItemListener {
                 if (en.isNarcedBy(team) && !player.isObserver()) {
                     buff = new StringBuilder(Messages.getString("MekDisplay.NARCedBy"));
                     buff.append(player.getName())
-                          .append(" [").append(Player.TEAM_NAMES[team]).append(']');
+                          .append(" [").append(player.getTeamName()).append(']');
                     ((DefaultListModel<String>) narcList.getModel()).addElement(buff.toString());
                 }
 
                 if (en.isINarcedBy(team) && !player.isObserver()) {
                     buff = new StringBuilder(Messages.getString("MekDisplay.INarcHoming"));
                     buff.append(player.getName()).append(" [")
-                          .append(Player.TEAM_NAMES[team]).append("] ")
+                          .append(player.getTeamName()).append("] ")
                           .append(Messages.getString("MekDisplay.attached"))
                           .append('.');
                     ((DefaultListModel<String>) narcList.getModel()).addElement(buff.toString());

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/MekTableModel.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/MekTableModel.java
@@ -282,7 +282,7 @@ public class MekTableModel extends AbstractTableModel {
         result.append(UIUtil.fontHTML(owner.getColour().getColour())).append(owner.getName())
               .append("</FONT>").append(fontHTML()).append(sep).append("</FONT>")
               .append(UIUtil.fontHTML(isEnemy ? Color.RED : uiGreen()))
-              .append(Player.TEAM_NAMES[owner.getTeam()]);
+              .append(owner.getTeamName());
         return result.toString();
     }
 

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/PlayerTable.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/PlayerTable.java
@@ -221,7 +221,7 @@ class PlayerTable extends JTable {
             boolean isEnemy = lobby.localPlayer().isEnemyOf(player);
             Color color = isEnemy ? GUIPreferences.getInstance().getWarningColor() : uiGreen();
             result.append("<FONT").append(UIUtil.colorString(color)).append(">");
-            result.append(Player.TEAM_NAMES[player.getTeam()]);
+            result.append(player.getTeamName());
             result.append("</FONT>");
 
             // Deployment Position

--- a/megamek/src/megamek/common/Player.java
+++ b/megamek/src/megamek/common/Player.java
@@ -310,6 +310,14 @@ public final class Player extends TurnOrdered {
     public void setTeam(int team) {
         this.team = team;
     }
+    
+    public String getTeamName() {
+        if (getTeam() <= TEAM_NONE) {
+            return "No Team";
+        }
+        
+        return "Team " + getTeam();
+    }
 
     public boolean isDone() {
         return done;
@@ -1008,15 +1016,12 @@ public final class Player extends TurnOrdered {
     }
 
     public String getColoredPlayerNameWithTeam() {
-        if (team == -1) {
-            team = 0;
-        }
         return "<B><font color='" +
               getColour().getHexString(0x00F0F0F0) +
               "'>" +
               getName() +
               " (" +
-              TEAM_NAMES[team] +
+              getTeamName() +
               ")</font></B>";
     }
 


### PR DESCRIPTION
Added a "getTeamName" function to the Player class which returns the team name with lower bound safety check and no upper bound. So now you can just call that instead of calling "Player.TEAM_NAMES[player.getTeam()]"

Also a minor optimization to the RoundsInAirDialog, which was refreshing many times per round even when the dialog wasn't visible.

Fixes #8569 