### PR TITLE
Updated Gradle Actions to Make Staging Data Less Painful

### DIFF
--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -135,13 +135,109 @@ tasks.withType(Checkstyle).configureEach {
     maxHeapSize = "4g"
 }
 
-tasks.register('stageDataFiles', Sync) {
-    dependsOn gradle.includedBuild('mm-data').task(':stageMMFiles')
+// Data is staged directly out of mm-data/data (no intermediate staging copy) and split
+// into several Sync tasks by how often the content changes. The large, rarely-edited
+// binary trees (images, boards, fonts) each own a disjoint subtree of data/, so editing
+// loose data (units, scenarios) only re-copies the small text payload and leaves the
+// image/board assets untouched (UP-TO-DATE). stageDataFiles aggregates them.
+def mmDataDir = "../../mm-data"
+def mmDataOut = "${layout.projectDirectory.asFile}/data"
+
+// Never stage macOS/Windows directory-metadata junk, regardless of what a developer's
+// file browser may have dropped into the source tree.
+tasks.withType(Sync).configureEach {
+    exclude "**/.DS_Store"
+    exclude "**/Thumbs.db"
+}
+
+tasks.register('stageDataImages', Sync) {
+    description = "Syncs image data from mm-data"
+    group = 'build'
+    from("${mmDataDir}/data/images") {
+        include "camo/**/*.*"
+        include "fluff/**/*.*"
+        include "hexes/**/*.*"
+        include "misc/**/*.*"
+        include "portraits/**/*.*"
+        include "temp/**/*.*"
+        include "units/**/*.*"
+        include "universe/**/*.*"
+        include "widgets/**/*.*"
+    }
+    into "${mmDataOut}/images"
+}
+
+tasks.register('stageDataBoards', Sync) {
+    description = "Syncs board data from mm-data"
+    group = 'build'
+    from "${mmDataDir}/data/boards"
+    into "${mmDataOut}/boards"
+}
+
+tasks.register('stageDataFonts', Sync) {
+    description = "Syncs font data from mm-data"
+    group = 'build'
+    from "${mmDataDir}/data/fonts"
+    into "${mmDataOut}/fonts"
+}
+
+tasks.register('stageDataMekfiles', Sync) {
+    dependsOn gradle.includedBuild('mm-data').task(':unitFilesZip')
+    description = "Syncs unit files (loose text plus the zipped unit archive) from mm-data"
+    group = 'build'
+    from("${mmDataDir}/data/mekfiles") {
+        include "*.txt"
+        include "*.xml"
+    }
+    from "${mmDataDir}/build/staging/mekfiles"
+    into "${mmDataOut}/mekfiles"
+}
+
+tasks.register('stageDataRat', Sync) {
+    dependsOn gradle.includedBuild('mm-data').task(':ratZip')
+    description = "Syncs the random assignment table archive from mm-data"
+    group = 'build'
+    from "${mmDataDir}/build/staging/rat"
+    into "${mmDataOut}/rat"
+}
+
+tasks.register('stageData', Sync) {
+    description = "Syncs all remaining loose data from mm-data"
+    group = 'build'
+    from("${mmDataDir}/data") {
+        include "css/**/*.*"
+        include "forcegenerator/**/*.*"
+        include "mapgen/**/*.*"
+        include "mapsetup/**/*.*"
+        include "names/**/*.*"
+        include "scenarios/**/*.*"
+        include "sounds/**/*.*"
+        include "sourcebooks/*.*"
+        include "universe/eras.xml"
+        include "universe/ranks.xml"
+        include "universe/commands/**/*.*"
+        include "universe/factions/**/*.*"
+    }
+    into mmDataOut
+    // The big asset trees are owned by the dedicated tasks above; don't delete them.
+    preserve {
+        include "images/**"
+        include "boards/**"
+        include "fonts/**"
+        include "mekfiles/**"
+        include "rat/**"
+    }
+}
+
+tasks.register('stageDataFiles') {
     description = "Syncs Data Files from MM Data"
     group = 'build'
-    from "../../mm-data/build/staging/mm"
-    into "${layout.projectDirectory.asFile}/data"
-
+    dependsOn stageDataImages
+    dependsOn stageDataBoards
+    dependsOn stageDataFonts
+    dependsOn stageDataMekfiles
+    dependsOn stageDataRat
+    dependsOn stageData
 }
 
 tasks.register('generateDynamicFiles') {

--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -140,7 +140,10 @@ tasks.withType(Checkstyle).configureEach {
 // binary trees (images, boards, fonts) each own a disjoint subtree of data/, so editing
 // loose data (units, scenarios) only re-copies the small text payload and leaves the
 // image/board assets untouched (UP-TO-DATE). stageDataFiles aggregates them.
-def mmDataDir = "../../mm-data"
+// Derived from rootDir (the megamek build root) rather than a build-file-relative path,
+// so it survives project-layout changes. mm-data is a sibling of this build root
+// (settings.gradle includes it as ../mm-data).
+def mmDataDir = "${rootDir}/../mm-data"
 def mmDataOut = "${layout.projectDirectory.asFile}/data"
 
 // Never stage macOS/Windows directory-metadata junk, regardless of what a developer's
@@ -230,7 +233,7 @@ tasks.register('stageData', Sync) {
 }
 
 tasks.register('stageDataFiles') {
-    description = "Syncs Data Files from MM Data"
+    description = "Aggregates the split Sync tasks that stage MegaMek's data/ directory from mm-data."
     group = 'build'
     dependsOn stageDataImages
     dependsOn stageDataBoards


### PR DESCRIPTION
# REQUIRES https://github.com/MegaMek/megameklab/pull/2278
# REQUIRES https://github.com/MegaMek/mekhq/pull/9707
# REQUIRES https://github.com/MegaMek/mm-data/pull/493

# Disclaimer
I'm not Tex and I can't replace Tex. I'm a monkey with a keyboard being fact checked by Claude. It's possible this PR could cause everything to explode and need to be rolled back. I am fully open to this and happy for it to take place. At this venture all I can do is say "works on my machine" and hope it works on yours' too.

# Introduction
Moving to a single data directory was one of our best - and worst - ideas. Not because it was a bad move, it is objectively better than anything we had before. Tex was 100% right in making the switch and we've all benefited from the change.

It was 'bad' because of how painful it made working with data. No so much instantial changes where you change one thing and move on with your life, but iterative changes became a nightmare. Every little change resulted in 7-10 minutes of waiting for data to stage before you could even check if your fix/change worked. This quickly mounts up to hours of lost dev time over any given week.

# How Things Used to Work
Essentially we were building the entire data directory twice.

First we were prepping it for duplication and then we were duplicating it. This meant that we were building and then moving nearly a gig of data _twice_. Any time anything changes - even a single white space - we would need to copy and distribute this data block _twice_.

If you, like me, have a terrible computer the processing takes forever. In my case this was made worse by me having to work off a pen drive due to hdd constraints. 

# How Things Work Now
The immediate change is that rather than viewing the data directory as a single gig-sized whole, we break it up into separate 'boxes'. If something changes within a box - say, the boards directory - then only that box is rebuild.

So, in the example above, if you change a single white space in a directory we only need to restate that directory (or the 'box' it's in for small directories).

We also threw out the middleman step where we previously prepped data for staging and then staged it (the double-handling). Removing that means we are facing **significantly** reduced staging time by a magnitude.

# The Difference
## Before (full build)
<img width="505" height="28" alt="image" src="https://github.com/user-attachments/assets/f02cca89-e4e1-4376-b4b8-01db6e1c2e01" />

## After (full build)
<img width="523" height="28" alt="image" src="https://github.com/user-attachments/assets/70f2e113-cdc4-45f5-bf80-8a20fea12acb" />

## After (partial build, after making a data change)
<img width="505" height="28" alt="image" src="https://github.com/user-attachments/assets/f6b9f569-7350-41cd-9c53-934ddc4f8d40" />