### PR TITLE
Fix trailer ammo selection never reaching the server 

### DIFF
--- a/megamek/src/megamek/client/Client.java
+++ b/megamek/src/megamek/client/Client.java
@@ -1566,10 +1566,17 @@ public class Client extends AbstractClient {
     }
 
     /**
-     * Send mode-change data to the server
+     * Send ammo-change data to the server.
+     *
+     * @param entityId      the unit that owns the weapon being reloaded
+     * @param weaponId      the equipment number of the weapon on that unit
+     * @param ammoId        the equipment number of the ammo bin on the carrying unit
+     * @param ammoCarrierId the unit that owns the ammo bin. This is the same as entityId unless the bin belongs to a
+     *                      directly connected trailer sharing ammo with this unit.
+     * @param reason        the report message id explaining the change, or 0 for no report
      */
-    public void sendAmmoChange(int nEntity, int nWeapon, int nAmmo, int reason) {
-        send(new Packet(PacketCommand.ENTITY_AMMO_CHANGE, nEntity, nWeapon, nAmmo, reason));
+    public void sendAmmoChange(int entityId, int weaponId, int ammoId, int ammoCarrierId, int reason) {
+        send(new Packet(PacketCommand.ENTITY_AMMO_CHANGE, entityId, weaponId, ammoId, ammoCarrierId, reason));
     }
 
     /**

--- a/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
+++ b/megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2018-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -1466,6 +1466,7 @@ public class ArtilleryTargetingControl {
                               shooter.getId(),
                               shooter.getEquipmentNum(actualFireInfo.getWeapon()),
                               ammo.equipmentNum,
+                              shooter.getId(),
                               actualFireInfo.getAmmo().getSwitchedReason());
 
                         if (artilleryCommandAndControl.isArtillerySingle()) {

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -3290,7 +3290,7 @@ public class FireControl {
 
             // If the selected ammo would cause the shot to miss, skip loading it.
             final WeaponAttackAction cloneWAA = new WeaponAttackAction(info.getAction());
-            cloneWAA.setAmmoId(shooter.getEquipmentNum(mountedAmmo));
+            cloneWAA.setAmmoId(mountedAmmo.getEntity().getEquipmentNum(mountedAmmo));
             cloneWAA.setAmmoMunitionType(mountedAmmo.getType().getMunitionType());
             cloneWAA.setAmmoCarrier(mountedAmmo.getEntity().getId());
             if (cloneWAA.toHit(owner.getGame(), owner.getPrecognition().getECMInfo()).getValue() > 12) {
@@ -3327,8 +3327,10 @@ public class FireControl {
             info.getAction().setAmmoMunitionType(cloneWAA.getAmmoMunitionType());
             info.getAction().setAmmoCarrier(cloneWAA.getAmmoCarrier());
 
+            Entity ammoCarrier = mountedAmmo.getEntity();
             owner.sendAmmoChange(info.getShooter().getId(), shooter.getEquipmentNum(currentWeapon),
-                  shooter.getEquipmentNum(mountedAmmo), mountedAmmo.getSwitchedReason());
+                  ammoCarrier.getEquipmentNum(mountedAmmo), ammoCarrier.getId(),
+                  mountedAmmo.getSwitchedReason());
         }
     }
 

--- a/megamek/src/megamek/client/ui/dialogs/unitDisplay/WeaponPanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitDisplay/WeaponPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2015-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -82,6 +82,7 @@ import megamek.common.equipment.AmmoType.AmmoTypeEnum;
 import megamek.common.equipment.AmmoType.Munitions;
 import megamek.common.equipment.HandheldWeapon;
 import megamek.common.equipment.Mounted;
+import megamek.common.equipment.TrainAmmoSharing;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.equipment.WeaponType;
 import megamek.common.game.Game;
@@ -1934,20 +1935,8 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
         } else {
 
             vAmmo = new ArrayList<>();
-            // Ammo sharing between adjacent trailers
-            List<AmmoMounted> fullAmmoList = new ArrayList<>(entity.getAmmo());
-            if (entity.getTowedBy() != Entity.NONE) {
-                Entity ahead = entity.getGame().getEntity(entity.getTowedBy());
-                if (ahead != null) {
-                    fullAmmoList.addAll(ahead.getAmmo());
-                }
-            }
-            if (entity.getTowing() != Entity.NONE) {
-                Entity behind = entity.getGame().getEntity(entity.getTowing());
-                if (behind != null) {
-                    fullAmmoList.addAll(behind.getAmmo());
-                }
-            }
+            // Ammo sharing between adjacent trailers. The server validates against this same rule.
+            List<AmmoMounted> fullAmmoList = TrainAmmoSharing.getSharedAmmo(entity);
             int newSelectedIndex = -1;
             int i = 0;
             for (AmmoMounted ammo : fullAmmoList) {
@@ -2589,21 +2578,27 @@ public class WeaponPanel extends PicMap implements ListSelectionListener, Action
                         // FIXME: Consider new AmmoType::equals / BombType::equals
                         if (bWeapon.getType().equals(sWeapon.getType())) {
                             entity.loadWeapon(bWeapon, mAmmo);
-                            // Alert the server of the update.
+                            // Alert the server of the update. The ammo bin may belong to a connected trailer, so
+                            // its equipment number must be resolved against its own carrier.
+                            Entity ammoCarrier = mAmmo.getEntity();
                             clientgui.getClient().sendAmmoChange(
                                   entity.getId(),
                                   entity.getEquipmentNum(bWeapon),
-                                  entity.getEquipmentNum(mAmmo),
+                                  ammoCarrier.getEquipmentNum(mAmmo),
+                                  ammoCarrier.getId(),
                                   0);
                         }
                     }
                 }
             } else {
                 entity.loadWeapon(mWeapon, mAmmo);
-                // Alert the server of the update.
+                // Alert the server of the update. The ammo bin may belong to a connected trailer, so its
+                // equipment number must be resolved against its own carrier.
+                Entity ammoCarrier = mAmmo.getEntity();
                 clientgui.getClient().sendAmmoChange(entity.getId(),
                       entity.getEquipmentNum(mWeapon),
-                      entity.getEquipmentNum(mAmmo),
+                      ammoCarrier.getEquipmentNum(mAmmo),
+                      ammoCarrier.getId(),
                       0);
             }
 

--- a/megamek/src/megamek/common/equipment/TrainAmmoSharing.java
+++ b/megamek/src/megamek/common/equipment/TrainAmmoSharing.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.equipment;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import megamek.common.annotations.Nullable;
+import megamek.common.game.Game;
+import megamek.common.units.Entity;
+
+/**
+ * Stateless rules helper for ammunition shared along a tractor-and-trailer train. A unit may feed its weapons from the
+ * ammo bins of the unit it tows and the unit towing it, so an ammo bin is not necessarily owned by the unit firing it.
+ * <p>
+ * This is the single definition of which units may supply each other. The client offers exactly this set in the ammo
+ * dropdown and the server validates against it, so the two cannot drift apart.
+ * </p>
+ * Extracted from {@link Entity} and {@code TWGameManager} so the rule does not add to either of those already very
+ * large classes; this mirrors the codebase's other Entity-operating utilities ({@link BridgeLayerLogic},
+ * {@code megamek.common.compute.Compute}).
+ *
+ * @author Claude Code (Opus 5)
+ */
+public final class TrainAmmoSharing {
+
+    private TrainAmmoSharing() {
+    }
+
+    /**
+     * @param shooter the unit whose weapons are being loaded
+     *
+     * @return every ammo bin the unit may draw from, in display order: its own bins first, then those of the unit
+     *       towing it, then those of the unit it tows. Units not in a train return only their own bins.
+     */
+    public static List<AmmoMounted> getSharedAmmo(Entity shooter) {
+        List<AmmoMounted> sharedAmmo = new ArrayList<>(shooter.getAmmo());
+        Game game = shooter.getGame();
+        if (game == null) {
+            return sharedAmmo;
+        }
+        if (shooter.getTowedBy() != Entity.NONE) {
+            Entity ahead = game.getEntity(shooter.getTowedBy());
+            if (ahead != null) {
+                sharedAmmo.addAll(ahead.getAmmo());
+            }
+        }
+        if (shooter.getTowing() != Entity.NONE) {
+            Entity behind = game.getEntity(shooter.getTowing());
+            if (behind != null) {
+                sharedAmmo.addAll(behind.getAmmo());
+            }
+        }
+        return sharedAmmo;
+    }
+
+    /**
+     * Whether one unit may fire another's ammo. The server must check this because the ammo bin named in an ammo
+     * change packet arrives from the client.
+     *
+     * @param shooter     the unit firing the weapon
+     * @param ammoCarrier the unit that owns the ammo bin
+     *
+     * @return {@code true} when the carrier is the shooter itself or a unit directly connected to it in the same
+     *       train, {@code false} otherwise
+     */
+    public static boolean canShareAmmoWith(Entity shooter, Entity ammoCarrier) {
+        if (shooter.equals(ammoCarrier)) {
+            return true;
+        }
+        int carrierId = ammoCarrier.getId();
+        return (shooter.getTowedBy() == carrierId) || (shooter.getTowing() == carrierId);
+    }
+
+    /**
+     * Reconnects weapons linked to another unit's ammo bin after the owning unit has been transferred.
+     * <p>
+     * Packets are Java-serialized object graphs and a {@link Mounted} holds a hard reference to its owning entity, so a
+     * weapon linked to a trailer's bin drags a copy of that trailer along with it. The receiving side would otherwise
+     * hold a detached duplicate rather than the unit the game knows about. Links to bins the unit owns itself are left
+     * alone, and a link whose carrier has left the game is cleared so nothing keeps firing a detached copy.
+     * </p>
+     *
+     * @param entity the unit whose weapon links should be checked
+     * @param game   the game holding the canonical units, or {@code null} to do nothing
+     */
+    public static void relinkExternalAmmo(Entity entity, @Nullable Game game) {
+        if (game == null) {
+            return;
+        }
+        for (WeaponMounted weapon : entity.getTotalWeaponList()) {
+            if (!(weapon.getLinked() instanceof AmmoMounted linkedAmmo)) {
+                continue;
+            }
+            Entity staleCarrier = linkedAmmo.getEntity();
+            if ((staleCarrier == null) || staleCarrier.equals(entity)) {
+                continue;
+            }
+            Entity canonicalCarrier = game.getEntity(staleCarrier.getId());
+            if (canonicalCarrier == null) {
+                weapon.setLinked(null);
+                continue;
+            }
+            weapon.setLinked(canonicalCarrier.getAmmo(staleCarrier.getEquipmentNum(linkedAmmo)));
+        }
+    }
+}

--- a/megamek/src/megamek/common/units/Entity.java
+++ b/megamek/src/megamek/common/units/Entity.java
@@ -1341,6 +1341,8 @@ public abstract class Entity extends TurnOrdered
                 }
             }
         }
