### PR TITLE
Fix force generator discarding zero availability and subcommand tech percentages (Fixes #8635, #8634)

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/FactionRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/FactionRecord.java
@@ -464,6 +464,12 @@ public class FactionRecord {
      * would miss every time and silently hand the lookup off to the parent faction, discarding the subcommand's own
      * declared percentages.</p>
      *
+     * <p>That one declared value is the faction's percentage whatever rating is asked about, so the single-level case
+     * deliberately also covers the {@code -1} a caller passes to mean "this faction applies no rating adjustments".
+     * Returning nothing for {@code -1} instead would send the lookup to the parent faction, which is the very
+     * substitution this translation exists to prevent. A faction with a full rating system has no single value to
+     * fall back on, so {@code -1} stays out of range for it and reads as absent.</p>
+     *
      * @param rating equipment rating as supplied by the caller
      *
      * @return the index to read from this faction's percentage lists

--- a/megamek/src/megamek/client/ratgenerator/FactionRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/FactionRecord.java
@@ -429,13 +429,47 @@ public class FactionRecord {
         salvage.get(era).remove(faction);
     }
 
-    public Integer getPctTech(TechCategory category, int era, int rating) {
-        if (!pctTech.containsKey(category) || !pctTech.get(category).containsKey(era)
-              || pctTech.get(category).get(era).isEmpty()
-              || pctTech.get(category).get(era).size() <= rating) {
+    /**
+     * Get the C/SL/O percentage this faction declares for the given rating, without consulting parent factions.
+     *
+     * @param category the category (Clan, SL/advanced IS, Omni) and unit type to look up
+     * @param era      the year for which the percentage was recorded
+     * @param rating   equipment rating expressed in this faction's rating level system, typically F (0) to A (4)
+     *
+     * @return the declared percentage, or {@code null} if this faction records none for that category and era
+     */
+    public @Nullable Integer getPctTech(TechCategory category, int era, int rating) {
+        Map<Integer, ArrayList<Integer>> percentagesByEra = pctTech.get(category);
+        if (percentagesByEra == null) {
             return null;
         }
-        return pctTech.get(category).get(era).get(rating);
+        List<Integer> percentagesByRating = percentagesByEra.get(era);
+        if ((percentagesByRating == null) || percentagesByRating.isEmpty()) {
+            return null;
+        }
+        int percentageIndex = pctTechIndex(rating);
+        if ((percentageIndex < 0) || (percentageIndex >= percentagesByRating.size())) {
+            return null;
+        }
+        return percentagesByRating.get(percentageIndex);
+    }
+
+    /**
+     * Translates an equipment rating into a position within this faction's C/SL/O percentage lists.
+     *
+     * <p>Those lists hold one value per rating level the faction itself declares, so the position is normally the
+     * rating itself. A faction that declares exactly one rating level is the documented special case: it is a
+     * subcommand locked to that one rating within its parent's system, and the caller's rating is a position in the
+     * <em>parent's</em> larger system rather than in this faction's single-entry lists. Indexing the lists with it
+     * would miss every time and silently hand the lookup off to the parent faction, discarding the subcommand's own
+     * declared percentages.</p>
+     *
+     * @param rating equipment rating as supplied by the caller
+     *
+     * @return the index to read from this faction's percentage lists
+     */
+    private int pctTechIndex(int rating) {
+        return (ratingLevels.size() == 1) ? 0 : rating;
     }
 
     /**

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -698,6 +698,7 @@ public class RATGenerator {
 
         // Iterate through all available chassis
         double chassisWeightTotal = 0.0;
+        int chassisExcludedByZeroAvailability = 0;
         for (String chassisKey : chassisIndex.get(currentEra).keySet()) {
             ChassisRecord curChassis = chassis.get(chassisKey);
             if (curChassis == null) {
@@ -740,6 +741,16 @@ public class RATGenerator {
             AvailabilityRating chassisAvRating = findChassisAvailabilityRecord(currentEra,
                   chassisKey, fRec, year);
             if (chassisAvRating == null) {
+                continue;
+            }
+
+            // An availability of zero means the faction does not field this chassis, even when a parent faction
+            // does (see docs/Customization/RAT and Force Generator Stuff/rat-generator.txt). It has to be honoured
+            // before the interpolation below, which would otherwise pull the zero up towards a non-zero value in
+            // the next era and put the chassis back in the table. The model loop applies the same rule in
+            // ChassisRecord.totalModelWeight.
+            if (chassisAvRating.getAvailability() <= 0) {
+                chassisExcludedByZeroAvailability++;
                 continue;
             }
 
@@ -830,6 +841,11 @@ public class RATGenerator {
                 }
 
             }
+        }
+
+        if (chassisExcludedByZeroAvailability > 0) {
+            LOGGER.debug("[ForceGen][Availability] {} chassis excluded for {} in era {}: availability of zero",
+                  chassisExcludedByZeroAvailability, fRec.getKey(), currentEra);
         }
 
         if (unitWeights.isEmpty() || chassisWeightTotal == 0.0) {

--- a/megamek/testresources/data/forcegenerator/3050.xml
+++ b/megamek/testresources/data/forcegenerator/3050.xml
@@ -29,7 +29,10 @@
     </factions>
     <units>
         <chassis name='Archer' unitType='Mek'>
-            <availability>LA:6</availability>
+            <!-- MRG:0 marks the Archer as one the Merged Test Faction does not field. The next era bucket rates it
+                 MRG:6, so a year between the two buckets is where a zero that is not honoured gets interpolated
+                 back into the table. See ChassisZeroAvailabilityTest. -->
+            <availability>LA:6,MRG:0</availability>
             <model name='ARC-2R'>
                 <roles>fire_support</roles>
                 <availability>General:6</availability>

--- a/megamek/testresources/data/forcegenerator/3060.xml
+++ b/megamek/testresources/data/forcegenerator/3060.xml
@@ -29,7 +29,8 @@
     </factions>
     <units>
         <chassis name='Archer' unitType='Mek'>
-            <availability>LA:6</availability>
+            <!-- MRG:6 is the non-zero far end of the interpolation the 3050 bucket's MRG:0 is tested against. -->
+            <availability>LA:6,MRG:6</availability>
             <model name='ARC-2R'>
                 <roles>fire_support</roles>
                 <availability>General:6</availability>

--- a/megamek/unittests/megamek/client/ratgenerator/ChassisZeroAvailabilityTest.java
+++ b/megamek/unittests/megamek/client/ratgenerator/ChassisZeroAvailabilityTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.ratgenerator;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import megamek.common.units.UnitType;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A chassis availability of zero means the faction does not field that chassis, even where a parent faction does. The
+ * rule is documented in {@code docs/Customization/RAT and Force Generator Stuff/rat-generator.txt}: "A value of zero is
+ * a special case which indicates unavailable even if available to a parent faction."
+ *
+ * <p>The lookup honours it, but for a year that falls between two era buckets the generator used to interpolate the
+ * current era's zero towards the next era's value before testing it, which put the chassis back in the table. These
+ * tests pin the zero down at both era boundaries and in between.</p>
+ */
+class ChassisZeroAvailabilityTest {
+
+    private static final int ERA = 3050;
+    private static final int NEXT_ERA = 3060;
+    /** Between the two era buckets, which is the only place the interpolation runs. */
+    private static final int YEAR_BETWEEN_ERAS = 3055;
+
+    private static final String ZERO_RATED_FACTION = "MRG";
+    private static final String AVAILABLE_FACTION = "LA";
+    private static final String ARCHER = "Archer ARC-2R";
+
+    private static RATGenerator ratGenerator;
+
+    @BeforeAll
+    static void loadForceGeneratorFromTestData() throws Exception {
+        ratGenerator = ForceGeneratorTestFixture.loadFromTestData(ERA);
+        // The interpolation reads the next bucket, so it has to be loaded too
+        ratGenerator.loadYear(NEXT_ERA);
+    }
+
+    @AfterAll
+    static void clearSharedSingletons() throws Exception {
+        ForceGeneratorTestFixture.reset();
+    }
+
+    @Test
+    void zeroRatedChassisIsKeptOutOfTheTableBetweenEras() {
+        List<UnitTable.TableEntry> table = generateMekTableFor(ZERO_RATED_FACTION, YEAR_BETWEEN_ERAS);
+
+        assertFalse(containsUnit(table, ARCHER),
+              "A chassis rated zero must stay out of the table; interpolating towards the next era's value put it"
+                    + " back in");
+    }
+
+    @Test
+    void zeroRatedChassisIsKeptOutOfTheTableOnTheEraBoundary() {
+        List<UnitTable.TableEntry> table = generateMekTableFor(ZERO_RATED_FACTION, ERA);
+
+        assertFalse(containsUnit(table, ARCHER), "A chassis rated zero must stay out of the table");
+    }
+
+    @Test
+    void theSameChassisReturnsOnceTheNextEraRatesIt() {
+        List<UnitTable.TableEntry> table = generateMekTableFor(ZERO_RATED_FACTION, NEXT_ERA);
+
+        assertTrue(containsUnit(table, ARCHER),
+              "The next era rates this chassis above zero, so honouring the zero must not keep it out for good");
+    }
+
+    @Test
+    void aFactionThatFieldsTheChassisIsUnaffected() {
+        List<UnitTable.TableEntry> table = generateMekTableFor(AVAILABLE_FACTION, YEAR_BETWEEN_ERAS);
+
+        assertTrue(containsUnit(table, ARCHER),
+              "Honouring another faction's zero must not disturb a faction that does field the chassis");
+    }
+
+    private static List<UnitTable.TableEntry> generateMekTableFor(String factionKey, int year) {
+        FactionRecord factionRecord = ratGenerator.getFaction(factionKey);
+        assertNotNull(factionRecord, "Test data should provide faction " + factionKey);
+
+        return ratGenerator.generateTable(factionRecord, UnitType.MEK, year, null, null, 0, null, null, 0, null);
+    }
+
+    private static boolean containsUnit(List<UnitTable.TableEntry> table, String unitName) {
+        return table.stream()
+              .filter(UnitTable.TableEntry::isUnit)
+              .anyMatch(tableEntry -> unitName.equals(tableEntry.getUnitEntry().getName()));
+    }
+}

--- a/megamek/unittests/megamek/client/ratgenerator/FactionRecordPctTechRatingTest.java
+++ b/megamek/unittests/megamek/client/ratgenerator/FactionRecordPctTechRatingTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.ratgenerator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import megamek.client.ratgenerator.FactionRecord.TechCategory;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers how a faction's Clan/Star League/Omni percentages are indexed by equipment rating.
+ *
+ * <p>Those lists hold one value per rating level the faction itself declares
+ * ({@code docs/Customization/RAT and Force Generator Stuff/rat-generator.txt}). A subcommand that declares a single
+ * rating level therefore records a single value, while the rating it is asked about is a position in its parent's
+ * larger system. Reading the one-entry list at that position missed every time, and the miss was indistinguishable
+ * from "this faction declares nothing", so the subcommand's own percentages were dropped in favour of its parent's.</p>
+ */
+class FactionRecordPctTechRatingTest {
+
+    private static final int ERA = 3078;
+    /** The Inner Sphere rating system is F, D, C, B, A, so A sits at index 4. */
+    private static final int RATING_INDEX_A = 4;
+    private static final int RATING_INDEX_F = 0;
+
+    /**
+     * A subcommand locked to one rating within its parent's system, as CGB.FRR is locked to A within the Free
+     * Rasalhague Republic's F-A system.
+     */
+    private static FactionRecord subcommandLockedToRatingA() {
+        FactionRecord subcommand = new FactionRecord("CGB.FRR", "Kungsarme");
+        subcommand.setRatings("A");
+        subcommand.setParentFactions("FRR");
+        subcommand.setPctTech(TechCategory.IS_ADVANCED, ERA, "76");
+        return subcommand;
+    }
+
+    private static FactionRecord factionWithFullRatingSystem() {
+        FactionRecord faction = new FactionRecord("FRR", "Free Rasalhague Republic");
+        faction.setRatings("F,D,C,B,A");
+        faction.setPctTech(TechCategory.IS_ADVANCED, ERA, "13,19,33,46,74");
+        return faction;
+    }
+
+    @Test
+    void singleRatingSubcommandReadsItsOwnDeclaredPercentage() {
+        FactionRecord subcommand = subcommandLockedToRatingA();
+
+        assertEquals(76, subcommand.getPctTech(TechCategory.IS_ADVANCED, ERA, RATING_INDEX_A),
+              "The subcommand declares one value for its one rating level, so asking at its rating must find it"
+                    + " rather than fall through to the parent faction");
+    }
+
+    @Test
+    void factionWithAFullRatingSystemStillReadsByRating() {
+        FactionRecord faction = factionWithFullRatingSystem();
+
+        assertEquals(74, faction.getPctTech(TechCategory.IS_ADVANCED, ERA, RATING_INDEX_A));
+        assertEquals(13, faction.getPctTech(TechCategory.IS_ADVANCED, ERA, RATING_INDEX_F));
+    }
+
+    @Test
+    void aCategoryTheFactionNeverDeclaresIsStillAbsent() {
+        FactionRecord subcommand = subcommandLockedToRatingA();
+
+        assertNull(subcommand.getPctTech(TechCategory.CLAN, ERA, RATING_INDEX_A),
+              "Only the declared category should resolve; an undeclared one must stay absent so the caller can fall"
+                    + " back");
+    }
+
+    @Test
+    void anEraTheFactionNeverDeclaresIsStillAbsent() {
+        FactionRecord subcommand = subcommandLockedToRatingA();
+
+        assertNull(subcommand.getPctTech(TechCategory.IS_ADVANCED, 3145, RATING_INDEX_A));
+    }
+
+    @Test
+    void aRatingBeyondAFullRatingSystemIsAbsentRatherThanAnError() {
+        FactionRecord faction = factionWithFullRatingSystem();
+
+        assertNull(faction.getPctTech(TechCategory.IS_ADVANCED, ERA, 9),
+              "A rating the faction has no column for must read as absent");
+    }
+
+    @Test
+    void aNegativeRatingIsAbsentRatherThanAnError() {
+        FactionRecord faction = factionWithFullRatingSystem();
+
+        assertNull(faction.getPctTech(TechCategory.IS_ADVANCED, ERA, -1),
+              "A faction that applies no rating adjustments is asked with -1, which must not reach into the list");
+    }
+}

--- a/megamek/unittests/megamek/client/ratgenerator/FactionRecordPctTechRatingTest.java
+++ b/megamek/unittests/megamek/client/ratgenerator/FactionRecordPctTechRatingTest.java
@@ -53,6 +53,8 @@ class FactionRecordPctTechRatingTest {
     /** The Inner Sphere rating system is F, D, C, B, A, so A sits at index 4. */
     private static final int RATING_INDEX_A = 4;
     private static final int RATING_INDEX_F = 0;
+    /** What a caller passes when the faction applies no rating adjustments at all. */
+    private static final int NO_RATING_ADJUSTMENT = -1;
 
     /**
      * A subcommand locked to one rating within its parent's system, as CGB.FRR is locked to A within the Free
@@ -115,10 +117,19 @@ class FactionRecordPctTechRatingTest {
     }
 
     @Test
-    void aNegativeRatingIsAbsentRatherThanAnError() {
+    void aNegativeRatingIsAbsentRatherThanAnErrorForAFullRatingSystem() {
         FactionRecord faction = factionWithFullRatingSystem();
 
-        assertNull(faction.getPctTech(TechCategory.IS_ADVANCED, ERA, -1),
+        assertNull(faction.getPctTech(TechCategory.IS_ADVANCED, ERA, NO_RATING_ADJUSTMENT),
               "A faction that applies no rating adjustments is asked with -1, which must not reach into the list");
+    }
+
+    @Test
+    void singleRatingSubcommandStillReadsItsValueWhenNoRatingAdjustmentApplies() {
+        FactionRecord subcommand = subcommandLockedToRatingA();
+
+        assertEquals(76, subcommand.getPctTech(TechCategory.IS_ADVANCED, ERA, NO_RATING_ADJUSTMENT),
+              "A subcommand declares one value that holds whatever rating is asked about, so -1 must read it rather"
+                    + " than report nothing and send the lookup to the parent faction");
     }
 }


### PR DESCRIPTION
## What this fixes

Two Force Generator bugs, both reported by SuperStucco, where a number written in the availability
data was being quietly thrown away.

---

### 1. A zero availability was ignored on some years (#8635)

The data uses `0` to mean "this faction does not field this chassis, even though a parent faction
does". It exists so a unit available to every Inner Sphere state except one can be written as
`IS:6,X:0` instead of listing every other faction by hand. This is documented behaviour, in
`docs/Customization/RAT and Force Generator Stuff/rat-generator.txt`:

> A value of zero is a special case which indicates unavailable even if available to a parent
> faction.

**Worked example** - the Dervish, for the Ghost Bear Dominion's Kungsarme, in 3079:

| | |
|---|---|
| What 3078 says | `CGB.FRR:0` - they do not field it |
| What 3082 says | `CGB.FRR:3` |
| Year asked for | 3079, which sits between the two era files |
| What the player got | A Dervish in the table anyway |

When the chosen year falls between two era files, the generator blends the current era's
availability with the next era's. It was doing that blend *before* checking whether the number was
above zero, so the 0 was blended towards 3, came out at 0.75, and 0.75 passed the "above zero"
test.

Picking a year that lands exactly on an era boundary always worked, because there is no blending
there. That is why this looked intermittent.

**Root cause.** The zero is now honoured before the blend runs, which is what the model-level loop
in `ChassisRecord.totalModelWeight` has always done. The two paths now agree.

**Impact on the data.** A chassis rated `0` for a faction now stays out for that whole era
regardless of what the next era file says, so it no longer has to be zeroed in both files. Nothing
changes for a chassis rated above zero.

---

### 2. A subcommand's tech percentages were replaced by its parent's (#8634)

A faction that declares a single rating level is a subcommand locked to that one rating inside its
parent's system - the Kungsarme is always rating A within the Free Rasalhague Republic's F-D-C-B-A
range. Its Clan / Star League / Omni percentages are therefore a single number, because it has a
single rating level. From the same document:

> There should be one value for each of the faction's available rating levels, from lowest to
> highest.

**Worked example** - the Kungsarme's Star League percentage in 3078:

| | |
|---|---|
| What the data says | `<pctSL>76</pctSL>` - one value, for its one rating level |
| Where the code looked | Position 4, because rating A is 4th in the *Republic's* system |
| What the one-entry list had at position 4 | Nothing |
| What the code concluded | "This faction declares nothing", so fall back to the parent |
| What the player got | The Republic's 74, not the Kungsarme's 76 |

This is why SuperStucco's log showed a target of 74.25 - that is the Republic's rating-A value
interpolated across eras, not the Kungsarme's own.

**Root cause.** The rating is now translated into a position in the faction's *own* percentage list
before it is read. The RAT Generator editor already wrote these values to position 0, so the write
side and the read side finally agree.

**Impact.** This runs on shipped data with nothing edited by anyone: there are 134 factions with a
single rating level, and 83 single-value `pctSL` entries in `3078.xml` alone. All of them were
reading their parent's numbers and now read their own.

**What was deliberately left alone.** The issue asks for the parent fallback to be removed entirely.
It is not removed here. That fallback dates to a 2016 change of Neoancient's, meant for subcommands
that genuinely declare no numbers of their own, and with the lookup fixed that is the only time it
fires. Removing it *without* this fix would leave all 134 of those factions with no C/SL/O target at
all instead of the right one. Discussed on the issue; happy to follow up as a separate change if
SuperStucco still wants it.

---

## Files Changed

| File | Change |
|---|---|
| `megamek/src/megamek/client/ratgenerator/RATGenerator.java` | Honour a chassis availability of zero before the era blend; count exclusions and log a summary |
| `megamek/src/megamek/client/ratgenerator/FactionRecord.java` | Read C/SL/O percentages at the faction's own rating position; tidy the lookup into guard clauses |
| `megamek/testresources/data/forcegenerator/3050.xml` | Test data: a chassis rated zero for one faction |
| `megamek/testresources/data/forcegenerator/3060.xml` | Test data: the non-zero far end of the blend |
| `megamek/unittests/.../ChassisZeroAvailabilityTest.java` | New - 4 tests |
| `megamek/unittests/.../FactionRecordPctTechRatingTest.java` | New - 6 tests |

## Testing

- `./gradlew build` green, including `checkstyleMain` and `checkstyleTest`.
- All 65 tests in `megamek.client.ratgenerator` pass, including the 8 pre-existing classes.
- The 10 new tests were verified to actually catch these bugs: with the two source fixes stashed,
  exactly 3 fail (the zero-availability blend, the subcommand percentage, and a negative rating
  index reaching past the start of the list) and the other 7 pass unchanged as controls.

## What is NOT proven yet

- **Neither fix has been exercised in a running game.** Both were confirmed against the shipped data
  by reading it and by the tests above, but nobody has opened Create Random Army and generated a
  table with this build. That is the obvious first thing to check.
- **The 74.25 in the issue log is explained but not reproduced.** The Republic's 3078 rating-A value
  is 74, which is clearly where the number comes from, but I could not reconcile the exact decimal
  against my copy of the era files. It may be a data difference rather than anything in the code.
- **One narrower case is untouched.** A rating-specific zero inside a multi-rating code such as
  `FS!A:8!B:0` still goes through the old blend. That is a different shape from what was reported,
  so it is left for its own change once we know whether the data uses that pattern.
- **The second fix changes numbers in generated tables.** Any faction with a single rating level now
  targets its own Clan/SL/Omni percentages instead of its parent's. That is the point of the fix,
  but it does mean generated forces for those 134 commands will not match previous builds, and the
  new numbers are only as good as the data.

Fixes #8635
Fixes #8634
