### PR TITLE
Fix: MML #2273 Add andNot F_AERO_WEAPON and F_PROTO_WEAPON Flags to BA Tube Artillery

### DIFF
--- a/megamek/src/megamek/common/weapons/battleArmor/innerSphere/ISBATubeArtillery.java
+++ b/megamek/src/megamek/common/weapons/battleArmor/innerSphere/ISBATubeArtillery.java
@@ -69,7 +69,11 @@ public class ISBATubeArtillery extends ArtilleryWeapon {
         bv = 27;
         cost = 200000;
         rulesRefs = "96, TO:AUE";
-        flags = flags.or(F_BA_WEAPON, F_MEK_MORTAR, F_MISSILE).andNot(F_MEK_WEAPON).andNot(F_TANK_WEAPON);
+        flags = flags.or(F_BA_WEAPON, F_MEK_MORTAR, F_MISSILE)
+              .andNot(F_MEK_WEAPON)
+              .andNot(F_TANK_WEAPON)
+              .andNot(F_AERO_WEAPON)
+              .andNot(F_PROTO_WEAPON);
         damage = DAMAGE_BY_CLUSTER_TABLE;
         atClass = CLASS_ARTILLERY;
         infDamageClass = WEAPON_CLUSTER_MISSILE;


### PR DESCRIPTION
Fix https://github.com/MegaMek/megameklab/issues/2273

Add andNot F_AERO_WEAPON and F_PROTO_WEAPON flags to BA Tube Artillery