### PR TITLE
Stop a throwing packet handler from freezing the server (Fixes #8597)

### DIFF
--- a/megamek/resources/megamek/client/messages.properties
+++ b/megamek/resources/megamek/client/messages.properties
@@ -823,6 +823,10 @@ ChatLounge.GenerateBattlefield=Generate Battlefield
 ChatLounge.GenerateBattlefieldTooltip=Asks the server to build the game board now and show it to all players.<br>The game will be played on exactly this board. Pressing again re-rolls generated maps.<br>Changing the map, planetary conditions or board-related options discards it.
 ChatLounge.GenerateBattlefieldTooltipSurprise=The battlefield cannot be built in the lobby while a Surprise board is selected,<br>as that would reveal which board was picked.
 ChatLounge.GenerateBattlefieldTooltipIncomplete=The battlefield cannot be built while the board selection is incomplete.<br>Assign a board to every board slot first.
+# Server chat sent by LobbyBoardHandler in response to a Generate Battlefield request
+LobbyBoard.chat.built={0} built the battlefield
+LobbyBoard.chat.surpriseRefusal=The battlefield cannot be built in the lobby while a Surprise board is selected.
+LobbyBoard.chat.buildFailed=The battlefield could not be built from the current map settings. See the server log for details.
 ChatLounge.MapListPopup.selectTwoOrMoreHint=Select two or more boards first (Ctrl-click or Shift-click), then right-click one of the selected boards.
 ChatLounge.MapPreviewButton.rotate=Rotate board (180 degrees)
 ChatLounge.MapPreviewButton.rotateTooltip=Turns this board by 180 degrees. Only possible for fixed boards with an even width.

--- a/megamek/src/megamek/common/util/BoardUtilities.java
+++ b/megamek/src/megamek/common/util/BoardUtilities.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2005-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2005-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -797,7 +797,9 @@ public class BoardUtilities {
     private static int pickTerrainDensity(int terrainType, int probHeavy, int probUltra) {
         int heavyThreshold = 100 - probHeavy;
         int ultraThreshold = 100;
-        int sum = 100 + probUltra;
+        // probUltra is an unvalidated client-supplied percentage; keep the roll bound positive so a wildly
+        // out-of-range value cannot make Compute.randomInt throw.
+        int sum = Math.max(1, 100 + probUltra);
 
         int roll = Compute.randomInt(sum);
 
@@ -953,8 +955,14 @@ public class BoardUtilities {
             // Locate the center of the crater.
             Point center = new Point(Compute.randomInt(width), Compute.randomInt(height));
 
-            // What is the diameter of this crater?
-            int radius = Compute.randomInt(maxRadius - minRadius + 1) + minRadius;
+            // What is the diameter of this crater? The radius bounds come straight from client-supplied map
+            // settings and are not validated anywhere, so an inverted or negative range must not reach
+            // Compute.randomInt (which rejects a bound of zero or less) or the array sizing below. Guarded the
+            // same way as the crater count above: an unusable range degrades to a fixed minimum radius.
+            int radius = Math.max(0, minRadius);
+            if (maxRadius > radius) {
+                radius += Compute.randomInt(maxRadius - radius + 1);
+            }
 
             // Terrestrial crater depth to radius ratio is typically 1:5 to 1:7.
             // Hexes are 30m across and levels are 6m high.

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2000-2005 - Ben Mazur (bmazur@sev.org)
  * Copyright (c) 2013 - Edward Cullen (eddy@obsessedcomputers.co.uk)
- * Copyright (C) 2002-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2002-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/src/megamek/server/Server.java
+++ b/megamek/src/megamek/server/Server.java
@@ -1416,8 +1416,16 @@ public class Server implements Runnable {
                         GAME_LOCK.unlock();
                     }
             }
-        } catch (InvalidPacketDataException e) {
-            LOGGER.error("Invalid packet data:", e);
+        } catch (InvalidPacketDataException invalidPacketData) {
+            LOGGER.error("Invalid packet data:", invalidPacketData);
+        } catch (RuntimeException handlerFailure) {
+            // A packet handler that throws must not take the thread down with it. Both callers of this method
+            // run on threads the server cannot lose: the packet pump, whose loop would end and leave the server
+            // silently ignoring every further packet from every client, and the connection receive thread that
+            // dispatches immediate packets. Logging and dropping the offending packet keeps the game running
+            // and leaves a stack trace to diagnose from.
+            LOGGER.error(handlerFailure, "Uncaught exception handling {} packet from connection {} - the packet "
+                  + "was dropped", packet.command(), connId);
         }
     }
 

--- a/megamek/src/megamek/server/totalWarfare/LobbyBoardHandler.java
+++ b/megamek/src/megamek/server/totalWarfare/LobbyBoardHandler.java
@@ -79,6 +79,9 @@ class LobbyBoardHandler extends AbstractTWRuleHandler {
      * outside the lounge phase and while a surprise board is selected (building it would reveal the surprise).
      * Requesting again re-rolls: a fresh board is built and broadcast each time.
      *
+     * <p>A failure to assemble the board never escapes this method: the requester is told, the reason is
+     * logged, and the previously built board (if any) is left in place.</p>
+     *
      * @param connId the connection that sent the request
      */
     void handleGenerationRequest(int connId) {
@@ -103,8 +106,23 @@ class LobbyBoardHandler extends AbstractTWRuleHandler {
             return;
         }
 
-        Board newBoard = TWBoardTransformer.instantiateBoard(getGame().getMapSettings(),
-              getGame().getPlanetaryConditions(), getGame().getOptions());
+        Board newBoard;
+        try {
+            newBoard = TWBoardTransformer.instantiateBoard(getGame().getMapSettings(),
+                  getGame().getPlanetaryConditions(), getGame().getOptions());
+        } catch (RuntimeException buildFailure) {
+            // Board assembly rejects settings it cannot build from: a selected board file that is missing or
+            // the wrong size makes BoardUtilities.combine() throw, and out-of-range random map generator
+            // parameters make the generator throw. The request must fail on its own instead of escaping into
+            // the packet handler, which would take the server's packet thread down with it.
+            LOGGER.error(buildFailure,
+                  "[LobbyBoard] {}: building the battlefield failed - the current map settings could not be "
+                        + "assembled into a board; the previous lounge board (if any) is kept", playerName);
+            gameManager.sendServerChat(connId,
+                  "The battlefield could not be built from the current map settings. See the server log for "
+                        + "details.");
+            return;
+        }
         getGame().setBoard(newBoard);
         boardGeneratedInLounge = true;
         LOGGER.info("[LobbyBoard] {} built the battlefield ({}x{} hexes)",

--- a/megamek/src/megamek/server/totalWarfare/LobbyBoardHandler.java
+++ b/megamek/src/megamek/server/totalWarfare/LobbyBoardHandler.java
@@ -35,6 +35,7 @@ package megamek.server.totalWarfare;
 
 import java.util.Objects;
 
+import megamek.client.ui.Messages;
 import megamek.common.Player;
 import megamek.common.board.Board;
 import megamek.common.board.postprocess.TWBoardTransformer;
@@ -101,8 +102,7 @@ class LobbyBoardHandler extends AbstractTWRuleHandler {
         if (hasSurpriseBoardSelection()) {
             LOGGER.debug("[LobbyBoard] {}: generation request refused - a surprise board is selected",
                   playerName);
-            gameManager.sendServerChat(connId,
-                  "The battlefield cannot be built in the lobby while a Surprise board is selected.");
+            gameManager.sendServerChat(connId, Messages.getString("LobbyBoard.chat.surpriseRefusal"));
             return;
         }
 
@@ -118,16 +118,14 @@ class LobbyBoardHandler extends AbstractTWRuleHandler {
             LOGGER.error(buildFailure,
                   "[LobbyBoard] {}: building the battlefield failed - the current map settings could not be "
                         + "assembled into a board; the previous lounge board (if any) is kept", playerName);
-            gameManager.sendServerChat(connId,
-                  "The battlefield could not be built from the current map settings. See the server log for "
-                        + "details.");
+            gameManager.sendServerChat(connId, Messages.getString("LobbyBoard.chat.buildFailed"));
             return;
         }
         getGame().setBoard(newBoard);
         boardGeneratedInLounge = true;
         LOGGER.info("[LobbyBoard] {} built the battlefield ({}x{} hexes)",
               playerName, newBoard.getWidth(), newBoard.getHeight());
-        gameManager.sendServerChat(playerName + " built the battlefield");
+        gameManager.sendServerChat(Messages.getString("LobbyBoard.chat.built", playerName));
         gameManager.resetPlayersDone();
         gameManager.send(gameManager.getPacketHelper().createBoardsPacket());
     }

--- a/megamek/unittests/megamek/common/util/BoardUtilitiesTest.java
+++ b/megamek/unittests/megamek/common/util/BoardUtilitiesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2014-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,8 +32,10 @@
  */
 package megamek.common.util;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import megamek.common.board.Board;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -82,5 +84,35 @@ class BoardUtilitiesTest {
         distanceFromCenter = 8;
         expected = 0;
         assertEquals(expected, BoardUtilities.craterProfile(distanceFromCenter, craterRadius, maxDepth));
+    }
+
+    /**
+     * Crater radius bounds come from unvalidated client-supplied map settings. An inverted range
+     * (max below min) must not reach {@link megamek.common.compute.Compute#randomInt(int)}, which rejects a
+     * bound of zero or less, nor the crater-profile array sizing.
+     */
+    @Test
+    void addCratersToleratesAnInvertedRadiusRange() {
+        Board board = emptyBoard();
+
+        assertDoesNotThrow(() -> BoardUtilities.addCraters(board, 6, 2, 1, 1));
+    }
+
+    /** A negative minimum radius must not produce a negative crater-profile array size either. */
+    @Test
+    void addCratersToleratesANegativeRadiusRange() {
+        Board board = emptyBoard();
+
+        assertDoesNotThrow(() -> BoardUtilities.addCraters(board, -5, -2, 1, 1));
+    }
+
+    /** @return a small blank board that craters can be placed on */
+    private static Board emptyBoard() {
+        Board board = new Board();
+        board.load("""
+              size 5 5
+              hex 0101 0 "" ""
+              end""", null);
+        return board;
     }
 }

--- a/megamek/unittests/megamek/server/ServerPacketHandlingTest.java
+++ b/megamek/unittests/megamek/server/ServerPacketHandlingTest.java
@@ -38,6 +38,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 
@@ -102,5 +104,9 @@ class ServerPacketHandlingTest {
         // The dispatching thread survived the first packet, so the next one is still processed
         assertDoesNotThrow(() -> server.handle(TEST_CONNECTION_ID,
               new Packet(PacketCommand.LOBBY_GENERATE_BOARD)));
+
+        // Not throwing is not enough on its own: an early return inside handle() would be just as silent.
+        // Assert the second packet actually reached the handler.
+        verify(gameManager, times(2)).handlePacket(anyInt(), any());
     }
 }

--- a/megamek/unittests/megamek/server/ServerPacketHandlingTest.java
+++ b/megamek/unittests/megamek/server/ServerPacketHandlingTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.server;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+import java.io.IOException;
+
+import megamek.common.Player;
+import megamek.common.game.Game;
+import megamek.common.net.enums.PacketCommand;
+import megamek.common.net.packets.Packet;
+import megamek.server.totalWarfare.TWGameManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that a packet handler which throws cannot take down the server thread that dispatched the packet.
+ * {@link Server#handle(int, Packet)} runs on the packet pump thread and on the connection receive thread; an
+ * exception escaping it would end the pump loop, after which the server ignores every further packet from every
+ * client without any indication that it has stopped listening.
+ */
+class ServerPacketHandlingTest {
+
+    private static final int TEST_CONNECTION_ID = 0;
+
+    private Server server;
+    private TWGameManager gameManager;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        gameManager = spy(new TWGameManager());
+        Game game = new Game();
+        Player player = new Player(TEST_CONNECTION_ID, "Test Player");
+        game.addPlayer(TEST_CONNECTION_ID, player);
+        gameManager.setGame(game);
+
+        // Port 0 binds an ephemeral port, so the test never collides with a running server
+        server = new Server(null, 0, gameManager);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.die();
+        }
+    }
+
+    @Test
+    void anExceptionFromAPacketHandlerDoesNotEscapeTheDispatchingThread() {
+        doThrow(new IllegalArgumentException("board is the wrong size, expected 2x2, got 0x0"))
+              .when(gameManager).handlePacket(anyInt(), any());
+
+        assertDoesNotThrow(() -> server.handle(TEST_CONNECTION_ID,
+              new Packet(PacketCommand.LOBBY_GENERATE_BOARD)));
+    }
+
+    @Test
+    void theServerKeepsHandlingPacketsAfterAHandlerThrew() {
+        doThrow(new IllegalStateException("first packet fails"))
+              .doNothing()
+              .when(gameManager).handlePacket(anyInt(), any());
+
+        server.handle(TEST_CONNECTION_ID, new Packet(PacketCommand.LOBBY_GENERATE_BOARD));
+
+        // The dispatching thread survived the first packet, so the next one is still processed
+        assertDoesNotThrow(() -> server.handle(TEST_CONNECTION_ID,
+              new Packet(PacketCommand.LOBBY_GENERATE_BOARD)));
+    }
+}

--- a/megamek/unittests/megamek/server/totalWarfare/LobbyBoardHandlerTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/LobbyBoardHandlerTest.java
@@ -33,6 +33,7 @@
 
 package megamek.server.totalWarfare;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -164,6 +165,31 @@ class LobbyBoardHandlerTest {
         lobbyBoardHandler.handleGenerationRequest(0);
 
         assertFalse(lobbyBoardHandler.hasBoardFromLounge());
+    }
+
+    @Test
+    void generationRequestSurvivesABoardThatCannotBeAssembled() {
+        // A selected board whose file is missing loads as an empty board, which BoardUtilities.combine()
+        // rejects as the wrong size. The failure must not escape into the packet handler.
+        game.setMapSettings(createMapSettingsFor(List.of("thisBoardFileDoesNotExist")));
+
+        assertDoesNotThrow(() -> lobbyBoardHandler.handleGenerationRequest(0));
+
+        assertFalse(lobbyBoardHandler.hasBoardFromLounge());
+        assertEquals(0, game.getBoard().getWidth());
+    }
+
+    @Test
+    void aFailedGenerationKeepsThePreviouslyBuiltBoard() {
+        lobbyBoardHandler.handleGenerationRequest(0);
+        assertTrue(lobbyBoardHandler.hasBoardFromLounge());
+
+        game.setMapSettings(createMapSettingsFor(List.of("thisBoardFileDoesNotExist")));
+        assertDoesNotThrow(() -> lobbyBoardHandler.handleGenerationRequest(0));
+
+        // The board everyone is already previewing must not be torn down by a failed re-roll
+        assertTrue(lobbyBoardHandler.hasBoardFromLounge());
+        assertEquals(2, game.getBoard().getWidth());
     }
 
     @Test


### PR DESCRIPTION
Restores #8598, which was reverted in #8601. The server-side code is unchanged from that merge; this PR adds the analysis of the two static-analysis alerts raised on it (they are false positives), plus a pre-PR fix moving the lobby chat messages into the resource bundle.

## What this fixes, in plain terms

Right now, if anything goes wrong deep inside the server while it is handling a message from a client, **the whole server stops listening to everybody, forever.** There is no error box, no chat message, and usually nothing in the log. To the players it just looks like the game froze: nobody can move, the phase never advances, chat does nothing. The only way out is to restart the server.

The reason it is so total: the server has one thread whose entire job is to take messages off a queue and act on them. That thread had no safety net. One unexpected error inside any handler ends that thread, and the queue is never touched again. The server process is still running and still accepting connections - it simply never acts on anything anyone sends.

The **Generate Battlefield** button added in #8536 gives this an easy way to happen on purpose.

### Worked example

Host a lobby and pick a board named `RiverValley`. Now suppose that board file is not actually readable on the server - somebody renamed it, or it was deleted after the lobby scanned the folder.

Press **Generate Battlefield**.

- **Before this PR:** the board loader quietly produces an empty board, the assembly step rejects it, and the resulting error escapes and kills the message thread. The lobby goes dead for every player at once. Ready buttons stop responding, chat stops working, map changes do nothing. Nothing in the log says why.
- **After this PR:** the player who pressed the button gets a chat message - *"The battlefield could not be built from the current map settings. See the server log for details."* - the log gets a `[LobbyBoard]` entry with the full stack trace, and the lobby carries on exactly as before. If a battlefield had already been generated and everyone was previewing it, that board stays; the failed re-roll does not tear it down.

## Root cause

`Server.handle(int, Packet)` caught only `InvalidPacketDataException`. Anything else propagated to the caller, and neither caller has a guard of its own:

- `PacketPump.run()` calls `handle(...)` in a bare loop. An escaping exception ends the thread's `run()` method, so the loop terminates and the packet queue is never drained again.
- `ConnectionHandler.packetReceived(...)` dispatches immediate packets (`CHAT`, `CLIENT_NAME`, `CLOSE_CONNECTION`, `CLIENT_VERSIONS`) on the connection receive thread through the same unguarded path.

Reaching it from the lobby: `LobbyBoardHandler.handleGenerationRequest()` called `TWBoardTransformer.instantiateBoard()` unguarded. That throws in two ways today:

1. **A selected board that will not load.** `Board.load(File)` swallows the `IOException` and leaves an empty 0x0 board, then `BoardUtilities.combine()` throws `IllegalArgumentException: board is the wrong size, expected WxH, got 0x0`. The server's re-scan plus `MapSettings.removeUnavailable()` covers the common cases, but not a board file removed or renamed between the lobby scan and the button press.
2. **Out-of-range random map generator parameters.** The numeric `MapSettings` fields arrive from the client with no validation at all - only board *names* are checked. `MapSettings.validateMapGenParameters()` would clamp them, but it is `@Deprecated(since = "0.51.0", forRemoval = true)` with **zero callers**, and nothing replaced it. Most generator call sites guard themselves, but two did not: `addCraters()` rolled the crater radius with no range check (`IllegalArgumentException: bound must be positive`, plus `NegativeArraySizeException` from the crater-profile array on a negative minimum), and `pickTerrainDensity()` used `100 + probUltra` as a roll bound. Both are fixed here; the general validation gap is tracked as #8603.

**This is not a regression from #8536.** The same unguarded call already runs at game start via `applyBoardSettings()`, on the same packet-handling path. #8536 added a button that reaches it on demand, which is what made it visible. It came from a Copilot review comment on #8536 (`LobbyBoardHandler.java:115`) that was still open when that PR merged.

## Changes

Five commits, readable independently.

1. **Fail the lobby request instead of throwing** (`LobbyBoardHandler`) - `handleGenerationRequest()` catches `RuntimeException` around the board build, logs under the existing `[LobbyBoard]` tag, and tells the requester in chat. The board is stored only after a successful build, so a failed re-roll leaves the existing battlefield in place.
2. **Stop any handler from killing the dispatching thread** (`Server`) - `handle()` also catches `RuntimeException`, logs the packet command and connection id, and drops that one packet. `Error` and its subclasses are deliberately **not** caught. This is the root-cause fix and it also protects the pre-existing game-start path.
3. Copyright year on `Server.java`. The catch parameter of the existing `InvalidPacketDataException` clause was renamed from `e` per the naming standard, as it is part of the same statement.
4. **Guard the two unvalidated generator calls** (`BoardUtilities`) - `addCraters()` now clamps its radius range the same way the crater count directly above it does, and `pickTerrainDensity()` floors its roll bound at 1. These were reachable from the lobby button *and* from board assembly at game start, where a throw would now be caught by change 2 but leave the game silently failing to start.
5. **Chat messages into `messages.properties`** - found by the pre-PR checklist. The new failure message was a hardcoded user-facing string. The two messages already in that method (the surprise-board refusal, and the `"built the battlefield"` broadcast, which was string concatenation) were hardcoded too, so all three moved together rather than leaving the method half converted. Adds `LobbyBoard.chat.built`, `LobbyBoard.chat.surpriseRefusal`, `LobbyBoard.chat.buildFailed`, English only; other locales fall back to English. Server-side chat is already localised this way elsewhere in the server package (the Gamemaster command messages).

## Files Changed

- `megamek/src/megamek/common/util/BoardUtilities.java` - guard the crater radius roll and the terrain-density roll bound
- `megamek/src/megamek/server/Server.java` - catch `RuntimeException` in `handle()`; catch-parameter rename; copyright year
- `megamek/src/megamek/server/totalWarfare/LobbyBoardHandler.java` - guard the board build, log and notify the requester, keep the previous board; chat messages via `Messages`
- `megamek/resources/megamek/client/messages.properties` - 3 new keys (English only)
- `megamek/unittests/megamek/server/totalWarfare/LobbyBoardHandlerTest.java` - 2 new regression tests
- `megamek/unittests/megamek/server/ServerPacketHandlingTest.java` - **new**, 2 tests
- `megamek/unittests/megamek/common/util/BoardUtilitiesTest.java` - 2 new regression tests

## Testing

**Automated.** 6 tests, each verified to fail with its own fix reverted:

- `generationRequestSurvivesABoardThatCannotBeAssembled` and `aFailedGenerationKeepsThePreviouslyBuiltBoard` select a board with no file behind it. Reverting the handler guard makes both fail with the exact exception from the original review comment: `IllegalArgumentException: board is the wrong size, expected 2x2, got 0x0`.
- `anExceptionFromAPacketHandlerDoesNotEscapeTheDispatchingThread` and `theServerKeepsHandlingPacketsAfterAHandlerThrew` drive `Server.handle()` with a game manager whose `handlePacket` throws. Reverting the `Server` guard makes both fail.
- `addCratersToleratesAnInvertedRadiusRange` and `addCratersToleratesANegativeRadiusRange` pass min/max the wrong way round and negative. Reverting the `BoardUtilities` guard makes them fail with `IllegalArgumentException: bound must be positive` and `NegativeArraySizeException: -4` respectively.

The three new message keys were checked to actually resolve (a missing key returns `!key!` silently, so this was verified rather than assumed).

Full suite green on this branch: `./gradlew :megamek:test` exit 0, **14,370 tests, 0 failures, 0 errors, 8 skipped.**

## On the two CodeQL alerts from #8598

CodeQL `java/unused-format-argument` flagged both new `LOGGER.error(...)` calls ("refers to 0 arguments but supplies 1/2"). **These are false positives; the logging is deliberately unchanged.**

- `MMLogger.parametrizedStringAnyway()` checks `message.contains("{}")` and routes to Log4j's `ParameterizedMessage`. The `String.format` fallback CodeQL is modelling only runs when the message contains **no** `{}`. Both flagged messages contain `{}` with matching counts (1 placeholder/1 argument, 2/2) and render correctly.
- The rule fires on MegaMek's standard logging idiom generally. Open alert **10362** is a pre-existing instance on `PreEndDeclarationsDisplay.java:568`, an ordinary `LOGGER.debug("...{}...", args)` call. The two here were flagged only because they are new lines in the diff - and they will be flagged again on this PR for the same reason.
- Converting them to `%s`/`String.format` would contradict the coding standard ("always use templated messages") and diverge from several hundred existing call sites.

Suggest dismissing alerts **10512** and **10513** as false positive.

## What is NOT proven yet

- **No multiplayer playtest.** Unit tests only. This is the one pre-PR gate still open. Manual route: lobby, select a fixed board, delete or rename that `.board` file in the server's boards folder, press **Generate Battlefield**. Expect a chat message to the presser, an `[LobbyBoard]` error with stack trace in `megamek.log`, and a fully responsive lobby. Before this change the server stops answering every client at that point.
- **The generator-parameter trigger is now reproduced in tests, but only at the `BoardUtilities` level.** No client was built that actually sends inverted settings over the wire, so the full client-to-server path for that trigger is still reasoned rather than exercised. The board-load trigger *is* reproduced end to end in the handler tests.
- **The two generator guards are point fixes, not validation.** Any future generator code reading a `MapSettings` range is equally unprotected, because nothing validates those numbers on ingress. That is #8603.
- **Commit 2 changes global server behavior.** Exceptions that previously ended the pump thread are now logged and swallowed. Strictly better than a silent freeze, but a handler bug that used to stop the server will now leave the game running in whatever state the failed handler left behind. The `LOGGER.error` call is what makes such a bug visible, so log reports matter more than they did before.
- **`ServerPacketHandlingTest` constructs a real `Server` on an ephemeral port** (`new Server(null, 0, gameManager)`, `die()` in teardown). Green across four full local runs, but if CI restricts socket binding this test could fail there. Straightforward to convert to a spy if that happens.
- **Commit 4 touches two pre-existing strings** that this fix did not otherwise need to change. Included so the method is not left half converted; happy to drop it to just the new string if that reads as scope creep.

Fixes #8597
