### PR TITLE
Stabilize SettingsPane tests on EDT

### DIFF
--- a/megamek/unittests/megamek/client/ui/settings/SettingsPaneTest.java
+++ b/megamek/unittests/megamek/client/ui/settings/SettingsPaneTest.java
@@ -38,11 +38,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.Component;
 import java.awt.Container;
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ListResourceBundle;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import javax.swing.JLabel;
 import javax.swing.SwingUtilities;
@@ -61,140 +63,153 @@ class SettingsPaneTest {
           });
 
     @Test
-    void pagesAreCreatedLazilyAndCached() {
-        SettingsRoute first = new SettingsRoute("first", List.of("First"));
-        SettingsRoute second = new SettingsRoute("second", List.of("Second"));
+    void pagesAreCreatedLazilyAndCached() throws Exception {
         AtomicInteger firstBuilds = new AtomicInteger();
         AtomicInteger secondBuilds = new AtomicInteger();
-        Map<String, Supplier<Component>> factories = new HashMap<>();
-        factories.put("first", () -> {
-            firstBuilds.incrementAndGet();
-            return page("First section", "first summary");
-        });
-        factories.put("second", () -> {
-            secondBuilds.incrementAndGet();
-            return page("Second section", "second summary");
-        });
-        SettingsPane pane = new SettingsPane(List.of(first, second), factories, NAVIGATION_TEXT, "Details");
+        runOnEdt(() -> {
+            SettingsRoute first = new SettingsRoute("first", List.of("First"));
+            SettingsRoute second = new SettingsRoute("second", List.of("Second"));
+            Map<String, Supplier<Component>> factories = new HashMap<>();
+            factories.put("first", () -> {
+                firstBuilds.incrementAndGet();
+                return page("First section", "first summary");
+            });
+            factories.put("second", () -> {
+                secondBuilds.incrementAndGet();
+                return page("Second section", "second summary");
+            });
+            SettingsPane pane = new SettingsPane(List.of(first, second), factories, NAVIGATION_TEXT, "Details");
 
-        pane.selectRoute(second);
-        pane.selectRoute(second);
+            pane.selectRoute(second);
+            pane.selectRoute(second);
 
-        assertEquals(1, firstBuilds.get());
-        assertEquals(1, secondBuilds.get());
+            assertEquals(1, firstBuilds.get());
+            assertEquals(1, secondBuilds.get());
+        });
     }
 
     @Test
-    void activeFilterExpandsOnlyMatchingSection() {
-        SettingsRoute route = new SettingsRoute("page", List.of("Page"));
-        SettingsPagePanel page = SettingsPagePanel.builder("Test", PAGE_TEXT, "header", null)
-              .sectionsExpandedByDefault(false)
-              .literalSection("Alpha", "alpha summary", new JLabel())
-              .literalSection("Beta", "beta summary", new JLabel())
-              .build();
-        SettingsPane pane = new SettingsPane(List.of(route), Map.of("page", () -> page),
-              NAVIGATION_TEXT, "Details");
+    void activeFilterExpandsOnlyMatchingSection() throws Exception {
+        runOnEdt(() -> {
+            SettingsRoute route = new SettingsRoute("page", List.of("Page"));
+            SettingsPagePanel page = SettingsPagePanel.builder("Test", PAGE_TEXT, "header", null)
+                .sectionsExpandedByDefault(false)
+                .literalSection("Alpha", "alpha summary", new JLabel())
+                .literalSection("Beta", "beta summary", new JLabel())
+                .build();
+            SettingsPane pane = new SettingsPane(List.of(route), Map.of("page", () -> page),
+                NAVIGATION_TEXT, "Details");
 
-        pane.setFilterText("beta");
-        pane.selectRoute(route);
+            pane.setFilterText("beta");
+            pane.selectRoute(route);
 
-        List<CollapsibleSectionPanel> sections = findSections(page);
-        assertEquals(2, sections.size());
-        assertFalse(sections.get(0).isExpanded());
-        assertTrue(sections.get(1).isExpanded());
+            List<CollapsibleSectionPanel> sections = findSections(page);
+            assertEquals(2, sections.size());
+            assertFalse(sections.get(0).isExpanded());
+            assertTrue(sections.get(1).isExpanded());
+        });
+        flushEventQueue();
     }
 
     @Test
-    void parentRouteFallsBackToFirstDescendantPage() {
-        SettingsRoute initial = new SettingsRoute("initial", List.of("Initial"));
-        SettingsRoute parent = new SettingsRoute("group", List.of("Group"));
-        SettingsRoute child = new SettingsRoute("child", List.of("Group", "Child"),
-              List.of("group", "group.child"), List.of(), true);
+    void parentRouteFallsBackToFirstDescendantPage() throws Exception {
         AtomicInteger childBuilds = new AtomicInteger();
-        Map<String, Supplier<Component>> factories = new HashMap<>();
-        factories.put("initial", () -> page("Initial", null));
-        factories.put("child", () -> {
-            childBuilds.incrementAndGet();
-            return page("Child", null);
-        });
-        SettingsPane pane = new SettingsPane(List.of(initial, parent, child), factories,
-              NAVIGATION_TEXT, "Details");
+        runOnEdt(() -> {
+            SettingsRoute initial = new SettingsRoute("initial", List.of("Initial"));
+            SettingsRoute parent = new SettingsRoute("group", List.of("Group"));
+            SettingsRoute child = new SettingsRoute("child", List.of("Group", "Child"),
+                  List.of("group", "group.child"), List.of(), true);
+            Map<String, Supplier<Component>> factories = new HashMap<>();
+            factories.put("initial", () -> page("Initial", null));
+            factories.put("child", () -> {
+                childBuilds.incrementAndGet();
+                return page("Child", null);
+            });
+            SettingsPane pane = new SettingsPane(List.of(initial, parent, child), factories,
+                  NAVIGATION_TEXT, "Details");
 
-        assertTrue(pane.selectRoute(parent));
-        assertEquals(1, childBuilds.get());
+            assertTrue(pane.selectRoute(parent));
+            assertEquals(1, childBuilds.get());
+        });
     }
 
     @Test
     void searchIndexRefreshesResultsAfterEachPage() throws Exception {
-        SettingsRoute first = new SettingsRoute("first", List.of("First"));
-        SettingsRoute second = new SettingsRoute("second", List.of("Second"));
         AtomicInteger secondBuilds = new AtomicInteger();
-        SettingsPane pane = new SettingsPane(List.of(first, second), Map.of(
-              "first", () -> page("Initial", null),
-              "second", () -> {
-                  secondBuilds.incrementAndGet();
-                  return page("Needle section", null);
-              }), NAVIGATION_TEXT, "Details");
+        AtomicReference<SettingsPane> pane = new AtomicReference<>();
+        runOnEdt(() -> {
+            SettingsRoute first = new SettingsRoute("first", List.of("First"));
+            SettingsRoute second = new SettingsRoute("second", List.of("Second"));
+            pane.set(new SettingsPane(List.of(first, second), Map.of(
+                  "first", () -> page("Initial", null),
+                  "second", () -> {
+                      secondBuilds.incrementAndGet();
+                      return page("Needle section", null);
+                  }), NAVIGATION_TEXT, "Details"));
+            pane.get().setFilterText("needle");
+        });
+        finishSearchIndexing();
 
-        pane.setFilterText("needle");
-        flushEventQueue();
-
-        JLabel status = findComponent(pane, "lblSettingsFilterStatus", JLabel.class);
-        assertEquals(1, secondBuilds.get());
-        assertEquals("1 matches", status.getText());
-        flushEventQueue();
+        runOnEdt(() -> {
+            JLabel status = findComponent(pane.get(), "lblSettingsFilterStatus", JLabel.class);
+            assertEquals(1, secondBuilds.get());
+            assertEquals("1 matches", status.getText());
+        });
     }
 
     @Test
     void clearingFilterCancelsQueuedIndexingAndLaterSearchRestartsIt() throws Exception {
-        SettingsRoute first = new SettingsRoute("first", List.of("First"));
-        SettingsRoute second = new SettingsRoute("second", List.of("Second"));
         AtomicInteger secondBuilds = new AtomicInteger();
-        SettingsPane pane = new SettingsPane(List.of(first, second), Map.of(
-              "first", () -> page("Initial", null),
-              "second", () -> {
-                  secondBuilds.incrementAndGet();
-                  return page("Needle section", null);
-              }), NAVIGATION_TEXT, "Details");
+        AtomicReference<SettingsPane> pane = new AtomicReference<>();
 
-        SwingUtilities.invokeAndWait(() -> {
-            pane.setFilterText("needle");
-            pane.setFilterText("");
+        runOnEdt(() -> {
+            SettingsRoute first = new SettingsRoute("first", List.of("First"));
+            SettingsRoute second = new SettingsRoute("second", List.of("Second"));
+            pane.set(new SettingsPane(List.of(first, second), Map.of(
+                  "first", () -> page("Initial", null),
+                  "second", () -> {
+                      secondBuilds.incrementAndGet();
+                      return page("Needle section", null);
+                  }), NAVIGATION_TEXT, "Details"));
+            pane.get().setFilterText("needle");
+            pane.get().setFilterText("");
         });
         flushEventQueue();
         assertEquals(0, secondBuilds.get());
 
-        pane.setFilterText("needle");
-        flushEventQueue();
+        runOnEdt(() -> pane.get().setFilterText("needle"));
+        finishSearchIndexing();
         assertEquals(1, secondBuilds.get());
-        flushEventQueue();
     }
 
     @Test
     void failedSearchIndexFactoryCanBeRetried() throws Exception {
-        SettingsRoute first = new SettingsRoute("first", List.of("First"));
-        SettingsRoute retry = new SettingsRoute("retry", List.of("Retry"));
         AtomicInteger attempts = new AtomicInteger();
-        SettingsPane pane = new SettingsPane(List.of(first, retry), Map.of(
-              "first", () -> page("Initial", null),
-              "retry", () -> {
-                  if (attempts.getAndIncrement() == 0) {
-                      throw new IllegalStateException("First indexing attempt fails");
-                  }
-                  return page("Needle section", null);
-              }), NAVIGATION_TEXT, "Details");
-
-        pane.setFilterText("needle");
+        AtomicReference<SettingsPane> pane = new AtomicReference<>();
+        runOnEdt(() -> {
+            SettingsRoute first = new SettingsRoute("first", List.of("First"));
+            SettingsRoute retry = new SettingsRoute("retry", List.of("Retry"));
+            pane.set(new SettingsPane(List.of(first, retry), Map.of(
+                  "first", () -> page("Initial", null),
+                  "retry", () -> {
+                      if (attempts.getAndIncrement() == 0) {
+                          throw new IllegalStateException("First indexing attempt fails");
+                      }
+                      return page("Needle section", null);
+                  }), NAVIGATION_TEXT, "Details"));
+            pane.get().setFilterText("needle");
+        });
         flushEventQueue();
         assertEquals(1, attempts.get());
 
-        pane.setFilterText("needle ");
-        flushEventQueue();
+        runOnEdt(() -> pane.get().setFilterText("needle "));
+        finishSearchIndexing();
 
-        JLabel status = findComponent(pane, "lblSettingsFilterStatus", JLabel.class);
-        assertEquals(2, attempts.get());
-        assertEquals("1 matches", status.getText());
-        flushEventQueue();
+        runOnEdt(() -> {
+            JLabel status = findComponent(pane.get(), "lblSettingsFilterStatus", JLabel.class);
+            assertEquals(2, attempts.get());
+            assertEquals("1 matches", status.getText());
+        });
     }
 
     private static SettingsPagePanel page(String title, String summary) {
@@ -247,6 +262,40 @@ class SettingsPaneTest {
     }
 
     private static void flushEventQueue() throws Exception {
-        SwingUtilities.invokeAndWait(() -> { });
+        runOnEdt(() -> { });
+    }
+
+    private static void finishSearchIndexing() throws Exception {
+        flushEventQueue();
+        flushEventQueue();
+    }
+
+    private static void runOnEdt(CheckedRunnable runnable) throws Exception {
+        try {
+            SwingUtilities.invokeAndWait(() -> {
+                try {
+                    runnable.run();
+                } catch (Throwable throwable) {
+                    throw new RuntimeException(throwable);
+                }
+            });
+        } catch (InvocationTargetException exception) {
+            Throwable failure = exception.getCause();
+            if (failure instanceof RuntimeException && failure.getCause() != null) {
+                failure = failure.getCause();
+            }
+            if (failure instanceof Error error) {
+                throw error;
+            }
+            if (failure instanceof Exception checkedException) {
+                throw checkedException;
+            }
+            throw exception;
+        }
+    }
+
+    @FunctionalInterface
+    private interface CheckedRunnable {
+        void run() throws Exception;
     }
 }


### PR DESCRIPTION
## Summary

- run all `SettingsPaneTest` Swing construction, mutation, and UI assertions on the event dispatch thread
- fully drain incremental search-index steps before asserting filter status
- prevent intermittent `JTree.setExpandedState()` `EmptyStackException` and stale `No matches` assertions caused by worker-thread Swing access and incomplete event-queue draining

## Validation

- complete forced-headless `SettingsPaneTest` class passed five uncached repetitions on JDK 21
- all shared settings tests pass headlessly without cached test results
- `:megamek:checkstyleTest` passes

## Context

These failures surfaced in the JDK 21 and JDK 25 matrix jobs for MegaMek/mekhq#9700 because that workflow also runs the companion MegaMek test suite.