### PR TITLE
Fix bot units loitering instead of following movement orders

### DIFF
--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -466,7 +466,9 @@ public class BasicPathRanker extends PathRanker {
     /**
      * Whether a unit has left the fighting line - pulling back under forced withdrawal, or ordered
      * somewhere else entirely (a destination edge or a player waypoint). Such a unit earns no hold
-     * credit (it has somewhere to be, however good its current hex) and does not anchor a formation.
+     * credit (it has somewhere to be, however good its current hex), and its say in where the
+     * formation's centre lies is sharply reduced - not removed, so the centre moves continuously as
+     * units leave the line (see {@code MutualSupportPathRanker}'s withdrawing centre weight).
      */
     protected boolean isWithdrawing(Entity unit) {
         BehaviorType behaviorType = getOwner().getUnitBehaviorTracker().getBehaviorType(unit, getOwner());

--- a/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
+++ b/megamek/src/megamek/client/bot/princess/BasicPathRanker.java
@@ -463,11 +463,16 @@ public class BasicPathRanker extends PathRanker {
         return positions;
     }
 
-    /** Whether a unit has left the fighting line to pull back. */
+    /**
+     * Whether a unit has left the fighting line - pulling back under forced withdrawal, or ordered
+     * somewhere else entirely (a destination edge or a player waypoint). Such a unit earns no hold
+     * credit (it has somewhere to be, however good its current hex) and does not anchor a formation.
+     */
     protected boolean isWithdrawing(Entity unit) {
+        BehaviorType behaviorType = getOwner().getUnitBehaviorTracker().getBehaviorType(unit, getOwner());
         return getOwner().isFallingBack(unit)
-              || getOwner().getUnitBehaviorTracker()
-                    .getBehaviorType(unit, getOwner()).equals(BehaviorType.ForcedWithdrawal);
+              || behaviorType.equals(BehaviorType.ForcedWithdrawal)
+              || behaviorType.equals(BehaviorType.MoveToDestination);
     }
 
     @Override
@@ -1897,12 +1902,17 @@ public class BasicPathRanker extends PathRanker {
               standoffDistance, distToEnemy, distToCluster, braveryMod);
         double aggressionMod = standoff.aggressionMod();
 
-        // A withdrawing unit has no business being pulled toward the enemy: kill the aggression pull (and,
-        // below, the closing incentive and mutual support pull) so the self-preservation term is what actually decides
-        // its path. Includes trapped withdrawers (NoPathToDestination while wanting to fall back), whose
-        // fallback retreat pull in calculateSelfPreservationMod would otherwise fight these terms.
+        // A unit with a movement mission has no business being pulled toward the enemy: kill the aggression
+        // pull (and, below, the closing incentive and mutual support pull) so the destination and
+        // self-preservation terms are what actually decide its path. Covers forced withdrawal, trapped
+        // withdrawers (NoPathToDestination while wanting to fall back), and units ORDERED somewhere -
+        // MoveToDestination, whether a flee edge or a player waypoint. Without the last one, an ordered
+        // retreat past a superior enemy loitered: the order registered but the closing pull and the
+        // exchange-priced terms vetoed every step of the route, and the unit crept in place all game
+        // (community game 2026-08-07, 395 MoveToDestination rows with near-zero net displacement).
         BehaviorType moverBehavior = getOwner().getUnitBehaviorTracker().getBehaviorType(movingUnit, getOwner());
         boolean withdrawing = (moverBehavior == BehaviorType.ForcedWithdrawal)
+              || (moverBehavior == BehaviorType.MoveToDestination)
               || ((moverBehavior == BehaviorType.NoPathToDestination) && getOwner().wantsToFallBack(movingUnit));
         if (withdrawing) {
             aggressionMod = 0;

--- a/megamek/unittests/megamek/client/bot/princess/MutualSupportPathRankerTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/MutualSupportPathRankerTest.java
@@ -629,6 +629,22 @@ class MutualSupportPathRankerTest {
     }
 
     /**
+     * A unit ORDERED somewhere - a flee edge or a player waypoint - has somewhere to be, however good
+     * its current hex. Without this exemption an ordered retreat past a superior enemy loitered: the
+     * hold credit and closing pulls vetoed every step of the route while the order sat registered
+     * (community game 2026-08-07 - a star told to withdraw north crept in place all game).
+     */
+    @Test
+    void aDestinationOrderedUnitHoldsNothing() {
+        when(mockBehaviorTracker.getBehaviorType(eq(mockMover), any(Princess.class)))
+              .thenReturn(BehaviorType.MoveToDestination);
+        setEnemyDistances(10.0, 10.0, CURRENT_POSITION);
+        assertEquals(0.0,
+              testRanker.calculatePositionHoldMod(pathEndingAt(CURRENT_POSITION), mockGame,
+                    damageDealing(20.0), 0.0, 1.0), TOLERANCE);
+    }
+
+    /**
      * The AMM ledger fix, pinned. The base ranker's estimate against unmoved enemies is a range-table
      * lookup with no to-hit roll, so it thinks a walking shooter shoots as well as a standing one. The
      * discount prices the attacker movement modifier back in as a hit-chance ratio at the needing-8s


### PR DESCRIPTION
## Summary

A bot unit ordered somewhere - a flee edge or a player waypoint - was still ranked like it meant to stay and fight. Against a superior enemy the closing pull and exchange terms vetoed every step of the ordered route: the order registered, the unit crept in place. Reported from a community game (dev vs Princess, 2026-08-07): a Clan star told to withdraw north "basically did nothing except move in place for the entire fight" - its logs show 395 MoveToDestination ranking rows and near-zero net displacement.

## Bug Fixed

- **Destination-ordered loitering**: `MoveToDestination` now gets the same exemptions `ForcedWithdrawal` already has. The aggression pull, closing incentive and mutual support go quiet; the destination and self-preservation terms decide the path. The unit also earns no position hold credit and does not anchor a formation - it has somewhere to be. Bravery still applies, so ordered movement routes around fire rather than through it.

## Changes

1. **BasicPathRanker.java** - `MoveToDestination` joins the movement-mission exemption in `rankPath`; `isWithdrawing` covers destination-ordered units (no hold credit, no formation anchoring).
2. **MutualSupportPathRankerTest.java** - pinning test written from the community game's failure case.

## Testing

- Unit tests: all Princess/CASPAR suites and checkstyle green; new pinning test (a destination-ordered unit on a positive-exchange hex earns no hold credit).
- The reporting game's TSVs were the diagnostic source; the fix targets exactly the recorded behavior state.