+        // Weapons may be linked to a connected trailer's ammo bin, which arrives here as a detached copy.
+        TrainAmmoSharing.relinkExternalAmmo(this, game);
     }
 
     /**

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -27560,36 +27560,51 @@ public class TWGameManager extends AbstractGameManager {
         int entityId = packet.getIntValue(0);
         int weaponId = packet.getIntValue(1);
         int ammoId = packet.getIntValue(2);
-        int reason = packet.getIntValue(3);
-        Entity e = game.getEntity(entityId);
+        int ammoCarrierId = packet.getIntValue(3);
+        int reason = packet.getIntValue(4);
+        Entity shooter = game.getEntity(entityId);
 
         // Did we receive a request for a valid Entity?
-        if (null == e) {
+        if (null == shooter) {
             LOGGER.error("Could not find entity# {}", entityId);
             return;
         }
         Player player = game.getPlayer(connIndex);
-        if ((null != player) && (e.getOwner() != player)) {
-            LOGGER.error("Player {} does not own the entity {}", player.getName(), e.getDisplayName());
+        if ((null != player) && (shooter.getOwner() != player)) {
+            LOGGER.error("Player {} does not own the entity {}", player.getName(), shooter.getDisplayName());
+            return;
+        }
+
+        // The ammo may be carried by a directly connected trailer rather than by the firing unit itself. Resolve
+        // the bin against its own carrier, but never trust the client about which unit that is allowed to be.
+        Entity ammoCarrier = (ammoCarrierId == entityId) ? shooter : game.getEntity(ammoCarrierId);
+        if (null == ammoCarrier) {
+            LOGGER.error("Could not find ammo carrier# {}", ammoCarrierId);
+            return;
+        }
+        if (!TrainAmmoSharing.canShareAmmoWith(shooter, ammoCarrier)) {
+            LOGGER.error("Entity {} may not draw ammo from {}",
+                  shooter.getDisplayName(),
+                  ammoCarrier.getDisplayName());
             return;
         }
 
         // Make sure that the entity has the given equipment.
-        WeaponMounted weaponMounted = (WeaponMounted) e.getEquipment(weaponId);
-        AmmoMounted mAmmo = (AmmoMounted) e.getEquipment(ammoId);
+        WeaponMounted weaponMounted = (WeaponMounted) shooter.getEquipment(weaponId);
+        AmmoMounted selectedAmmo = ammoCarrier.getAmmo(ammoId);
         AmmoMounted oldAmmo = (weaponMounted == null) ? null : weaponMounted.getLinkedAmmo();
-        if (null == mAmmo) {
-            LOGGER.error("Entity {} does not have ammo #{}", e.getDisplayName(), ammoId);
+        if (null == selectedAmmo) {
+            LOGGER.error("Entity {} does not have ammo #{}", ammoCarrier.getDisplayName(), ammoId);
             return;
         }
         if (null == weaponMounted) {
-            LOGGER.error("Entity {} does not have weapon #{}", e.getDisplayName(), weaponId);
+            LOGGER.error("Entity {} does not have weapon #{}", shooter.getDisplayName(), weaponId);
             return;
         }
         if (weaponMounted.getType().getAmmoType() == AmmoType.AmmoTypeEnum.NA) {
             LOGGER.error("Item #{} of entity {} is a {} and does not use ammo.",
                   weaponId,
-                  e.getDisplayName(),
+                  shooter.getDisplayName(),
                   weaponMounted.getName());
             return;
         }
@@ -27597,22 +27612,22 @@ public class TWGameManager extends AbstractGameManager {
               .hasFlag(WeaponType.F_DOUBLE_ONE_SHOT)) {
             LOGGER.error("Item #{} of entity {} is a {} and cannot use external ammo.",
                   weaponId,
-                  e.getDisplayName(),
+                  shooter.getDisplayName(),
                   weaponMounted.getName());
             return;
         }
 
         // Load the weapon.
-        e.loadWeapon(weaponMounted, mAmmo);
+        shooter.loadWeapon(weaponMounted, selectedAmmo);
 
         // Report the change, if reason is provided and it's not already being used.
-        if (reason != 0 && oldAmmo != mAmmo) {
-            Report r = new Report(1500);
-            r.subject = entityId;
-            r.addDesc(e);
-            r.add(mAmmo.getShortName());
-            r.add(ReportMessages.getString(String.valueOf(reason)));
-            addReport(r);
+        if (reason != 0 && oldAmmo != selectedAmmo) {
+            Report ammoChangeReport = new Report(1500);
+            ammoChangeReport.subject = entityId;
+            ammoChangeReport.addDesc(shooter);
+            ammoChangeReport.add(selectedAmmo.getShortName());
+            ammoChangeReport.add(ReportMessages.getString(String.valueOf(reason)));
+            addReport(ammoChangeReport);
         }
     }
 

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -27589,8 +27589,9 @@ public class TWGameManager extends AbstractGameManager {
             return;
         }
 
-        // Make sure that the entity has the given equipment.
-        WeaponMounted weaponMounted = (WeaponMounted) shooter.getEquipment(weaponId);
+        // Make sure that the entity has the given equipment. Both indices come from the client, so resolve them
+        // through the type-checked accessors rather than casting whatever equipment sits at that index.
+        WeaponMounted weaponMounted = shooter.getWeapon(weaponId);
         AmmoMounted selectedAmmo = ammoCarrier.getAmmo(ammoId);
         AmmoMounted oldAmmo = (weaponMounted == null) ? null : weaponMounted.getLinkedAmmo();
         if (null == selectedAmmo) {

--- a/megamek/unittests/megamek/common/equipment/TrainAmmoSharingTest.java
+++ b/megamek/unittests/megamek/common/equipment/TrainAmmoSharingTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.equipment;
+
+import static megamek.testUtilities.MMTestUtilities.getEntityForUnitTesting;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import megamek.common.Player;
+import megamek.common.game.Game;
+import megamek.common.interfaces.IEntityRemovalConditions;
+import megamek.common.units.Entity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for ammunition shared along a tractor-and-trailer train (issue #8520).
+ *
+ * <p>Two behaviors are covered. First, which units may supply ammo to which - the client offers this set in the ammo
+ * dropdown and the server validates against it. Second, the repair of weapon links that point at another unit's ammo
+ * bin: packets are Java-serialized object graphs and a {@link Mounted} holds a hard reference to its owning entity, so
+ * such a link arrives as a detached duplicate of the carrier rather than the unit the game knows about.</p>
+ */
+class TrainAmmoSharingTest {
+
+    private static final int TRACTOR_ID = 1;
+    private static final int TRAILER_ID = 2;
+    private static final int UNCONNECTED_ID = 3;
+
+    private Game game;
+    private Entity tractor;
+    private Entity canonicalTrailer;
+    private Entity unconnected;
+
+    @BeforeEach
+    void setUp() {
+        Player owner = new Player(0, "Owner");
+
+        game = new Game();
+        game.addPlayer(0, owner);
+
+        tractor = loadBulldog(TRACTOR_ID, owner);
+        canonicalTrailer = loadBulldog(TRAILER_ID, owner);
+        unconnected = loadBulldog(UNCONNECTED_ID, owner);
+        tractor.setTowing(TRAILER_ID);
+        canonicalTrailer.setTowedBy(TRACTOR_ID);
+
+        game.addEntity(tractor);
+        game.addEntity(canonicalTrailer);
+        game.addEntity(unconnected);
+    }
+
+    private Entity loadBulldog(int id, Player owner) {
+        Entity entity = getEntityForUnitTesting("Bulldog Medium Tank", true);
+        assertNotNull(entity, "Bulldog Medium Tank not found");
+        entity.setId(id);
+        entity.setOwner(owner);
+        return entity;
+    }
+
+    private WeaponMounted ammoUsingWeapon(Entity entity) {
+        for (WeaponMounted weapon : entity.getTotalWeaponList()) {
+            if (!entity.getAmmo(weapon).isEmpty()) {
+                return weapon;
+            }
+        }
+        throw new AssertionError("No ammo-using weapon found on " + entity.getDisplayName());
+    }
+
+    /** A second instance of the trailer with the same id, standing in for one that arrived inside a packet. */
+    private Entity duplicateTrailer() {
+        Entity duplicate = loadBulldog(TRAILER_ID, game.getPlayer(0));
+        assertNotSame(canonicalTrailer, duplicate);
+        return duplicate;
+    }
+
+    // --- which units may share ammo ---
+
+    @Test
+    void aUnitMayAlwaysUseItsOwnAmmo() {
+        assertTrue(TrainAmmoSharing.canShareAmmoWith(tractor, tractor));
+    }
+
+    @Test
+    void connectedTrailersMayShareBothWays() {
+        assertTrue(TrainAmmoSharing.canShareAmmoWith(tractor, canonicalTrailer),
+              "A tractor may draw from the trailer it tows");
+        assertTrue(TrainAmmoSharing.canShareAmmoWith(canonicalTrailer, tractor),
+              "A trailer may draw from the unit towing it");
+    }
+
+    @Test
+    void anUnconnectedUnitMayNotShare() {
+        assertFalse(TrainAmmoSharing.canShareAmmoWith(tractor, unconnected));
+        assertFalse(TrainAmmoSharing.canShareAmmoWith(unconnected, tractor));
+    }
+
+    @Test
+    void sharedAmmoListsOwnBinsFirstThenTheConnectedUnit() {
+        List<AmmoMounted> shared = TrainAmmoSharing.getSharedAmmo(tractor);
+
+        int ownBinCount = tractor.getAmmo().size();
+        assertEquals(ownBinCount + canonicalTrailer.getAmmo().size(), shared.size());
+        for (int index = 0; index < ownBinCount; index++) {
+            assertSame(tractor.getAmmo().get(index), shared.get(index), "Own bins come first");
+        }
+        assertSame(canonicalTrailer.getAmmo().get(0), shared.get(ownBinCount),
+              "The towed unit's bins follow");
+    }
+
+    @Test
+    void sharedAmmoOfALoneUnitIsJustItsOwn() {
+        List<AmmoMounted> shared = TrainAmmoSharing.getSharedAmmo(unconnected);
+
+        assertEquals(unconnected.getAmmo().size(), shared.size());
+    }
+
+    // --- repairing links that crossed a packet boundary ---
+
+    @Test
+    void linkToDuplicateCarrierIsRepointedAtTheCanonicalBin() {
+        Entity duplicate = duplicateTrailer();
+        WeaponMounted launcher = ammoUsingWeapon(tractor);
+        AmmoMounted staleBin = duplicate.getAmmo().get(0);
+        launcher.setLinked(staleBin);
+
+        tractor.setGame(game);
+
+        AmmoMounted relinked = ammoUsingWeapon(tractor).getLinkedAmmo();
+        assertNotSame(staleBin, relinked, "The detached copy must not survive");
+        assertSame(canonicalTrailer.getAmmo().get(0), relinked,
+              "The link must point at the bin the game knows about");
+        assertSame(canonicalTrailer, relinked.getEntity());
+    }
+
+    @Test
+    void linkToOwnAmmoIsLeftAlone() {
+        WeaponMounted launcher = ammoUsingWeapon(tractor);
+        AmmoMounted ownBin = tractor.getAmmo().get(1);
+        launcher.setLinked(ownBin);
+
+        tractor.setGame(game);
+
+        assertSame(ownBin, ammoUsingWeapon(tractor).getLinkedAmmo(),
+              "A link to this unit's own ammo must be untouched");
+    }
+
+    @Test
+    void linkToDepartedCarrierIsCleared() {
+        Entity duplicate = duplicateTrailer();
+        WeaponMounted launcher = ammoUsingWeapon(tractor);
+        launcher.setLinked(duplicate.getAmmo().get(0));
+
+        // The trailer is destroyed and removed before this unit's update is applied.
+        game.removeEntity(TRAILER_ID, IEntityRemovalConditions.REMOVE_DEVASTATED);
+
+        tractor.setGame(game);
+
+        assertNull(ammoUsingWeapon(tractor).getLinkedAmmo(),
+              "A link to a unit that has left the game must be dropped");
+    }
+}

