### PR TITLE
Add per-game metrics and CSV results to the headless AI match harness

### DIFF
--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -706,7 +706,9 @@ tasks.register('aiMatch', JavaExec) {
     group = 'utility'
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'megamek.utilities.AIMatchRunner'
-    args(project.hasProperty("aiMatchArgs") ? project.property("aiMatchArgs").split(' ') : "")
+    // no property -> no args, so AIMatchRunner prints its usage message; split on runs of
+    // whitespace so accidental double spaces do not become empty arguments
+    args(project.hasProperty("aiMatchArgs") ? project.property("aiMatchArgs").trim().split('\\s+') : [])
 
     jvmArgs = mmJvmOptions
 }

--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -701,8 +701,8 @@ tasks.register('testAi', JavaExec) {
 tasks.register('aiMatch', JavaExec) {
     dependsOn jar
     description = 'Run a scenario headlessly N times as a bot-vs-bot match and collect per-game results. ' +
-          'Args via -PaiMatchArgs="<scenarioFile> [repetitions] [roundsLimit] [timeoutMinutes]" ' +
-          '(quote the scenario path, it may not contain spaces).'
+          'Args via -PaiMatchArgs="<scenarioFile> [repetitions] [roundsLimit] [timeoutMinutes]". ' +
+          'Arguments are split on spaces, so the scenario path cannot contain spaces.'
     group = 'utility'
     classpath = sourceSets.main.runtimeClasspath
     mainClass = 'megamek.utilities.AIMatchRunner'

--- a/megamek/build.gradle
+++ b/megamek/build.gradle
@@ -698,6 +698,29 @@ tasks.register('testAi', JavaExec) {
     jvmArgs = mmJvmOptions
 }
 
+tasks.register('aiMatch', JavaExec) {
+    dependsOn jar
+    description = 'Run a scenario headlessly N times as a bot-vs-bot match and collect per-game results. ' +
+          'Args via -PaiMatchArgs="<scenarioFile> [repetitions] [roundsLimit] [timeoutMinutes]" ' +
+          '(quote the scenario path, it may not contain spaces).'
+    group = 'utility'
+    classpath = sourceSets.main.runtimeClasspath
+    mainClass = 'megamek.utilities.AIMatchRunner'
+    args(project.hasProperty("aiMatchArgs") ? project.property("aiMatchArgs").split(' ') : "")
+
+    jvmArgs = mmJvmOptions
+}
+
+tasks.register('printAiMatchClasspath') {
+    dependsOn classes
+    description = 'Print the runtime classpath for launching AIMatchRunner directly with java, so batch ' +
+          'drivers can run several match processes in parallel without contending for the Gradle build lock.'
+    group = 'utility'
+    doLast {
+        println sourceSets.main.runtimeClasspath.asPath
+    }
+}
+
 tasks.register('roundTripSaveUnitsTest', Test) {
     useJUnitPlatform {
         includeTags 'on-demand'

--- a/megamek/docs/Customization/Scenarios/ScenarioV2 HowTo.mms
+++ b/megamek/docs/Customization/Scenarios/ScenarioV2 HowTo.mms
@@ -436,7 +436,8 @@ factions:
       # Optional: how quickly will I try to escape once damaged?
       bravery: 5
       # Optional: use forced Withdrawal, this is true by default
-      forcedwithdrawal: true
+      # (note the key is "forcedwithdraw" - unknown keys are silently ignored)
+      forcedwithdraw: true
       # Optional: the edge to retreat to, nearest by default; use south, north, west, east, nearest
       withdrawto: nearest
       # Optional: flee = true will try to reach the destination edge even when not crippled

--- a/megamek/src/megamek/utilities/AIMatchRunner.java
+++ b/megamek/src/megamek/utilities/AIMatchRunner.java
@@ -33,8 +33,14 @@
 package megamek.utilities;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.Set;
+import java.util.StringJoiner;
 import java.util.TreeMap;
 
 import megamek.client.bot.AIType;
@@ -56,6 +62,10 @@ public final class AIMatchRunner {
     private static final int DEFAULT_REPETITIONS = 10;
     private static final int DEFAULT_ROUNDS_LIMIT = 12;
     private static final int DEFAULT_TIMEOUT_MINUTES = 10;
+
+    private static final String RESULTS_FILE_STAMP_FORMAT = "_yyyy-MM-dd_HH-mm-ss";
+    private static final String RESULTS_CSV_HEADER = "game,scenario,finished,rounds,winning_team,team,ai_types,"
+          + "units_fielded,survivors,crippled_survivors,destroyed,fled,bv_initial,bv_remaining";
 
     private AIMatchRunner() {}
 
@@ -79,36 +89,90 @@ public final class AIMatchRunner {
         int draws = 0;
         int unfinished = 0;
 
-        for (int gameNumber = 1; gameNumber <= repetitions; gameNumber++) {
-            ScenarioGameRunner runner = null;
-            try {
-                runner = new ScenarioGameRunner(scenarioFile);
-                if (teamAITypes.isEmpty()) {
-                    teamAITypes = runner.getBotTeamAITypes();
-                }
-                ScenarioGameRunner.GameResult result = runner.runGame(roundsLimit, timeoutMinutes);
-                if (!result.finished()) {
-                    unfinished++;
-                    logger.warn("Game {}/{} did not finish within the timeout", gameNumber, repetitions);
-                } else if (result.winningTeam() == Player.TEAM_NONE) {
-                    draws++;
-                    logger.info("Game {}/{}: draw (no sole surviving team)", gameNumber, repetitions);
-                } else {
-                    teamWins.merge(result.winningTeam(), 1, Integer::sum);
-                    logger.info("Game {}/{}: team {} {} wins", gameNumber, repetitions, result.winningTeam(),
-                          teamAITypes.getOrDefault(result.winningTeam(), Set.of()));
-                }
-            } catch (Exception exception) {
-                logger.error(exception, "Game " + gameNumber + "/" + repetitions + " failed to run");
-            } finally {
-                if (runner != null) {
-                    runner.shutdown();
+        File resultsFile = resultsFile();
+        try (PrintWriter resultsWriter = new PrintWriter(resultsFile, StandardCharsets.UTF_8)) {
+            resultsWriter.println(RESULTS_CSV_HEADER);
+
+            for (int gameNumber = 1; gameNumber <= repetitions; gameNumber++) {
+                ScenarioGameRunner runner = null;
+                try {
+                    runner = new ScenarioGameRunner(scenarioFile);
+                    if (teamAITypes.isEmpty()) {
+                        teamAITypes = runner.getBotTeamAITypes();
+                    }
+                    ScenarioGameRunner.GameResult result = runner.runGame(roundsLimit, timeoutMinutes);
+                    if (!result.finished()) {
+                        unfinished++;
+                        logger.warn("Game {}/{} did not finish within the timeout", gameNumber, repetitions);
+                    } else if (result.winningTeam() == Player.TEAM_NONE) {
+                        draws++;
+                        logger.info("Game {}/{}: draw (no sole surviving team)", gameNumber, repetitions);
+                    } else {
+                        teamWins.merge(result.winningTeam(), 1, Integer::sum);
+                        logger.info("Game {}/{}: team {} {} wins", gameNumber, repetitions, result.winningTeam(),
+                              teamAITypes.getOrDefault(result.winningTeam(), Set.of()));
+                    }
+                    writeResultRows(resultsWriter, gameNumber, scenarioFile.getName(), result, teamAITypes);
+                } catch (Exception exception) {
+                    logger.error(exception, "Game " + gameNumber + "/" + repetitions + " failed to run");
+                } finally {
+                    if (runner != null) {
+                        runner.shutdown();
+                    }
                 }
             }
+        } catch (IOException ioException) {
+            logger.error(ioException, "Could not write the results file " + resultsFile);
         }
 
         logger.info(formatSummary(repetitions, teamWins, teamAITypes, draws, unfinished));
+        logger.info("Per-game results written to {}", resultsFile.getAbsolutePath());
         System.exit(0);
+    }
+
+    /**
+     * Returns the timestamped CSV file the per-game results are written to, in the standard log directory.
+     */
+    private static File resultsFile() {
+        File logDirectory = new File(PreferenceManager.getClientPreferences().getLogDirectory());
+        if (!logDirectory.exists() && !logDirectory.mkdirs()) {
+            logger.warn("Could not create log directory {}; writing results to the working directory",
+                  logDirectory.getAbsolutePath());
+            logDirectory = new File(".");
+        }
+        String stamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern(RESULTS_FILE_STAMP_FORMAT));
+        return new File(logDirectory, "ai_match_results" + stamp + ".csv");
+    }
+
+    /**
+     * Writes one CSV row per combatant team for the given game, so the batch can be analyzed as long-format
+     * data (each row keyed by game number and team). Rows are flushed immediately so a crashed or aborted
+     * batch still leaves the completed games' results on disk.
+     */
+    private static void writeResultRows(PrintWriter resultsWriter, int gameNumber, String scenarioName,
+          ScenarioGameRunner.GameResult result, Map<Integer, Set<AIType>> teamAITypes) {
+        for (ScenarioGameRunner.TeamStanding standing : result.teamStandings()) {
+            StringJoiner aiTypes = new StringJoiner("+");
+            for (AIType aiType : teamAITypes.getOrDefault(standing.team(), Set.of())) {
+                aiTypes.add(aiType.name());
+            }
+            resultsWriter.println(String.join(",",
+                  Integer.toString(gameNumber),
+                  scenarioName.replace(',', ' '),
+                  Boolean.toString(result.finished()),
+                  Integer.toString(result.rounds()),
+                  Integer.toString(result.winningTeam()),
+                  Integer.toString(standing.team()),
+                  aiTypes.toString(),
+                  Integer.toString(standing.unitsFielded()),
+                  Integer.toString(standing.survivors()),
+                  Integer.toString(standing.crippledSurvivors()),
+                  Integer.toString(standing.destroyed()),
+                  Integer.toString(standing.fled()),
+                  Integer.toString(standing.bvInitial()),
+                  Integer.toString(standing.bvRemaining())));
+        }
+        resultsWriter.flush();
     }
 
     /**

--- a/megamek/src/megamek/utilities/ScenarioGameRunner.java
+++ b/megamek/src/megamek/utilities/ScenarioGameRunner.java
@@ -157,7 +157,8 @@ public class ScenarioGameRunner {
      * @param destroyed         units destroyed, whether salvageable, devastated, or lost with their crew
      * @param fled              units that left the board in retreat, were captured, or were pushed off
      * @param bvInitial         the team's total Battle Value at game start
-     * @param bvRemaining       the team's total Battle Value still on the board at game end
+     * @param bvRemaining       the team's total Battle Value of usable assets still in play at game end,
+     *                          per {@link Player#getBV()} (units counting toward the strength sum)
      */
     public record TeamStanding(int team, int unitsFielded, int survivors, int crippledSurvivors, int destroyed,
           int fled, int bvInitial, int bvRemaining) {}

--- a/megamek/src/megamek/utilities/ScenarioGameRunner.java
+++ b/megamek/src/megamek/utilities/ScenarioGameRunner.java
@@ -56,17 +56,20 @@ import megamek.client.bot.BotFactory;
 import megamek.client.bot.princess.BehaviorSettings;
 import megamek.client.bot.princess.BehaviorSettingsFactory;
 import megamek.common.Player;
+import megamek.common.annotations.Nullable;
 import megamek.common.enums.GamePhase;
 import megamek.common.event.GameListenerAdapter;
 import megamek.common.event.GamePhaseChangeEvent;
 import megamek.common.game.Game;
 import megamek.common.game.IGame;
+import megamek.common.interfaces.IEntityRemovalConditions;
 import megamek.common.jacksonAdapters.BotParser;
 import megamek.common.loaders.MekSummaryCache;
 import megamek.common.net.marshalling.SanityInputFilter;
 import megamek.common.preference.PreferenceManager;
 import megamek.common.scenario.Scenario;
 import megamek.common.scenario.ScenarioLoader;
+import megamek.common.units.EjectedCrew;
 import megamek.common.units.Entity;
 import megamek.logging.MMLogger;
 import megamek.server.Server;
@@ -130,14 +133,45 @@ public class ScenarioGameRunner {
     }
 
     /**
-     * The result of a single scenario game: whether it finished (rather than timing out) and which team won,
-     * defined as the sole surviving combatant team. The unit-less headless watcher is ignored, and a game that
-     * ends with more than one (or no) combatant team still standing is a draw.
+     * The result of a single scenario game: whether it finished (rather than timing out), which team won -
+     * defined as the sole surviving combatant team - and the end-of-game standing of every combatant team.
+     * The unit-less headless watcher is ignored, and a game that ends with more than one (or no) combatant
+     * team still standing is a draw.
      *
-     * @param finished    whether the game finished within the timeout
-     * @param winningTeam the sole surviving combatant team, or {@link Player#TEAM_NONE} for a draw
+     * @param finished      whether the game finished within the timeout
+     * @param winningTeam   the sole surviving combatant team, or {@link Player#TEAM_NONE} for a draw
+     * @param rounds        the round the game ended on
+     * @param teamStandings the end-of-game standing of each combatant team, ordered by team id
      */
-    public record GameResult(boolean finished, int winningTeam) {}
+    public record GameResult(boolean finished, int winningTeam, int rounds, List<TeamStanding> teamStandings) {}
+
+    /**
+     * The end-of-game standing of one combatant team. Ejected crew entities are not counted as units. Units
+     * whose removal condition is neither destruction nor retreat (for example never-deployed units) appear in
+     * {@code unitsFielded} only.
+     *
+     * @param team              the team id
+     * @param unitsFielded      units the team started the game with
+     * @param survivors         units still on the board and not destroyed at game end
+     * @param crippledSurvivors survivors that report {@link Entity#isCrippled()}
+     * @param destroyed         units destroyed, whether salvageable, devastated, or lost with their crew
+     * @param fled              units that left the board in retreat, were captured, or were pushed off
+     * @param bvInitial         the team's total Battle Value at game start
+     * @param bvRemaining       the team's total Battle Value still on the board at game end
+     */
+    public record TeamStanding(int team, int unitsFielded, int survivors, int crippledSurvivors, int destroyed,
+          int fled, int bvInitial, int bvRemaining) {}
+
+    /** Mutable accumulator behind {@link TeamStanding}, keyed by team while walking players and entities. */
+    private static final class TeamTally {
+        private int unitsFielded;
+        private int survivors;
+        private int crippledSurvivors;
+        private int destroyed;
+        private int fled;
+        private int bvInitial;
+        private int bvRemaining;
+    }
 
     /**
      * Connects the watcher and bots, then runs the game.
@@ -207,7 +241,82 @@ public class ScenarioGameRunner {
         } else {
             logger.error("Scenario game timed out");
         }
-        return new GameResult(finished, determineWinningTeam(watcherSlot.getTeam()));
+        return new GameResult(finished, determineWinningTeam(watcherSlot.getTeam()), game.getCurrentRound(),
+              collectTeamStandings(watcherSlot.getTeam()));
+    }
+
+    /**
+     * Collects the end-of-game standing of every combatant team: units fielded, survivors (and how many of them
+     * are crippled), destroyed and fled counts, and Battle Value at start versus game end. Ejected crew entities
+     * are skipped so a unit and its ejected pilot are not counted twice.
+     *
+     * @param watcherTeam the team of the headless watcher, which is excluded
+     *
+     * @return one {@link TeamStanding} per combatant team, ordered by team id
+     */
+    private List<TeamStanding> collectTeamStandings(int watcherTeam) {
+        Map<Integer, TeamTally> tallies = new TreeMap<>();
+
+        for (Player player : game.getPlayersList()) {
+            if (player.getTeam() == watcherTeam) {
+                continue;
+            }
+            TeamTally tally = tallies.computeIfAbsent(player.getTeam(), team -> new TeamTally());
+            tally.unitsFielded += player.getInitialEntityCount();
+            tally.bvInitial += player.getInitialBV();
+            tally.bvRemaining += player.getBV();
+        }
+
+        for (Entity entity : game.getEntitiesVector()) {
+            TeamTally tally = tallyFor(tallies, entity, watcherTeam);
+            if (tally == null) {
+                continue;
+            }
+            if (entity.isDestroyed()) {
+                tally.destroyed++;
+            } else {
+                tally.survivors++;
+                if (entity.isCrippled()) {
+                    tally.crippledSurvivors++;
+                }
+            }
+        }
+
+        for (Entity entity : game.getOutOfGameEntitiesVector()) {
+            TeamTally tally = tallyFor(tallies, entity, watcherTeam);
+            if (tally == null) {
+                continue;
+            }
+            switch (entity.getRemovalCondition()) {
+                case IEntityRemovalConditions.REMOVE_SALVAGEABLE,
+                     IEntityRemovalConditions.REMOVE_EJECTED,
+                     IEntityRemovalConditions.REMOVE_DEVASTATED -> tally.destroyed++;
+                case IEntityRemovalConditions.REMOVE_IN_RETREAT,
+                     IEntityRemovalConditions.REMOVE_CAPTURED,
+                     IEntityRemovalConditions.REMOVE_PUSHED -> tally.fled++;
+                default -> { } // never deployed or unknown; counted in unitsFielded only
+            }
+        }
+
+        List<TeamStanding> standings = new ArrayList<>();
+        for (Map.Entry<Integer, TeamTally> entry : tallies.entrySet()) {
+            TeamTally tally = entry.getValue();
+            standings.add(new TeamStanding(entry.getKey(), tally.unitsFielded, tally.survivors,
+                  tally.crippledSurvivors, tally.destroyed, tally.fled, tally.bvInitial, tally.bvRemaining));
+        }
+        return standings;
+    }
+
+    /**
+     * Returns the tally the given entity counts toward, or {@code null} when it should not be counted:
+     * watcher-team and ownerless entities are not combatants, and ejected crew are not units.
+     */
+    private @Nullable TeamTally tallyFor(Map<Integer, TeamTally> tallies, Entity entity, int watcherTeam) {
+        Player owner = entity.getOwner();
+        if ((owner == null) || (owner.getTeam() == watcherTeam) || (entity instanceof EjectedCrew)) {
+            return null;
+        }
+        return tallies.computeIfAbsent(owner.getTeam(), team -> new TeamTally());
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds per-game metrics and machine-readable results to the headless bot-vs-bot harness (`ScenarioGameRunner` / `AIMatchRunner`). This is the measurement base for a series of Princess behavior fixes (forced-withdrawal loiter, physical hit-table modeling, herding); each will be validated with 100+ headless games before and after the change. The benchmark scenarios themselves ship in a companion mm-data PR.

## Changes Made

- **Per-game standings**: `GameResult` now reports the end round and a `TeamStanding` per combatant team: units fielded, survivors, crippled survivors, destroyed, fled, and Battle Value at start and end. Ejected crew are not counted as units; the watcher faction is excluded.
- **CSV results**: `AIMatchRunner` writes `logs/ai_match_results_<stamp>.csv`, one row per team per game, flushed per game so an aborted batch keeps its completed games.
- **Gradle entry points**: new `aiMatch` task runs a headless batch; `printAiMatchClasspath` lets batch drivers launch parallel workers with plain `java` instead of contending for the Gradle build lock.
- **Docs fix**: the ScenarioV2 HowTo documented the bot key as `forcedwithdrawal`. The parser accepts `forcedwithdraw` and silently ignores unknown keys, so the documented spelling never worked.

## Files Changed

- `megamek/src/megamek/utilities/ScenarioGameRunner.java` - end round + `TeamStanding` metrics in `GameResult`
- `megamek/src/megamek/utilities/AIMatchRunner.java` - per-game CSV output
- `megamek/build.gradle` - `aiMatch` and `printAiMatchClasspath` tasks
- `megamek/docs/Customization/Scenarios/ScenarioV2 HowTo.mms` - bot key fix

## Testing

- `compileJava`, `compileTestJava`, `checkstyleMain`, `javadoc` all pass.
- Manual: single game via `gradlew aiMatch` (standings and BV checked against the gamelog; mirror forces report identical starting BV). A 2-game batch across two parallel worker JVMs merged cleanly.
- No unit tests: this is measurement tooling, verified by live headless runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
