### PR TITLE
Fix bot restore from saves killing every connecting client

### DIFF
--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -939,8 +939,11 @@ public class TWGameManager extends AbstractGameManager {
             for (int boardId : game.getBoardIds()) {
                 send(connId, createSpecialHexDisplayPacket(connId, boardId));
             }
+            // Copy to a plain HashMap: getBotTypes() returns a Collections.unmodifiableMap view, and
+            // SanityInputFilter rejects Collections$UnmodifiableMap on the receiving side - the packet
+            // would kill every connecting client, which is exactly a bot taking over a loaded seat.
             send(connId, new Packet(PacketCommand.PRINCESS_SETTINGS, getGame().getBotSettings(),
-                  getGame().getBotTypes()));
+                  new HashMap<>(getGame().getBotTypes())));
             send(connId, new Packet(PacketCommand.UPDATE_GROUND_OBJECTS, getGame().getGroundObjects()));
         }
     }


### PR DESCRIPTION
## Summary

Follow-up fix to #8660. Restoring bots from a loaded save killed the bot client the moment it connected: the seat stayed a ghost, and the Edit Bots dialog fell back to Princess because the remembered types never reached the client.

## Bug Fixed

- **Bot-type sync packet rejected by the network filter**: the packet carried the map straight from `Game.getBotTypes()`, which returns a `Collections.unmodifiableMap` view. `SanityInputFilter` allows the unmodifiable List/Collection wrappers but not `Collections$UnmodifiableMap`, so the receiving side rejected the packet and the connection died. Session log: `Class is Rejected: java.util.Collections$UnmodifiableMap`.

## Changes

1. **TWGameManager.java** - the send site copies the map into a plain `HashMap` (the same shape as the bot-settings map sent beside it). The getter keeps its unmodifiable view.

## Files Changed

- `megamek/src/megamek/server/totalWarfare/TWGameManager.java` - defensive copy at the packet send site

## Testing

- Manual: load a save with remembered bots, replace bots via Edit Bots. Before: both bots connect then drop, seats stay ghosts. After: bots take their seats, CASPAR preselects CASPAR.
- Considered instead allowing `Collections$UnmodifiableMap` in `SanityInputFilter`; rejected - view wrappers should not go on the wire at all, and the filter gap is what caught this.