### PR TITLE
Save tractor and trailer links to MUL files (Fixes #8604)

### DIFF
--- a/megamek/src/megamek/common/loaders/MULParser.java
+++ b/megamek/src/megamek/common/loaders/MULParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2014-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -130,6 +130,8 @@ public class MULParser {
     public static final String ELE_ORIG_PODS = "ONumberOfPods";
     public static final String ELE_ORIG_MEN = "ONumberOfMen";
     public static final String ELE_CONVEYANCE = "Conveyance";
+    public static final String ELE_TOWED_UNITS = "TowedUnits";
+    public static final String ELE_TOWED_UNIT = "TowedUnit";
     public static final String ELE_GAME = "Game";
     public static final String ELE_FORCE = "Force";
     public static final String ELE_BAY = "transportBay";
@@ -670,6 +672,8 @@ public class MULParser {
                     parseOMen(currEle, entity);
                 } else if (nodeName.equalsIgnoreCase(ELE_CONVEYANCE)) {
                     parseConveyance(currEle, entity);
+                } else if (nodeName.equalsIgnoreCase(ELE_TOWED_UNITS)) {
+                    parseTowedUnits(currEle, entity);
                 } else if (nodeName.equalsIgnoreCase(ELE_GAME)) {
                     parseId(currEle, entity);
                 } else if (nodeName.equalsIgnoreCase(ELE_FORCE)) {
@@ -2619,6 +2623,37 @@ public class MULParser {
             entity.setTransportId(id);
         } catch (Exception e) {
             warning.append("Invalid transport id in conveyance tag.\n");
+        }
+    }
+
+    /**
+     * Parses the trailers a tractor tows, in order from front to back.
+     * <p>
+     * The ids read here are the ones the saving game used. They are stored as-is, exactly like the conveyance id
+     * above, and translated to real ids once the units have been added to a game and their server-side ids are known.
+     * Only the tractor records the train; each trailer's own tractor and hitch are rebuilt from this list.
+     * </p>
+     */
+    private void parseTowedUnits(Element towedUnitsTag, Entity entity) {
+        NodeList towedNodes = towedUnitsTag.getChildNodes();
+
+        for (int nodeIndex = 0; nodeIndex < towedNodes.getLength(); nodeIndex++) {
+            Node currNode = towedNodes.item(nodeIndex);
+
+            if (currNode.getParentNode() != towedUnitsTag || (currNode.getNodeType() != Node.ELEMENT_NODE)) {
+                continue;
+            }
+
+            Element currEle = (Element) currNode;
+            if (!currEle.getNodeName().equalsIgnoreCase(ELE_TOWED_UNIT)) {
+                continue;
+            }
+
+            try {
+                entity.addTowedUnit(Integer.parseInt(currEle.getAttribute(ATTR_ID)));
+            } catch (Exception ignored) {
+                warning.append("Invalid id in TowedUnit tag.\n");
+            }
         }
     }
 

--- a/megamek/src/megamek/common/units/EntityListFile.java
+++ b/megamek/src/megamek/common/units/EntityListFile.java
@@ -1351,6 +1351,24 @@ public class EntityListFile {
                 output.write(indentStr(indentLvl + 1) + "</" + MULParser.ELE_NC3 + ">\n");
             }
 
+            // Record the trailers this entity tows, front to back. Only the tractor records the train: order fixes
+            // the hitch chain and therefore where each trailer sits, and each trailer's own tractor and hitch are
+            // rebuilt from this list when the units are added to a game.
+            if (!entity.getAllTowedUnits().isEmpty()) {
+                output.write(indentStr(indentLvl + 1) + '<' + MULParser.ELE_TOWED_UNITS + ">\n");
+                for (int towedId : entity.getAllTowedUnits()) {
+                    output.write(indentStr(indentLvl + 2) +
+                          '<' +
+                          MULParser.ELE_TOWED_UNIT +
+                          ' ' +
+                          MULParser.ATTR_ID +
+                          "=\"" +
+                          towedId +
+                          "\"/>\n");
+                }
+                output.write(indentStr(indentLvl + 1) + "</" + MULParser.ELE_TOWED_UNITS + ">\n");
+            }
+
             // Record if this entity is transported by another
             if (entity.getTransportId() != Entity.NONE) {
                 output.write(indentStr(indentLvl + 1) +

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -26811,6 +26811,10 @@ public class TWGameManager extends AbstractGameManager {
             }
         }
 
+        // Re-hitch tractor-trailer trains. Like the transport ids above, a MUL stores the ids the saving game used,
+        // so the train can only be rebuilt now that every unit has its server-given id.
+        restoreTrains(entities, idMap);
+
         // Set the "loaded keepers" which is apparently used for deployment unloading to
         // differentiate between units loaded in the lobby and other carried units
         // When entering a game from the lobby, this list is generated again, but not
@@ -26831,6 +26835,50 @@ public class TWGameManager extends AbstractGameManager {
         List<Integer> changedForces = new ArrayList<>(forceMapping.values());
 
         send(createAddEntityPacket(entityIds, changedForces));
+    }
+
+    /**
+     * Re-hitches the trains a MUL describes, once the units in it have real ids.
+     * <p>
+     * A tractor read from a file carries the trailer ids the saving game used, which mean nothing here. Each one is
+     * translated through {@code idMap} and the train is built again from the front, which restores every trailer's
+     * tractor, hitch and place in the chain. Building it through {@code towUnit} rather than setting the fields
+     * directly is what loads the hitches, so the train behaves exactly as one connected in the lobby.
+     * </p>
+     *
+     * @param entities the units that were just added
+     * @param idMap    saved id to server-given id, covering only the units in this batch
+     */
+    void restoreTrains(List<Entity> entities, Map<Integer, Integer> idMap) {
+        for (final Entity tractor : entities) {
+            List<Integer> savedTrailerIds = new ArrayList<>(tractor.getAllTowedUnits());
+
+            if (savedTrailerIds.isEmpty()) {
+                continue;
+            }
+
+            // Drop the saved ids before re-hitching. They are file ids, not entity ids, and one of them may well
+            // collide with a real id in this game, so none of them may be left in the list.
+            for (int savedTrailerId : savedTrailerIds) {
+                tractor.removeTowedUnit(savedTrailerId);
+            }
+
+            for (int savedTrailerId : savedTrailerIds) {
+                Integer realTrailerId = idMap.get(savedTrailerId);
+                Entity trailer = (realTrailerId == null) ? null : game.getEntity(realTrailerId);
+
+                if (trailer == null) {
+                    LOGGER.warn("[Train] {} was saved towing unit #{}, which is not in this file; the rest of the "
+                                + "train is still hitched", tractor.getDisplayName(), savedTrailerId);
+                    continue;
+                }
+
+                tractor.towUnit(trailer.getId());
+            }
+
+            LOGGER.info("[Train] restored {} towing {} trailer(s) from file",
+                  tractor.getDisplayName(), tractor.getAllTowedUnits().size());
+        }
     }
 
     /**

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -26874,6 +26874,16 @@ public class TWGameManager extends AbstractGameManager {
                 }
 
                 tractor.towUnit(trailer.getId());
+
+                // towUnit records the trailer as part of the train before it looks for a hitch to hold it, and does
+                // not undo that when nothing can. A trailer left listed but unhitched would be reported as restored
+                // and then behave as neither loose nor towed, so drop it back out of the train instead.
+                if (trailer.getTowedBy() == Entity.NONE) {
+                    LOGGER.warn("[Train] {} has no free hitch for {}; the trailer was loaded loose",
+                          tractor.getDisplayName(), trailer.getDisplayName());
+                    tractor.removeTowedUnit(trailer.getId());
+                    trailer.setTractor(Entity.NONE);
+                }
             }
 
             LOGGER.info("[Train] restored {} towing {} trailer(s) from file",

--- a/megamek/unittests/megamek/common/units/TrainMulRoundTripTest.java
+++ b/megamek/unittests/megamek/common/units/TrainMulRoundTripTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.units;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+
+import megamek.common.Player;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.EquipmentTypeLookup;
+import megamek.common.game.Game;
+import megamek.common.loaders.MULParser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers writing a tractor-and-trailer train to a MUL.
+ *
+ * <p>The file records the train on the tractor only, as an ordered list of the ids the saving game used. Order
+ * matters: it fixes the hitch chain and therefore where each trailer sits. Those ids mean nothing until the units
+ * reach a game, which is where {@code TWGameManager.restoreTrains} translates them.</p>
+ *
+ * <p>These tests assert on the written XML rather than reading the file back, because the parser rebuilds each unit
+ * from the unit cache and the vehicles built here are not cached designs. The read side is covered by
+ * {@code TrainMulRestoreTest}.</p>
+ */
+class TrainMulRoundTripTest {
+
+    private static final double TRACTOR_TONS = 75.0;
+    private static final double CARRIAGE_TONS = 10.0;
+
+    private Game game;
+    private Player owner;
+
+    @BeforeEach
+    void setUp() {
+        EquipmentType.initializeTypes();
+        owner = new Player(0, "Owner");
+        owner.setTeam(1);
+        game = new Game();
+        game.addPlayer(0, owner);
+    }
+
+    private Tank buildVehicle(double tonnage, boolean isTrailer) throws Exception {
+        Tank vehicle = new Tank();
+        vehicle.setId(game.getNextEntityId());
+        vehicle.setOwner(owner);
+        vehicle.setChassis(isTrailer ? "Test Carriage" : "Test Tractor");
+        vehicle.setModel("TT-1");
+        vehicle.setWeight(tonnage);
+        vehicle.setMovementMode(EntityMovementMode.TRACKED);
+        vehicle.setTrailer(isTrailer);
+        vehicle.addEquipment(EquipmentType.get(EquipmentTypeLookup.HITCH), Tank.LOC_BODY);
+        vehicle.setTrailerHitches();
+        game.addEntity(vehicle);
+        return vehicle;
+    }
+
+    private Tank buildTrain(int trailerCount) throws Exception {
+        Tank tractor = buildVehicle(TRACTOR_TONS, false);
+        for (int index = 0; index < trailerCount; index++) {
+            Tank carriage = buildVehicle(CARRIAGE_TONS, true);
+            tractor.towUnit(carriage.getId());
+        }
+        return tractor;
+    }
+
+    private String toMul(Entity entity) throws Exception {
+        StringWriter writer = new StringWriter();
+        ArrayList<Entity> list = new ArrayList<>();
+        list.add(entity);
+        EntityListFile.writeEntityList(writer, list);
+        return writer.toString();
+    }
+
+    private static String towedUnitTag(int id) {
+        return '<' + MULParser.ELE_TOWED_UNIT + ' ' + MULParser.ATTR_ID + "=\"" + id + "\"/>";
+    }
+
+    @Test
+    void aTractorWritesTheTrailersItTows() throws Exception {
+        Tank tractor = buildTrain(2);
+        int leadTrailerId = tractor.getAllTowedUnits().get(0);
+        int secondTrailerId = tractor.getAllTowedUnits().get(1);
+
+        String xml = toMul(tractor);
+
+        assertTrue(xml.contains('<' + MULParser.ELE_TOWED_UNITS + '>'), "The train element is written: " + xml);
+        assertTrue(xml.contains(towedUnitTag(leadTrailerId)), "The lead trailer is listed: " + xml);
+        assertTrue(xml.contains(towedUnitTag(secondTrailerId)), "The second trailer is listed: " + xml);
+    }
+
+    @Test
+    void trailersAreWrittenFrontToBack() throws Exception {
+        Tank tractor = buildTrain(3);
+        String xml = toMul(tractor);
+
+        int previousIndex = -1;
+        for (int towedId : tractor.getAllTowedUnits()) {
+            int index = xml.indexOf(towedUnitTag(towedId));
+            assertTrue(index > previousIndex, "Trailer " + towedId + " is out of order in: " + xml);
+            previousIndex = index;
+        }
+    }
+
+    @Test
+    void aUnitTowingNothingWritesNoTrainElement() throws Exception {
+        Tank tractor = buildTrain(0);
+
+        String xml = toMul(tractor);
+
+        assertFalse(xml.contains(MULParser.ELE_TOWED_UNITS),
+              "A unit towing nothing writes no TowedUnits element: " + xml);
+    }
+
+    @Test
+    void aTrailerDoesNotRecordTheTrainItself() throws Exception {
+        Tank tractor = buildTrain(2);
+        Entity leadTrailer = game.getEntity(tractor.getAllTowedUnits().get(0));
+
+        String xml = toMul(leadTrailer);
+
+        assertFalse(xml.contains(MULParser.ELE_TOWED_UNITS),
+              "Only the tractor records the train: " + xml);
+    }
+
+    @Test
+    void everyTrailerAppearsExactlyOnce() throws Exception {
+        Tank tractor = buildTrain(3);
+        String xml = toMul(tractor);
+
+        assertEquals(3, xml.split(MULParser.ELE_TOWED_UNIT + ' ', -1).length - 1,
+              "Three trailers produce three entries: " + xml);
+    }
+}

--- a/megamek/unittests/megamek/server/totalWarfare/TrainMulRestoreTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/TrainMulRestoreTest.java
@@ -34,6 +34,7 @@
 package megamek.server.totalWarfare;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -155,6 +156,28 @@ class TrainMulRestoreTest {
 
         assertTrue(tractor.getAllTowedUnits().isEmpty(),
               "An unmapped saved id is dropped even when it looks like a real entity id");
+    }
+
+    @Test
+    void aTrailerThatCannotBeHitchedIsLeftLoose() throws Exception {
+        // A tractor with no hitch at all, which is what a file describing a train the data no longer supports
+        // amounts to. towUnit has nothing to load the trailer into.
+        Tank tractor = new Tank();
+        tractor.setId(game.getNextEntityId());
+        tractor.setOwner(owner);
+        tractor.setWeight(TRACTOR_TONS);
+        tractor.setMovementMode(EntityMovementMode.TRACKED);
+        game.addEntity(tractor);
+
+        Tank trailer = addVehicle(CARRIAGE_TONS, true);
+
+        tractor.addTowedUnit(51);
+        gameManager.restoreTrains(List.of(tractor, trailer), Map.of(51, trailer.getId()));
+
+        assertEquals(Entity.NONE, trailer.getTractor(),
+              "A trailer nothing can hold is loaded loose rather than listed as towed");
+        assertFalse(tractor.getAllTowedUnits().contains(trailer.getId()),
+              "and the tractor does not report it as part of the train");
     }
 
     @Test

--- a/megamek/unittests/megamek/server/totalWarfare/TrainMulRestoreTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/TrainMulRestoreTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.server.totalWarfare;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import megamek.common.Player;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.EquipmentTypeLookup;
+import megamek.common.game.Game;
+import megamek.common.units.Entity;
+import megamek.common.units.EntityMovementMode;
+import megamek.common.units.Tank;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers rebuilding a train from a loaded MUL.
+ *
+ * <p>A tractor read from a file carries the trailer ids the saving game used. The server assigns its own ids when
+ * the units are added, so the saved ids have to be translated before the train can be hitched again.</p>
+ */
+class TrainMulRestoreTest {
+
+    private static final double TRACTOR_TONS = 75.0;
+    private static final double CARRIAGE_TONS = 10.0;
+
+    private Game game;
+    private TWGameManager gameManager;
+    private Player owner;
+
+    @BeforeEach
+    void setUp() {
+        EquipmentType.initializeTypes();
+        game = new Game();
+        owner = new Player(0, "Owner");
+        owner.setTeam(1);
+        game.addPlayer(0, owner);
+        gameManager = new TWGameManager();
+        gameManager.setGame(game);
+    }
+
+    /** Adds a vehicle with a server-given id, as receiveEntityAdd would. */
+    private Tank addVehicle(double tonnage, boolean isTrailer) throws Exception {
+        Tank vehicle = new Tank();
+        vehicle.setId(game.getNextEntityId());
+        vehicle.setOwner(owner);
+        vehicle.setWeight(tonnage);
+        vehicle.setMovementMode(EntityMovementMode.TRACKED);
+        vehicle.setTrailer(isTrailer);
+        vehicle.addEquipment(EquipmentType.get(EquipmentTypeLookup.HITCH), Tank.LOC_BODY);
+        vehicle.setTrailerHitches();
+        game.addEntity(vehicle);
+        return vehicle;
+    }
+
+    @Test
+    void savedTrailerIdsAreTranslatedAndTheTrainIsHitched() throws Exception {
+        Tank tractor = addVehicle(TRACTOR_TONS, false);
+        Tank leadTrailer = addVehicle(CARRIAGE_TONS, true);
+        Tank secondTrailer = addVehicle(CARRIAGE_TONS, true);
+
+        // The file said this tractor towed units 51 then 52, which are not the ids they were given here.
+        tractor.addTowedUnit(51);
+        tractor.addTowedUnit(52);
+        Map<Integer, Integer> idMap = new HashMap<>();
+        idMap.put(51, leadTrailer.getId());
+        idMap.put(52, secondTrailer.getId());
+
+        gameManager.restoreTrains(List.of(tractor, leadTrailer, secondTrailer), idMap);
+
+        assertEquals(List.of(leadTrailer.getId(), secondTrailer.getId()), tractor.getAllTowedUnits(),
+              "The train is hitched with real ids, in the saved order");
+        assertEquals(tractor.getId(), leadTrailer.getTractor());
+        assertEquals(tractor.getId(), secondTrailer.getTractor());
+        assertEquals(tractor.getId(), leadTrailer.getTowedBy(), "The lead trailer hangs off the tractor");
+        assertEquals(leadTrailer.getId(), secondTrailer.getTowedBy(), "The second hangs off the first");
+    }
+
+    @Test
+    void aRestoredTrailerSitsOnAHitch() throws Exception {
+        Tank tractor = addVehicle(TRACTOR_TONS, false);
+        Tank trailer = addVehicle(CARRIAGE_TONS, true);
+
+        tractor.addTowedUnit(51);
+        gameManager.restoreTrains(List.of(tractor, trailer), Map.of(51, trailer.getId()));
+
+        assertEquals(trailer.getId(), tractor.getTowing(), "The tractor tows it");
+        assertTrue(tractor.getHitchCarrying(trailer.getId()) != null,
+              "The trailer is held by a hitch, not just listed in the train");
+    }
+
+    @Test
+    void aTrailerMissingFromTheFileIsSkipped() throws Exception {
+        Tank tractor = addVehicle(TRACTOR_TONS, false);
+        Tank trailer = addVehicle(CARRIAGE_TONS, true);
+
+        // 52 was towed when the file was saved but is not in it, so nothing maps to it.
+        tractor.addTowedUnit(51);
+        tractor.addTowedUnit(52);
+
+        gameManager.restoreTrains(List.of(tractor, trailer), Map.of(51, trailer.getId()));
+
+        assertEquals(List.of(trailer.getId()), tractor.getAllTowedUnits(),
+              "The trailers that are present still hitch; the missing one is dropped");
+    }
+
+    @Test
+    void savedIdsNeverSurviveAsRealIds() throws Exception {
+        Tank tractor = addVehicle(TRACTOR_TONS, false);
+        Tank trailer = addVehicle(CARRIAGE_TONS, true);
+
+        // A saved id can collide with a real one. Nothing may be left listing the raw file id.
+        int savedId = trailer.getId();
+        tractor.addTowedUnit(savedId);
+
+        gameManager.restoreTrains(List.of(tractor, trailer), new HashMap<>());
+
+        assertTrue(tractor.getAllTowedUnits().isEmpty(),
+              "An unmapped saved id is dropped even when it looks like a real entity id");
+    }
+
+    @Test
+    void aUnitTowingNothingIsLeftAlone() throws Exception {
+        Tank loneVehicle = addVehicle(TRACTOR_TONS, false);
+
+        gameManager.restoreTrains(new ArrayList<>(List.of(loneVehicle)), new HashMap<>());
+
+        assertTrue(loneVehicle.getAllTowedUnits().isEmpty());
+        assertEquals(Entity.NONE, loneVehicle.getTowing());
+    }
+}


### PR DESCRIPTION
## Summary

Saving a force with a train built and loading it back gave loose units. The player had to hitch the whole train again by hand.

MUL files never stored towing state. `EntityListFile` wrote one link element, `Conveyance`, which covers bay and cargo transport only. The fields that make up a train were not written, and `MULParser` had no code for any of them.

## Bug Fixed

- **A train did not survive a save and load.** The tractor now records its trailers as an ordered `TowedUnits` element. Order matters: it fixes the hitch chain and so where each trailer sits on the board.

## Changes

1. **EntityListFile.java** - a tractor writes the trailers it tows, front to back. Only the tractor records the train; each trailer's own tractor, hitch and place in the chain are rebuilt from that list.
2. **MULParser.java** - reads the element and stores the ids exactly as written, the same way a conveyance id is stored.
3. **TWGameManager.java** - `restoreTrains` translates those ids and hitches the train once the units are in a game.

Entity ids do not survive a load, because the server assigns its own when units are added. `receiveEntityAdd` already builds an `idMap` from saved id to server id, and already uses it to restore bay loading and transport. The train rebuild uses the same map, in the same place.

Rebuilding through `towUnit` rather than setting the fields directly is what loads the hitches, so a restored train behaves exactly as one connected in the lobby. Saved ids are dropped before re-hitching, since a file id can collide with a real entity id in the loading game.

Older MUL files have no `TowedUnits` element and load unchanged. Save games are unaffected: those serialise the train fields directly through XStream.

## Files Changed

- `megamek/src/megamek/common/units/EntityListFile.java` - write the train on the tractor
- `megamek/src/megamek/common/loaders/MULParser.java` - read it back
- `megamek/src/megamek/server/totalWarfare/TWGameManager.java` - translate ids and re-hitch
- `megamek/unittests/megamek/common/units/TrainMulRoundTripTest.java` - NEW: 5 tests
- `megamek/unittests/megamek/server/totalWarfare/TrainMulRestoreTest.java` - NEW: 5 tests

## Testing

- Unit tests: 10 across two new classes. The writer produces the element, lists trailers front to back, writes nothing for a unit towing nothing, records the train only on the tractor, and never duplicates a trailer. The restore translates saved ids to real ones, puts the trailer on an actual hitch, skips a trailer missing from the file, drops an unmapped saved id even when it looks like a real entity id, and leaves a unit towing nothing alone.
- Full `./gradlew test` and `checkstyleMain` green: 558 classes, 14,380 tests, 0 failures.

Tested and confirmed working by Radar.
