### PR TITLE
Fix AUTO posture never defending when a flee edge is stored

### DIFF
--- a/megamek/src/megamek/client/bot/princess/PostureResolver.java
+++ b/megamek/src/megamek/client/bot/princess/PostureResolver.java
@@ -128,8 +128,12 @@ public class PostureResolver {
 
     private CombatPosture resolveAuto(BehaviorSettings settings, int round,
           List<Coords> ownPositions, List<Coords> enemyPositions) {
-        // A destination edge is a movement mission: the force is going somewhere whatever the enemy does.
-        if (settings.shouldGoHome() || settings.shouldAutoFlee()) {
+        // A flee order with a destination edge is a movement mission: the force is going somewhere
+        // whatever the enemy does. Both halves are required, matching the engine's own MoveToDestination
+        // condition in UnitBehavior: the config dialog stores the flee-edge dropdown even when fleeing is
+        // off, so an edge alone is a leftover setting, not a mission - reading it as one locked every such
+        // force out of ever defending.
+        if (settings.shouldAutoFlee() && settings.shouldGoHome()) {
             return resolved(round, CombatPosture.ATTACK, "the mission requires movement");
         }
 

--- a/megamek/unittests/megamek/client/bot/princess/PostureResolverTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PostureResolverTest.java
@@ -75,12 +75,28 @@ class PostureResolverTest {
     }
 
     @Test
-    void aDestinationEdgeMeansTheMissionRequiresMovementSoTheForceAttacks() {
+    void aFleeOrderWithADestinationEdgeMeansTheMissionRequiresMovementSoTheForceAttacks() {
+        settings.setAutoFlee(true);
         settings.setDestinationEdge(CardinalEdge.NORTH);
         // Even with the enemy charging at us round after round, a force that must reach an edge attacks.
         assertEquals(CombatPosture.ATTACK, resolver.resolve(settings, 1, ownPositions, enemyAtDistance(20)));
         assertEquals(CombatPosture.ATTACK, resolver.resolve(settings, 2, ownPositions, enemyAtDistance(15)));
         assertEquals(CombatPosture.ATTACK, resolver.resolve(settings, 3, ownPositions, enemyAtDistance(10)));
+    }
+
+    /**
+     * The config dialog stores the flee-edge dropdown even when fleeing is off, so an edge alone is a
+     * leftover setting, not a mission - the engine's own MoveToDestination condition requires both. A
+     * force carrying such a leftover must still read the battle and stand on the defensive. Found in a
+     * live game: a defending company on AUTO could never resolve to DEFEND because its saved config
+     * carried a flee edge with fleeing off.
+     */
+    @Test
+    void aDestinationEdgeWithoutAFleeOrderIsALeftoverSettingNotAMission() {
+        settings.setDestinationEdge(CardinalEdge.NORTH);
+        assertEquals(CombatPosture.ATTACK, resolver.resolve(settings, 1, ownPositions, enemyAtDistance(20)));
+        assertEquals(CombatPosture.DEFEND, resolver.resolve(settings, 2, ownPositions, enemyAtDistance(17)),
+              "the closing enemy flips the force to the defensive despite the stale edge setting");
     }
 
     @Test


### PR DESCRIPTION
## Summary

Follow-up fix to #8659. A bot on AUTO combat posture could never resolve to Defend if its saved config carried a flee edge - even with fleeing off. Found in a live game: a defending company announced only "Attack - the mission requires movement" every round while the enemy pressed it.

## Bug Fixed

- **AUTO posture locked to Attack by a leftover setting**: the resolver read `shouldGoHome() || shouldAutoFlee()`, so a destination edge alone counted as a movement mission. But the bot config dialog stores the flee-edge dropdown even when the flee checkbox is off, and the engine itself (`UnitBehavior`'s `MoveToDestination`) only acts on the edge when auto-flee is also set. An edge without a flee order is a leftover, not a mission.

## Changes

1. **PostureResolver.java** - the movement-mission check now requires both, matching the engine's own condition.
2. **PostureResolverTest.java** - the movement-mission test sets both flags; new pinning test for the leftover-edge case (closing enemy flips the force to Defend despite a stale edge).

## Testing

- Unit tests: PostureResolverTest, including the new leftover-edge pinning test.
- Manual: the live game that surfaced it - bot on AUTO with a stored flee edge, fleeing off; before: ATTACK every round; after: flips to DEFEND when the enemy closes.