--- a/megamek/unittests/megamek/server/totalWarfare/TWGameManagerTrailerAmmoTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/TWGameManagerTrailerAmmoTest.java
@@ -1,0 +1,251 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.server.totalWarfare;
+
+import static megamek.testUtilities.MMTestUtilities.getEntityForUnitTesting;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import megamek.common.Player;
+import megamek.common.enums.GamePhase;
+import megamek.common.equipment.AmmoMounted;
+import megamek.common.equipment.AmmoType;
+import megamek.common.equipment.WeaponMounted;
+import megamek.common.game.Game;
+import megamek.common.net.enums.PacketCommand;
+import megamek.common.net.packets.Packet;
+import megamek.common.units.Entity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for trailer ammo sharing (issue #8520).
+ *
+ * <p>A unit towing an ammo trailer may fire the trailer's ammo. The ammo change packet therefore has to name the unit
+ * that carries the bin, because the bin's equipment number is only meaningful on its own carrier. Before the fix the
+ * client sent an equipment number looked up on the firing unit, which produced -1 for any trailer bin, so the server
+ * dropped the selection and kept firing whatever was already linked.</p>
+ *
+ * <p>The server must also refuse a carrier that is not part of the same train, since the equipment number arrives
+ * from the client.</p>
+ */
+class TWGameManagerTrailerAmmoTest {
+
+    private static final int TRACTOR_ID = 1;
+    private static final int TRAILER_ID = 2;
+    private static final int UNCONNECTED_ID = 3;
+    private static final int OWNER_CONNECTION_ID = 0;
+    private static final int NO_REPORT = 0;
+
+    private Game game;
+    private TWGameManager gameManager;
+    private Entity tractor;
+    private Entity trailer;
+    private Entity unconnected;
+
+    @BeforeEach
+    void setUp() {
+        Player owner = new Player(OWNER_CONNECTION_ID, "Owner");
+        owner.setTeam(1);
+
+        game = new Game();
+        game.setPhase(GamePhase.FIRING);
+        game.addPlayer(OWNER_CONNECTION_ID, owner);
+
+        tractor = loadBulldog(TRACTOR_ID, owner);
+        trailer = loadBulldog(TRAILER_ID, owner);
+        unconnected = loadBulldog(UNCONNECTED_ID, owner);
+
+        // Hook the trailer up behind the tractor.
+        tractor.setTowing(TRAILER_ID);
+        trailer.setTowedBy(TRACTOR_ID);
+
+        game.addEntity(tractor);
+        game.addEntity(trailer);
+        game.addEntity(unconnected);
+
+        gameManager = mock(TWGameManager.class);
+        doNothing().when(gameManager).entityUpdate(anyInt());
+        when(gameManager.getGame()).thenReturn(game);
+        doCallRealMethod().when(gameManager).setGame(any(Game.class));
+        doCallRealMethod().when(gameManager).handlePacket(anyInt(), any(Packet.class));
+        gameManager.setGame(game);
+    }
+
+    private Entity loadBulldog(int id, Player owner) {
+        Entity entity = getEntityForUnitTesting("Bulldog Medium Tank", true);
+        assertNotNull(entity, "Bulldog Medium Tank not found");
+        entity.setId(id);
+        entity.setOwner(owner);
+        return entity;
+    }
+
+    /** The first weapon on the unit with at least two bins it can draw from, so the choice is meaningful. */
+    private WeaponMounted multiBinWeapon(Entity entity) {
+        for (WeaponMounted weapon : entity.getTotalWeaponList()) {
+            if (compatibleBins(entity, weapon).size() >= 2) {
+                return weapon;
+            }
+        }
+        throw new AssertionError("No weapon with two compatible ammo bins on " + entity.getDisplayName());
+    }
+
+    /** Every bin on the given unit that the weapon could actually be loaded with. */
+    private List<AmmoMounted> compatibleBins(Entity entity, WeaponMounted weapon) {
+        List<AmmoMounted> bins = new ArrayList<>();
+        for (AmmoMounted ammo : entity.getAmmo()) {
+            if (AmmoType.isAmmoValid(ammo, weapon.getType())) {
+                bins.add(ammo);
+            }
+        }
+        return bins;
+    }
+
+    private void sendAmmoChange(Entity shooter, WeaponMounted weapon, Entity ammoCarrier, AmmoMounted ammo) {
+        gameManager.handlePacket(OWNER_CONNECTION_ID, new Packet(PacketCommand.ENTITY_AMMO_CHANGE,
+              shooter.getId(),
+              shooter.getEquipmentNum(weapon),
+              ammoCarrier.getEquipmentNum(ammo),
+              ammoCarrier.getId(),
+              NO_REPORT));
+    }
+
+    @Test
+    void trailerAmmoIsLinkedToTheTractorWeapon() {
+        WeaponMounted launcher = multiBinWeapon(tractor);
+        AmmoMounted trailerAmmo = compatibleBins(trailer, launcher).get(0);
+
+        sendAmmoChange(tractor, launcher, trailer, trailerAmmo);
+
+        assertSame(trailerAmmo, launcher.getLinkedAmmo(),
+              "Weapon should fire the selected trailer bin");
+    }
+
+    @Test
+    void ammoAheadInTheTrainIsLinkedToTheTrailerWeapon() {
+        WeaponMounted launcher = multiBinWeapon(trailer);
+        AmmoMounted tractorAmmo = compatibleBins(tractor, launcher).get(1);
+
+        sendAmmoChange(trailer, launcher, tractor, tractorAmmo);
+
+        assertSame(tractorAmmo, launcher.getLinkedAmmo(),
+              "A trailer may draw from the unit towing it");
+    }
+
+    @Test
+    void ownAmmoStillChanges() {
+        WeaponMounted launcher = multiBinWeapon(tractor);
+        AmmoMounted otherOwnBin = null;
+        for (AmmoMounted bin : compatibleBins(tractor, launcher)) {
+            if (bin != launcher.getLinkedAmmo()) {
+                otherOwnBin = bin;
+                break;
+            }
+        }
+        assertNotNull(otherOwnBin, "Expected a second compatible bin on the tractor");
+
+        sendAmmoChange(tractor, launcher, tractor, otherOwnBin);
+
+        assertSame(otherOwnBin, launcher.getLinkedAmmo(),
+              "Selecting a bin on the firing unit itself must keep working");
+    }
+
+    @Test
+    void ammoOnAnUnconnectedUnitIsRejected() {
+        WeaponMounted launcher = multiBinWeapon(tractor);
+        AmmoMounted originalAmmo = launcher.getLinkedAmmo();
+        AmmoMounted foreignAmmo = compatibleBins(unconnected, launcher).get(0);
+
+        sendAmmoChange(tractor, launcher, unconnected, foreignAmmo);
+
+        assertSame(originalAmmo, launcher.getLinkedAmmo(),
+              "A unit not in the train must not supply ammo");
+    }
+
+    @Test
+    void unknownCarrierIsRejected() {
+        WeaponMounted launcher = multiBinWeapon(tractor);
+        AmmoMounted originalAmmo = launcher.getLinkedAmmo();
+
+        gameManager.handlePacket(OWNER_CONNECTION_ID, new Packet(PacketCommand.ENTITY_AMMO_CHANGE,
+              tractor.getId(),
+              tractor.getEquipmentNum(launcher),
+              0,
+              99,
+              NO_REPORT));
+
+        assertSame(originalAmmo, launcher.getLinkedAmmo(),
+              "An unknown carrier id must leave the link alone");
+    }
+
+    @Test
+    void unknownBinOnAValidCarrierIsRejected() {
+        WeaponMounted launcher = multiBinWeapon(tractor);
+        AmmoMounted originalAmmo = launcher.getLinkedAmmo();
+
+        gameManager.handlePacket(OWNER_CONNECTION_ID, new Packet(PacketCommand.ENTITY_AMMO_CHANGE,
+              tractor.getId(),
+              tractor.getEquipmentNum(launcher),
+              -1,
+              trailer.getId(),
+              NO_REPORT));
+
+        assertSame(originalAmmo, launcher.getLinkedAmmo(),
+              "An unresolvable bin must leave the link alone");
+    }
+
+    @Test
+    void trailerAmmoSurvivesRelinkOnTheTractor() {
+        WeaponMounted launcher = multiBinWeapon(tractor);
+        AmmoMounted trailerAmmo = compatibleBins(trailer, launcher).get(0);
+        sendAmmoChange(tractor, launcher, trailer, trailerAmmo);
+
+        // A server-side setGame pass must not disturb a link that already points at the canonical bin.
+        tractor.setGame(game);
+
+        assertSame(trailerAmmo, launcher.getLinkedAmmo(),
+              "Relinking must be a no-op when the bin is already canonical");
+        assertEquals(TRAILER_ID, launcher.getLinkedAmmo().getEntity().getId());
+    }
+}

--- a/megamek/unittests/megamek/server/totalWarfare/TWGameManagerTrailerAmmoTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/TWGameManagerTrailerAmmoTest.java
@@ -236,6 +236,26 @@ class TWGameManagerTrailerAmmoTest {
     }
 
     @Test
+    void nonWeaponEquipmentIndexIsRejectedWithoutThrowing() {
+        WeaponMounted launcher = multiBinWeapon(tractor);
+        AmmoMounted originalAmmo = launcher.getLinkedAmmo();
+        // Point the weapon index at an ammo bin. Both indices come from the client, so a bad one must be
+        // rejected rather than escaping as a ClassCastException - nothing between here and the packet pump
+        // catches RuntimeException, so a throw would kill the server's packet thread.
+        int ammoBinIndex = tractor.getEquipmentNum(compatibleBins(tractor, launcher).get(0));
+
+        gameManager.handlePacket(OWNER_CONNECTION_ID, new Packet(PacketCommand.ENTITY_AMMO_CHANGE,
+              tractor.getId(),
+              ammoBinIndex,
+              ammoBinIndex,
+              tractor.getId(),
+              NO_REPORT));
+
+        assertSame(originalAmmo, launcher.getLinkedAmmo(),
+              "A non-weapon equipment index must leave the link alone");
+    }
+
+    @Test
     void trailerAmmoSurvivesRelinkOnTheTractor() {
         WeaponMounted launcher = multiBinWeapon(tractor);
         AmmoMounted trailerAmmo = compatibleBins(trailer, launcher).get(0);


### PR DESCRIPTION
Summary

A vehicle towing an ammo trailer could not use the trailer's ammo. Picking a [TR] bin in the ammo dropdown did nothing — the weapon fired the first body ton instead. With the body emptied, the player got a to-hit number but the weapon did not fire.

The dropdown has offered trailer ammo since 2020 (8bfd94c1e4). The packet that tells the server about the choice was never extended to carry it, so the feature has never worked end to end.

Bug Fixed

- The packet could not name another unit's bin. WeaponPanel sent entity.getEquipmentNum(ammo), which returns -1 for a bin owned by a trailer, and the packet had no field for the carrying unit. The server logged does not have ammo #-1 and left the weapon linked to whatever it had before.
- To-hit and attack resolution disagreed. WeaponAttackAction already carries ammoId plus ammoCarrier, and ComputeToHit resolves both. So the player got a to-hit number for ammo the server was never going to fire.
- Cross-entity links leaked into packets. An ammo link to another unit puts an Entity reference inside the tractor's serialized form, so the receiving side would hold a detached duplicate of the trailer.

Changes

1. TrainAmmoSharing.java (NEW) — stateless helper holding the whole rule: which units may supply each other, the shared bin list, and the post-transfer relink.
2. Client.java — sendAmmoChange takes the carrying unit's id.
3. WeaponPanel.java — resolves the bin's equipment number against its own carrier and sends that carrier's id. Builds the dropdown from TrainAmmoSharing.getSharedAmmo instead of its own inline copy of the rule.
4. TWGameManager.java — resolves the bin against the named carrier, after checking the carrier is the firing unit or a directly connected trailer. The equipment number comes from the client, so it is not taken on trust.
5. Entity.java — setGame repoints a cross-entity ammo link at the canonical bin, mirroring the fixup already there for carriedObjects.
6. FireControl.java / ArtilleryTargetingControl.java — updated for the new signature.

Files Changed

- megamek/src/megamek/common/equipment/TrainAmmoSharing.java — NEW: the s and server
- megamek/src/megamek/client/Client.java — carrier id added to sendAmmoChange
- megamek/src/megamek/client/ui/dialogs/unitDisplay/WeaponPanel.java — both call sites resolve the bin against its carrier; dropdown uses the shared rule                        - megamek/src/megamek/server/totalWarfare/TWGameManager.java — carrier re
- megamek/src/megamek/common/units/Entity.java — one-line relink call in setGame                                                                                                 - megamek/src/megamek/client/bot/princess/FireControl.java — new signaturhe carrier to match the setAmmoCarrier two lines above it
- megamek/src/megamek/client/bot/princess/ArtilleryTargetingControl.java — new signature
- megamek/unittests/megamek/common/equipment/TrainAmmoSharingTest.java — NEW: 8 tests
- megamek/unittests/megamek/server/totalWarfare/TWGameManagerTrailerAmmoTest.java — NEW: 7 tests
                                                                                                                                                                                 Testing

- Unit tests: 15 new, all passing.                                                                                                                                                 - TWGameManagerTrailerAmmoTest (7) drives real ENTITY_AMMO_CHANGE packetwo tow-linked Bulldog Medium Tanks: draw from the trailer behind, drawfrom the tractor ahead, own ammo still changes, plus rejection of an unconnected carrier, an unknown carrier id, and an unresolvable bin.
  - TrainAmmoSharingTest (8) covers the sharing predicate, the shared bin list and its order, and the relink — duplicate carrier repointed, own ammo untouched, departed carrier cleared.
- Full ./gradlew test and checkstyleMain green.
- Manual: confirmed in game with a Mobile Long Tom and an Ammunition Carro bin now fires that bin.

Fixes #8520