### PR TITLE
Render HTML fragments in option descriptions

### DIFF
--- a/megamek/src/megamek/client/ui/settings/SettingsContentHost.java
+++ b/megamek/src/megamek/client/ui/settings/SettingsContentHost.java
@@ -43,6 +43,8 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JPanel;
@@ -52,6 +54,7 @@ import javax.swing.Scrollable;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
+import javax.swing.text.html.HTML;
 
 import org.apache.commons.text.StringEscapeUtils;
 
@@ -62,6 +65,7 @@ import megamek.common.ui.FastJScrollPane;
 /** Owns the central scrollable settings content and an optional sticky help panel. */
 public class SettingsContentHost extends JPanel {
     private static final int SCROLL_SPEED = 16;
+    private static final Pattern HTML_TAG_PATTERN = Pattern.compile("</?([A-Za-z][A-Za-z0-9]*)\\b[^<>]*>");
 
     private final JPanel contentPanel = new SettingsContentPanel();
     private final JScrollPane contentScrollPane;
@@ -121,9 +125,25 @@ public class SettingsContentHost extends JPanel {
         if (helpText == null || helpText.isBlank()) {
             return;
         }
-        helpPanel.setHelpText(helpText.regionMatches(true, 0, "<html>", 0, "<html>".length())
+        boolean isHtmlDocument = helpText.regionMatches(true, 0, "<html>", 0, "<html>".length());
+        if (isHtmlDocument) {
+            helpPanel.setHelpText(helpText);
+            return;
+        }
+        String body = containsHtmlTag(helpText)
               ? helpText
-              : "<html>" + StringEscapeUtils.escapeHtml4(helpText) + "</html>");
+              : StringEscapeUtils.escapeHtml4(helpText);
+        helpPanel.setHelpText("<html>" + body + "</html>");
+    }
+
+    private static boolean containsHtmlTag(String text) {
+        var matcher = HTML_TAG_PATTERN.matcher(text);
+        while (matcher.find()) {
+            if (HTML.getTag(matcher.group(1).toLowerCase(Locale.ROOT)) != null) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /** Finds the nearest settings content host containing {@code component}. */

--- a/megamek/unittests/megamek/client/ui/settings/SettingsContentHostTest.java
+++ b/megamek/unittests/megamek/client/ui/settings/SettingsContentHostTest.java
@@ -104,10 +104,21 @@ class SettingsContentHostTest {
     void plainHelpTextIsEscapedBeforeRenderingAsHtml() {
         SettingsContentHost host = new SettingsContentHost(new JLabel("Source"), "Details", true);
 
-        host.setHelpText("Use A < B & C > D");
+        host.setHelpText("Use A < B & C > D or <value>");
 
         JEditorPane helpPane = findComponent(host, "settingsHelpText", JEditorPane.class);
-        assertTrue(helpPane.getText().contains("A &lt; B &amp; C &gt; D"), helpPane.getText());
+        assertTrue(helpPane.getText().contains("A &lt; B &amp; C &gt; D or &lt;value&gt;"), helpPane.getText());
+    }
+
+    @Test
+    void htmlFragmentHelpTextIsPreservedAsMarkup() {
+        SettingsContentHost host = new SettingsContentHost(new JLabel("Source"), "Details", true);
+
+        host.setHelpText("First line.<br><br><b>Warning:</b> Second line.");
+
+        JEditorPane helpPane = findComponent(host, "settingsHelpText", JEditorPane.class);
+        assertTrue(helpPane.getText().contains("<b>Warning:</b>"), helpPane.getText());
+        assertFalse(helpPane.getText().contains("&lt;br&gt;"), helpPane.getText());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- render Swing-supported inline HTML fragments in settings option descriptions
- preserve complete HTML documents while continuing to escape genuine plain text and tag-shaped placeholders
- add regression coverage for inline markup, plain text, and complete HTML input

## Problem
`SettingsContentHost` escaped every description that did not begin with `<html>`. Resource strings commonly use fragments such as `<br>` and `<b>` without an outer `<html>` element, causing those tags to appear literally in the Option Details panel.

## Testing
- `./gradlew :megamek:test --tests "megamek.client.ui.settings.SettingsContentHostTest" :megamek:checkstyleMain :megamek:checkstyleTest`