### PR TITLE
Promote position discipline and terrain valuation to Princess

### DIFF
--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -49,6 +49,7 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Stream;
 
+import megamek.client.bot.Messages;
 import megamek.client.bot.princess.UnitBehavior.BehaviorType;
 import megamek.client.bot.princess.coverage.Builder;
 import megamek.client.bot.princess.geometry.ConvexBoardArea;
@@ -56,6 +57,7 @@ import megamek.client.bot.princess.geometry.CoordFacingCombo;
 import megamek.client.bot.princess.geometry.HexLine;
 import megamek.common.Hex;
 import megamek.common.LosEffects;
+import megamek.common.analysis.DamageProfile;
 import megamek.common.annotations.Nullable;
 import megamek.common.battleArmor.BattleArmor;
 import megamek.common.board.Board;
@@ -143,6 +145,59 @@ public class BasicPathRanker extends PathRanker {
     // Per-spotter memory of the last priority target it positioned for, keyed by the spotter's entity id. Drives the
     // TAG-spotter positioning hysteresis so it keeps painting one high-value target instead of flipping each turn.
     private final Map<Integer, Integer> lastSpotterPriorityTarget = new HashMap<>();
+
+    // ----- Position discipline (shared by every bot; the terrain-doctrine mechanisms promoted from CASPAR) -----
+
+    /**
+     * Position discipline is dormant beyond this range: out of contact there is no exchange to hold and
+     * the force should move loose and fast.
+     */
+    protected static final int THREAT_CONTACT_RANGE = 15;
+
+    /**
+     * Reference movement rate that prices "one turn of advance" ({@code TEMPO_REFERENCE_MP * aggression}),
+     * the yardstick every position-discipline bound is measured against. At default aggression (2.5) a
+     * turn of advance is worth 37.5 - the same scale as the stock per-hex aggression gradient over a
+     * full move.
+     */
+    protected static final double TEMPO_REFERENCE_MP = 15.0;
+
+    /**
+     * The to-hit number the hit-chance-ratio discounts are priced at: gunnery 4 plus a typical spread of
+     * range and target modifiers. Only the RATIO of hit chances at this number matters - walking turns 8s
+     * into 9s whoever you are - so the midpoint stands in for every shooter without pretending the
+     * estimate knows its real to-hit.
+     */
+    protected static final int REPRESENTATIVE_TO_HIT = 8;
+
+    /**
+     * How much of a turn of advance the hold credit may reach under each posture: an attacking force
+     * keeps the credit modest so a good hex never outbids the advance, while a defending force holds
+     * harder. Both keep the credit strictly below one turn of advance.
+     */
+    protected static final double HOLD_CREDIT_ATTACK_CAP_FACTOR = 0.4;
+    protected static final double HOLD_CREDIT_DEFEND_CAP_FACTOR = 0.8;
+
+    // Posture is a force-level call, made once per round and per board: every unit on a board moves under
+    // the same answer, and enemies on another board have no say in it.
+    private final Map<Integer, PostureResolver> postureResolverByBoard = new HashMap<>();
+    private final Map<Integer, CombatPosture> postureByBoard = new HashMap<>();
+    private int postureResolvedRound = -1;
+    private CombatPosture posture = CombatPosture.ATTACK;
+    private CombatPosture announcedPosture;
+    private double lastPositionQuality;
+    private double lastPositionHoldMod;
+
+    // Per-hex terrain labels, built once per board per round (fires burn woods away, buildings fall),
+    // then every path evaluation is one array lookup.
+    private final Map<Integer, HexPropertiesMap> hexPropertiesByBoard = new HashMap<>();
+    private int hexPropertiesRound = -1;
+
+    // Sustainable-output curves per unit, dry and standing in water, rebuilt per round (weapons and
+    // sinks get shot away). Keyed by unit id.
+    private final Map<Integer, DamageProfile> dryProfileByUnit = new HashMap<>();
+    private final Map<Integer, DamageProfile> waterProfileByUnit = new HashMap<>();
+    private int profileCacheRound = -1;
 
     public BasicPathRanker(Princess owningPrincess) {
         super(owningPrincess);
@@ -286,16 +341,32 @@ public class BasicPathRanker extends PathRanker {
      * How much of its raw damage-at-range a unit keeps after its own movement makes it a worse shot.
      *
      * <p>The unmoved-enemy estimate above is a range-table lookup with no to-hit roll in it, so the one
-     * certain cost of moving - the attacker movement modifier, +1 walked, +2 ran, +3 jumped - does not
-     * exist in it, and a short step reads as free. The base ranker keeps that behavior; a subclass can
-     * return the fraction of the raw estimate the path's movement mode actually leaves it.</p>
+     * certain cost of moving - the attacker movement modifier, +1 walked, +2 ran, +3 jumped - did not
+     * exist in it, and a short step read as free. This prices it back in as a hit-chance ratio at the
+     * {@link #REPRESENTATIVE_TO_HIT} midpoint: standing keeps everything, walking keeps about two-thirds,
+     * running two-fifths, a standard jump one-fifth. The modifier comes from the same engine call the
+     * server fires with ({@link Compute#getAttackerMovementModifier}), so infantry's exemption, the
+     * dual-cockpit dedicated gunner, and the jumping-jack abilities are all priced without naming them.</p>
      *
      * @param path the path being evaluated
      *
-     * @return the fraction of the raw damage estimate to keep; 1.0 by default
+     * @return the fraction of the raw damage estimate the path's movement mode leaves the unit
      */
     protected double attackerMovementDamageDiscount(MovePath path) {
-        return 1.0;
+        int attackerMovementModifier = Compute.getAttackerMovementModifier(path.getEntity().getGame(),
+              path.getEntity().getId(),
+              path.getLastStepMovementType()).getValue();
+        if (attackerMovementModifier <= 0) {
+            return 1.0;
+        }
+        if (attackerMovementModifier >= TargetRoll.AUTOMATIC_FAIL) {
+            // Sprinting: no attacks at all after this move. Unreachable from the current call site
+            // (sprint paths contribute no damage before the discount applies), but the sentinel is
+            // Integer.MAX_VALUE - 1 and must never reach the addition below.
+            return 0.0;
+        }
+        return Compute.oddsAbove(REPRESENTATIVE_TO_HIT + attackerMovementModifier)
+              / Compute.oddsAbove(REPRESENTATIVE_TO_HIT);
     }
 
     /**
@@ -303,16 +374,93 @@ public class BasicPathRanker extends PathRanker {
      *
      * <p>The twin of {@link #attackerMovementDamageDiscount}: the raw damage-at-range estimate above has no
      * to-hit roll, so the cover the destination hex gives - the woods and partial-cover modifiers the full
-     * fire-control guess prices against already-moved enemies - does not exist in it, and a covered hex and
-     * an open one read the same. The base ranker keeps that behavior; a subclass can return the fraction of
-     * the raw estimate the destination's cover actually lets through.</p>
+     * fire-control guess prices against already-moved enemies - did not exist in it, and a covered hex and
+     * an open one read the same. This discounts that raw estimate by the hit-chance ratio the destination's
+     * cover implies, from the per-round {@link HexPropertiesMap} labels. Only cover a unit can FIGHT from
+     * is credited: woodline edges and partial cover count; deep woods - concealing but blind -
+     * deliberately do not, so the discount never coaxes a unit into ground it cannot shoot from.</p>
      *
      * @param path the path being evaluated
      *
-     * @return the fraction of the raw enemy damage estimate to keep; 1.0 by default
+     * @return the fraction of the raw enemy damage estimate the destination's cover lets through
      */
     protected double incomingFireTerrainDiscount(MovePath path) {
-        return 1.0;
+        HexProperties properties = hexProperties(path.getEntity().getGame(), path.getFinalBoardId())
+              .at(path.getFinalCoords());
+        return incomingFireTerrainDiscount(properties);
+    }
+
+    /** The pure pricing: what fraction of incoming fire the cover modifiers let through. */
+    static double incomingFireTerrainDiscount(HexProperties properties) {
+        int coverModifiers = (properties.concealmentEdge() ? properties.concealment() : 0)
+              + (properties.partialCover() ? 1 : 0);
+        if (coverModifiers <= 0) {
+            return 1.0;
+        }
+        return Compute.oddsAbove(REPRESENTATIVE_TO_HIT + coverModifiers)
+              / Compute.oddsAbove(REPRESENTATIVE_TO_HIT);
+    }
+
+    /**
+     * The per-hex terrain labels for a board, computed once per round and shared by every path of every
+     * mover on it.
+     */
+    protected HexPropertiesMap hexProperties(Game game, int boardId) {
+        int round = game.getCurrentRound();
+        if (round != hexPropertiesRound) {
+            hexPropertiesRound = round;
+            hexPropertiesByBoard.clear();
+        }
+        return hexPropertiesByBoard.computeIfAbsent(boardId,
+              id -> HexPropertiesMap.of(game, game.getBoard(id), id));
+    }
+
+    /**
+     * The posture the force fights under this round on the given board, resolved once per round per board
+     * and shared by every unit there. Only units on that board have a say: entity lists are game-wide, and
+     * in a multi-board game mixing boards would make the closing rate meaningless. When the answer
+     * changes, the bot says so in the chat with its reason, so an observer can follow the force's intent
+     * without reading logs.
+     */
+    protected CombatPosture resolvePosture(Game game, int boardId) {
+        int round = game.getCurrentRound();
+        if (round != postureResolvedRound) {
+            postureResolvedRound = round;
+            postureByBoard.clear();
+        }
+        posture = postureByBoard.computeIfAbsent(boardId, id -> {
+            PostureResolver resolver = postureResolverByBoard.computeIfAbsent(id,
+                  newBoard -> new PostureResolver());
+            CombatPosture resolved = resolver.resolve(getOwner().getBehaviorSettings(), round,
+                  deployedPositions(getOwner().getEntitiesOwned(), id),
+                  deployedPositions(getOwner().getEnemyEntities(), id));
+            if (resolved != announcedPosture) {
+                announcedPosture = resolved;
+                getOwner().sendChat(Messages.getString("Princess.posture.announce",
+                      resolved, resolver.resolutionReason()));
+            }
+            return resolved;
+        });
+        return posture;
+    }
+
+    /** The positions of the given units that are deployed on the given board; the rest have no say. */
+    static List<Coords> deployedPositions(List<Entity> units, int boardId) {
+        List<Coords> positions = new ArrayList<>(units.size());
+        for (Entity unit : units) {
+            Coords position = unit.getPosition();
+            if ((null != position) && unit.isDeployed() && (unit.getBoardId() == boardId)) {
+                positions.add(position);
+            }
+        }
+        return positions;
+    }
+
+    /** Whether a unit has left the fighting line to pull back. */
+    protected boolean isWithdrawing(Entity unit) {
+        return getOwner().isFallingBack(unit)
+              || getOwner().getUnitBehaviorTracker()
+                    .getBehaviorType(unit, getOwner()).equals(BehaviorType.ForcedWithdrawal);
     }
 
     @Override
@@ -786,6 +934,18 @@ public class BasicPathRanker extends PathRanker {
 
         if ((distToEnemy == 0) && !(movingUnit instanceof Infantry)) {
             distToEnemy = 2;
+        }
+
+        // A laid defense does not pay tempo. Once the enemy is inside contact range and the force's
+        // posture is DEFEND, the enemy is coming to us: the closing charge that keeps an attack from
+        // dithering would here bleed the defender off its firing positions one hex at a time. Out of
+        // contact the charge stands, so a defending force still closes ranks toward its line. The gate
+        // reads the unit's CURRENT distance, not the path's, so every candidate path of the pass sees
+        // the same flat field.
+        if ((CombatPosture.DEFEND == resolvePosture(game, movingUnit.getBoardId()))
+              && (distanceToClosestEnemy(movingUnit, movingUnit.getPosition(), game)
+                    <= THREAT_CONTACT_RANGE)) {
+            return 0;
         }
 
         double aggression = getOwner().getBehaviorSettings().getHyperAggressionValue();
@@ -1954,22 +2114,36 @@ public class BasicPathRanker extends PathRanker {
      * logging is effectively unavailable: it is off by default and rotates away within a minute of a company-scale
      * game.</p>
      *
-     * @return named values to record alongside the path's modifiers; empty by default
+     * @return named values to record alongside the path's modifiers
      */
     protected Map<String, Double> doctrineScores() {
-        // Base ranker: the modifier values already recorded tell the whole story.
-        return Map.of();
+        Map<String, Double> scores = new HashMap<>();
+        // Position persistence: the force-level posture this path was ranked under (CombatPosture
+        // ordinal: 0 attack, 1 defend), the exchange quality of the hex a stationary path holds, and what
+        // holding it was credited. Quality and credit are zero for any path that moved; reset at the top
+        // of calculatePositionHoldMod so no path inherits the previous path's figures.
+        scores.put("combatPosture", (double) posture.ordinal());
+        scores.put("positionQuality", lastPositionQuality);
+        scores.put("positionHoldMod", lastPositionHoldMod);
+        return scores;
     }
 
     /**
-     * Utility credit for keeping a position worth keeping, given what {@link #rankPath} has already computed
-     * about the exchange the path's destination offers.
+     * Position persistence: a unit already standing on ground that gives a positive exchange earns credit
+     * for keeping it, so it stops shuffling between equivalent hexes for a movement modifier it does not
+     * need - the two-step that walks a firing line out of its positions.
      *
-     * <p>The base ranker awards nothing: every term above already weighs the destination on its merits, and a
-     * unit with a better hex in reach should take it. A subclass with a doctrine of position persistence can
-     * override this to bias a unit toward standing its ground when the ground is good - countering the constant
-     * pull of the movement modifier and aggression gradient that otherwise makes a unit shuffle between
-     * equivalent hexes.</p>
+     * <p>Quality is the exchange the stationary path itself was just evaluated at - expected damage dealt,
+     * weighted by the chance of standing to deliver it, minus expected damage taken - raised by
+     * {@link #heatSinkSustainBoost} when the hex lets a hot unit sustain more. The exchange already
+     * appears once in the bravery term for every path equally; counting it again here, only for standing
+     * still, is the deliberate asymmetry that makes a good position sticky. Ground that gives nothing (or
+     * worse) holds nothing: the credit never anchors a unit in a losing exchange.</p>
+     *
+     * <p>Dormant outside {@link #THREAT_CONTACT_RANGE}: on the approach there is no exchange to hold and
+     * the force should move loose and fast. Withdrawing units are leaving, not holding. The credit is
+     * capped strictly below one turn of advance, harder under DEFEND than ATTACK
+     * ({@link #HOLD_CREDIT_DEFEND_CAP_FACTOR}, {@link #HOLD_CREDIT_ATTACK_CAP_FACTOR}).</p>
      *
      * @param path                the path being ranked (a copy, safe to inspect)
      * @param game                the current game
@@ -1977,11 +2151,76 @@ public class BasicPathRanker extends PathRanker {
      * @param expectedDamageTaken the damage it is estimated to take there, path hazards included
      * @param successProbability  the chance the path completes without a failed piloting roll
      *
-     * @return the utility credit, added to the path's utility; 0 by default
+     * @return the utility credit, added to the path's utility
      */
     protected double calculatePositionHoldMod(MovePath path, Game game, FiringPhysicalDamage damageEstimate,
           double expectedDamageTaken, double successProbability) {
-        return 0;
+        // Reset first: these are recorded for every path, and an early exit must not leave the previous
+        // path's figures standing in the log.
+        lastPositionQuality = 0;
+        lastPositionHoldMod = 0;
+
+        Entity movingUnit = path.getEntity();
+        if ((path.getHexesMoved() > 0) || movingUnit.isAirborneAeroOnGroundMap() || isWithdrawing(movingUnit)) {
+            return 0;
+        }
+        if (distanceToClosestEnemy(movingUnit, path.getFinalCoords(), game) > THREAT_CONTACT_RANGE) {
+            return 0;
+        }
+
+        double quality = (successProbability * damageEstimate.getMaximumDamageEstimate()
+              * heatSinkSustainBoost(movingUnit, game, path))
+              - expectedDamageTaken;
+        lastPositionQuality = quality;
+        if (quality <= 0) {
+            return 0;
+        }
+
+        double aggression = getOwner().getBehaviorSettings().getHyperAggressionValue();
+        double capFactor = (CombatPosture.DEFEND == resolvePosture(game, movingUnit.getBoardId()))
+              ? HOLD_CREDIT_DEFEND_CAP_FACTOR
+              : HOLD_CREDIT_ATTACK_CAP_FACTOR;
+        double holdCredit = capFactor * Math.min(quality, TEMPO_REFERENCE_MP * aggression);
+        lastPositionHoldMod = holdCredit;
+        return holdCredit;
+    }
+
+    /**
+     * Mechanism C1: how much a heat-sink hex raises this unit's sustainable output where it stands. The
+     * ratio of the sustained-damage curves at the fight's current range - standing in water versus dry -
+     * from the same {@link DamageProfile} data the analysis display shows. For a cool-running unit the
+     * curves are identical and the boost is 1; for a Mek whose guns outrun its dry sinks the water closes
+     * the gap between what it can fire once and what it can fire every round.
+     */
+    private double heatSinkSustainBoost(Entity movingUnit, Game game, MovePath path) {
+        if (!movingUnit.tracksHeat()) {
+            return 1.0;
+        }
+        HexProperties standingOn = hexProperties(game, path.getFinalBoardId()).at(path.getFinalCoords());
+        if (!standingOn.heatSink()) {
+            return 1.0;
+        }
+        int round = game.getCurrentRound();
+        if (round != profileCacheRound) {
+            profileCacheRound = round;
+            dryProfileByUnit.clear();
+            waterProfileByUnit.clear();
+        }
+        boolean extremeRange = isExtremeRange(game);
+        DamageProfile dryProfile = dryProfileByUnit.computeIfAbsent(movingUnit.getId(),
+              id -> DamageProfile.of(movingUnit, extremeRange));
+        DamageProfile waterProfile = waterProfileByUnit.computeIfAbsent(movingUnit.getId(),
+              id -> DamageProfile.of(movingUnit, extremeRange,
+                    (movingUnit.getCrew() != null) ? movingUnit.getCrew().getGunnery() : 4,
+                    movingUnit.getHeatCapacityWithWater()));
+        int range = Math.max(1, (int) Math.ceil(
+              distanceToClosestEnemy(movingUnit, path.getFinalCoords(), game)));
+        double drySustained = dryProfile.sustainedDamage(range);
+        double waterSustained = waterProfile.sustainedDamage(range);
+        if ((drySustained <= 0) || (waterSustained <= drySustained)) {
+            return 1.0;
+        }
+        return waterSustained / drySustained;
     }
 
     protected boolean isLosRange(Game game) {

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -425,6 +425,13 @@ public class BasicPathRanker extends PathRanker {
     protected CombatPosture resolvePosture(Game game, int boardId) {
         int round = game.getCurrentRound();
         if (round != postureResolvedRound) {
+            if (round < postureResolvedRound) {
+                // The round going backwards means a new game on a reused bot client (a server reset
+                // keeps bots connected, and initialize() only runs once per client). The resolvers'
+                // closing-rate history and the announcement memory belong to the previous game.
+                postureResolverByBoard.clear();
+                announcedPosture = null;
+            }
             postureResolvedRound = round;
             postureByBoard.clear();
         }

--- a/megamek/src/megamek/client/bot/princess/MutualSupportPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/MutualSupportPathRanker.java
@@ -37,16 +37,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import megamek.client.bot.Messages;
-import megamek.common.analysis.DamageProfile;
 import megamek.client.bot.princess.UnitBehavior.BehaviorType;
+import megamek.common.analysis.DamageProfile;
 import megamek.common.annotations.Nullable;
 import megamek.common.board.Board;
 import megamek.common.board.Coords;
-import megamek.common.compute.Compute;
 import megamek.common.game.Game;
 import megamek.common.moves.MovePath;
-import megamek.common.rolls.TargetRoll;
 import megamek.common.units.Entity;
 import megamek.logging.MMLogger;
 
@@ -159,73 +156,15 @@ public class MutualSupportPathRanker extends BasicPathRanker {
     /** At most this many covering friends earn the bonus; a whole company stacking adds nothing. */
     private static final int COVER_BONUS_MAX_FRIENDS = 2;
 
-    /**
-     * Cover shaping only applies once the destination is within this range of an enemy; out of contact the
-     * force moves loose and fast (traveling, not bounding overwatch).
-     */
-    private static final int THREAT_CONTACT_RANGE = 15;
-
-    /**
-     * Reference movement rate used to scale the turns-to-close tempo term: a full move's advance is worth
-     * {@code TEMPO_REFERENCE_MP * hyperAggressionValue} to every unit regardless of its speed, which is what
-     * puts a 3/5 assault and a 6/9 medium on one commit tempo.
-     *
-     * <p>Sized against the noise floor rather than for slider parity. The mechanism study measured the
-     * competing rank terms at roughly 50 for one risky piloting roll, up to 100 for facing and 250 for
-     * sprint exposure, while stock aggression gave a slow assault a whole-turn commit signal of about 7.5 -
-     * which is why heavy companies dithered instead of committing. The first benchmark used 6.0 (15 points
-     * per move at default aggression), still under that floor, and arrival stagger only improved 12%.
-     * Fifteen gives 37.5 per move, above the single-roll term and below the sprint penalty.</p>
-     */
-    private static final double TEMPO_REFERENCE_MP = 15.0;
-
-    /**
-     * How much of a turn of advance the hold credit may reach under each posture: an attacking force keeps
-     * the credit modest so a good hex never outbids the advance (the Eisenhower governor - momentum is worth
-     * more than any one position), while a defending force holds harder, the same asymmetry as the formation
-     * penalty cap. Both keep the credit strictly below one turn of advance.
-     */
-    private static final double HOLD_CREDIT_ATTACK_CAP_FACTOR = 0.4;
-    private static final double HOLD_CREDIT_DEFEND_CAP_FACTOR = 0.8;
-
-    /**
-     * The to-hit number the attacker-movement damage discount is priced at: gunnery 4 plus a typical spread
-     * of range and target modifiers. Only the RATIO of hit chances at this number matters - walking turns
-     * 8s into 9s whoever you are - so the midpoint stands in for every shooter without pretending the
-     * estimate knows its real to-hit.
-     */
-    private static final int REPRESENTATIVE_TO_HIT = 8;
-
     private final Map<Integer, SupportEnvelope> envelopeCache = new HashMap<>();
     private int envelopeCacheRound = -1;
 
-    // Posture is a force-level call, made once per round and per board: every unit on a board moves
-    // under the same answer, and enemies on another board have no say in it - a game-wide entity list
-    // would blend boards into a meaningless closing rate.
-    private final Map<Integer, PostureResolver> postureResolverByBoard = new HashMap<>();
-    private final Map<Integer, CombatPosture> postureByBoard = new HashMap<>();
-    private int postureResolvedRound = -1;
-    private CombatPosture posture = CombatPosture.ATTACK;
-    private CombatPosture announcedPosture;
     private double lastPosturePenalty;
-    private double lastPositionQuality;
-    private double lastPositionHoldMod;
 
     // Bank labels are a property of the board, recomputed per round (ice can break) and shared by
     // every path of every mover. Keyed by board id.
     private final Map<Integer, BankRegions> bankRegionsByBoard = new HashMap<>();
     private int bankRegionsRound = -1;
-
-    // Per-hex terrain labels, same lifecycle: built once per board per round (fires burn woods away,
-    // buildings fall), then every path evaluation is one array lookup.
-    private final Map<Integer, HexPropertiesMap> hexPropertiesByBoard = new HashMap<>();
-    private int hexPropertiesRound = -1;
-
-    // Sustainable-output curves per unit, dry and standing in water, rebuilt per round (weapons and
-    // sinks get shot away). Keyed by unit id. Mechanism C1.
-    private final Map<Integer, DamageProfile> dryProfileByUnit = new HashMap<>();
-    private final Map<Integer, DamageProfile> waterProfileByUnit = new HashMap<>();
-    private int profileCacheRound = -1;
 
     // Per-ranking-pass caches. rankPath is called once per candidate path for a single mover, and a
     // company-scale turn evaluates thousands of paths per unit, so anything that depends only on the
@@ -440,89 +379,6 @@ public class MutualSupportPathRanker extends BasicPathRanker {
     }
 
     /**
-     * Mechanism A of the terrain doctrine: position persistence. A unit already standing on ground that gives
-     * a positive exchange earns credit for keeping it, so it stops shuffling between equivalent hexes for a
-     * movement modifier it does not need - the two-step that walks a firing line out of its positions and
-     * triggers anti-missile fire on the way.
-     *
-     * <p>Quality is the exchange the stationary path itself was just evaluated at - expected damage dealt,
-     * weighted by the chance of standing to deliver it, minus expected damage taken. The exchange already
-     * appears once in the bravery term for every path equally; counting it again here, only for standing
-     * still, is the deliberate asymmetry that makes a good position sticky. Ground that gives nothing (or
-     * worse) holds nothing: the credit never anchors a unit in a losing exchange, so displacement stays a
-     * live option evaluated on the same terms as everything else.</p>
-     *
-     * <p>Dormant outside {@link #THREAT_CONTACT_RANGE}: on the approach there is no exchange to hold and the
-     * force should move loose and fast. Withdrawing units are leaving, not holding. The credit is capped
-     * strictly below one turn of advance, harder under DEFEND than ATTACK
-     * ({@link #HOLD_CREDIT_DEFEND_CAP_FACTOR}, {@link #HOLD_CREDIT_ATTACK_CAP_FACTOR}), so a position is
-     * never worth more than the advance it would delay.</p>
-     */
-    @Override
-    protected double calculatePositionHoldMod(MovePath path, Game game, FiringPhysicalDamage damageEstimate,
-          double expectedDamageTaken, double successProbability) {
-        // Reset first: these are recorded for every path, and an early exit must not leave the previous
-        // path's figures standing in the log.
-        lastPositionQuality = 0;
-        lastPositionHoldMod = 0;
-
-        Entity movingUnit = path.getEntity();
-        if ((path.getHexesMoved() > 0) || movingUnit.isAirborneAeroOnGroundMap() || isWithdrawing(movingUnit)) {
-            return 0;
-        }
-        if (distanceToClosestEnemy(movingUnit, path.getFinalCoords(), game) > THREAT_CONTACT_RANGE) {
-            return 0;
-        }
-
-        double quality = (successProbability * damageEstimate.getMaximumDamageEstimate()
-              * heatSinkSustainBoost(movingUnit, game, path))
-              - expectedDamageTaken;
-        lastPositionQuality = quality;
-        if (quality <= 0) {
-            return 0;
-        }
-
-        double aggression = getOwner().getBehaviorSettings().getHyperAggressionValue();
-        double capFactor = (CombatPosture.DEFEND == resolvePosture(game, movingUnit.getBoardId()))
-              ? HOLD_CREDIT_DEFEND_CAP_FACTOR
-              : HOLD_CREDIT_ATTACK_CAP_FACTOR;
-        double holdCredit = capFactor * Math.min(quality, TEMPO_REFERENCE_MP * aggression);
-        lastPositionHoldMod = holdCredit;
-        return holdCredit;
-    }
-
-    /**
-     * The two-step's hidden cost, made visible. The base ranker's estimate against enemies that have not
-     * yet moved is a damage-at-range table with no to-hit roll, so the attacker movement modifier - the one
-     * certain cost of moving - is absent from it and a short step reads as free. This prices it back in as
-     * a hit-chance ratio at the {@link #REPRESENTATIVE_TO_HIT} midpoint: standing keeps everything, walking
-     * keeps about two-thirds, running two-fifths, a standard jump one-fifth.
-     *
-     * <p>The modifier itself comes from the same engine call the server fires with
-     * ({@link Compute#getAttackerMovementModifier}), so infantry's exemption, the dual-cockpit dedicated
-     * gunner, and the jumping-jack abilities are all priced without this class knowing their names.
-     * The anatomy of the shuffle measured on the water arms: the bravery term paid for half of all
-     * two-steps, and against unmoved enemies its gain was computed with this cost missing.</p>
-     */
-    @Override
-    protected double attackerMovementDamageDiscount(MovePath path) {
-        int attackerMovementModifier = Compute.getAttackerMovementModifier(path.getEntity().getGame(),
-              path.getEntity().getId(),
-              path.getLastStepMovementType()).getValue();
-        if (attackerMovementModifier <= 0) {
-            return 1.0;
-        }
-        if (attackerMovementModifier >= TargetRoll.AUTOMATIC_FAIL) {
-            // Sprinting: no attacks at all after this move. Unreachable from the current call site
-            // (sprint paths contribute no damage before the discount applies), but the sentinel is
-            // Integer.MAX_VALUE - 1 and must never reach the addition below.
-            return 0.0;
-        }
-        return Compute.oddsAbove(REPRESENTATIVE_TO_HIT + attackerMovementModifier)
-              / Compute.oddsAbove(REPRESENTATIVE_TO_HIT);
-    }
-
-    /**
      * The bank labels for a board, computed once per round and shared by every path of every mover.
      */
     private BankRegions bankRegions(Game game, int boardId) {
@@ -533,135 +389,6 @@ public class MutualSupportPathRanker extends BasicPathRanker {
         }
         return bankRegionsByBoard.computeIfAbsent(boardId,
               id -> BankRegions.of(game.getBoard(id), FormationSide.ANY_WATER_DEPTH));
-    }
-
-    /**
-     * The per-hex terrain labels for a board, computed once per round and shared by every path of every
-     * mover on it.
-     */
-    private HexPropertiesMap hexProperties(Game game, int boardId) {
-        int round = game.getCurrentRound();
-        if (round != hexPropertiesRound) {
-            hexPropertiesRound = round;
-            hexPropertiesByBoard.clear();
-        }
-        return hexPropertiesByBoard.computeIfAbsent(boardId,
-              id -> HexPropertiesMap.of(game, game.getBoard(id), id));
-    }
-
-    /**
-     * Mechanism B of the terrain doctrine, first term: cover is priced into the incoming-fire estimate
-     * where it was missing. Against already-moved enemies the fire-control guess prices the destination's
-     * woods and cover honestly; against unmoved enemies the estimate is a raw range table, so a covered
-     * hex and an open one read the same and terrain never influenced the choice. This discounts that raw
-     * estimate by the hit-chance ratio the destination's cover implies, the same representative-8s pricing
-     * as the movement discount.
-     *
-     * <p>Only cover a unit can FIGHT from is credited: a woodline-edge hex (fire out, hard to hit) and
-     * partial cover count; deep woods - concealing but blind - deliberately do not, so the discount can
-     * never coax a unit into ground it cannot shoot from (the dead-ground rule from the water PR, and
-     * rulings 3 and 9 of the command interview). A covered firing position takes less estimated damage,
-     * which raises its exchange, which the hold credit then makes sticky - the terrain preference emerges
-     * through the ledger rather than through a bonus term.</p>
-     */
-    @Override
-    protected double incomingFireTerrainDiscount(MovePath path) {
-        HexProperties properties = hexProperties(path.getEntity().getGame(), path.getFinalBoardId())
-              .at(path.getFinalCoords());
-        return incomingFireTerrainDiscount(properties);
-    }
-
-    /** The pure pricing: what fraction of incoming fire the cover modifiers let through. */
-    static double incomingFireTerrainDiscount(HexProperties properties) {
-        int coverModifiers = (properties.concealmentEdge() ? properties.concealment() : 0)
-              + (properties.partialCover() ? 1 : 0);
-        if (coverModifiers <= 0) {
-            return 1.0;
-        }
-        return Compute.oddsAbove(REPRESENTATIVE_TO_HIT + coverModifiers)
-              / Compute.oddsAbove(REPRESENTATIVE_TO_HIT);
-    }
-
-    /**
-     * Mechanism C1: how much a heat-sink hex raises this unit's sustainable output where it stands. The
-     * ratio of the sustained-damage curves at the fight's current range - standing in water versus dry -
-     * from the same {@link DamageProfile} data the analysis display shows. For a cool-running unit the
-     * curves are identical and the boost is 1; for a Mek whose guns outrun its dry sinks (the triple-PPC
-     * case) the water closes the gap between what it can fire once and what it can fire every round, and
-     * the position quality - and so the hold credit - rises by exactly that measured amount. Holding the
-     * sink only; moving to reach one is a DEFEND-gated question (interview ruling 4) left for the
-     * follow-on.
-     */
-    private double heatSinkSustainBoost(Entity movingUnit, Game game, MovePath path) {
-        if (!movingUnit.tracksHeat()) {
-            return 1.0;
-        }
-        HexProperties standingOn = hexProperties(game, path.getFinalBoardId()).at(path.getFinalCoords());
-        if (!standingOn.heatSink()) {
-            return 1.0;
-        }
-        int round = game.getCurrentRound();
-        if (round != profileCacheRound) {
-            profileCacheRound = round;
-            dryProfileByUnit.clear();
-            waterProfileByUnit.clear();
-        }
-        boolean extremeRange = isExtremeRange(game);
-        DamageProfile dryProfile = dryProfileByUnit.computeIfAbsent(movingUnit.getId(),
-              id -> DamageProfile.of(movingUnit, extremeRange));
-        DamageProfile waterProfile = waterProfileByUnit.computeIfAbsent(movingUnit.getId(),
-              id -> DamageProfile.of(movingUnit, extremeRange,
-                    (movingUnit.getCrew() != null) ? movingUnit.getCrew().getGunnery() : 4,
-                    movingUnit.getHeatCapacityWithWater()));
-        int range = Math.max(1, (int) Math.ceil(
-              distanceToClosestEnemy(movingUnit, path.getFinalCoords(), game)));
-        double drySustained = dryProfile.sustainedDamage(range);
-        double waterSustained = waterProfile.sustainedDamage(range);
-        if ((drySustained <= 0) || (waterSustained <= drySustained)) {
-            return 1.0;
-        }
-        return waterSustained / drySustained;
-    }
-
-    /**
-     * The posture the force fights under this round on the given board, resolved once per round per board
-     * and shared by every unit there. Only units on that board have a say: entity lists are game-wide, and
-     * in a multi-board game mixing boards would make the closing rate meaningless. When the answer changes -
-     * a flip of the auto-resolution or a new explicit order taking effect - the bot says so in the chat,
-     * with its reason, so an observer can follow the force's intent without reading logs.
-     */
-    private CombatPosture resolvePosture(Game game, int boardId) {
-        int round = game.getCurrentRound();
-        if (round != postureResolvedRound) {
-            postureResolvedRound = round;
-            postureByBoard.clear();
-        }
-        posture = postureByBoard.computeIfAbsent(boardId, id -> {
-            PostureResolver resolver = postureResolverByBoard.computeIfAbsent(id,
-                  newBoard -> new PostureResolver());
-            CombatPosture resolved = resolver.resolve(getOwner().getBehaviorSettings(), round,
-                  deployedPositions(getOwner().getEntitiesOwned(), id),
-                  deployedPositions(getOwner().getEnemyEntities(), id));
-            if (resolved != announcedPosture) {
-                announcedPosture = resolved;
-                getOwner().sendChat(Messages.getString("Princess.posture.announce",
-                      resolved, resolver.resolutionReason()));
-            }
-            return resolved;
-        });
-        return posture;
-    }
-
-    /** The positions of the given units that are deployed on the given board; the rest have no say. */
-    static List<Coords> deployedPositions(List<Entity> units, int boardId) {
-        List<Coords> positions = new ArrayList<>(units.size());
-        for (Entity unit : units) {
-            Coords position = unit.getPosition();
-            if ((null != position) && unit.isDeployed() && (unit.getBoardId() == boardId)) {
-                positions.add(position);
-            }
-        }
-        return positions;
     }
 
     /**
@@ -759,7 +486,8 @@ public class MutualSupportPathRanker extends BasicPathRanker {
      */
     @Override
     protected Map<String, Double> doctrineScores() {
-        Map<String, Double> scores = new HashMap<>();
+        // The base ranker records the position-discipline columns (posture, quality, hold credit).
+        Map<String, Double> scores = new HashMap<>(super.doctrineScores());
         scores.put("formationCentre_x", lastFormationCentre == null ? -1.0 : lastFormationCentre.getX());
         scores.put("formationCentre_y", lastFormationCentre == null ? -1.0 : lastFormationCentre.getY());
         scores.put("formationRadius", (double) lastFormationRadius);
@@ -767,20 +495,11 @@ public class MutualSupportPathRanker extends BasicPathRanker {
         scores.put("coverBonus", lastCoverBonus);
         scores.put("coveringFriends", (double) lastCoveringFriends);
         scores.put("turnsToOwnBand", lastTurnsToBand);
-        // The force-level posture this path was ranked under (CombatPosture ordinal: 0 attack, 1 defend)
-        // and what the posture charged this particular path. Fresh for every path: the penalty is computed
+        // What the posture charged this particular path. Fresh for every path: the penalty is computed
         // at the top of calculateMutualSupportMod before anything can return early.
-        scores.put("combatPosture", (double) posture.ordinal());
         scores.put("posturePenalty", lastPosturePenalty);
-        // Position persistence: the exchange quality of the hex a stationary path holds, and what holding
-        // it was credited. Both zero for any path that moved. Reset at the top of calculatePositionHoldMod.
-        scores.put("positionQuality", lastPositionQuality);
-        scores.put("positionHoldMod", lastPositionHoldMod);
         return scores;
     }
-
-
-
 
     /**
      * Whether a unit is part of the formation, and so gets a say in where its centre is.
@@ -807,13 +526,6 @@ public class MutualSupportPathRanker extends BasicPathRanker {
             return WITHDRAWING_CENTRE_WEIGHT;
         }
         return 1.0;
-    }
-
-    /** Whether a unit has left the fighting line to pull back. */
-    private boolean isWithdrawing(Entity unit) {
-        return getOwner().isFallingBack(unit)
-              || getOwner().getUnitBehaviorTracker()
-                    .getBehaviorType(unit, getOwner()).equals(BehaviorType.ForcedWithdrawal);
     }
 
     /**

--- a/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/BasicPathRankerTest.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -107,6 +108,9 @@ class BasicPathRankerTest {
     @BeforeEach
     void beforeEach() {
         final BehaviorSettings mockBehavior = mock(BehaviorSettings.class);
+        // The promoted position discipline resolves posture during ranking; a real settings object
+        // always carries one (the field defaults to AUTO), so the mock must too.
+        when(mockBehavior.getCombatPosture()).thenReturn(CombatPosture.ATTACK);
         when(mockBehavior.getFallShameValue()).thenReturn(BehaviorSettings.FALL_SHAME_VALUES[5]);
         when(mockBehavior.getBraveryValue()).thenReturn(BehaviorSettings.BRAVERY[5]);
         when(mockBehavior.getHyperAggressionValue()).thenReturn(BehaviorSettings.HYPER_AGGRESSION_VALUES[5]);
@@ -472,6 +476,11 @@ class BasicPathRankerTest {
         expected.setMyEstimatedDamage(2.5);
         expected.setMyEstimatedPhysicalDamage(0.0);
 
+        // The pricing discounts have their own dedicated tests; hold them neutral here so this test
+        // keeps pinning the LOS/kick mechanics at their legacy figures.
+        doReturn(1.0).when(testRanker).attackerMovementDamageDiscount(any(MovePath.class));
+        doReturn(1.0).when(testRanker).incomingFireTerrainDiscount(any(MovePath.class));
+
         EntityEvaluationResponse actual = testRanker.evaluateUnmovedEnemy(mockEnemyMek, mockPath, false, false);
         assertEntityEvaluationResponseEquals(expected, actual);
     }
@@ -504,6 +513,11 @@ class BasicPathRankerTest {
         expected.setEstimatedEnemyDamage(2.125);
         expected.setMyEstimatedDamage(0.0);
         expected.setMyEstimatedPhysicalDamage(0.0);
+        // The pricing discounts have their own dedicated tests; hold them neutral here so this test
+        // keeps pinning the LOS/kick mechanics at their legacy figures.
+        doReturn(1.0).when(testRanker).attackerMovementDamageDiscount(any(MovePath.class));
+        doReturn(1.0).when(testRanker).incomingFireTerrainDiscount(any(MovePath.class));
+
         EntityEvaluationResponse actual = testRanker.evaluateUnmovedEnemy(mockEnemyMek, mockPath, false, false);
         assertEntityEvaluationResponseEquals(expected, actual);
     }
@@ -537,6 +551,11 @@ class BasicPathRankerTest {
         expected.setEstimatedEnemyDamage(4.625);
         expected.setMyEstimatedDamage(0.0);
         expected.setMyEstimatedPhysicalDamage(0.0);
+
+        // The pricing discounts have their own dedicated tests; hold them neutral here so this test
+        // keeps pinning the LOS/kick mechanics at their legacy figures.
+        doReturn(1.0).when(testRanker).attackerMovementDamageDiscount(any(MovePath.class));
+        doReturn(1.0).when(testRanker).incomingFireTerrainDiscount(any(MovePath.class));
 
         EntityEvaluationResponse actual = testRanker.evaluateUnmovedEnemy(mockEnemyMek, mockPath, false, false);
         assertEntityEvaluationResponseEquals(expected, actual);
@@ -629,6 +648,11 @@ class BasicPathRankerTest {
         expected.setEstimatedEnemyDamage(2.125);
         expected.setMyEstimatedDamage(0.0);
         expected.setMyEstimatedPhysicalDamage(0.0);
+
+        // The pricing discounts have their own dedicated tests; hold them neutral here so this test
+        // keeps pinning the LOS/kick mechanics at their legacy figures.
+        doReturn(1.0).when(testRanker).attackerMovementDamageDiscount(any(MovePath.class));
+        doReturn(1.0).when(testRanker).incomingFireTerrainDiscount(any(MovePath.class));
 
         EntityEvaluationResponse actual = testRanker.evaluateUnmovedEnemy(mockEnemyMek, mockPath, false, false);
         assertEntityEvaluationResponseEquals(expected, actual);
@@ -989,6 +1013,10 @@ class BasicPathRankerTest {
               any(Game.class));
         doReturn(12.0).when(testRanker).distanceToClosestEnemy(any(Entity.class), any(Coords.class), any(Game.class));
         doReturn(0.0).when(testRanker).checkPathForHazards(any(MovePath.class), any(Entity.class), any(Game.class));
+        // Position persistence has its own dedicated tests; hold it neutral so this test keeps pinning
+        // the legacy utility arithmetic.
+        doReturn(0.0).when(testRanker).calculatePositionHoldMod(any(MovePath.class), any(Game.class),
+              any(BasicPathRanker.FiringPhysicalDamage.class), anyDouble(), anyDouble());
 
         final Entity mockMover = mock(BipedMek.class);
         when(mockMover.isClan()).thenReturn(false);

--- a/megamek/unittests/megamek/client/bot/princess/MutualSupportPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/MutualSupportPathRankerTest.java
@@ -653,13 +653,19 @@ class MutualSupportPathRankerTest {
               testRanker.attackerMovementDamageDiscount(ran), TOLERANCE);
     }
 
-    /** Princess's estimate is untouched: the base ranker's discount is exactly 1.0 for every path. */
+    /**
+     * The promotion: the pricing lives in the base ranker now, so Princess prices her own movement the
+     * same way CASPAR does - running keeps two-fifths of the raw estimate for both.
+     */
     @Test
-    void theBaseRankerDoesNotDiscountMovement() {
+    void princessPricesHerOwnMovementTheSameWay() {
+        when(mockGame.getEntity(1)).thenReturn(mockMover);
+        when(mockMover.getGame()).thenReturn(mockGame);
         BasicPathRanker princessRanker = new BasicPathRanker(mockPrincess);
         MovePath ran = pathEndingAt(CLOSING_DESTINATION);
         when(ran.getLastStepMovementType()).thenReturn(EntityMovementType.MOVE_RUN);
-        assertEquals(1.0, princessRanker.attackerMovementDamageDiscount(ran), TOLERANCE);
+        assertEquals(Compute.oddsAbove(10) / Compute.oddsAbove(8),
+              princessRanker.attackerMovementDamageDiscount(ran), TOLERANCE);
     }
 
     /**
@@ -692,11 +698,44 @@ class MutualSupportPathRankerTest {
         assertEquals(1.0, MutualSupportPathRanker.incomingFireTerrainDiscount(deepWoods), TOLERANCE);
     }
 
-    /** Princess's incoming-fire estimate is untouched: the base ranker's discount is exactly 1.0. */
+    /**
+     * The promotion: cover pricing lives in the base ranker, so Princess values a woodline edge exactly
+     * as CASPAR does, and a stationary Princess on a positive exchange earns the same capped hold credit.
+     */
     @Test
-    void theBaseRankerDoesNotDiscountIncomingFire() {
-        BasicPathRanker princessRanker = new BasicPathRanker(mockPrincess);
-        assertEquals(1.0, princessRanker.incomingFireTerrainDiscount(pathEndingAt(CLOSING_DESTINATION)),
+    void princessEarnsHoldCreditAndPricesCoverToo() {
+        HexProperties woodlineEdge = new HexProperties(0, false, 1, true, 0, false, false);
+        assertEquals(Compute.oddsAbove(9) / Compute.oddsAbove(8),
+              BasicPathRanker.incomingFireTerrainDiscount(woodlineEdge), TOLERANCE);
+
+        when(mockBehavior.getCombatPosture()).thenReturn(CombatPosture.ATTACK);
+        BasicPathRanker princessRanker = spy(new BasicPathRanker(mockPrincess));
+        doReturn(mockPrincess).when(princessRanker).getOwner();
+        doReturn(10.0).when(princessRanker)
+              .distanceToClosestEnemy(any(Entity.class), eq(CURRENT_POSITION), any(Game.class));
+        // quality 15 = 1.0 success * 20 dealt - 5 taken; credited at the attack factor, same as CASPAR
+        assertEquals(0.4 * 15.0,
+              princessRanker.calculatePositionHoldMod(pathEndingAt(CURRENT_POSITION), mockGame,
+                    damageDealing(20.0), 5.0, 1.0), TOLERANCE);
+    }
+
+    /** The defender-tempo port: a Princess defender in contact pays no closing charge either. */
+    @Test
+    void princessDefenderInContactPaysNoClosingCharge() {
+        when(mockBehavior.getCombatPosture()).thenReturn(CombatPosture.DEFEND);
+        BasicPathRanker princessRanker = spy(new BasicPathRanker(mockPrincess));
+        doReturn(mockPrincess).when(princessRanker).getOwner();
+        doReturn(10.0).when(princessRanker)
+              .distanceToClosestEnemy(any(Entity.class), any(Coords.class), any(Game.class));
+        assertEquals(0.0,
+              princessRanker.calculateAggressionMod(mockMover, pathEndingAt(HOLDING_DESTINATION), mockGame),
+              TOLERANCE);
+
+        // Out of contact the pull stands: the stock gradient at distance 20 and aggression 2.5.
+        doReturn(20.0).when(princessRanker)
+              .distanceToClosestEnemy(any(Entity.class), any(Coords.class), any(Game.class));
+        assertEquals(20.0 * 2.5,
+              princessRanker.calculateAggressionMod(mockMover, pathEndingAt(HOLDING_DESTINATION), mockGame),
               TOLERANCE);
     }
 

--- a/megamek/unittests/megamek/client/bot/princess/MutualSupportPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/MutualSupportPathRankerTest.java
@@ -36,10 +36,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -717,6 +720,50 @@ class MutualSupportPathRankerTest {
         assertEquals(0.4 * 15.0,
               princessRanker.calculatePositionHoldMod(pathEndingAt(CURRENT_POSITION), mockGame,
                     damageDealing(20.0), 5.0, 1.0), TOLERANCE);
+    }
+
+    /**
+     * A server reset keeps bot clients connected and initialize() runs only once per client, so the same
+     * ranker sees the round counter go backwards when a new game starts. The posture machinery must not
+     * carry the previous game into the new one: the resolvers' closing-rate history is cleared, and the
+     * first posture of the new game is announced even when it matches the old game's last announcement.
+     */
+    @Test
+    void aNewGameOnAReusedClientForgetsThePreviousGamesPosture() {
+        when(mockBehavior.getCombatPosture()).thenReturn(CombatPosture.AUTO);
+        when(mockMover.isDeployed()).thenReturn(true);
+        BasicPathRanker princessRanker = spy(new BasicPathRanker(mockPrincess));
+        doReturn(mockPrincess).when(princessRanker).getOwner();
+
+        Entity distantEnemy = enemyMekAt(new Coords(0, 30));
+        Entity closingEnemy = enemyMekAt(new Coords(0, 26));
+
+        // Game one, rounds 1-2: the enemy closes hard, the force stands on the defensive.
+        when(mockGame.getCurrentRound()).thenReturn(1);
+        when(mockPrincess.getEnemyEntities()).thenReturn(List.of(distantEnemy));
+        princessRanker.resolvePosture(mockGame, 0);
+        when(mockGame.getCurrentRound()).thenReturn(2);
+        when(mockPrincess.getEnemyEntities()).thenReturn(List.of(closingEnemy));
+        assertEquals(CombatPosture.DEFEND, princessRanker.resolvePosture(mockGame, 0),
+              "precondition: game one must end standing on the defensive");
+
+        // Server reset, new game: round 1 again, the enemy back at distance. A leaked resolver would
+        // still be holding game one's closing history and defensive stance.
+        when(mockGame.getCurrentRound()).thenReturn(1);
+        when(mockPrincess.getEnemyEntities()).thenReturn(List.of(distantEnemy));
+        assertEquals(CombatPosture.ATTACK, princessRanker.resolvePosture(mockGame, 0),
+              "the new game reads the battle fresh");
+
+        // Both games' postures were announced - including the new game's, which a leaked
+        // announcedPosture would have suppressed had the values matched across the reset.
+        verify(mockPrincess, times(3)).sendChat(anyString());
+    }
+
+    private Entity enemyMekAt(Coords position) {
+        Entity enemy = mock(BipedMek.class);
+        when(enemy.getPosition()).thenReturn(position);
+        when(enemy.isDeployed()).thenReturn(true);
+        return enemy;
     }
 
     /** The defender-tempo port: a Princess defender in contact pays no closing charge either. */


### PR DESCRIPTION
**Requires #8669 merged first** - this PR is based on its branch and will be retargeted to main once it lands.

## Summary

Follow-on to #8669: everything CASPAR proved out there - sticky firing positions, honest
movement and cover pricing, heat-sink valuation, posture resolution - now applies to Princess,
the bot every player faces. The mechanisms move from the CASPAR ranker into BasicPathRanker;
there is one implementation, shared by both bots. Measured old-vs-new on mirror matches (stock
Princess both sides): the defender's standing-and-firing rate more than doubles and woodline use
nearly triples, on a map the code was never tuned on.

## Changes Made

**What moves down**
- Hold credit, attacker-movement discount, cover discount, heat-sink sustain boost, posture
  resolution with chat announcements, and the per-round HexProperties/profile caches move from
  MutualSupportPathRanker into BasicPathRanker. The seams stay, now implemented instead of
  neutral; CASPAR's duplicate overrides are deleted.

**The one real port**
- The defender-tempo rule joins Princess's stock per-hex aggression gradient: under a resolved
  DEFEND with the enemy inside contact range the closing charge is zero, exactly the CASPAR rule.

**What stays CASPAR-only**
- Mutual-support cohesion, the set-friend cover bonus, the turns-at-own-speed closing tempo, and
  the water-crossing posture charge - CASPAR's own doctrine, unchanged.

**Player-visible**
- Princess now honors the Combat Posture setting (it existed in the dialog since #8659 but only
  CASPAR read it), announces posture changes in chat with the reason, and records the position
  columns in the ranker TSV.

## Files Changed

- `megamek/src/megamek/client/bot/princess/BasicPathRanker.java` - the promoted mechanisms
- `megamek/src/megamek/client/bot/princess/MutualSupportPathRanker.java` - reduced to CASPAR's
  own doctrine
- `megamek/unittests/.../BasicPathRankerTest.java` - legacy ranking tests hold the new pricing
  neutral (it has its own tests); posture stubbed in setup
- `megamek/unittests/.../MutualSupportPathRankerTest.java` - the Princess-neutrality pins invert
  into Princess-parity pins (same discounts, hold credit, and defender gate for the base ranker)

## Testing

- Full suite: 14,865 tests, one failure - `SettingsContentHostTest`, the pre-existing UI failure
  tracked as #8662; it fails on unmodified main too. Javadoc and checkstyle clean.
- Unit tests: parity pins for every promoted mechanism (same discounts, hold credit, and defender
  gate for the base ranker as for CASPAR).
- Cross-build A/B, stock Princess both sides, east seat ordered posture defend, 30 games per arm
  per build. Old build = main plus only the #8665 fix (unmodified main cannot start a game -
  see the severity comment on #8665).

| Defender seat | River old -> new | LumpyWoods old -> new |
|---|---|---|
| Two-step rate | 51.7% -> 31.7% | 55.0% -> 34.3% |
| Stationary rate | 24.7% -> 53.4% | 16.5% -> 52.1% |
| Fired from same hex | 19.7% -> 46.8% | 14.5% -> 41.4% |
| Woodline firing share | - | 21.2% -> 60.1% |

- The attacking seat (no posture order) improves the same way - both seats run the new code, so
  the mirror shows the full effect players will see.
- Games run longer (river 20.1 -> 29.9 mean rounds, lumpy 14.6 -> 25.2) and still decide: 2 of 60
  new-build games hit the 40-round cap. A settled defense makes the attacker do the approaching.
- Deep-woods firing share stays ~1% (the dead-ground rule holds for Princess too).

## Out of scope

- The remaining terrain terms (overlook, defilade, flank discount, indifference band,
  engagement-range discipline) - queued behind this, one at a time with A/B.
- CASPAR's mutual-support doctrine stays CASPAR's.