### PR TITLE
Fixing missing analysis tab

### DIFF
--- a/megamek/src/megamek/client/ui/entityreadout/LiveEntityViewPane.java
+++ b/megamek/src/megamek/client/ui/entityreadout/LiveEntityViewPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -39,6 +39,7 @@ import megamek.client.ui.Messages;
 import megamek.client.ui.baseComponents.MenuButton;
 import megamek.client.ui.clientGUI.calculationReport.FlexibleCalculationReport;
 import megamek.client.ui.dialogs.unitSelectorDialogs.AvailabilityPanel;
+import megamek.client.ui.dialogs.unitSelectorDialogs.DamageAnalysisPanel;
 import megamek.client.ui.dialogs.unitSelectorDialogs.EntityReadoutPanel;
 import megamek.client.ui.panels.alphaStrike.ConfigurableASCardPanel;
 import megamek.client.ui.util.ViewFormatting;
@@ -57,6 +58,7 @@ class LiveEntityViewPane extends EnhancedTabbedPane {
     private final EntityReadoutPanel troPanel = new EntityReadoutPanel();
     private final ConfigurableASCardPanel alphaStrikeCardPanel;
     private final AvailabilityPanel factionPanel = new AvailabilityPanel();
+    private final DamageAnalysisPanel analysisPanel = new DamageAnalysisPanel();
     private boolean menuVisible = true;
 
     private final int entityId;
@@ -89,6 +91,7 @@ class LiveEntityViewPane extends EnhancedTabbedPane {
         addTab(Messages.getString("TRO.title"), troPanel);
         addTab(Messages.getString("ASCard.title"), alphaStrikeCardPanel);
         addTab(Messages.getString("FactionAvailability.title"), factionPanel.getPanel());
+        addTab(Messages.getString("DamageAnalysis.title"), analysisPanel);
 
         updateDisplayedEntity();
     }
@@ -109,6 +112,8 @@ class LiveEntityViewPane extends EnhancedTabbedPane {
                 alphaStrikeCardPanel.setASElement(ASConverter.convert(entity, new FlexibleCalculationReport()));
             }
         }
+
+        analysisPanel.setEntity(entity);
     }
 
     private void toggleMenus() {


### PR DESCRIPTION
## Summary

The Analysis tab shows up in the unit selector but not in the lobby. The lobby uses a different readout pane that never got the tab added. This adds it.

## Bug Fixed

- **Analysis tab missing from lobby unit view**: MegaMek has two readout panes. `EntityViewPane` (unit selectors) received the `DamageAnalysisPanel` tab. `LiveEntityViewPane` (lobby, via `LiveReadoutDialog`) did not. All three lobby view paths share that pane, so the tab was missing from every one of them.

## Changes

1. **LiveEntityViewPane.java** - Add `Damage and set its  entity in `updateDisplayedEntity()`.

## Files Changed

- `megamek/src/megamek/client/ui/entityreadout/LiveEntityViewPane.java` - Add the Analysis tab

## Testing

- Unit tests: none. This is UI wiring with no testable logic.
- Manual testing:
  - Lobby right-click a unit -> View... -> A
  - Lobby double-click a unit -> Analysis tab appears
  - Charts use the crew's real gunnery (no o)
  - Large craft and capital-scale unit render correctly
  - Unit selector Analysis tab still works

