### PR TITLE
Restore the herding accessors as deprecated delegates so MekHQ builds

### DIFF
--- a/megamek/src/megamek/client/bot/princess/BehaviorSettings.java
+++ b/megamek/src/megamek/client/bot/princess/BehaviorSettings.java
@@ -277,6 +277,37 @@ public class BehaviorSettings implements Serializable {
     }
 
     /**
+     * @return TRUE if I should only form up with my units.
+     *
+     * @deprecated since 0.50.08, use {@link #isExclusiveMutualSupport()}. The setting was renamed from herding to
+     *       mutual support; this delegates so code outside MegaMek keeps building.
+     */
+    @Deprecated(since = "0.50.08", forRemoval = true)
+    public boolean isExclusiveHerding() {
+        return isExclusiveMutualSupport();
+    }
+
+    /**
+     * @param exclusiveHerding Set TRUE if I should only form up with my units.
+     *
+     * @deprecated since 0.50.08, use {@link #setExclusiveMutualSupport(boolean)}.
+     */
+    @Deprecated(since = "0.50.08", forRemoval = true)
+    public void setExclusiveHerding(boolean exclusiveHerding) {
+        setExclusiveMutualSupport(exclusiveHerding);
+    }
+
+    /**
+     * @param exclusiveHerding Set TRUE if I should only form up with my units.
+     *
+     * @deprecated since 0.50.08, use {@link #setExclusiveMutualSupport(String)}.
+     */
+    @Deprecated(since = "0.50.08", forRemoval = true)
+    public void setExclusiveHerding(String exclusiveHerding) {
+        setExclusiveMutualSupport(exclusiveHerding);
+    }
+
+    /**
      * @return TRUE if I should immediately proceed to my home board edge.
      */
     public boolean shouldGoHome() {
@@ -609,6 +640,69 @@ public class BehaviorSettings implements Serializable {
         } catch (final NumberFormatException ex) {
             throw new PrincessException(ex);
         }
+    }
+
+    /**
+     * How close do I want to stick to my teammates?
+     *
+     * @return Index of the current mutual support value.
+     *
+     * @deprecated since 0.50.08, use {@link #getMutualSupportIndex()}. The setting was renamed from herding to
+     *       mutual support; this delegates so code outside MegaMek keeps building.
+     */
+    @Deprecated(since = "0.50.08", forRemoval = true)
+    public int getHerdMentalityIndex() {
+        return getMutualSupportIndex();
+    }
+
+    /**
+     * How close do I want to stick to my teammates?
+     *
+     * @return Current mutual support value.
+     *
+     * @deprecated since 0.50.08, use {@link #getMutualSupportValue()}.
+     */
+    @Deprecated(since = "0.50.08", forRemoval = true)
+    public double getHerdMentalityValue() {
+        return getMutualSupportValue();
+    }
+
+    /**
+     * How close do I want to stick to my teammates?
+     *
+     * @param index The index [0-10] of the mutual support value that should be used.
+     *
+     * @return The mutual support value at the specified index.
+     *
+     * @deprecated since 0.50.08, use {@link #getMutualSupportValue(int)}.
+     */
+    @Deprecated(since = "0.50.08", forRemoval = true)
+    public double getHerdMentalityValue(final int index) {
+        return getMutualSupportValue(index);
+    }
+
+    /**
+     * How close do I want to stick to my teammates?
+     *
+     * @param herdMentalityIndex The index [0-10] of the mutual support that should be used.
+     *
+     * @deprecated since 0.50.08, use {@link #setMutualSupportIndex(int)}.
+     */
+    @Deprecated(since = "0.50.08", forRemoval = true)
+    public void setHerdMentalityIndex(final int herdMentalityIndex) {
+        setMutualSupportIndex(herdMentalityIndex);
+    }
+
+    /**
+     * How close do I want to stick to my teammates?
+     *
+     * @param index The index ["0"-"10"] of the mutual support value that should be used.
+     *
+     * @deprecated since 0.50.08, use {@link #setMutualSupportIndex(String)}.
+     */
+    @Deprecated(since = "0.50.08", forRemoval = true)
+    public void setHerdMentalityIndex(final String index) throws PrincessException {
+        setMutualSupportIndex(index);
     }
 
     /**

--- a/megamek/unittests/megamek/client/bot/princess/BehaviorSettingsTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BehaviorSettingsTest.java
@@ -60,6 +60,38 @@ import org.xml.sax.SAXException;
  */
 class BehaviorSettingsTest {
 
+    /**
+     * The herding accessors were renamed to mutual support, which broke MekHQ's build: it calls them from
+     * BotForce, CustomizeBotForceDialog and Unit. They are kept as deprecated delegates so code outside MegaMek
+     * keeps working, and this pins that they really do delegate rather than drift into a second copy of the state.
+     */
+    @Test
+    @SuppressWarnings("removal")
+    void deprecatedHerdingAccessorsDelegateToMutualSupport() throws PrincessException {
+        BehaviorSettings behaviorSettings = new BehaviorSettings();
+
+        behaviorSettings.setHerdMentalityIndex(7);
+        assertEquals(7, behaviorSettings.getMutualSupportIndex(), "the old setter must write the new state");
+        assertEquals(7, behaviorSettings.getHerdMentalityIndex(), "and the old getter must read it back");
+
+        behaviorSettings.setMutualSupportIndex(2);
+        assertEquals(2, behaviorSettings.getHerdMentalityIndex(), "the old getter must see a new-setter write");
+
+        behaviorSettings.setHerdMentalityIndex("9");
+        assertEquals(9, behaviorSettings.getMutualSupportIndex(), "the string overload must delegate too");
+
+        assertEquals(behaviorSettings.getMutualSupportValue(), behaviorSettings.getHerdMentalityValue(),
+              "values must agree");
+        assertEquals(behaviorSettings.getMutualSupportValue(4), behaviorSettings.getHerdMentalityValue(4),
+              "indexed values must agree");
+
+        behaviorSettings.setExclusiveHerding(true);
+        assertTrue(behaviorSettings.isExclusiveMutualSupport(), "the old flag setter must write the new flag");
+        assertTrue(behaviorSettings.isExclusiveHerding(), "and the old flag getter must read it back");
+        behaviorSettings.setExclusiveHerding("false");
+        assertFalse(behaviorSettings.isExclusiveMutualSupport(), "the string overload must delegate too");
+    }
+
     @Test
     void testSetDescription() throws PrincessException {
         BehaviorSettings behaviorSettings = new BehaviorSettings();

--- a/megamek/unittests/megamek/client/bot/princess/BehaviorSettingsTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BehaviorSettingsTest.java
@@ -88,8 +88,18 @@ class BehaviorSettingsTest {
         behaviorSettings.setExclusiveHerding(true);
         assertTrue(behaviorSettings.isExclusiveMutualSupport(), "the old flag setter must write the new flag");
         assertTrue(behaviorSettings.isExclusiveHerding(), "and the old flag getter must read it back");
+
+        // The other direction, which is the one that catches a deprecated getter quietly acquiring a field of
+        // its own: write through the current setter, read through the deprecated getter.
+        behaviorSettings.setExclusiveMutualSupport(false);
+        assertFalse(behaviorSettings.isExclusiveHerding(), "the old flag getter must see a new-setter write");
+        behaviorSettings.setExclusiveMutualSupport(true);
+        assertTrue(behaviorSettings.isExclusiveHerding(), "and must follow it back again");
+
         behaviorSettings.setExclusiveHerding("false");
         assertFalse(behaviorSettings.isExclusiveMutualSupport(), "the string overload must delegate too");
+        behaviorSettings.setExclusiveMutualSupport("true");
+        assertTrue(behaviorSettings.isExclusiveHerding(), "including the new string overload, read the old way");
     }
 
     @Test


### PR DESCRIPTION
## Summary

**MekHQ does not build against current main.** Renaming Princess's herding setting to mutual support
(#8644) deleted eight public methods from `BehaviorSettings` outright. MekHQ calls them from
`BotForce`, `CustomizeBotForceDialog` and `Unit`.

This puts them back as deprecated delegates. No behaviour change, no new state, additions only.

## Bug Fixed

#8644 kept compatibility everywhere it was looked for:

| State | Still works |
|---|---|
| Saved behavior presets | reads `herdMentalityIndex` |
| Chat command | `he` still resolves |
| Scenario files | accepts `herdmentality:` |

It did not keep the **Java API**, which is the one thing downstream projects compile against. That is
the case the PR checklist calls out by name: *"don't delete public APIs outright (external consumers:
MML, MekHQ); use `@Deprecated(forRemoval=true)`, remove internal uses, provide a replacement."*

## Changes

1. **BehaviorSettings.java** — the eight deleted methods restored as
   `@Deprecated(since = "0.50.08", forRemoval = true)` delegates:

| Restored | Delegates to |
|---|---|
| `getHerdMentalityIndex()` | `getMutualSupportIndex()` |
| `setHerdMentalityIndex(int)` | `setMutualSupportIndex(int)` |
| `setHerdMentalityIndex(String)` | `setMutualSupportIndex(String)` |
| `getHerdMentalityValue()` | `getMutualSupportValue()` |
| `getHerdMentalityValue(int)` | `getMutualSupportValue(int)` |
| `isExclusiveHerding()` | `isExclusiveMutualSupport()` |
| `setExclusiveHerding(boolean)` | `setExclusiveMutualSupport(boolean)` |
| `setExclusiveHerding(String)` | `setExclusiveMutualSupport(String)` |

   Each forwards to the current method. There is no second copy of the setting, so the two names
   cannot drift apart.

2. **BehaviorSettingsTest.java** — pins the delegation in both directions: an old setter followed by
   a new getter, and a new setter followed by an old getter. Removing these again has to be
   deliberate rather than accidental.

## Files Changed

- `megamek/src/megamek/client/bot/princess/BehaviorSettings.java` — 8 deprecated delegates
- `megamek/unittests/megamek/client/bot/princess/BehaviorSettingsTest.java` — delegation test

## Testing

- `BehaviorSettingsTest` passes, including the new case. `checkstyleMain` and `javadoc` clean.
- Confirmed all eight methods MekHQ needs now resolve, and that all eight carry
  `@Deprecated(forRemoval = true)`.
- **MegaMekLab was checked and calls none of them**, so MekHQ is the only affected consumer.

## Notes

MekHQ needs no change to build again, and can migrate to the new names on its own schedule.

One leftover from the rename is deliberately not touched here: `BotCommandsPanel.setHerdMentality` is
a private helper that already sends `ChatCommands.MUTUAL_SUPPORT`. It is a stale name rather than a
stale call, so it belongs in a tidy-up rather than in a fix for a broken downstream build.
