### PR TITLE
Fix Word of Blake and ComStar Level IV generation crashing on an unrestricted unit type

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/ForceDescriptor.java
+++ b/megamek/src/megamek/client/ratgenerator/ForceDescriptor.java
@@ -907,8 +907,10 @@ public class ForceDescriptor {
         // let the normal ladder field a non-artillery unit of the original type as a last resort.
         // Skipped when a model is already pinned (battery uniformity), so the pinned gun wins and
         // every element resolves to the same unit instead of re-picking its own.
-        if (models.isEmpty() && (isUnitType(UnitType.MEK) || isUnitType(UnitType.TANK))
-              && roles.contains(MissionRole.ARTILLERY)) {
+        boolean hasNoPinnedModel = models.isEmpty();
+        boolean carriesArtillery = roles.contains(MissionRole.ARTILLERY);
+        boolean canMountArtillery = isUnitType(UnitType.MEK) || isUnitType(UnitType.TANK);
+        if (hasNoPinnedModel && carriesArtillery && canMountArtillery) {
             ModelRecord artilleryUnitRecord = generateArtilleryPreferred();
             if (artilleryUnitRecord != null) {
                 return artilleryUnitRecord;

--- a/megamek/src/megamek/client/ratgenerator/ForceDescriptor.java
+++ b/megamek/src/megamek/client/ratgenerator/ForceDescriptor.java
@@ -907,7 +907,7 @@ public class ForceDescriptor {
         // let the normal ladder field a non-artillery unit of the original type as a last resort.
         // Skipped when a model is already pinned (battery uniformity), so the pinned gun wins and
         // every element resolves to the same unit instead of re-picking its own.
-        if (models.isEmpty() && ((unitType == UnitType.MEK) || (unitType == UnitType.TANK))
+        if (models.isEmpty() && (isUnitType(UnitType.MEK) || isUnitType(UnitType.TANK))
               && roles.contains(MissionRole.ARTILLERY)) {
             ModelRecord artilleryUnitRecord = generateArtilleryPreferred();
             if (artilleryUnitRecord != null) {
@@ -1002,7 +1002,7 @@ public class ForceDescriptor {
     private @Nullable ModelRecord generateArtilleryPreferred() {
         // Front-line (Mek) prefers an artillery Mek, then an artillery vehicle. Second-line (Tank)
         // stays vehicle, honoring the "front line = Mek, otherwise = vehicle" rule.
-        int[] preferredTypes = (unitType == UnitType.TANK)
+        int[] preferredTypes = isUnitType(UnitType.TANK)
               ? new int[] { UnitType.TANK }
               : new int[] { UnitType.MEK, UnitType.TANK };
         for (int candidateType : preferredTypes) {
@@ -2126,6 +2126,22 @@ public class ForceDescriptor {
 
     public void setUnitType(Integer unitType) {
         this.unitType = unitType;
+    }
+
+    /**
+     * Null-safe test of this descriptor's unit type. {@code unitType} is a boxed {@link Integer} and
+     * is legitimately {@code null} whenever the ruleset places no restriction on unit type - the
+     * ComStar and Word of Blake tables of contents both declare {@code <unitType>null</unitType>}.
+     * Comparing the field to a {@link UnitType} constant directly unboxes it, so an unrestricted
+     * descriptor throws a {@link NullPointerException} rather than simply failing the test.
+     *
+     * @param candidateUnitType the {@link UnitType} constant to test against
+     *
+     * @return {@code true} if this descriptor has a unit type and it is the given one; {@code false}
+     *       when the descriptor carries no unit type at all
+     */
+    private boolean isUnitType(int candidateUnitType) {
+        return (unitType != null) && (unitType == candidateUnitType);
     }
 
     public String getUnitTypeName() {

--- a/megamek/unittests/megamek/client/ratgenerator/ForceDescriptorArtilleryUnitTypeTest.java
+++ b/megamek/unittests/megamek/client/ratgenerator/ForceDescriptorArtilleryUnitTypeTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.ratgenerator;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression coverage for artillery generation on a force that declares no unit type.
+ *
+ * <p>A descriptor's unit type is legitimately {@code null} when the ruleset places no restriction on
+ * it - the ComStar and Word of Blake tables of contents both declare {@code <unitType>null</unitType>},
+ * and the Level IV they build attaches artillery sub-formations. The artillery ladder compared the
+ * boxed field to a {@code UnitType} constant, which unboxes it, so generating a Word of Blake Level IV
+ * threw a {@link NullPointerException} instead of simply falling through to the Mek-then-vehicle
+ * preference. Generation failed outright and no force was produced.</p>
+ */
+class ForceDescriptorArtilleryUnitTypeTest {
+
+    private static final int ERA = 3050;
+    /** The only faction the trimmed test era file rates units for. */
+    private static final String TEST_FACTION = "LA";
+
+    @BeforeAll
+    static void loadForceGeneratorFromTestData() throws Exception {
+        ForceGeneratorTestFixture.loadFromTestData(ERA);
+        // The trimmed test data carries no faction_rules directory, so this initializes the ruleset
+        // registry to an empty map rather than populating it. That is all this test needs: the
+        // sub-force recursion reads the registry, and without the call it is left null.
+        Ruleset.loadData();
+    }
+
+    @AfterAll
+    static void clearSharedSingletons() throws Exception {
+        ForceGeneratorTestFixture.reset();
+    }
+
+    @Test
+    void artilleryForceWithNoUnitTypeGeneratesWithoutThrowing() {
+        ForceDescriptor artilleryForce = new ForceDescriptor();
+        artilleryForce.setFaction(TEST_FACTION);
+        artilleryForce.setYear(ERA);
+        artilleryForce.setUnitType(null);
+        // An equipment rating is needed only so the rating fallback ladder has somewhere to start;
+        // the unit type is the subject of this test.
+        artilleryForce.setRating("A");
+        artilleryForce.getRoles().add(MissionRole.ARTILLERY);
+        // The battery-uniformity branch that picks one gun for the whole formation only runs on a
+        // node that has children and no unit pinned yet, which is where the unboxing happened.
+        artilleryForce.addSubForce(artilleryForce.createChild(0));
+
+        assertDoesNotThrow(() -> artilleryForce.generateUnits(null, 0.0),
+              "an artillery force with no unit type must fall through to the Mek/vehicle preference"
+                    + " rather than unboxing a null unit type");
+    }
+}


### PR DESCRIPTION
## Summary

Generating a Word of Blake or ComStar Level IV failed outright and produced no force at all. A force
that places no restriction on unit type crashed the artillery step.

Two lines of fix. The rest is a regression test and naming three conditions.

## Changes Made

**The crash**

- A force's unit type is a boxed `Integer`, and is legitimately null when the ruleset places no
  restriction on it. ComStar and Word of Blake both declare `<unitType>null</unitType>`.
- The artillery step compared that field straight to a `UnitType` constant. Java unboxes to make that
  comparison, so "no restriction" threw instead of simply failing the test.
- Now tested through a null-safe helper. No restriction means the force takes the Mek-then-vehicle
  preference, which is what it should have got all along.

**Why both factions**

- Word of Blake has no Level IV of its own. All of its Level III entries are gated to the Shadow
  Divisions, so it inherits ComStar's Level IV, and ComStar's is what attaches the artillery.
- One defect, one fix, both factions.

**Naming**

- The guard above the fix combined three ideas in one expression: nothing pinned yet, the force
  carries artillery, the unit type can mount it. Split into named booleans. No behaviour change.

## Files Changed

Main edits:

- `megamek/src/megamek/client/ratgenerator/ForceDescriptor.java` - null-safe `isUnitType` helper,
  applied to the two artillery-path comparisons; named booleans on the guard

Tests:

- `megamek/unittests/megamek/client/ratgenerator/ForceDescriptorArtilleryUnitTypeTest.java` - drives
  an artillery force with no unit type through `generateUnits`

## Testing

- Confirmed in game. A Word of Blake 3075 Level IV that failed three times running now generates.
- The new test was checked by reverting the fix and watching it fail with the original
  `NullPointerException`, not just by watching it go green.
- `ratgenerator` and `ForceGenerator` suites green.

The log line that identified it:

```
[ForceGen] generation FAILED for faction=WOB year=3075 unitType=null echelon=6; no force was produced
java.lang.NullPointerException: Cannot invoke "java.lang.Integer.intValue()" because "this.unitType" is null
    at ForceDescriptor.generateArtilleryPreferred(ForceDescriptor.java:1034)
    at ForceDescriptor.generateUnits(ForceDescriptor.java:260)
```

## How far it reaches

I swept for the same fault rather than fixing only the line that crashed.

| Site | Status |
|---|---|
| `ForceDescriptor` artillery preference, artillery ladder | **Fixed here.** The only two unguarded comparisons. |
| `ForceDescriptor:894` | Already safe. Null-fills the field on the line above. |
| `ForceDescriptor:2617`, `ForceGenWarshipCsv` | Already safe. Explicit null guards. |
| `MissionRole.fitsUnitType`, `AbstractUnitRecord` | Already safe. Take primitives, so nothing unboxes. |
| MekHQ's `getUnitType() ==` sites | Already safe. All `Entity.getUnitType()`, which returns a primitive. |

Only `CS` and `WOB` declare an unrestricted unit type. The other 28 rulesets that attach artillery all
name a concrete unit type and never reached the unboxing.

## What is not proven yet

- ComStar Level IV is fixed by the same code on the same path, but the in game confirmation above was
  Word of Blake. The regression test asserts the null unit type case directly rather than either
  faction's route to it, so it covers both, but nobody has watched a ComStar Level IV generate.

## Out of scope

- Word of Blake's own Level IV entry. It inherits ComStar's, which is why the two share this defect.
  Whether it should have its own is a data question, not a crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
