### PR TITLE
Fix Issue #8599 Jump and Paratrooper Infantry cannot drop at above altitude 8

### DIFF
--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/MovementDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/MovementDisplay.java
@@ -5373,11 +5373,6 @@ public class MovementDisplay extends ActionPhaseDisplay {
             if (currentTransporter instanceof InfantryTransporter infantryTransporter) {
                 isInfantryTransporter = true;
 
-                // Can't drop infantry from above 8 Altitude
-                if (cmd.getFinalAltitude() > 8) {
-                    continue;
-                }
-
                 for (Entity entity : infantryTransporter.getDroppableUnits()) {
                     if (!alreadyDropped.contains(entity.getId())) {
                         currentUnits.add(entity);


### PR DESCRIPTION
Removing the upper altitude limit of 8 for infantry transports dropping troops 