### PR TITLE
Reattach javadoc blocks stranded above the wrong method

### DIFF
--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -2751,13 +2751,6 @@ public class FireControl {
     }
 
     /**
-     * Figures out the best firing plan
-     *
-     * @param params - the appropriate firing plan calculation parameters
-     *
-     * @return the 'best' firing plan - uses heat as disutility and includes the possibility of twisting
-     */
-    /**
      * @param shooter the unit to check
      *
      * @return {@code true} if the shooter has at least one weapon in a Directional Torso Mount whose arc can still be
@@ -2846,6 +2839,13 @@ public class FireControl {
         return flips;
     }
 
+    /**
+     * Figures out the best firing plan
+     *
+     * @param params - the appropriate firing plan calculation parameters
+     *
+     * @return the 'best' firing plan - uses heat as disutility and includes the possibility of twisting
+     */
     FiringPlan determineBestFiringPlan(final FiringPlanCalculationParameters params) {
         // unpack parameters for easier reference
         final Entity shooter = params.getShooter();

--- a/megamek/src/megamek/client/ui/clientGUI/ClientGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/ClientGUI.java
@@ -846,11 +846,6 @@ public class ClientGUI extends AbstractClientGUI
     }
 
     /**
-     * Updates the frame title to show the current round and phase information. The title format is: "PlayerName - Round
-     * X - Phase phase - MegaMek" For phases before the game starts (lobby, selection, etc.), only shows: "PlayerName -
-     * MegaMek"
-     */
-    /**
      * Opens, follows and closes the Game Master vote dialog as the server shares the vote's state: the dialog opens
      * when a vote is called, follows the ballots as they come in, and closes when the vote resolves. The outcome
      * itself is announced in the chat.
@@ -934,6 +929,11 @@ public class ClientGUI extends AbstractClientGUI
               Messages.getString("GameMasterVoteDialog.passed.message", gameMasterName)).setVisible(true));
     }
 
+    /**
+     * Updates the frame title to show the current round and phase information. The title format is: "PlayerName - Round
+     * X - Phase phase - MegaMek" For phases before the game starts (lobby, selection, etc.), only shows: "PlayerName -
+     * MegaMek"
+     */
     private void updateFrameTitle() {
         StringBuilder title = new StringBuilder(client.getName());
 

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/LOSElevationDiagramPanel.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/LOSElevationDiagramPanel.java
@@ -2261,9 +2261,6 @@ class LOSElevationDiagramPanel extends JPanel {
     }
 
     /**
-     * Draws the LOS line from attacker to target.
-     */
-    /**
      * Draws zigzag "break" indicators at the top and/or bottom edges when the elevation range has been capped. This is
      * a standard engineering diagram convention indicating that the axis has been truncated. A small label shows the
      * actual extreme elevation beyond the visible range.

--- a/megamek/src/megamek/common/board/BridgeConstruction.java
+++ b/megamek/src/megamek/common/board/BridgeConstruction.java
@@ -169,16 +169,6 @@ public final class BridgeConstruction {
     }
 
     /**
-     * @param bank      a hex adjacent to a bridge site
-     * @param targetHex the bridge site hex
-     *
-     * @return {@code true} if the bank can anchor a bridge - a unit can get on or off the span there. Over water this
-     *       means the bank is dry land (or shallow water) or holds a bridge; over a dry canyon it means the bank is a
-     *       rim higher than the canyon floor, or holds a bridge. A deep-water bank, or a canyon-floor bank no higher
-     *       than the site, cannot anchor; a span may still point that way to be continued by a further span (wide
-     *       rivers/canyons). Flat ground anchors nothing, so a flat site is never valid.
-     */
-    /**
      * @param bank      a hex adjacent to a bridge site (e.g. the bridgelayer's own hex)
      * @param targetHex the hex a bridge would be placed in
      *
@@ -191,6 +181,16 @@ public final class BridgeConstruction {
         return anchorsBridge(bank, targetHex);
     }
 
+    /**
+     * @param bank      a hex adjacent to a bridge site
+     * @param targetHex the bridge site hex
+     *
+     * @return {@code true} if the bank can anchor a bridge - a unit can get on or off the span there. Over water this
+     *       means the bank is dry land (or shallow water) or holds a bridge; over a dry canyon it means the bank is a
+     *       rim higher than the canyon floor, or holds a bridge. A deep-water bank, or a canyon-floor bank no higher
+     *       than the site, cannot anchor; a span may still point that way to be continued by a further span (wide
+     *       rivers/canyons). Flat ground anchors nothing, so a flat site is never valid.
+     */
     private static boolean anchorsBridge(Hex bank, Hex targetHex) {
         if (bank.containsTerrain(Terrains.BRIDGE)) {
             return true;

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -252,8 +252,10 @@ public class TWGameManager extends AbstractGameManager {
 
     /**
      * Special packet queue for client feedback requests.
+     * <p>
+     * Package-private for test access; see TWGameManagerCFRPacketQueueTest.
+     * </p>
      */
-    /** Package-private for test access; see TWGameManagerCFRPacketQueueTest. */
     final ConcurrentLinkedQueue<Server.ReceivedPacket> cfrPacketQueue = new ConcurrentLinkedQueue<>();
 
     public TWGameManager() {


### PR DESCRIPTION
## Summary

Adding a method above an existing one leaves the older method's javadoc stranded on whatever now
follows it. Five of these had built up in `megamek/src`. Each goes back on the method it was written
for. No code changes.

## Bug Fixed

- **FireControl**: "Figures out the best firing plan", with `@param params` and `@return`, belongs to `determineBestFiringPlan`. It sat on `usesDirectionalTorsoMounts`, which takes an `Entity` and returns a boolean.
- **ClientGUI**: the frame title description belongs to `updateFrameTitle`. It sat on `updateGameMasterVoteDialog`.
- **BridgeConstruction**: the anchor test description belongs to `anchorsBridge`. It sat on the public wrapper, which already has its own javadoc.
- **LOSElevationDiagramPanel**: a one-line stub that `drawLosLine`'s fuller javadoc already replaced. Removed instead of moved, so the method does not end up with two.
- **TWGameManager**: two javadocs sat on the `cfrPacketQueue` field, both describing it. Merged into one.

## Files Changed

- `megamek/src/megamek/client/bot/princess/FireControl.java`
- `megamek/src/megamek/client/ui/clientGUI/ClientGUI.java`
- `megamek/src/megamek/common/board/BridgeConstruction.java`
- `megamek/src/megamek/client/ui/clientGUI/boardview/LOSElevationDiagramPanel.java`
- `megamek/src/megamek/server/totalWarfare/TWGameManager.java`

## Testing

- No tests added. Only comments moved, so there is no behaviour to assert.
- `./gradlew test` green: 568 classes, 14,451 tests. `compileJava` and `checkstyleMain` clean.

## Notes

CodeQL only reports these when the stranded javadoc has `@param` tags, because those become
provably wrong. The rest sit quietly describing the wrong method, which is how they piled up.

A sixth candidate in `FactionRecord` is left alone on purpose. Its block opens `/*`, not `/**`, so
it is a plain comment about the fields below it, not a javadoc that lost its method.
