### PR TITLE
Stop a throwing packet handler from freezing the server (Fixes #8597)

### DIFF
--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2000-2005 - Ben Mazur (bmazur@sev.org)
  * Copyright (c) 2013 - Edward Cullen (eddy@obsessedcomputers.co.uk)
- * Copyright (C) 2002-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2002-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -1416,8 +1416,16 @@ public class Server implements Runnable {
                         GAME_LOCK.unlock();
                     }
             }
-        } catch (InvalidPacketDataException e) {
-            LOGGER.error("Invalid packet data:", e);
+        } catch (InvalidPacketDataException invalidPacketData) {
+            LOGGER.error("Invalid packet data:", invalidPacketData);
+        } catch (RuntimeException handlerFailure) {
+            // A packet handler that throws must not take the thread down with it. Both callers of this method
+            // run on threads the server cannot lose: the packet pump, whose loop would end and leave the server
+            // silently ignoring every further packet from every client, and the connection receive thread that
+            // dispatches immediate packets. Logging and dropping the offending packet keeps the game running
+            // and leaves a stack trace to diagnose from.
+            LOGGER.error(handlerFailure, "Uncaught exception handling {} packet from connection {} - the packet "
+                  + "was dropped", packet.command(), connId);
         }
     }
 

--- a/megamek/src/megamek/server/totalWarfare/LobbyBoardHandler.java
+++ b/megamek/src/megamek/server/totalWarfare/LobbyBoardHandler.java
@@ -79,6 +79,9 @@ class LobbyBoardHandler extends AbstractTWRuleHandler {
      * outside the lounge phase and while a surprise board is selected (building it would reveal the surprise).
      * Requesting again re-rolls: a fresh board is built and broadcast each time.
      *
+     * <p>A failure to assemble the board never escapes this method: the requester is told, the reason is
+     * logged, and the previously built board (if any) is left in place.</p>
+     *
      * @param connId the connection that sent the request
      */
     void handleGenerationRequest(int connId) {
@@ -103,8 +106,23 @@ class LobbyBoardHandler extends AbstractTWRuleHandler {
             return;
         }
 
-        Board newBoard = TWBoardTransformer.instantiateBoard(getGame().getMapSettings(),
-              getGame().getPlanetaryConditions(), getGame().getOptions());
+        Board newBoard;
+        try {
+            newBoard = TWBoardTransformer.instantiateBoard(getGame().getMapSettings(),
+                  getGame().getPlanetaryConditions(), getGame().getOptions());
+        } catch (RuntimeException buildFailure) {
+            // Board assembly rejects settings it cannot build from: a selected board file that is missing or
+            // the wrong size makes BoardUtilities.combine() throw, and out-of-range random map generator
+            // parameters make the generator throw. The request must fail on its own instead of escaping into
+            // the packet handler, which would take the server's packet thread down with it.
+            LOGGER.error(buildFailure,
+                  "[LobbyBoard] {}: building the battlefield failed - the current map settings could not be "
+                        + "assembled into a board; the previous lounge board (if any) is kept", playerName);
+            gameManager.sendServerChat(connId,
+                  "The battlefield could not be built from the current map settings. See the server log for "
+                        + "details.");
+            return;
+        }
         getGame().setBoard(newBoard);
         boardGeneratedInLounge = true;
         LOGGER.info("[LobbyBoard] {} built the battlefield ({}x{} hexes)",

--- a/megamek/unittests/megamek/server/ServerPacketHandlingTest.java
+++ b/megamek/unittests/megamek/server/ServerPacketHandlingTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.server;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+import java.io.IOException;
+
+import megamek.common.Player;
+import megamek.common.game.Game;
+import megamek.common.net.enums.PacketCommand;
+import megamek.common.net.packets.Packet;
+import megamek.server.totalWarfare.TWGameManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that a packet handler which throws cannot take down the server thread that dispatched the packet.
+ * {@link Server#handle(int, Packet)} runs on the packet pump thread and on the connection receive thread; an
+ * exception escaping it would end the pump loop, after which the server ignores every further packet from every
+ * client without any indication that it has stopped listening.
+ */
+class ServerPacketHandlingTest {
+
+    private static final int TEST_CONNECTION_ID = 0;
+
+    private Server server;
+    private TWGameManager gameManager;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        gameManager = spy(new TWGameManager());
+        Game game = new Game();
+        Player player = new Player(TEST_CONNECTION_ID, "Test Player");
+        game.addPlayer(TEST_CONNECTION_ID, player);
+        gameManager.setGame(game);
+
+        // Port 0 binds an ephemeral port, so the test never collides with a running server
+        server = new Server(null, 0, gameManager);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.die();
+        }
+    }
+
+    @Test
+    void anExceptionFromAPacketHandlerDoesNotEscapeTheDispatchingThread() {
+        doThrow(new IllegalArgumentException("board is the wrong size, expected 2x2, got 0x0"))
+              .when(gameManager).handlePacket(anyInt(), any());
+
+        assertDoesNotThrow(() -> server.handle(TEST_CONNECTION_ID,
+              new Packet(PacketCommand.LOBBY_GENERATE_BOARD)));
+    }
+
+    @Test
+    void theServerKeepsHandlingPacketsAfterAHandlerThrew() {
+        doThrow(new IllegalStateException("first packet fails"))
+              .doNothing()
+              .when(gameManager).handlePacket(anyInt(), any());
+
+        server.handle(TEST_CONNECTION_ID, new Packet(PacketCommand.LOBBY_GENERATE_BOARD));
+
+        // The dispatching thread survived the first packet, so the next one is still processed
+        assertDoesNotThrow(() -> server.handle(TEST_CONNECTION_ID,
+              new Packet(PacketCommand.LOBBY_GENERATE_BOARD)));
+    }
+}

--- a/megamek/unittests/megamek/server/totalWarfare/LobbyBoardHandlerTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/LobbyBoardHandlerTest.java
@@ -33,6 +33,7 @@
 
 package megamek.server.totalWarfare;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -164,6 +165,31 @@ class LobbyBoardHandlerTest {
         lobbyBoardHandler.handleGenerationRequest(0);
 
         assertFalse(lobbyBoardHandler.hasBoardFromLounge());
+    }
+
+    @Test
+    void generationRequestSurvivesABoardThatCannotBeAssembled() {
+        // A selected board whose file is missing loads as an empty board, which BoardUtilities.combine()
+        // rejects as the wrong size. The failure must not escape into the packet handler.
+        game.setMapSettings(createMapSettingsFor(List.of("thisBoardFileDoesNotExist")));
+
+        assertDoesNotThrow(() -> lobbyBoardHandler.handleGenerationRequest(0));
+
+        assertFalse(lobbyBoardHandler.hasBoardFromLounge());
+        assertEquals(0, game.getBoard().getWidth());
+    }
+
+    @Test
+    void aFailedGenerationKeepsThePreviouslyBuiltBoard() {
+        lobbyBoardHandler.handleGenerationRequest(0);
+        assertTrue(lobbyBoardHandler.hasBoardFromLounge());
+
+        game.setMapSettings(createMapSettingsFor(List.of("thisBoardFileDoesNotExist")));
+        assertDoesNotThrow(() -> lobbyBoardHandler.handleGenerationRequest(0));
+
+        // The board everyone is already previewing must not be torn down by a failed re-roll
+        assertTrue(lobbyBoardHandler.hasBoardFromLounge());
+        assertEquals(2, game.getBoard().getWidth());
     }
 
     @Test


### PR DESCRIPTION
## Root Cause

If a server-side packet handler throws an unchecked exception, the server stops responding to every client, permanently, with no error dialog and usually nothing in the log. Players see the game freeze: units stop moving, the phase never advances, chat goes nowhere.

`Server.handle(int, Packet)` caught only `InvalidPacketDataException`. Anything else propagated to the caller, and neither caller guards against it. `PacketPump.run()` calls `handle(...)` in a bare loop, so an escaping exception ends the thread's `run()` method and the packet queue is never drained again. The connection receive thread dispatches immediate packets (`CHAT`, `CLIENT_NAME`, `CLOSE_CONNECTION`, `CLIENT_VERSIONS`) through the same unguarded path.

The **Generate Battlefield** button from #8536 gives this a reachable, on-demand trigger: `LobbyBoardHandler.handleGenerationRequest()` called `TWBoardTransformer.instantiateBoard()` unguarded, and board assembly throws when it cannot build from the given settings.

This is not a regression from #8536 - the same unguarded call already runs at game start via `applyBoardSettings()`, on the same packet-handling path. That PR added a button that reaches it on demand, which is what made it visible. It came from a Copilot review comment on #8536 (`LobbyBoardHandler.java:115`) that was left unaddressed when that PR merged; the comment was correct, and the consequence is worse than it suggested.

## Changes

Two independent commits, readable separately.

**1. Fail the lobby generation request instead of throwing** (`LobbyBoardHandler`)

`handleGenerationRequest()` now catches `RuntimeException` around the board build, logs it under the existing `[LobbyBoard]` tag, and tells the requester in chat. The board is only stored after a successful build, so a failed re-roll leaves the battlefield everyone is already previewing in place rather than tearing it down.

Two ways this actually throws today:
- A selected board that will not load. `Board.load(File)` swallows the `IOException` and leaves an empty 0x0 board, then `BoardUtilities.combine()` throws `IllegalArgumentException: board is the wrong size, expected WxH, got 0x0`. The server's re-scan plus `MapSettings.removeUnavailable()` covers the common cases, but not a board file removed or renamed on the server between the lobby scan and the button press.
- Out-of-range random map generator parameters. `BoardUtilities.generateRandom()` calls `Compute.randomInt(max - min + 1)` in several places, which bottoms out in `Random.nextInt(bound)` and throws when `bound <= 0`. Those numeric `MapSettings` fields arrive from the client with no server-side `min <= max` validation - only board *names* are validated.

**2. Stop any packet handler from killing the dispatching thread** (`Server`)

`handle()` also catches `RuntimeException`, logs it with the packet command and connection id, and drops the offending packet. `Error` and its subclasses are deliberately not caught. This is the root-cause fix and it also protects the pre-existing game-start path.

The catch parameter of the existing `InvalidPacketDataException` clause was renamed from `e` per the naming standard, as it is part of the same statement. `Server.java`'s copyright year was updated to 2026 for the modification.

## Files Changed

- `megamek/src/megamek/server/totalWarfare/LobbyBoardHandler.java` - guard the board build, log and notify the requester, keep the previous board
- `megamek/src/megamek/server/Server.java` - catch `RuntimeException` in `handle()`; catch-parameter rename; copyright year
- `megamek/unittests/megamek/server/totalWarfare/LobbyBoardHandlerTest.java` - 2 new regression tests
- `megamek/unittests/megamek/server/ServerPacketHandlingTest.java` - **new**, 2 tests

## Testing

**Automated.** 4 new tests, each verified to fail without its fix:

- `generationRequestSurvivesABoardThatCannotBeAssembled` and `aFailedGenerationKeepsThePreviouslyBuiltBoard` select a board with no file behind it. Reverting the handler guard makes both fail with the exact exception from the review comment: `IllegalArgumentException: board is the wrong size, expected 2x2, got 0x0`.
- `anExceptionFromAPacketHandlerDoesNotEscapeTheDispatchingThread` and `theServerKeepsHandlingPacketsAfterAHandlerThrew` drive `Server.handle()` with a game manager whose `handlePacket` throws. Reverting the `Server` guard makes both fail.

Full suite green after the change: 14,367 tests, 0 failures, 0 errors, 8 skipped.

## What is NOT proven yet

- **No multiplayer playtest.** The behavior is covered by unit tests only. The manual route to confirm the lobby half is: enter a lobby, select a fixed board, delete or rename that `.board` file in the server's boards folder, press **Generate Battlefield**. Expected now: a chat message to the presser, an `[LobbyBoard]` error with a stack trace in the log, the game still fully responsive. Before this change, the server stops answering every client at that point.
- **The generator-parameter trigger is reasoned from the code, not reproduced.** The unguarded `randomInt` call sites and the absence of server-side `min <= max` validation are verified by reading; no client was built that actually sends such settings. The board-load trigger *is* reproduced, in the tests.
- **The second commit changes global server behavior.** Exceptions that previously ended the pump thread are now logged and swallowed. That is strictly better than a silent freeze, but it means a handler bug that used to stop the server will now leave the game running in whatever state the failed handler left behind. The `LOGGER.error` call is what makes such a bug visible, so log reports matter more than before.
- Input validation of client-supplied `MapSettings` generator parameters is *not* addressed here; this PR only stops the resulting exception from being fatal. Worth a follow-up.

Fixes #8597
