### PR TITLE
Reattach javadoc blocks stranded above the wrong method

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2751,13 +2751,6 @@ public class FireControl {
     }
 
     /**
-     * Figures out the best firing plan
-     *
-     * @param params - the appropriate firing plan calculation parameters
-     *
-     * @return the 'best' firing plan - uses heat as disutility and includes the possibility of twisting
-     */
-    /**
      * @param shooter the unit to check
      *
      * @return {@code true} if the shooter has at least one weapon in a Directional Torso Mount whose arc can still be
@@ -2846,6 +2839,13 @@ public class FireControl {
         return flips;
     }
 
+    /**
+     * Figures out the best firing plan
+     *
+     * @param params - the appropriate firing plan calculation parameters
+     *
+     * @return the 'best' firing plan - uses heat as disutility and includes the possibility of twisting
+     */
     FiringPlan determineBestFiringPlan(final FiringPlanCalculationParameters params) {
         // unpack parameters for easier reference
         final Entity shooter = params.getShooter();

--- a/megamek/src/megamek/client/ui/clientGUI/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/ClientGUI.java
@@ -846,11 +846,6 @@ public class ClientGUI extends AbstractClientGUI
     }
 
     /**
-     * Updates the frame title to show the current round and phase information. The title format is: "PlayerName - Round
-     * X - Phase phase - MegaMek" For phases before the game starts (lobby, selection, etc.), only shows: "PlayerName -
-     * MegaMek"
-     */
-    /**
      * Opens, follows and closes the Game Master vote dialog as the server shares the vote's state: the dialog opens
      * when a vote is called, follows the ballots as they come in, and closes when the vote resolves. The outcome
      * itself is announced in the chat.
@@ -934,6 +929,11 @@ public class ClientGUI extends AbstractClientGUI
               Messages.getString("GameMasterVoteDialog.passed.message", gameMasterName)).setVisible(true));
     }
 
+    /**
+     * Updates the frame title to show the current round and phase information. The title format is: "PlayerName - Round
+     * X - Phase phase - MegaMek" For phases before the game starts (lobby, selection, etc.), only shows: "PlayerName -
+     * MegaMek"
+     */
     private void updateFrameTitle() {
         StringBuilder title = new StringBuilder(client.getName());
 

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/LOSElevationDiagramPanel.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/LOSElevationDiagramPanel.java
@@ -2261,9 +2261,6 @@ class LOSElevationDiagramPanel extends JPanel {
     }
 
     /**
-     * Draws the LOS line from attacker to target.
-     */
-    /**
      * Draws zigzag "break" indicators at the top and/or bottom edges when the elevation range has been capped. This is
      * a standard engineering diagram convention indicating that the axis has been truncated. A small label shows the
      * actual extreme elevation beyond the visible range.

--- a/megamek/src/megamek/common/board/BridgeConstruction.java
+++ b/megamek/src/megamek/common/board/BridgeConstruction.java
@@ -169,16 +169,6 @@ public final class BridgeConstruction {
     }
 
     /**
-     * @param bank      a hex adjacent to a bridge site
-     * @param targetHex the bridge site hex
-     *
-     * @return {@code true} if the bank can anchor a bridge - a unit can get on or off the span there. Over water this
-     *       means the bank is dry land (or shallow water) or holds a bridge; over a dry canyon it means the bank is a
-     *       rim higher than the canyon floor, or holds a bridge. A deep-water bank, or a canyon-floor bank no higher
-     *       than the site, cannot anchor; a span may still point that way to be continued by a further span (wide
-     *       rivers/canyons). Flat ground anchors nothing, so a flat site is never valid.
-     */
-    /**
      * @param bank      a hex adjacent to a bridge site (e.g. the bridgelayer's own hex)
      * @param targetHex the hex a bridge would be placed in
      *
@@ -191,6 +181,16 @@ public final class BridgeConstruction {
         return anchorsBridge(bank, targetHex);
     }
 
+    /**
+     * @param bank      a hex adjacent to a bridge site
+     * @param targetHex the bridge site hex
+     *
+     * @return {@code true} if the bank can anchor a bridge - a unit can get on or off the span there. Over water this
+     *       means the bank is dry land (or shallow water) or holds a bridge; over a dry canyon it means the bank is a
+     *       rim higher than the canyon floor, or holds a bridge. A deep-water bank, or a canyon-floor bank no higher
+     *       than the site, cannot anchor; a span may still point that way to be continued by a further span (wide
+     *       rivers/canyons). Flat ground anchors nothing, so a flat site is never valid.
+     */
     private static boolean anchorsBridge(Hex bank, Hex targetHex) {
         if (bank.containsTerrain(Terrains.BRIDGE)) {
             return true;

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -252,8 +252,10 @@ public class TWGameManager extends AbstractGameManager {
 
     /**
      * Special packet queue for client feedback requests.
+     * <p>
+     * Package-private for test access; see TWGameManagerCFRPacketQueueTest.
+     * </p>
      */
-    /** Package-private for test access; see TWGameManagerCFRPacketQueueTest. */
     final ConcurrentLinkedQueue<Server.ReceivedPacket> cfrPacketQueue = new ConcurrentLinkedQueue<>();
 
     public TWGameManager() {


### PR DESCRIPTION
## Summary

Adding a method above an existing one leaves that method's javadoc stranded, describing whatever now follows it. Five of these had built up in `megamek/src`. Each is put back on the method it was written for.

CodeQL only reports the ones where the stranded block carries `@param` tags, since those become provably spurious. The rest sit in the source quietly describing the wrong thing, which is how these accumulated.

## Bug Fixed

- **FireControl**: "Figures out the best firing plan", with `@param params` and a `@return`, belonged to `determineBestFiringPlan`. It had been left on `usesDirectionalTorsoMounts`, a boolean predicate taking an `Entity`.
- **ClientGUI**: "Updates the frame title to show the current round and phase information" belonged to `updateFrameTitle`. It had been left on `updateGameMasterVoteDialog`.
- **BridgeConstruction**: the description of the internal anchor test belonged to `anchorsBridge`. It had been left on `isAnchoringBank`, the public wrapper, which has its own javadoc saying it exposes that internal test.
- **LOSElevationDiagramPanel**: "Draws the LOS line from attacker to target" is a stub that `drawLosLine`'s own fuller javadoc already replaced. Removed rather than moved, since moving it would put two javadocs back on one method.
- **TWGameManager**: two javadocs sat on the `cfrPacketQueue` field, both describing it. Merged into one.

## Changes

1. **FireControl.java** - javadoc returned to `determineBestFiringPlan`
2. **ClientGUI.java** - javadoc returned to `updateFrameTitle`
3. **BridgeConstruction.java** - javadoc returned to `anchorsBridge`
4. **LOSElevationDiagramPanel.java** - superseded stub removed from `drawLosLine`
5. **TWGameManager.java** - the field's two javadocs merged into one

## Files Changed

- `megamek/src/megamek/client/bot/princess/FireControl.java` - javadoc reattached to `determineBestFiringPlan`
- `megamek/src/megamek/client/ui/clientGUI/ClientGUI.java` - javadoc reattached to `updateFrameTitle`
- `megamek/src/megamek/common/board/BridgeConstruction.java` - javadoc reattached to `anchorsBridge`
- `megamek/src/megamek/client/ui/clientGUI/boardview/LOSElevationDiagramPanel.java` - superseded stub removed
- `megamek/src/megamek/server/totalWarfare/TWGameManager.java` - two javadocs on one field merged

## Testing

- Unit tests: none added. No code changed, only comment placement, so there is no behaviour to assert. `./gradlew test` is green at 568 classes and 14,447 tests, unchanged from before.
- `./gradlew compileJava` and `checkstyleMain` both clean.
- Verified by re-running the scan that found them: zero remaining across `megamek/src`.

## How they were found

A javadoc that ends immediately where another begins means the first one lost its method. Scanning `megamek/src` for that pattern turned up six candidates; five were real and are fixed here.

The sixth, in `FactionRecord`, is deliberately left alone. The block above its `omniMargin` field opens `/*` rather than `/**`, so it is a plain comment explaining the group of fields below it, not a javadoc that lost its method. Reattaching it would have been wrong. The check now requires the preceding block to open `/**` before reporting.

## Notes

Found while addressing CodeQL feedback on #8596, which flagged three spurious `@param` tags on one method in that branch. Those two cases are fixed there. This PR is the same class of defect found elsewhere in the tree, kept separate because none of it relates to that branch's subject.
