### PR TITLE
Fix Princess ignoring elevation in physical attack estimates

### DIFF
--- a/megamek/src/megamek/client/bot/PhysicalCalculator.java
+++ b/megamek/src/megamek/client/bot/PhysicalCalculator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2003, 2004, 2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2003-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2003-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -345,11 +345,19 @@ public final class PhysicalCalculator {
         // Find arc the attack comes in
         target_arc = getThreatHitArc(to.getPosition(), to.getFacing(), from.getPosition());
 
+        // Absolute levels: Entity#getElevation() alone is relative to the hex floor, so two Meks standing on
+        // ground both report 0 even when one is on a hill - the hex level must be added or the elevation-based
+        // hit-table selection below never fires on sloped terrain.
+        Hex attackerHex = game.getHexOf(from);
+        Hex targetHex = game.getHexOf(to);
+        int attackerLevel = from.getElevation() + ((attackerHex == null) ? 0 : attackerHex.getLevel());
+        int targetLevel = to.getElevation() + ((targetHex == null) ? 0 : targetHex.getLevel());
+
         // Check for punches If the target is a Mek, must determine if punch lands on the punch, kick, or full table
         if (to instanceof Mek) {
             if (!to.isProne()) {
                 location_table = ToHitData.HIT_PUNCH;
-                if (to.getElevation() == (from.getElevation() + 1)) {
+                if (targetLevel == (attackerLevel + 1)) {
                     location_table = ToHitData.HIT_KICK;
                 }
             } else {
@@ -399,7 +407,7 @@ public final class PhysicalCalculator {
         if (to instanceof Mek) {
             location_table = ToHitData.HIT_KICK;
             if (!to.isProne()) {
-                if (to.getElevation() == (from.getElevation() - 1)) {
+                if (targetLevel == (attackerLevel - 1)) {
                     location_table = ToHitData.HIT_PUNCH;
                 }
             } else {
@@ -425,10 +433,10 @@ public final class PhysicalCalculator {
             // punch, or kick table
             if (to instanceof Mek) {
                 location_table = ToHitData.HIT_NORMAL;
-                if ((to.getElevation() == (from.getElevation() - 1)) && !to.isProne()) {
+                if ((targetLevel == (attackerLevel - 1)) && !to.isProne()) {
                     location_table = ToHitData.HIT_PUNCH;
                 }
-                if ((to.getElevation() == (from.getElevation() + 1)) && !to.isProne()) {
+                if ((targetLevel == (attackerLevel + 1)) && !to.isProne()) {
                     location_table = ToHitData.HIT_KICK;
                 }
             } else {

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -62,6 +62,7 @@ import megamek.common.board.Board;
 import megamek.common.board.Coords;
 import megamek.common.compute.Compute;
 import megamek.common.equipment.Engine;
+import megamek.common.equipment.MiscMounted;
 import megamek.common.equipment.MiscType;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.equipment.WeaponType;
@@ -108,6 +109,12 @@ public class BasicPathRanker extends PathRanker {
 
     // this is a value used to indicate how much we dis-value the unit being destroyed as a result of what it's doing
     private final int UNIT_DESTRUCTION_FACTOR = 1000;
+
+    // Utility weights for the non-damage consequences of physical attacks: an expected head hit also wounds
+    // the pilot (consciousness roll, cumulative death at six hits), and an expected critical can cripple out
+    // of proportion to its raw damage. Scaled against UNIT_DESTRUCTION_FACTOR (1000 = certain death).
+    private static final double PHYSICAL_PILOT_HIT_WEIGHT = 100.0;
+    private static final double PHYSICAL_CRIT_WEIGHT = 30.0;
 
     // penalty for ending a sprint inside enemy weapon range; a sprinting unit forfeits all of its attacks,
     // so this must outweigh the aggression/bravery incentives that would otherwise favor closing distance
@@ -355,26 +362,58 @@ public class BasicPathRanker extends PathRanker {
         return getFireControl(path.getEntity()).determineBestFiringPlan(guess).getUtility();
     }
 
-    double calculateKickDamagePotential(Entity enemy, MovePath path, Game game) {
+    /**
+     * Estimates the physical-attack threat an adjacent enemy Mek poses to the moving unit at the given path's
+     * end state: the better of its kick or its two-armed punch, valued as expected damage plus the expected
+     * cost of criticals, pilot hits, and outright kills. Which attack is better - and whether the head is even
+     * reachable - depends on the relative elevation: an enemy one level above resolves its kick on the punch
+     * table (head at 1 in 6), which is why standing below an adjacent enemy is far more dangerous than
+     * standing level with it.
+     *
+     * @param enemy the adjacent enemy Mek
+     * @param path  the path being evaluated for the moving unit
+     * @param game  the current game
+     *
+     * @return the expected utility cost of the enemy's best physical attack against the path's end position
+     */
+    double calculateEnemyPhysicalThreat(Entity enemy, MovePath path, Game game) {
         if (!(enemy instanceof Mek)) {
             return 0.0;
         }
 
-        // if they can kick me, and probably hit, they probably will.
-        PhysicalInfo theirKick = new PhysicalInfo(enemy,
-              null,
-              path.getEntity(),
-              new EntityState(path),
-              PhysicalAttackType.RIGHT_KICK,
-              game,
-              getOwner(),
-              true);
+        double kickThreat = physicalThreatValue(enemy, path, PhysicalAttackType.RIGHT_KICK, null, game);
+        double punchThreat = physicalThreatValue(enemy, path, PhysicalAttackType.LEFT_PUNCH, null, game)
+              + physicalThreatValue(enemy, path, PhysicalAttackType.RIGHT_PUNCH, null, game);
 
-        if (theirKick.getProbabilityToHit() <= 0.5) {
-            return 0.0;
+        // A physical weapon (hatchet, sword, club) replaces the punches or the kick in the physical phase;
+        // a Hatchetman's threat profile is its hatchet, not its fists.
+        double weaponThreat = 0.0;
+        for (MiscMounted club : enemy.getClubs()) {
+            weaponThreat = Math.max(weaponThreat,
+                  physicalThreatValue(enemy, path, PhysicalAttackType.WEAPON, club, game));
         }
 
-        return theirKick.getExpectedDamageOnHit() * theirKick.getProbabilityToHit();
+        // One physical attack per phase; assume the enemy picks its best option.
+        return Math.max(weaponThreat, Math.max(kickThreat, punchThreat));
+    }
+
+    /**
+     * Values one enemy physical attack against the moving unit's projected end state: expected damage plus
+     * weighted expected criticals, pilot hits, and kill probability. Unlike raw damage, this makes a
+     * head-capable attack (punch table) cost what it is actually worth - a 3-point head kick that risks
+     * knocking out or killing the pilot is not "3 damage".
+     */
+    private double physicalThreatValue(Entity enemy, MovePath path, PhysicalAttackType attackType,
+          @Nullable MiscMounted club, Game game) {
+        PhysicalInfo theirAttack = (club != null)
+              ? new PhysicalInfo(enemy, null, path.getEntity(), new EntityState(path), club, game, getOwner(), true)
+              : new PhysicalInfo(enemy, null, path.getEntity(), new EntityState(path), attackType, game,
+                    getOwner(), true);
+
+        return theirAttack.getExpectedDamage()
+              + (theirAttack.getExpectedCriticals() * PHYSICAL_CRIT_WEIGHT)
+              + (theirAttack.getExpectedPilotHits() * PHYSICAL_PILOT_HIT_WEIGHT)
+              + (theirAttack.getKillProbability() * UNIT_DESTRUCTION_FACTOR);
     }
 
     double calculateMyDamagePotential(MovePath path, Entity enemy, int distance, Game game) {
@@ -435,25 +474,49 @@ public class BasicPathRanker extends PathRanker {
         return myFiringPlan.getUtility();
     }
 
-    double calculateMyKickDamagePotential(MovePath path, Entity enemy, Game game) {
-        if (!(path.getEntity() instanceof Mek)) {
+    /**
+     * Estimates the physical damage the moving unit can deal from the given path's end state: the better of
+     * its kick or its two-armed punch, valued at plain expected damage. Deliberate asymmetry with
+     * {@link #calculateEnemyPhysicalThreat}: the crit, pilot-hit, and kill weightings apply only to physicals
+     * we might RECEIVE - they push units away from dangerous adjacency. Crediting our own attacks with those
+     * bonuses would inflate the bravery term and the close-range incentive and pull units toward point-blank
+     * range, where physicals are already strong.
+     *
+     * @param path  the path being evaluated
+     * @param enemy the adjacent enemy
+     * @param game  the current game
+     *
+     * @return the expected damage of the moving unit's best physical attack from the path's end position
+     */
+    double calculateMyPhysicalDamagePotential(MovePath path, Entity enemy, Game game) {
+        if (!(path.getEntity() instanceof Mek movingMek)) {
             return 0.0;
         }
 
-        PhysicalInfo myKick = new PhysicalInfo(path.getEntity(),
-              new EntityState(path),
-              enemy,
-              null,
-              PhysicalAttackType.RIGHT_KICK,
-              game,
-              getOwner(),
-              true);
+        double kickDamage = myPhysicalExpectedDamage(path, enemy, PhysicalAttackType.RIGHT_KICK, null, game);
+        double punchDamage = myPhysicalExpectedDamage(path, enemy, PhysicalAttackType.LEFT_PUNCH, null, game)
+              + myPhysicalExpectedDamage(path, enemy, PhysicalAttackType.RIGHT_PUNCH, null, game);
 
-        if (myKick.getProbabilityToHit() <= 0.5) {
-            return 0.0;
+        // A physical weapon replaces the punches or the kick; count our best single option.
+        double weaponDamage = 0.0;
+        for (MiscMounted club : movingMek.getClubs()) {
+            weaponDamage = Math.max(weaponDamage,
+                  myPhysicalExpectedDamage(path, enemy, PhysicalAttackType.WEAPON, club, game));
         }
 
-        return myKick.getExpectedDamageOnHit() * myKick.getProbabilityToHit();
+        return Math.max(weaponDamage, Math.max(kickDamage, punchDamage));
+    }
+
+    /** Expected damage of one of the moving unit's own physical attacks; see
+     * {@link #calculateMyPhysicalDamagePotential}. */
+    private double myPhysicalExpectedDamage(MovePath path, Entity enemy, PhysicalAttackType attackType,
+          @Nullable MiscMounted club, Game game) {
+        PhysicalInfo myAttack = (club != null)
+              ? new PhysicalInfo(path.getEntity(), new EntityState(path), enemy, null, club, game, getOwner(), true)
+              : new PhysicalInfo(path.getEntity(), new EntityState(path), enemy, null, attackType, game,
+                    getOwner(), true);
+
+        return myAttack.getExpectedDamage();
     }
 
     EntityEvaluationResponse evaluateMovedEnemy(Entity enemy, MovePath path, Game game) {
@@ -469,9 +532,9 @@ public class BasicPathRanker extends PathRanker {
               distance,
               game);
 
-        // if they can kick me, and probably hit, they probably will.
+        // if they can reach me with a physical attack, assume they will use their best one.
         if (distance <= 1) {
-            theirDamagePotential += calculateKickDamagePotential(enemy, path, game);
+            theirDamagePotential += calculateEnemyPhysicalThreat(enemy, path, game);
         }
 
         returnResponse.setEstimatedEnemyDamage(theirDamagePotential);
@@ -484,7 +547,7 @@ public class BasicPathRanker extends PathRanker {
 
             // How much physical damage can I do to them?
             if (distance <= 1) {
-                returnResponse.setMyEstimatedPhysicalDamage(calculateMyKickDamagePotential(path, enemy, game));
+                returnResponse.setMyEstimatedPhysicalDamage(calculateMyPhysicalDamagePotential(path, enemy, game));
             }
         }
 

--- a/megamek/src/megamek/client/bot/princess/EntityState.java
+++ b/megamek/src/megamek/client/bot/princess/EntityState.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2011 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -54,6 +54,7 @@ public class EntityState {
     private int facing;
     private int secondaryFacing; // to account for torso twists
     private int heat;
+    private final int elevation;
     private final int hexesMoved;
     private final boolean prone;
     private final boolean immobile;
@@ -71,6 +72,7 @@ public class EntityState {
     EntityState(Targetable target) {
         position = target.getPosition();
         facing = 0;
+        elevation = target.getElevation();
         hexesMoved = 0;
         heat = 0;
         prone = false;
@@ -87,6 +89,7 @@ public class EntityState {
     EntityState(Entity entity) {
         position = entity.getPosition();
         facing = entity.getFacing();
+        elevation = entity.getElevation();
         hexesMoved = entity.delta_distance;
         heat = entity.heat;
         prone = entity.isProne() || entity.isHullDown();
@@ -107,6 +110,7 @@ public class EntityState {
     EntityState(MovePath path) {
         position = path.getFinalCoords();
         facing = path.getFinalFacing();
+        elevation = path.getFinalElevation();
         hexesMoved = path.getHexesMoved();
         heat = path.getEntity().heat;
 
@@ -141,6 +145,17 @@ public class EntityState {
 
     public Coords getPosition() {
         return position;
+    }
+
+    /**
+     * Returns the elevation above the hex floor this state describes: the entity's current elevation, or the
+     * final elevation of the move path this state was built from. Combine with the hex level for the absolute
+     * level, as the physical hit-table resolution does.
+     *
+     * @return the elevation above the hex floor
+     */
+    public int getElevation() {
+        return elevation;
     }
 
     public int getFacing() {

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -46,6 +46,7 @@ import megamek.common.Player;
 import megamek.common.RangeType;
 import megamek.common.TargetRollModifier;
 import megamek.common.ToHitData;
+import megamek.common.actions.ClubAttackAction;
 import megamek.common.actions.EntityAction;
 import megamek.common.actions.FindClubAction;
 import megamek.common.actions.RepairWeaponMalfunctionAction;
@@ -505,8 +506,33 @@ public class FireControl {
           @Nullable EntityState targetState,
           final PhysicalAttackType attackType,
           final Game game) {
+        return guessToHitModifierPhysical(shooter, shooterState, target, targetState, attackType, null, game);
+    }
 
-        // todo weapons, frenzy (pg 144) & vehicle charges.
+    /**
+     * Makes a rather poor guess as to what the to hit modifier will be with a physical attack. This overload
+     * also covers physical-weapon (club/hatchet/sword) attacks, for which the mounted weapon must be given.
+     *
+     * @param shooter      The unit doing the attacking.
+     * @param shooterState The state of the unit doing the attacking.
+     * @param target       Who is being attacked.
+     * @param targetState  The state of the target.
+     * @param attackType   The type of physical attack being made.
+     * @param club         The physical weapon being swung; required for {@link PhysicalAttackType#WEAPON},
+     *                     ignored otherwise.
+     * @param game         The current {@link Game}
+     *
+     * @return The estimated to hit modifiers.
+     */
+    ToHitData guessToHitModifierPhysical(final Entity shooter,
+          @Nullable EntityState shooterState,
+          final Targetable target,
+          @Nullable EntityState targetState,
+          final PhysicalAttackType attackType,
+          @Nullable final MiscMounted club,
+          final Game game) {
+
+        // todo frenzy (pg 144) & vehicle charges.
         // todo heat mods to piloting?
 
         if (!(shooter instanceof Mek shooterMek)) {
@@ -547,12 +573,13 @@ public class FireControl {
             return new ToHitData(TH_PHY_NOT_IN_ARC);
         }
 
-        // Check elevation difference.
+        // Check elevation difference. Use the (possibly hypothetical) state elevations, not the entities'
+        // current ones: a path can end on a different level than the unit stands on now.
         final Hex attackerHex = game.getBoard(target).getHex(shooterState.getPosition());
         final Hex targetHex = game.getBoard(target).getHex(targetState.getPosition());
-        final int attackerElevation = shooter.getElevation() + attackerHex.getLevel();
-        final int attackerHeight = shooter.relHeight() + attackerHex.getLevel();
-        final int targetElevation = target.getElevation() + targetHex.getLevel();
+        final int attackerElevation = shooterState.getElevation() + attackerHex.getLevel();
+        final int attackerHeight = attackerElevation + (shooterState.isProne() ? 0 : shooter.getHeight());
+        final int targetElevation = targetState.getElevation() + targetHex.getLevel();
         final int targetHeight = targetElevation + target.getHeight();
         if (attackType.isPunch()) {
             if (shooter.hasQuirk(OptionsConstants.QUIRK_NEG_NO_ARMS)) {
@@ -587,6 +614,30 @@ public class FireControl {
             }
             if (!shooter.hasWorkingSystem(Mek.ACTUATOR_HAND, armLocation)) {
                 toHitData.addModifier(TH_PHY_P_HAND);
+            }
+        } else if (PhysicalAttackType.WEAPON == attackType) {
+            if (club == null) {
+                return new ToHitData(TH_PHY_NOT_MEK);
+            }
+            // Reach approximated like a punch: the weapon is swung by the arms.
+            if ((attackerHeight < targetElevation) || (attackerHeight > targetHeight)) {
+                return new ToHitData(TH_PHY_TOO_MUCH_ELEVATION);
+            }
+            if (shooterState.isProne()) {
+                return new ToHitData(TH_PHY_P_TAR_PRONE);
+            }
+
+            toHitData.addModifier(shooter.getCrew().getPiloting(), TH_PHY_BASE);
+            toHitData.addModifier(ClubAttackAction.getHitModFor(club.getType()), club.getName());
+            // Damaged arm actuators penalize the swing when the weapon is arm-mounted.
+            int clubLocation = club.getLocation();
+            if ((Mek.LOC_LEFT_ARM == clubLocation) || (Mek.LOC_RIGHT_ARM == clubLocation)) {
+                if (!shooter.hasWorkingSystem(Mek.ACTUATOR_UPPER_ARM, clubLocation)) {
+                    toHitData.addModifier(TH_PHY_P_UPPER_ARM);
+                }
+                if (!shooter.hasWorkingSystem(Mek.ACTUATOR_LOWER_ARM, clubLocation)) {
+                    toHitData.addModifier(TH_PHY_P_LOWER_ARM);
+                }
             }
         } else { // assuming kick
 

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -164,6 +164,8 @@ public class FireControl {
           "target elevation not in range");
     static final TargetRollModifier TH_PHY_P_TAR_PRONE = new TargetRollModifier(TargetRoll.IMPOSSIBLE,
           "can't punch while prone");
+    static final TargetRollModifier TH_PHY_NO_CLUB = new TargetRollModifier(TargetRoll.IMPOSSIBLE,
+          "no physical weapon given");
     static final TargetRollModifier TH_PHY_P_TAR_INF = new TargetRollModifier(TargetRoll.IMPOSSIBLE,
           "can't punch infantry");
     static final TargetRollModifier TH_PHY_P_NO_ARM = new TargetRollModifier(TargetRoll.IMPOSSIBLE, "Your arm's off!");
@@ -617,7 +619,7 @@ public class FireControl {
             }
         } else if (PhysicalAttackType.WEAPON == attackType) {
             if (club == null) {
-                return new ToHitData(TH_PHY_NOT_MEK);
+                return new ToHitData(TH_PHY_NO_CLUB);
             }
             // Reach approximated like a punch: the weapon is swung by the arms.
             if ((attackerHeight < targetElevation) || (attackerHeight > targetHeight)) {

--- a/megamek/src/megamek/client/bot/princess/FireControl.java
+++ b/megamek/src/megamek/client/bot/princess/FireControl.java
@@ -575,14 +575,18 @@ public class FireControl {
             return new ToHitData(TH_PHY_NOT_IN_ARC);
         }
 
-        // Check elevation difference. Use the (possibly hypothetical) state elevations, not the entities'
-        // current ones: a path can end on a different level than the unit stands on now.
+        // Check elevation difference. Use the (possibly hypothetical) state elevations and stances, not the
+        // entities' current ones: a path can end on a different level, or in a different stance, than the
+        // unit is in now.
         final Hex attackerHex = game.getBoard(target).getHex(shooterState.getPosition());
         final Hex targetHex = game.getBoard(target).getHex(targetState.getPosition());
         final int attackerElevation = shooterState.getElevation() + attackerHex.getLevel();
-        final int attackerHeight = attackerElevation + (shooterState.isProne() ? 0 : shooter.getHeight());
+        final int attackerHeight = attackerElevation
+              + PhysicalHitTable.projectedHeight(shooterMek, shooterState.isProne());
         final int targetElevation = targetState.getElevation() + targetHex.getLevel();
-        final int targetHeight = targetElevation + target.getHeight();
+        final int targetHeight = targetElevation + ((target instanceof Entity targetEntity)
+              ? PhysicalHitTable.projectedHeight(targetEntity, targetState.isProne())
+              : target.getHeight());
         if (attackType.isPunch()) {
             if (shooter.hasQuirk(OptionsConstants.QUIRK_NEG_NO_ARMS)) {
                 return new ToHitData(TH_PHY_P_NO_ARMS_QUIRK);

--- a/megamek/src/megamek/client/bot/princess/PhysicalHitTable.java
+++ b/megamek/src/megamek/client/bot/princess/PhysicalHitTable.java
@@ -42,11 +42,12 @@ import megamek.common.units.Targetable;
 /**
  * Resolves which hit-location table a physical attack lands on, from the attacker's and target's (possibly
  * hypothetical) positions and elevations. This mirrors the rules-engine logic in
- * {@link megamek.common.actions.KickAttackAction#toHit} and {@link megamek.common.actions.PunchAttackAction#toHit}
- * so Princess's damage estimates use the same table the attack would actually resolve on: a kick delivered
- * from one level above a standing Mek lands on the punch table (head reachable), a punch delivered at the
- * target's base level lands on the kick table (legs), and physicals against height-zero targets use the full
- * body table. Keep this in sync with those two action classes when their elevation rules change.
+ * {@link megamek.common.actions.KickAttackAction#toHit}, {@link megamek.common.actions.PunchAttackAction#toHit},
+ * and {@link megamek.common.actions.ClubAttackAction#toHit} so Princess's damage estimates use the same table
+ * the attack would actually resolve on: a kick delivered from one level above a standing Mek lands on the
+ * punch table (head reachable), a punch delivered at the target's base level lands on the kick table (legs),
+ * and physicals against height-zero targets use the full body table. Keep this in sync with those three
+ * action classes when their elevation rules change.
  *
  * <p>Special cases the rules engine handles that this estimate deliberately does not: converted QuadVees,
  * grounded DropShips, and hull-down attackers (prone and hull-down attackers are rejected as illegal by the
@@ -60,7 +61,7 @@ final class PhysicalHitTable {
     /**
      * Resolves the hit-location table for the given physical attack.
      *
-     * @param attackType   the punch or kick being evaluated
+     * @param attackType   the punch, kick, or physical-weapon attack being evaluated
      * @param shooter      the attacking entity
      * @param shooterState the attacker's (possibly hypothetical) position and elevation
      * @param target       the target of the attack

--- a/megamek/src/megamek/client/bot/princess/PhysicalHitTable.java
+++ b/megamek/src/megamek/client/bot/princess/PhysicalHitTable.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.bot.princess;
+
+import megamek.common.Hex;
+import megamek.common.ToHitData;
+import megamek.common.game.Game;
+import megamek.common.units.Entity;
+import megamek.common.units.Mek;
+import megamek.common.units.Targetable;
+
+/**
+ * Resolves which hit-location table a physical attack lands on, from the attacker's and target's (possibly
+ * hypothetical) positions and elevations. This mirrors the rules-engine logic in
+ * {@link megamek.common.actions.KickAttackAction#toHit} and {@link megamek.common.actions.PunchAttackAction#toHit}
+ * so Princess's damage estimates use the same table the attack would actually resolve on: a kick delivered
+ * from one level above a standing Mek lands on the punch table (head reachable), a punch delivered at the
+ * target's base level lands on the kick table (legs), and physicals against height-zero targets use the full
+ * body table. Keep this in sync with those two action classes when their elevation rules change.
+ *
+ * <p>Special cases the rules engine handles that this estimate deliberately does not: converted QuadVees,
+ * grounded DropShips, and hull-down attackers (prone and hull-down attackers are rejected as illegal by the
+ * guess-level legality checks before table selection matters).</p>
+ */
+final class PhysicalHitTable {
+
+    private PhysicalHitTable() {
+    }
+
+    /**
+     * Resolves the hit-location table for the given physical attack.
+     *
+     * @param attackType   the punch or kick being evaluated
+     * @param shooter      the attacking entity
+     * @param shooterState the attacker's (possibly hypothetical) position and elevation
+     * @param target       the target of the attack
+     * @param targetState  the target's (possibly hypothetical) position and elevation
+     * @param game         the current game, for hex levels
+     *
+     * @return one of {@link ToHitData#HIT_PUNCH}, {@link ToHitData#HIT_KICK}, or {@link ToHitData#HIT_NORMAL}
+     */
+    static int resolve(PhysicalAttackType attackType, Entity shooter, EntityState shooterState,
+          Targetable target, EntityState targetState, Game game) {
+        if (!(target instanceof Entity targetEntity)) {
+            // buildings and other non-entity targets have no location table
+            return ToHitData.HIT_NORMAL;
+        }
+
+        // Without board data (or off-board positions) fall back to the attack type's usual table, which is
+        // what the estimate assumed before elevation was modeled at all. Physical weapons default to the
+        // full-body table, their on-the-level result.
+        int fallbackTable;
+        if (attackType.isPunch()) {
+            fallbackTable = ToHitData.HIT_PUNCH;
+        } else if (attackType.isKick()) {
+            fallbackTable = ToHitData.HIT_KICK;
+        } else {
+            fallbackTable = ToHitData.HIT_NORMAL;
+        }
+        var board = game.getBoard(target);
+        if (board == null) {
+            return fallbackTable;
+        }
+        Hex attackerHex = board.getHex(shooterState.getPosition());
+        Hex targetHex = board.getHex(targetState.getPosition());
+        if ((attackerHex == null) || (targetHex == null)) {
+            return fallbackTable;
+        }
+
+        // Absolute levels: hex floor plus the unit's elevation above it. A prone target has height 0.
+        // As with the attacker, getHeight() reads the current stance, so a currently-prone Mek whose
+        // projected state is standing needs its standing height restored; vehicles genuinely are height 0.
+        int targetHeightAboveFloor = targetState.isProne() ? 0
+              : ((targetEntity instanceof Mek) ? Math.max(1, targetEntity.getHeight())
+                    : targetEntity.getHeight());
+        int targetBase = targetState.getElevation() + targetHex.getLevel();
+        int targetTop = targetBase + targetHeightAboveFloor;
+
+        if (attackType.isPunch()) {
+            // Arms level: the attacker's top. Prone attackers are rejected as illegal before this matters,
+            // but Entity#getHeight() reads the CURRENT stance - a currently-prone Mek planning to stand
+            // reports height 0, so clamp to at least 1 for the projected standing height.
+            int attackerArms = shooterState.getElevation() + attackerHex.getLevel()
+                  + Math.max(1, shooter.getHeight());
+            if (attackerArms == targetBase) {
+                // punching at the target's feet: legs, or the full body of a height-zero target
+                return (targetHeightAboveFloor == 0) ? ToHitData.HIT_NORMAL : ToHitData.HIT_KICK;
+            }
+            return ToHitData.HIT_PUNCH;
+        }
+
+        int attackerBase = shooterState.getElevation() + attackerHex.getLevel();
+
+        if (attackType == PhysicalAttackType.WEAPON) {
+            // Physical weapons (hatchets, swords, clubs) per ClubAttackAction: on the level they sweep the
+            // full body; swung up at a taller target they reach the legs; swung down they land on the punch
+            // table.
+            if (attackerBase == targetBase) {
+                return ToHitData.HIT_NORMAL;
+            }
+            if (attackerBase < targetBase) {
+                return (targetHeightAboveFloor == 0) ? ToHitData.HIT_NORMAL : ToHitData.HIT_KICK;
+            }
+            return ToHitData.HIT_PUNCH;
+        }
+
+        // Kick: feet at the attacker's base level.
+        if (attackerBase < targetTop) {
+            return ToHitData.HIT_KICK;
+        }
+        // Feet level with (or above) the target's top: the kick reaches torso and head.
+        return (targetHeightAboveFloor > 0) ? ToHitData.HIT_PUNCH : ToHitData.HIT_NORMAL;
+    }
+}

--- a/megamek/src/megamek/client/bot/princess/PhysicalHitTable.java
+++ b/megamek/src/megamek/client/bot/princess/PhysicalHitTable.java
@@ -59,6 +59,26 @@ final class PhysicalHitTable {
     }
 
     /**
+     * Returns the height the entity would have in the given (possibly hypothetical) stance.
+     * {@link Entity#getHeight()} reads the CURRENT stance - a currently-prone Mek reports 0 even when the
+     * projected state stands it up, and a currently-standing superheavy reports 2 that a projected prone
+     * state should flatten. Only when the projected stance differs from the current one is the Mek height
+     * reconstructed (superheavies stand two levels tall); otherwise the entity's own height - including
+     * exotic overrides like LAMs in fighter mode - is trusted as-is.
+     *
+     * @param entity         the entity whose height is wanted
+     * @param projectedProne whether the projected state has the entity prone (or hull-down)
+     *
+     * @return the height above its base level the entity would have in the projected stance
+     */
+    static int projectedHeight(Entity entity, boolean projectedProne) {
+        if ((entity instanceof Mek mek) && (projectedProne != mek.isProne())) {
+            return projectedProne ? 0 : (mek.isSuperHeavy() ? 2 : 1);
+        }
+        return entity.getHeight();
+    }
+
+    /**
      * Resolves the hit-location table for the given physical attack.
      *
      * @param attackType   the punch, kick, or physical-weapon attack being evaluated
@@ -98,21 +118,17 @@ final class PhysicalHitTable {
             return fallbackTable;
         }
 
-        // Absolute levels: hex floor plus the unit's elevation above it. A prone target has height 0.
-        // As with the attacker, getHeight() reads the current stance, so a currently-prone Mek whose
-        // projected state is standing needs its standing height restored; vehicles genuinely are height 0.
-        int targetHeightAboveFloor = targetState.isProne() ? 0
-              : ((targetEntity instanceof Mek) ? Math.max(1, targetEntity.getHeight())
-                    : targetEntity.getHeight());
+        // Absolute levels: hex floor plus the unit's elevation above it, with heights taken in the
+        // PROJECTED stance (see projectedHeight).
+        int targetHeightAboveFloor = projectedHeight(targetEntity, targetState.isProne());
         int targetBase = targetState.getElevation() + targetHex.getLevel();
         int targetTop = targetBase + targetHeightAboveFloor;
 
         if (attackType.isPunch()) {
-            // Arms level: the attacker's top. Prone attackers are rejected as illegal before this matters,
-            // but Entity#getHeight() reads the CURRENT stance - a currently-prone Mek planning to stand
-            // reports height 0, so clamp to at least 1 for the projected standing height.
+            // Arms level: the attacker's top in its projected stance. Prone attackers are rejected as
+            // illegal before table selection matters.
             int attackerArms = shooterState.getElevation() + attackerHex.getLevel()
-                  + Math.max(1, shooter.getHeight());
+                  + projectedHeight(shooter, shooterState.isProne());
             if (attackerArms == targetBase) {
                 // punching at the target's feet: legs, or the full body of a height-zero target
                 return (targetHeightAboveFloor == 0) ? ToHitData.HIT_NORMAL : ToHitData.HIT_KICK;

--- a/megamek/src/megamek/client/bot/princess/PhysicalInfo.java
+++ b/megamek/src/megamek/client/bot/princess/PhysicalInfo.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2011 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2013-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2013-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -38,9 +38,11 @@ import java.text.NumberFormat;
 
 import megamek.client.bot.PhysicalOption;
 import megamek.common.ToHitData;
+import megamek.common.actions.ClubAttackAction;
 import megamek.common.actions.KickAttackAction;
 import megamek.common.actions.PhysicalAttackAction;
 import megamek.common.actions.PunchAttackAction;
+import megamek.common.equipment.MiscMounted;
 import megamek.common.board.Coords;
 import megamek.common.compute.Compute;
 import megamek.common.game.Game;
@@ -72,7 +74,9 @@ public class PhysicalInfo {
     private int damageDirection; // direction damage is coming from relative to target
     private double expectedCriticals;
     private double killProbability; // probability to destroy CT or HEAD (ignores criticalSlots)
+    private double expectedPilotHits; // expected crew hits: any head hit wounds the pilot, armor or not
     private double utility; // filled out externally
+    private MiscMounted club; // the physical weapon swung, for PhysicalAttackType.WEAPON attacks only
     private final Princess owner;
 
     /**
@@ -111,6 +115,30 @@ public class PhysicalInfo {
     }
 
     /**
+     * Constructor for a physical-weapon (club/hatchet/sword) attack.
+     *
+     * @param shooter      The {@link megamek.common.units.Entity} doing the attacking.
+     * @param shooterState The current {@link megamek.client.bot.princess.EntityState} of the attacker.
+     * @param target       The {@link megamek.common.units.Targetable} of the attack.
+     * @param targetState  The current {@link megamek.client.bot.princess.EntityState} of the target.
+     * @param club         The physical weapon being swung.
+     * @param game         The current {@link Game}
+     * @param owner        The owning {@link Princess} bot.
+     * @param guess        Set TRUE to estimate the chance to hit rather than doing the full calculation.
+     */
+    PhysicalInfo(Entity shooter, EntityState shooterState, Targetable target, EntityState targetState,
+          MiscMounted club, Game game, Princess owner, boolean guess) {
+
+        this.owner = owner;
+
+        setShooter(shooter);
+        setTarget(target);
+        setAttackType(PhysicalAttackType.WEAPON);
+        this.club = club;
+        initDamage(PhysicalAttackType.WEAPON, shooterState, targetState, guess, game);
+    }
+
+    /**
      * Builds a new {@link PhysicalAttackAction} from the given parameters.
      *
      * @param attackType The {@link PhysicalAttackType} of the attack.
@@ -126,8 +154,11 @@ public class PhysicalInfo {
         } else if (attackType.isKick()) {
             int legId = PhysicalAttackType.RIGHT_KICK == attackType ? KickAttackAction.RIGHT : KickAttackAction.LEFT;
             return new KickAttackAction(shooterId, target.getTargetType(), target.getId(), legId);
+        } else if ((PhysicalAttackType.WEAPON == attackType) && (club != null)) {
+            return new ClubAttackAction(shooterId, target.getTargetType(), target.getId(), club,
+                  ToHitData.HIT_NORMAL, false);
         } else {
-            // todo handle other physical attack types.
+            // todo handle other physical attack types (charge, DFA).
             return null;
         }
     }
@@ -164,6 +195,7 @@ public class PhysicalInfo {
             setMaxDamage(0);
             setExpectedCriticals(0);
             setKillProbability(0);
+            setExpectedPilotHits(0);
             setExpectedDamageOnHit(0);
             return;
         }
@@ -179,12 +211,24 @@ public class PhysicalInfo {
         if (guess) {
             setHitData(owner.getFireControl(getShooter()).guessToHitModifierPhysical(getShooter(), shooterState,
                   getTarget(),
-                  targetState, getAttackType(), game));
+                  targetState, getAttackType(), club, game));
+            // The guess path never resolves which hit-location table the attack lands on, so resolve it the
+            // way the rules engine would: elevation decides whether a kick reaches the legs or the head.
+            getHitData().setHitTable(PhysicalHitTable.resolve(getAttackType(), getShooter(), shooterState,
+                  getTarget(), targetState, game));
         } else {
+            // The real toHit() already resolved the correct hit-location table into the ToHitData.
             PhysicalAttackAction action = buildAction(physicalAttackType, getShooter().getId(), getTarget());
             setAction(action);
-            setHitData(physicalAttackType.isPunch() ? ((PunchAttackAction) action).toHit(game)
-                  : ((KickAttackAction) action).toHit(game));
+            if (action instanceof PunchAttackAction punchAction) {
+                setHitData(punchAction.toHit(game));
+            } else if (action instanceof KickAttackAction kickAction) {
+                setHitData(kickAction.toHit(game));
+            } else if (action instanceof ClubAttackAction clubAction) {
+                setHitData(clubAction.toHit(game));
+            } else {
+                setHitData(new ToHitData(ToHitData.IMPOSSIBLE, "unsupported physical attack type"));
+            }
         }
 
         // Get the attack direction.
@@ -198,6 +242,7 @@ public class PhysicalInfo {
             setMaxDamage(0);
             setExpectedCriticals(0);
             setKillProbability(0);
+            setExpectedPilotHits(0);
             setExpectedDamageOnHit(0);
             return;
         }
@@ -213,9 +258,24 @@ public class PhysicalInfo {
                 setMaxDamage(0);
                 setExpectedCriticals(0);
                 setKillProbability(0);
+                setExpectedPilotHits(0);
                 setExpectedDamageOnHit(0);
                 return;
             }
+        } else if (PhysicalAttackType.WEAPON == physicalAttackType) {
+            if (club == null) {
+                logger.warn(msg.append("\n\tweapon attack without a club!").toString());
+                setProbabilityToHit(0);
+                setMaxDamage(0);
+                setExpectedCriticals(0);
+                setKillProbability(0);
+                setExpectedPilotHits(0);
+                setExpectedDamageOnHit(0);
+                return;
+            }
+            boolean targetIsConventionalInfantry = (getTarget() instanceof Entity targetEntity)
+                  && targetEntity.isConventionalInfantry();
+            setMaxDamage(ClubAttackAction.getDamageFor(getShooter(), club, targetIsConventionalInfantry, false));
         } else { // assuming kick
             setMaxDamage((int) Math.floor(getShooter().getWeight() / 5.0));
         }
@@ -241,10 +301,17 @@ public class PhysicalInfo {
         final double ROLL_TWO = 0.028;
         setExpectedCriticals(ROLL_TWO * expectedCriticalHitCount * getProbabilityToHit());
         setKillProbability(0);
+        setExpectedPilotHits(0);
 
         if (!(getTarget() instanceof Mek targetMek)) {
             return;
         }
+
+        // Any hit on the head wounds the pilot regardless of armor, so the expected crew damage is simply
+        // the head's share of the resolved hit-location table. On the kick table that share is zero; a kick
+        // delivered from above resolves on the punch table and puts the head in play.
+        setExpectedPilotHits(ProbabilityCalculator.getHitProbability(getHitData().getHitTable(),
+              getDamageDirection(), Mek.LOC_HEAD) * getProbabilityToHit());
 
         // now guess how many critical hits will be done
         for (int i = 0; i <= 7; i++) {
@@ -258,12 +325,10 @@ public class PhysicalInfo {
                 }
                 hitLoc = Mek.getInnerLocation(hitLoc);
             }
-            double hitLocationProbability;
-            if (getAttackType().isPunch()) {
-                hitLocationProbability = ProbabilityCalculator.getHitProbability_Punch(getDamageDirection(), hitLoc);
-            } else { // assume kick
-                hitLocationProbability = ProbabilityCalculator.getHitProbability_Kick(getDamageDirection(), hitLoc);
-            }
+            // Use the hit-location table the attack actually resolves on (punch, kick, or full-body by
+            // relative elevation) rather than assuming the table from the attack type.
+            double hitLocationProbability = ProbabilityCalculator.getHitProbability(getHitData().getHitTable(),
+                  getDamageDirection(), hitLoc);
             int targetArmor = targetMek.getArmor(hitLoc, (getDamageDirection() == 3));
             int targetInternals = targetMek.getInternal(hitLoc);
             if (targetArmor < 0) {
@@ -402,6 +467,21 @@ public class PhysicalInfo {
 
     public void setKillProbability(double killProbability) {
         this.killProbability = killProbability;
+    }
+
+    /**
+     * Returns the expected number of crew hits this attack inflicts: the head's share of the resolved
+     * hit-location table times the probability to hit. Any head hit wounds the pilot regardless of armor,
+     * so this is nonzero exactly when the attack resolves on a table that can reach the head.
+     *
+     * @return the expected crew hits from this attack
+     */
+    public double getExpectedPilotHits() {
+        return expectedPilotHits;
+    }
+
+    public void setExpectedPilotHits(double expectedPilotHits) {
+        this.expectedPilotHits = expectedPilotHits;
     }
 
     public double getUtility() {

--- a/megamek/src/megamek/client/bot/princess/PhysicalInfo.java
+++ b/megamek/src/megamek/client/bot/princess/PhysicalInfo.java
@@ -37,6 +37,7 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 
 import megamek.client.bot.PhysicalOption;
+import megamek.common.TargetRollModifier;
 import megamek.common.ToHitData;
 import megamek.common.actions.ClubAttackAction;
 import megamek.common.actions.KickAttackAction;
@@ -46,6 +47,7 @@ import megamek.common.equipment.MiscMounted;
 import megamek.common.board.Coords;
 import megamek.common.compute.Compute;
 import megamek.common.game.Game;
+import megamek.common.rolls.TargetRoll;
 import megamek.common.units.BipedMek;
 import megamek.common.units.Entity;
 import megamek.common.units.Mek;
@@ -62,6 +64,9 @@ public class PhysicalInfo {
 
     private static final NumberFormat LOG_PER = NumberFormat.getPercentInstance();
     private static final NumberFormat LOG_DEC = DecimalFormat.getInstance();
+
+    private static final TargetRollModifier TH_UNSUPPORTED_ATTACK_TYPE = new TargetRollModifier(
+          TargetRoll.IMPOSSIBLE, "unsupported physical attack type");
 
     private Entity shooter;
     private Targetable target;
@@ -227,7 +232,7 @@ public class PhysicalInfo {
             } else if (action instanceof ClubAttackAction clubAction) {
                 setHitData(clubAction.toHit(game));
             } else {
-                setHitData(new ToHitData(ToHitData.IMPOSSIBLE, "unsupported physical attack type"));
+                setHitData(new ToHitData(TH_UNSUPPORTED_ATTACK_TYPE));
             }
         }
 

--- a/megamek/src/megamek/client/bot/princess/ProbabilityCalculator.java
+++ b/megamek/src/megamek/client/bot/princess/ProbabilityCalculator.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2011 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2011-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2011-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,6 +32,8 @@
  * affiliated with Microsoft.
  */
 package megamek.client.bot.princess;
+
+import megamek.common.ToHitData;
 
 /**
  * This class stores all the calculations of probabilities given the rule set
@@ -104,6 +106,27 @@ public class ProbabilityCalculator {
         }
         // assume attackedFromFacing==4
         return hitProbabilitiesKickLeftSide[hit_location];
+    }
+
+    /**
+     * Returns the probability that {@code hitLocation} (from class Mek) is hit for an attack resolved on the
+     * given hit-location table, from facing {@code attackedFromFacing} (0 = forward). Dispatches to the punch,
+     * kick, or full-body (weapons fire) table, so callers that resolve the table by relative elevation - see
+     * {@link PhysicalHitTable} - do not need to pick the array family themselves.
+     *
+     * @param hitTable           one of {@link ToHitData#HIT_PUNCH}, {@link ToHitData#HIT_KICK}, or any other
+     *                           value for the full-body table
+     * @param attackedFromFacing the facing the attack comes from, 0 defined as forward
+     * @param hitLocation        the Mek hit location index
+     *
+     * @return the probability of hitting that location on that table
+     */
+    static double getHitProbability(int hitTable, int attackedFromFacing, int hitLocation) {
+        return switch (hitTable) {
+            case ToHitData.HIT_PUNCH -> getHitProbability_Punch(attackedFromFacing, hitLocation);
+            case ToHitData.HIT_KICK -> getHitProbability_Kick(attackedFromFacing, hitLocation);
+            default -> getHitProbability(attackedFromFacing, hitLocation);
+        };
     }
 
     /**

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -575,11 +575,11 @@ class BasicPathRankerTest {
                     anyInt(),
                     any(Game.class));
         doReturn(10.0).when(testRanker)
-              .calculateKickDamagePotential(eq(mockEnemyMek), any(MovePath.class), any(Game.class));
+              .calculateEnemyPhysicalThreat(eq(mockEnemyMek), any(MovePath.class), any(Game.class));
         doReturn(14.5).when(testRanker)
               .calculateMyDamagePotential(any(MovePath.class), eq(mockEnemyMek), anyInt(), any(Game.class));
         doReturn(8.0).when(testRanker)
-              .calculateMyKickDamagePotential(any(MovePath.class), eq(mockEnemyMek), any(Game.class));
+              .calculateMyPhysicalDamagePotential(any(MovePath.class), eq(mockEnemyMek), any(Game.class));
         final Map<Integer, Double> testBestDamageByEnemies = new TreeMap<>();
         testBestDamageByEnemies.put(mockEnemyMekId, 0.0);
         doReturn(testBestDamageByEnemies).when(testRanker).getBestDamageByEnemies();
@@ -667,11 +667,11 @@ class BasicPathRankerTest {
                     anyInt(),
                     any(Game.class));
         doReturn(10.0).when(testRanker)
-              .calculateKickDamagePotential(eq(mockEnemyMek), any(MovePath.class), any(Game.class));
+              .calculateEnemyPhysicalThreat(eq(mockEnemyMek), any(MovePath.class), any(Game.class));
         doReturn(14.5).when(testRanker)
               .calculateMyDamagePotential(any(MovePath.class), eq(mockEnemyMek), anyInt(), any(Game.class));
         doReturn(8.0).when(testRanker)
-              .calculateMyKickDamagePotential(any(MovePath.class), eq(mockEnemyMek), any(Game.class));
+              .calculateMyPhysicalDamagePotential(any(MovePath.class), eq(mockEnemyMek), any(Game.class));
         final Map<Integer, Double> testBestDamageByEnemies = new TreeMap<>();
         testBestDamageByEnemies.put(mockEnemyMekId, 0.0);
         doReturn(testBestDamageByEnemies).when(testRanker).getBestDamageByEnemies();

--- a/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/FireControlTest.java
@@ -1720,6 +1720,9 @@ class FireControlTest {
         when(mockBoard.getHex(eq(mockShooterState.getPosition()))).thenReturn(mockShooterHex);
         when(mockShooter.getElevation()).thenReturn(0);
         when(mockShooter.relHeight()).thenReturn(2);
+        // the guess now derives the arms level from the projected state plus getHeight(), not relHeight()
+        when(mockShooter.getHeight()).thenReturn(2);
+        when(mockShooterState.getElevation()).thenReturn(0);
         when(mockShooter.getWeightClass()).thenReturn(EntityWeightClass.WEIGHT_LIGHT);
         when(mockShooter.isLocationBad(Mek.LOC_LEFT_ARM)).thenReturn(false);
         when(mockShooter.hasWorkingSystem(Mek.ACTUATOR_SHOULDER, Mek.LOC_LEFT_ARM)).thenReturn(true);
@@ -1990,10 +1993,11 @@ class FireControlTest {
                     PhysicalAttackType.RIGHT_PUNCH,
                     mockGame));
 
-        // Test trying to punch an infantry target.
+        // Test trying to punch an infantry target (standing one level up, in punch reach).
         infantryTarget = mock(Infantry.class);
         when(infantryTarget.getElevation()).thenReturn(1);
         when(infantryTarget.getHeight()).thenReturn(1);
+        when(mockTargetState.getElevation()).thenReturn(1);
         expected = new ToHitData(FireControl.TH_PHY_P_TAR_INF);
         assertToHitDataEquals(expected,
               testFireControl.guessToHitModifierPhysical(mockShooter,
@@ -2002,6 +2006,7 @@ class FireControlTest {
                     mockTargetState,
                     PhysicalAttackType.LEFT_PUNCH,
                     mockGame));
+        when(mockTargetState.getElevation()).thenReturn(0);
 
         // Test trying to punch while prone.
         when(mockShooterState.isProne()).thenReturn(true);
@@ -2013,6 +2018,7 @@ class FireControlTest {
                     mockTargetState,
                     PhysicalAttackType.LEFT_PUNCH,
                     mockGame));
+        when(mockShooterState.isProne()).thenReturn(false);
 
         // Test the target being at the wrong elevation for a punch.
         when(mockShooterHex.getLevel()).thenReturn(1);

--- a/megamek/unittests/megamek/client/bot/princess/PhysicalHitTableTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PhysicalHitTableTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.bot.princess;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import megamek.common.Hex;
+import megamek.common.ToHitData;
+import megamek.common.board.Board;
+import megamek.common.board.Coords;
+import megamek.common.game.Game;
+import megamek.common.units.BipedMek;
+import megamek.common.units.Tank;
+import megamek.common.units.Targetable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link PhysicalHitTable} resolves the same hit-location table the rules engine would:
+ * elevation decides whether a kick reaches the legs or the head, and whether a punch lands on the punch
+ * table, the kick table (a leg punch), or the full body of a height-zero target.
+ */
+class PhysicalHitTableTest {
+
+    private static final Coords ATTACKER_POSITION = new Coords(0, 0);
+    private static final Coords TARGET_POSITION = new Coords(1, 0);
+
+    private Game mockGame;
+    private Hex attackerHex;
+    private Hex targetHex;
+    private BipedMek attacker;
+    private BipedMek targetMek;
+    private EntityState attackerState;
+    private EntityState targetState;
+
+    @BeforeEach
+    void setUp() {
+        mockGame = mock(Game.class);
+        Board mockBoard = mock(Board.class);
+        doReturn(mockBoard).when(mockGame).getBoard(any(Targetable.class));
+
+        attackerHex = mock(Hex.class);
+        targetHex = mock(Hex.class);
+        when(mockBoard.getHex(ATTACKER_POSITION)).thenReturn(attackerHex);
+        when(mockBoard.getHex(TARGET_POSITION)).thenReturn(targetHex);
+
+        attacker = mock(BipedMek.class);
+        when(attacker.getHeight()).thenReturn(1);
+        targetMek = mock(BipedMek.class);
+        when(targetMek.getHeight()).thenReturn(1);
+
+        attackerState = mock(EntityState.class);
+        when(attackerState.getPosition()).thenReturn(ATTACKER_POSITION);
+        when(attackerState.getElevation()).thenReturn(0);
+        targetState = mock(EntityState.class);
+        when(targetState.getPosition()).thenReturn(TARGET_POSITION);
+        when(targetState.getElevation()).thenReturn(0);
+    }
+
+    private void setHexLevels(int attackerLevel, int targetLevel) {
+        when(attackerHex.getLevel()).thenReturn(attackerLevel);
+        when(targetHex.getLevel()).thenReturn(targetLevel);
+    }
+
+    @Test
+    void testKickOnTheLevelHitsLegs() {
+        setHexLevels(0, 0);
+        assertEquals(ToHitData.HIT_KICK, PhysicalHitTable.resolve(PhysicalAttackType.RIGHT_KICK,
+              attacker, attackerState, targetMek, targetState, mockGame));
+    }
+
+    @Test
+    void testKickFromOneLevelAboveHitsPunchTable() {
+        // The QA case: the kicker stands on a hill one level above a standing Mek, so its feet are level
+        // with the target's torso and head - the kick resolves on the punch table.
+        setHexLevels(1, 0);
+        assertEquals(ToHitData.HIT_PUNCH, PhysicalHitTable.resolve(PhysicalAttackType.RIGHT_KICK,
+              attacker, attackerState, targetMek, targetState, mockGame));
+    }
+
+    @Test
+    void testKickFromAboveOnHeightZeroTargetHitsFullBody() {
+        Tank targetTank = mock(Tank.class);
+        when(targetTank.getHeight()).thenReturn(0);
+        setHexLevels(1, 0);
+        assertEquals(ToHitData.HIT_NORMAL, PhysicalHitTable.resolve(PhysicalAttackType.RIGHT_KICK,
+              attacker, attackerState, targetTank, targetState, mockGame));
+    }
+
+    @Test
+    void testKickAgainstProneMekHitsFullBody() {
+        when(targetState.isProne()).thenReturn(true);
+        setHexLevels(1, 0);
+        assertEquals(ToHitData.HIT_NORMAL, PhysicalHitTable.resolve(PhysicalAttackType.RIGHT_KICK,
+              attacker, attackerState, targetMek, targetState, mockGame));
+    }
+
+    @Test
+    void testPunchOnTheLevelHitsPunchTable() {
+        setHexLevels(0, 0);
+        assertEquals(ToHitData.HIT_PUNCH, PhysicalHitTable.resolve(PhysicalAttackType.LEFT_PUNCH,
+              attacker, attackerState, targetMek, targetState, mockGame));
+    }
+
+    @Test
+    void testPunchAtTargetBaseHitsLegs() {
+        // The target stands one level above the attacker, so the attacker's arms are level with its feet:
+        // the punch resolves on the kick (leg) table.
+        setHexLevels(0, 1);
+        assertEquals(ToHitData.HIT_KICK, PhysicalHitTable.resolve(PhysicalAttackType.LEFT_PUNCH,
+              attacker, attackerState, targetMek, targetState, mockGame));
+    }
+
+    @Test
+    void testMissingBoardFallsBackToAttackTypeTable() {
+        Game boardlessGame = mock(Game.class);
+        assertEquals(ToHitData.HIT_KICK, PhysicalHitTable.resolve(PhysicalAttackType.RIGHT_KICK,
+              attacker, attackerState, targetMek, targetState, boardlessGame));
+        assertEquals(ToHitData.HIT_PUNCH, PhysicalHitTable.resolve(PhysicalAttackType.LEFT_PUNCH,
+              attacker, attackerState, targetMek, targetState, boardlessGame));
+    }
+}

--- a/megamek/unittests/megamek/client/bot/princess/PhysicalHitTableTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PhysicalHitTableTest.java
@@ -146,6 +146,19 @@ class PhysicalHitTableTest {
     }
 
     @Test
+    void testKickFromAboveOnStandingSuperHeavyStillHitsLegs() {
+        // A currently-prone superheavy whose projected state stands it up is two levels tall, so a kick
+        // from one level above still lands on its legs - not the punch table a normal Mek would offer.
+        when(targetMek.isSuperHeavy()).thenReturn(true);
+        when(targetMek.isProne()).thenReturn(true);
+        when(targetMek.getHeight()).thenReturn(0);
+        when(targetState.isProne()).thenReturn(false);
+        setHexLevels(1, 0);
+        assertEquals(ToHitData.HIT_KICK, PhysicalHitTable.resolve(PhysicalAttackType.RIGHT_KICK,
+              attacker, attackerState, targetMek, targetState, mockGame));
+    }
+
+    @Test
     void testMissingBoardFallsBackToAttackTypeTable() {
         Game boardlessGame = mock(Game.class);
         assertEquals(ToHitData.HIT_KICK, PhysicalHitTable.resolve(PhysicalAttackType.RIGHT_KICK,

--- a/megamek/unittests/megamek/client/bot/princess/PhysicalInfoTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PhysicalInfoTest.java
@@ -47,6 +47,7 @@ import megamek.common.ToHitData;
 import megamek.common.actions.KickAttackAction;
 import megamek.common.actions.PunchAttackAction;
 import megamek.common.board.Coords;
+import megamek.common.equipment.MiscMounted;
 import megamek.common.game.Game;
 import megamek.common.units.BipedMek;
 import megamek.common.units.Entity;
@@ -74,9 +75,12 @@ class PhysicalInfoTest {
         ToHitData mockToHit = mock(ToHitData.class);
         when(mockFireControl.guessToHitModifierPhysical(any(Entity.class), any(EntityState.class),
               any(Targetable.class), any(EntityState.class), any(PhysicalAttackType.class),
-              any(Game.class)))
+              nullable(MiscMounted.class), any(Game.class)))
               .thenReturn(mockToHit);
         when(mockToHit.getValue()).thenReturn(7);
+        // The hit-location distribution follows the table carried by the hit data (resolved by elevation in
+        // production); punches here resolve on the punch table.
+        when(mockToHit.getHitTable()).thenReturn(ToHitData.HIT_PUNCH);
 
         Entity mockShooter = mock(BipedMek.class);
         when(mockShooter.getId()).thenReturn(1);
@@ -121,7 +125,8 @@ class PhysicalInfoTest {
         assertEquals(0.0, testPhysicalInfo.getKillProbability(), TOLERANCE);
         assertEquals(5.0, testPhysicalInfo.getExpectedDamageOnHit(), TOLERANCE);
 
-        // Test a vanilla kick.
+        // Test a vanilla kick (kick table: no head, so no expected pilot hits).
+        when(mockToHit.getHitTable()).thenReturn(ToHitData.HIT_KICK);
         testPhysicalInfo.setShooter(mockShooter);
         testPhysicalInfo.setAttackType(kick);
         testPhysicalInfo.initDamage(kick, mockShooterState, mockTargetState, true, mockGame);
@@ -129,9 +134,20 @@ class PhysicalInfoTest {
         assertEquals(10.0, testPhysicalInfo.getMaxDamage(), TOLERANCE);
         assertEquals(0.0099, testPhysicalInfo.getExpectedCriticals(), TOLERANCE);
         assertEquals(0.0, testPhysicalInfo.getKillProbability(), TOLERANCE);
+        assertEquals(0.0, testPhysicalInfo.getExpectedPilotHits(), TOLERANCE);
         assertEquals(10.0, testPhysicalInfo.getExpectedDamageOnHit(), TOLERANCE);
 
+        // A kick resolved on the punch table (kicker one level above) puts the head in play: same raw
+        // damage, but now the pilot is expected to take hits.
+        when(mockToHit.getHitTable()).thenReturn(ToHitData.HIT_PUNCH);
+        testPhysicalInfo.setShooter(mockShooter);
+        testPhysicalInfo.setAttackType(kick);
+        testPhysicalInfo.initDamage(kick, mockShooterState, mockTargetState, true, mockGame);
+        assertEquals(10.0, testPhysicalInfo.getExpectedDamageOnHit(), TOLERANCE);
+        assertEquals(0.583 / 6.0, testPhysicalInfo.getExpectedPilotHits(), TOLERANCE);
+
         // Make the puncher heavier.
+        when(mockToHit.getHitTable()).thenReturn(ToHitData.HIT_PUNCH);
         when(mockShooter.getWeight()).thenReturn(100.0);
         testPhysicalInfo.setShooter(mockShooter);
         testPhysicalInfo.setAttackType(punch);


### PR DESCRIPTION
## Summary

QA: Princess parks units at head-kicking height - adjacent to and one level below an enemy - because her physical estimates use a hard-coded leg-only kick table. This models the real elevation-driven hit-table shifts (TW) for kicks, punches, and physical weapons, on both the receiving and giving side of the estimate. Validated with 100-game headless mirror arms on a rolling-hills scenario (harness from #8629). Applies to Princess and CASPAR (CASPAR subclasses Princess with no overrides).

## Bug Fixed

- **Leg-only kick model**: the path ranker valued an incoming kick as raw leg damage. A kick from one level above actually resolves on the punch table - head at 1 in 6, and any head hit wounds the pilot. New `PhysicalHitTable` resolves the table from relative elevation exactly as the rules-engine actions do; `PhysicalInfo` now carries expected pilot hits; enemy physical threat is valued as damage plus weighted crits, pilot hits, and kill chance. The old `p<=0.5` means-zero-threat cliff is gone.
- **Kick-only threat**: enemy punches and physical weapons (hatchets, swords, clubs) were never estimated. The enemy's best single physical option now is - a Hatchetman's threat profile is its hatchet, not its fists.
- **Projected-state elevation**: physical guesses mixed the path's final hex with the unit's *current* elevation. `EntityState` now carries the path's final elevation and the guess uses it throughout.
- **Legacy declared-attack bug**: `PhysicalCalculator` compared elevations without hex levels, so its punch/kick/club table selection never fired on sloped terrain - only on building/bridge elevation differences.
- **Deliberately NOT changed**: our own attacks stay valued at plain expected damage. Crediting them with the head/crit bonuses would inflate the bravery term and the #7627 close-range incentive and pull units toward point-blank range, where physicals are already strong. The weighting is defensive-only (asymmetry documented in the code).

## Files Changed

- `megamek/src/megamek/client/bot/princess/PhysicalHitTable.java` - NEW: elevation-based hit-table resolution
- `megamek/src/megamek/client/bot/princess/PhysicalInfo.java` - resolved tables, pilot hits, club attacks
- `megamek/src/megamek/client/bot/princess/FireControl.java` - projected-state elevations, club to-hit guess
- `megamek/src/megamek/client/bot/princess/EntityState.java` - elevation field
- `megamek/src/megamek/client/bot/princess/ProbabilityCalculator.java` - hit-table dispatcher
- `megamek/src/megamek/client/bot/princess/BasicPathRanker.java` - enemy physical threat / own physical damage
- `megamek/src/megamek/client/bot/PhysicalCalculator.java` - hex levels in table selection
- `megamek/unittests/.../PhysicalHitTableTest.java` - NEW: elevation matrix (7 cases)
- `megamek/unittests/.../PhysicalInfoTest.java`, `FireControlTest.java`, `BasicPathRankerTest.java` - updated

## Testing

- Unit: new `PhysicalHitTableTest` covers the elevation matrix including the QA case (kick from one level above resolves on the punch table) and the missing-board fallback; `PhysicalInfoTest` asserts head exposure directly (kick on punch table = p/6 expected pilot hits, kick table = zero). All `megamek.client.bot.princess` tests pass; checkstyle and javadoc clean. The new tests fail with the fix reverted (the resolver did not exist; pilot hits were structurally zero).
- Headless benchmark, 100-game mirror arms on Rolling Hills (scenario from MegaMek/mm-data#500): kick attempts taken fell 38% (996 to 620) and kick head hits 26%; units surviving at melee range rose significantly (crippled survivors 0.55 to 0.81 per game, destroyed down) and games run about 1.3 rounds longer without the free head-kick accelerant. Punch counts stayed flat - level adjacency is the least head-dangerous physical posture and still worth the damage trade.

## Out of scope

- Charges and Death From Above estimation (different mechanics, never previously modeled).
- The crude unmoved-enemy kick heuristic in `evaluateUnmovedEnemy` (flat weight-based estimate).
- Migrating declared-physical selection (`PhysicalCalculator.getBestPhysical`) onto `PhysicalInfo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
