### PR TITLE
Add nested subunits to command files (parent commands with their regiments)

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/FactionRecord.java
+++ b/megamek/src/megamek/client/ratgenerator/FactionRecord.java
@@ -76,6 +76,7 @@ public class FactionRecord {
     private boolean minor;
     private boolean clan;
     private boolean periphery;
+    private boolean subunit;
     private String name;
     private final TreeMap<Integer, String> altNames;
     private final TreeMap<Integer, String> aliases;
@@ -146,6 +147,7 @@ public class FactionRecord {
         setMinor(faction2.isMinorPower());
         setClan(faction2.isClan());
         setPeriphery(faction2.isPeriphery());
+        setSubunit(faction2.isSubunit());
         setParentFactions(String.join(",", faction2.getFallBackFactions()));
         setRatings(String.join(",", faction2.getRatingLevels()));
         List<String> dateRanges = new ArrayList<>(faction2.getYearsActive().stream().map(DateRange::toString).toList());
@@ -195,6 +197,23 @@ public class FactionRecord {
 
     public void setClan(boolean clan) {
         this.clan = clan;
+    }
+
+    /**
+     * Returns whether this record is a subordinate formation declared inside another command's file, such as an
+     * individual regiment of the St. Ives Lancers, rather than a command in its own right.
+     *
+     * <p>Subunits are fully generatable, but callers that offer a choice of whole commands should leave them out -
+     * otherwise a single faction's sub-faction list grows by every regiment of every command it owns.</p>
+     *
+     * @return {@code true} if this record came from another command's subunit declaration
+     */
+    public boolean isSubunit() {
+        return subunit;
+    }
+
+    public void setSubunit(boolean subunit) {
+        this.subunit = subunit;
     }
 
     public boolean isPeriphery() {

--- a/megamek/src/megamek/client/ui/dialogs/randomArmy/ForceGeneratorOptionsView.java
+++ b/megamek/src/megamek/client/ui/dialogs/randomArmy/ForceGeneratorOptionsView.java
@@ -856,15 +856,18 @@ public class ForceGeneratorOptionsView extends JPanel implements FocusListener, 
         cbSubFaction.removeAllItems();
         String currentFaction = ((FactionRecord) Objects.requireNonNull(cbFaction.getSelectedItem())).getKey();
         if (currentFaction != null) {
+            // Subunits are deliberately left out: this list offers whole commands, so including every regiment of
+            // every command would swell one faction's list by hundreds of entries.
             List<FactionRecord> sorted = RATGenerator.getInstance()
                   .getFactionList()
                   .stream()
-                  .filter(fr -> fr.getKey().startsWith(currentFaction + ".") &&
-                        fr.isActiveInYear(currentYear))
-                  .sorted(Comparator.comparing(fr -> fr.getName(currentYear)))
+                  .filter(factionRecord -> factionRecord.getKey().startsWith(currentFaction + ".") &&
+                        !factionRecord.isSubunit() &&
+                        factionRecord.isActiveInYear(currentYear))
+                  .sorted(Comparator.comparing(factionRecord -> factionRecord.getName(currentYear)))
                   .toList();
             cbSubFaction.addItem(null);
-            sorted.forEach(fr -> cbSubFaction.addItem(fr));
+            sorted.forEach(factionRecord -> cbSubFaction.addItem(factionRecord));
         }
         cbSubFaction.setSelectedItem(oldFaction);
         if (cbSubFaction.getSelectedItem() == null) {

--- a/megamek/src/megamek/common/universe/Faction2.java
+++ b/megamek/src/megamek/common/universe/Faction2.java
@@ -74,7 +74,7 @@ import megamek.common.annotations.Nullable;
                      "tags", "color", "logo", "logoChanges", "background", "backgroundChanges", "camos", "camosChanges", "nameGenerator", "eraMods",
                      "ratingLevels", "fallBackFactions", "preInvasionHonorRating", "postInvasionHonorRating",
                      "formationBaseSize", "formationGrouping", "rankSystem", "factionLeaders", "usesMercenaries",
-                     "aresConventionsSignatory" })
+                     "aresConventionsSignatory", "subunits" })
 public class Faction2 {
     private static final int UNKNOWN = -1;
     private static final String DEFAULT_RANK_SYSTEM_INNER_SPHERE = "SLDF";
@@ -113,9 +113,98 @@ public class Faction2 {
     private List<FactionLeaderData> factionLeaders = new ArrayList<>();
     private final NavigableMap<Integer, Boolean> usesMercenaries = new TreeMap<>();
     private final NavigableMap<Integer, Boolean> aresConventionsSignatory = new TreeMap<>();
+    private final Map<String, Faction2> subunits = new LinkedHashMap<>();
+
+    /**
+     * The key of the faction that declared this one as a subunit, or {@code null} when this faction has a file of its
+     * own. Derived at load time from the file structure rather than read from YAML, so it is never written back out.
+     */
+    @JsonIgnore
+    private String parentCommand;
 
     public List<String> getRatingLevels() {
         return ratingLevels;
+    }
+
+    /**
+     * Returns the subordinate formations declared inside this faction's own file, keyed by the short identifier used
+     * in the YAML file rather than by their full key. A command such as the St. Ives Lancers declares its regiments
+     * here instead of each regiment needing a separate file:
+     *
+     * <pre>
+     * key: CC.SIL
+     * name: St. Ives Lancers
+     * subunits:
+     *   1st:
+     *     name: 1st St. Ives Lancers
+     * </pre>
+     *
+     * <p>Subunits are a file-organisation convenience only. At load time {@link SubunitRegistrar} registers each one
+     * as a full faction in its own right under the composed key {@code CC.SIL.1st}, so everything that consumes
+     * factions - the lobby, RAT generation, MekHQ - sees a flat list and needs no knowledge of the nesting.</p>
+     *
+     * @return The subunits declared in this faction's file, in declaration order. Never {@code null}.
+     */
+    public Map<String, Faction2> getSubunits() {
+        return subunits;
+    }
+
+    /**
+     * Returns the key of the command that declared this faction as one of its {@link #getSubunits() subunits}, if any.
+     *
+     * <p>This is set only for factions that came from inside another faction's file, such as the 1st St. Ives Lancers
+     * declared inside {@code CC.SIL}. A command written in its own file returns {@code null} even when it falls back
+     * to another command, because falling back is not the same as being declared inside it.</p>
+     *
+     * @return The declaring command's key, or {@code null} when this faction has its own file
+     */
+    @JsonIgnore
+    public @Nullable String getParentCommand() {
+        return parentCommand;
+    }
+
+    /**
+     * Returns whether this faction was declared inside another faction's file rather than having a file of its own.
+     *
+     * <p>Useful where only whole commands should be offered rather than their individual regiments - the Force
+     * Generator's sub-faction list, for example, shows the St. Ives Lancers but not their seven regiments.</p>
+     *
+     * @return {@code true} if this faction is a subunit of another
+     */
+    @JsonIgnore
+    public boolean isSubunit() {
+        return parentCommand != null;
+    }
+
+    /**
+     * Records the command that declared this faction as a subunit. Package-private because it is derived from the
+     * file structure at load time by {@link SubunitRegistrar}, never read from YAML.
+     *
+     * @param parentCommand The declaring command's key
+     */
+    void setParentCommand(String parentCommand) {
+        this.parentCommand = parentCommand;
+    }
+
+    /**
+     * Sets this faction's key. Package-private because a key normally comes from the YAML file; it is assigned after
+     * loading only for {@link #getSubunits() subunits}, whose key is composed from their parent's key and their
+     * identifier within it.
+     *
+     * @param key The full faction key, such as {@code CC.SIL.1st}
+     */
+    void setKey(String key) {
+        this.key = key;
+    }
+
+    /**
+     * Sets the personnel name generator. Package-private because it is normally read from the YAML file; it is
+     * assigned after loading only when a subunit inherits its parent's generator.
+     *
+     * @param nameGenerator The name generator to use, such as {@code Clan}
+     */
+    void setNameGenerator(@Nullable String nameGenerator) {
+        this.nameGenerator = nameGenerator;
     }
 
     public String getKey() {

--- a/megamek/src/megamek/common/universe/Factions2.java
+++ b/megamek/src/megamek/common/universe/Factions2.java
@@ -112,6 +112,13 @@ public final class Factions2 {
     /** Maps a retired/aliased faction code to the surviving canonical faction key. See {@link Faction2#getAliases()}. */
     private final Map<String, String> aliasToCanonical = new HashMap<>();
 
+    /**
+     * Flattens subunits declared inside a faction file into {@link #factions}. Held for the lifetime of this instance
+     * rather than created per file, so that it remembers which keys came from a subunit declaration across all the
+     * directories that are loaded.
+     */
+    private final SubunitRegistrar subunitRegistrar = new SubunitRegistrar(factions);
+
     private Factions2() {
         loadFactionsFromFile();
     }
@@ -244,9 +251,21 @@ public final class Factions2 {
         }
     }
 
+    /**
+     * Reads one faction from the given source and registers it, together with any subunits it declares.
+     *
+     * <p>A command may declare its subordinate formations inline rather than in separate files; those are flattened
+     * into this same map by {@link SubunitRegistrar} so that every consumer sees one flat faction list.</p>
+     *
+     * @param source The stream to read the faction YAML from
+     * @param mapper The Jackson ObjectMapper to parse with
+     *
+     * @throws IOException When the source cannot be read or parsed
+     */
     private void loadFaction(InputStream source, ObjectMapper mapper) throws IOException {
         Faction2 faction = mapper.readValue(source, Faction2.class);
         factions.put(faction.getKey(), faction);
+        subunitRegistrar.registerSubunits(faction);
     }
 
     /**

--- a/megamek/src/megamek/common/universe/Factions2.java
+++ b/megamek/src/megamek/common/universe/Factions2.java
@@ -112,11 +112,7 @@ public final class Factions2 {
     /** Maps a retired/aliased faction code to the surviving canonical faction key. See {@link Faction2#getAliases()}. */
     private final Map<String, String> aliasToCanonical = new HashMap<>();
 
-    /**
-     * Flattens subunits declared inside a faction file into {@link #factions}. Held for the lifetime of this instance
-     * rather than created per file, so that it remembers which keys came from a subunit declaration across all the
-     * directories that are loaded.
-     */
+    /** Flattens subunits declared inside a faction file into {@link #factions}. */
     private final SubunitRegistrar subunitRegistrar = new SubunitRegistrar(factions);
 
     private Factions2() {

--- a/megamek/src/megamek/common/universe/SubunitRegistrar.java
+++ b/megamek/src/megamek/common/universe/SubunitRegistrar.java
@@ -32,9 +32,7 @@
  */
 package megamek.common.universe;
 
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import megamek.logging.MMLogger;
 
@@ -80,13 +78,6 @@ public class SubunitRegistrar {
     private final Map<String, Faction2> factions;
 
     /**
-     * The keys this registrar has already filled from a subunit declaration. Faction files loaded later override
-     * earlier ones - that is how a user directory customises the shipped data - so a subunit must be able to replace
-     * an earlier subunit registration while still refusing to overwrite a faction that has a file of its own.
-     */
-    private final Set<String> registeredSubunitKeys = new HashSet<>();
-
-    /**
      * @param factions The flat faction map to register subunits into; typically the map owned by {@link Factions2}
      */
     public SubunitRegistrar(Map<String, Faction2> factions) {
@@ -115,13 +106,18 @@ public class SubunitRegistrar {
             subunit.setParentCommand(parent.getKey());
             inheritFromParent(parent, subunit);
 
-            if (factions.containsKey(subunitKey) && !registeredSubunitKeys.contains(subunitKey)) {
+            // Whether the key may be taken over is decided from the occupant itself: a faction
+            // with a file of its own is never displaced, while an earlier subunit registration
+            // is, which is how a user directory overrides shipped data. Asking the occupant
+            // rather than tracking keys separately keeps the answer correct no matter what order
+            // the files happened to load in.
+            Faction2 existingFaction = factions.get(subunitKey);
+            if ((existingFaction != null) && !existingFaction.isSubunit()) {
                 LOGGER.warn("[Subunit] Subunit key {} of {} collides with a faction that has its own file; " +
                             "keeping that faction.", subunitKey, parent.getKey());
                 continue;
             }
             factions.put(subunitKey, subunit);
-            registeredSubunitKeys.add(subunitKey);
             LOGGER.debug("[Subunit] {} registered as a subunit of {}", subunitKey, parent.getKey());
 
             registerSubunits(subunit);

--- a/megamek/src/megamek/common/universe/SubunitRegistrar.java
+++ b/megamek/src/megamek/common/universe/SubunitRegistrar.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.universe;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import megamek.logging.MMLogger;
+
+/**
+ * Flattens the {@link Faction2#getSubunits() subunits} declared inside a faction file into standalone factions.
+ *
+ * <p>Commands are frequently a parent formation with several subordinate regiments - the St. Ives Lancers and their
+ * 1st through 7th regiments, or the Lyran Guards and their forty-five. Giving every regiment its own file makes the
+ * relationship invisible in the data and multiplies the file count, so a parent may instead declare them inline:</p>
+ *
+ * <pre>
+ * key: CC.SIL
+ * name: St. Ives Lancers
+ * fallBackFactions:
+ *   - CC.SIAC
+ * subunits:
+ *   1st:
+ *     name: 1st St. Ives Lancers
+ *     yearsActive:
+ *       - start: 2300
+ * </pre>
+ *
+ * <p>MegaMek's runtime model is a flat map of factions, because a regiment has to be selectable and generatable in
+ * its own right. This class therefore registers each subunit under the composed key {@code CC.SIL.1st}, so the
+ * nesting is purely a convenience in the file and every consumer continues to see one flat list.</p>
+ *
+ * <p>A subunit inherits from its parent only what it cannot otherwise obtain:</p>
+ * <ul>
+ *     <li>{@code fallBackFactions} defaults to the parent, which is what makes rating levels, formation sizes and the
+ *     rank system resolve up the chain - those already recurse through the fallback factions.</li>
+ *     <li>{@code tags} and {@code nameGenerator} are copied down when the subunit declares none, because
+ *     {@link Faction2#isClan()} and {@link Faction2#getNameGenerator()} read their field directly with no fallback.
+ *     Without this a Clan regiment would be treated as Inner Sphere and get a lance of four rather than a point of
+ *     five.</li>
+ * </ul>
+ *
+ * <p>Anything the subunit declares for itself always wins over the inherited value.</p>
+ */
+public class SubunitRegistrar {
+
+    private static final MMLogger LOGGER = MMLogger.create(SubunitRegistrar.class);
+
+    private final Map<String, Faction2> factions;
+
+    /**
+     * The keys this registrar has already filled from a subunit declaration. Faction files loaded later override
+     * earlier ones - that is how a user directory customises the shipped data - so a subunit must be able to replace
+     * an earlier subunit registration while still refusing to overwrite a faction that has a file of its own.
+     */
+    private final Set<String> registeredSubunitKeys = new HashSet<>();
+
+    /**
+     * @param factions The flat faction map to register subunits into; typically the map owned by {@link Factions2}
+     */
+    public SubunitRegistrar(Map<String, Faction2> factions) {
+        this.factions = factions;
+    }
+
+    /**
+     * Registers every subunit of the given faction, and their subunits in turn, into the faction map.
+     *
+     * <p>Nesting may go as deep as the data requires: a brigade may declare regiments which themselves declare
+     * battalions. Each level composes its key from the level above it.</p>
+     *
+     * @param parent The faction whose subunits should be registered; its own entry must already be in the map
+     */
+    public void registerSubunits(Faction2 parent) {
+        for (Map.Entry<String, Faction2> subunitEntry : parent.getSubunits().entrySet()) {
+            Faction2 subunit = subunitEntry.getValue();
+            if (subunit == null) {
+                LOGGER.warn("[Subunit] {} declares an empty subunit under '{}' - ignoring.",
+                      parent.getKey(), subunitEntry.getKey());
+                continue;
+            }
+
+            String subunitKey = composeSubunitKey(parent, subunitEntry.getKey(), subunit);
+            subunit.setKey(subunitKey);
+            subunit.setParentCommand(parent.getKey());
+            inheritFromParent(parent, subunit);
+
+            if (factions.containsKey(subunitKey) && !registeredSubunitKeys.contains(subunitKey)) {
+                LOGGER.warn("[Subunit] Subunit key {} of {} collides with a faction that has its own file; " +
+                            "keeping that faction.", subunitKey, parent.getKey());
+                continue;
+            }
+            factions.put(subunitKey, subunit);
+            registeredSubunitKeys.add(subunitKey);
+            LOGGER.debug("[Subunit] {} registered as a subunit of {}", subunitKey, parent.getKey());
+
+            registerSubunits(subunit);
+        }
+    }
+
+    /**
+     * Builds the full key for a subunit.
+     *
+     * <p>A subunit normally takes its key from its position in the file, so the {@code 1st} entry of {@code CC.SIL}
+     * becomes {@code CC.SIL.1st}. A subunit that spells out its own key keeps it, which lets imported data preserve
+     * identifiers that do not follow the parent's naming.</p>
+     *
+     * @param parent           The declaring faction
+     * @param subunitIdentifier The subunit's identifier within its parent's file
+     * @param subunit          The subunit itself
+     *
+     * @return The full key to register the subunit under
+     */
+    private String composeSubunitKey(Faction2 parent, String subunitIdentifier, Faction2 subunit) {
+        if ((subunit.getKey() != null) && !subunit.getKey().isBlank()) {
+            return subunit.getKey();
+        }
+        return parent.getKey() + "." + subunitIdentifier;
+    }
+
+    /**
+     * Copies down the values a subunit cannot resolve for itself. Values the subunit declares are left untouched.
+     *
+     * @param parent  The declaring faction
+     * @param subunit The subunit to complete
+     */
+    private void inheritFromParent(Faction2 parent, Faction2 subunit) {
+        if (subunit.getFallBackFactions().isEmpty()) {
+            subunit.getFallBackFactions().add(parent.getKey());
+        }
+        if (subunit.getTags().isEmpty()) {
+            subunit.getTags().addAll(parent.getTags());
+        }
+        if ((subunit.getNameGenerator() == null) || subunit.getNameGenerator().isBlank()) {
+            subunit.setNameGenerator(parent.getNameGenerator());
+        }
+    }
+}

--- a/megamek/testresources/data/universe/factions/SUBUNIT_test.yml
+++ b/megamek/testresources/data/universe/factions/SUBUNIT_test.yml
@@ -1,0 +1,53 @@
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+
+# Test fixture for nested subunits. Exercises key composition, inheritance of tags and the
+# name generator, a subunit overriding what it inherits, an explicit subunit key, and a
+# second level of nesting.
+key: TESTCMD
+name: Test Parent Command
+yearsActive:
+  - start: 2600
+tags:
+  - CLAN
+nameGenerator: Clan
+ratingLevels:
+  - Provisional Garrison
+  - Second Line
+  - Front Line
+fallBackFactions:
+  - CBS
+subunits:
+  1st:
+    name: 1st Test Regiment
+    yearsActive:
+      - start: 2300
+  2nd:
+    name: 2nd Test Regiment
+    tags:
+      - IS
+    nameGenerator: Generic
+    fallBackFactions:
+      - CBS
+  3rd:
+    key: TESTCMD.CustomKey
+    name: 3rd Test Regiment
+  4th:
+    name: 4th Test Regiment
+    subunits:
+      A:
+        name: A Battalion, 4th Test Regiment

--- a/megamek/unittests/megamek/common/universe/SubunitRegistrarTest.java
+++ b/megamek/unittests/megamek/common/universe/SubunitRegistrarTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.universe;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import megamek.client.ratgenerator.FactionRecord;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that subunits declared inside a faction file are registered as standalone factions, inherit only what they
+ * cannot resolve for themselves, and keep whatever they declare.
+ */
+class SubunitRegistrarTest {
+
+    private static final String PARENT_KEY = "TESTCMD";
+
+    private static Factions2 getTestFactions() {
+        return new Factions2("testresources/data/universe/factions");
+    }
+
+    private static Faction2 getRequiredFaction(Factions2 factions, String factionKey) {
+        Optional<Faction2> faction = factions.getFaction(factionKey);
+        assertTrue(faction.isPresent(), "Expected a faction registered under " + factionKey);
+        return faction.get();
+    }
+
+    @Test
+    void subunitIsRegisteredUnderComposedKey() {
+        Factions2 factions = getTestFactions();
+
+        Faction2 firstRegiment = getRequiredFaction(factions, "TESTCMD.1st");
+
+        assertEquals("TESTCMD.1st", firstRegiment.getKey());
+        assertEquals("1st Test Regiment", firstRegiment.getName());
+    }
+
+    @Test
+    void subunitKeepsAnExplicitlyDeclaredKey() {
+        Factions2 factions = getTestFactions();
+
+        Faction2 thirdRegiment = getRequiredFaction(factions, "TESTCMD.CustomKey");
+
+        assertEquals("TESTCMD.CustomKey", thirdRegiment.getKey());
+        assertEquals("3rd Test Regiment", thirdRegiment.getName());
+        assertTrue(factions.getFaction("TESTCMD.3rd").isEmpty(),
+              "A subunit with its own key must not also register under the composed key");
+    }
+
+    @Test
+    void subunitFallsBackToItsParentByDefault() {
+        Factions2 factions = getTestFactions();
+
+        Faction2 firstRegiment = getRequiredFaction(factions, "TESTCMD.1st");
+
+        assertIterableContainsExactly(PARENT_KEY, firstRegiment);
+    }
+
+    @Test
+    void subunitKeepsItsOwnFallBackFactions() {
+        Factions2 factions = getTestFactions();
+
+        Faction2 secondRegiment = getRequiredFaction(factions, "TESTCMD.2nd");
+
+        assertIterableContainsExactly("CBS", secondRegiment);
+    }
+
+    @Test
+    void subunitInheritsTagsAndNameGeneratorWhenItDeclaresNone() {
+        Factions2 factions = getTestFactions();
+
+        Faction2 firstRegiment = getRequiredFaction(factions, "TESTCMD.1st");
+
+        assertTrue(firstRegiment.isClan(),
+              "A regiment of a Clan command must count as Clan, or it gets Inner Sphere formation sizes");
+        assertEquals("Clan", firstRegiment.getNameGenerator());
+    }
+
+    @Test
+    void subunitTagsAndNameGeneratorAreNotOverwrittenWhenDeclared() {
+        Factions2 factions = getTestFactions();
+
+        Faction2 secondRegiment = getRequiredFaction(factions, "TESTCMD.2nd");
+
+        assertFalse(secondRegiment.isClan(), "A subunit's own tags must win over the parent's");
+        assertEquals("Generic", secondRegiment.getNameGenerator());
+    }
+
+    @Test
+    void subunitKeepsItsOwnYearsActive() {
+        Factions2 factions = getTestFactions();
+
+        Faction2 parentCommand = getRequiredFaction(factions, PARENT_KEY);
+        Faction2 firstRegiment = getRequiredFaction(factions, "TESTCMD.1st");
+
+        assertTrue(parentCommand.isActiveInYear(2600));
+        assertFalse(parentCommand.isActiveInYear(2400),
+              "The parent started in 2600 and must not be active before it");
+        assertTrue(firstRegiment.isActiveInYear(2400),
+              "The regiment started in 2300 and is active independently of its parent");
+    }
+
+    @Test
+    void subunitInheritsRatingLevelsThroughTheFallbackChain() {
+        Factions2 factions = getTestFactions();
+
+        Faction2 firstRegiment = getRequiredFaction(factions, "TESTCMD.1st");
+
+        assertTrue(firstRegiment.getRatingLevels().isEmpty(),
+              "The regiment declares no rating levels of its own");
+        assertEquals(5, firstRegiment.getFormationBaseSize(),
+              "A Clan regiment must resolve a point of five through its parent");
+    }
+
+    @Test
+    void nestedSubunitsAreRegisteredAtEveryLevel() {
+        Factions2 factions = getTestFactions();
+
+        Faction2 fourthRegiment = getRequiredFaction(factions, "TESTCMD.4th");
+        Faction2 battalion = getRequiredFaction(factions, "TESTCMD.4th.A");
+
+        assertEquals("A Battalion, 4th Test Regiment", battalion.getName());
+        assertIterableContainsExactly("TESTCMD.4th", battalion);
+        assertNotNull(fourthRegiment.getSubunits().get("A"));
+        assertSame(battalion, fourthRegiment.getSubunits().get("A"),
+              "The registered battalion must be the same object the parent declares");
+    }
+
+    @Test
+    void subunitsAreMarkedAsSuchAndParentsAreNot() {
+        Factions2 factions = getTestFactions();
+
+        Faction2 parentCommand = getRequiredFaction(factions, PARENT_KEY);
+        Faction2 firstRegiment = getRequiredFaction(factions, "TESTCMD.1st");
+        Faction2 battalion = getRequiredFaction(factions, "TESTCMD.4th.A");
+
+        assertFalse(parentCommand.isSubunit(), "A command with its own file is not a subunit");
+        assertNull(parentCommand.getParentCommand());
+
+        assertTrue(firstRegiment.isSubunit());
+        assertEquals(PARENT_KEY, firstRegiment.getParentCommand());
+
+        assertTrue(battalion.isSubunit(), "Nesting below the first level is still a subunit");
+        assertEquals("TESTCMD.4th", battalion.getParentCommand());
+    }
+
+    @Test
+    void aCommandThatMerelyFallsBackToAnotherCommandIsNotASubunit() {
+        Factions2 factions = getTestFactions();
+
+        Faction2 parentCommand = getRequiredFaction(factions, PARENT_KEY);
+
+        assertTrue(parentCommand.getFallBackFactions().contains("CBS"),
+              "The fixture command falls back to another faction");
+        assertFalse(parentCommand.isSubunit(),
+              "Falling back to another faction must not be mistaken for being declared inside it");
+    }
+
+    @Test
+    void parentRetainsItsSubunitDeclarations() {
+        Factions2 factions = getTestFactions();
+
+        Faction2 parentCommand = getRequiredFaction(factions, PARENT_KEY);
+
+        assertEquals(4, parentCommand.getSubunits().size());
+    }
+
+    @Test
+    void factionsWithoutSubunitsAreUnaffected() {
+        Factions2 factions = getTestFactions();
+
+        Faction2 bloodSpirit = getRequiredFaction(factions, "CBS");
+
+        assertTrue(bloodSpirit.getSubunits().isEmpty());
+        assertEquals("Clan Blood Spirit", bloodSpirit.getName());
+        assertFalse(bloodSpirit.getFallBackFactions().contains("CBS"),
+              "A faction without subunits must not gain a fallback to itself");
+    }
+
+    @Test
+    void theSubunitMarkerSurvivesConversionToAFactionRecord() {
+        Factions2 factions = getTestFactions();
+
+        FactionRecord parentRecord = new FactionRecord(getRequiredFaction(factions, PARENT_KEY));
+        FactionRecord regimentRecord = new FactionRecord(getRequiredFaction(factions, "TESTCMD.1st"));
+
+        // The Force Generator's sub-faction list filters on this, so it has to survive the conversion.
+        assertFalse(parentRecord.isSubunit());
+        assertTrue(regimentRecord.isSubunit());
+    }
+
+    @Test
+    void registeringAFactionWithoutSubunitsAddsNothing() {
+        Map<String, Faction2> factions = new HashMap<>();
+        SubunitRegistrar registrar = new SubunitRegistrar(factions);
+
+        Faction2 plainCommand = new Faction2();
+        plainCommand.setKey("PLAIN");
+        factions.put(plainCommand.getKey(), plainCommand);
+
+        registrar.registerSubunits(plainCommand);
+
+        assertEquals(1, factions.size(), "A command with no subunits must not add any entry");
+        assertSame(plainCommand, factions.get("PLAIN"));
+        assertTrue(plainCommand.getFallBackFactions().isEmpty(),
+              "A command with no subunits must be left exactly as loaded");
+        assertTrue(plainCommand.getTags().isEmpty());
+        assertTrue(plainCommand.getSubunits().isEmpty());
+    }
+
+    @Test
+    void aLaterSubunitDeclarationReplacesAnEarlierOne() {
+        Map<String, Faction2> factions = new HashMap<>();
+        SubunitRegistrar registrar = new SubunitRegistrar(factions);
+
+        Faction2 originalSubunit = new Faction2();
+        Faction2 originalParent = buildParentWithSubunit(originalSubunit);
+        factions.put(originalParent.getKey(), originalParent);
+        registrar.registerSubunits(originalParent);
+
+        Faction2 overridingSubunit = new Faction2();
+        Faction2 overridingParent = buildParentWithSubunit(overridingSubunit);
+        factions.put(overridingParent.getKey(), overridingParent);
+        registrar.registerSubunits(overridingParent);
+
+        assertSame(overridingSubunit, factions.get("OVR.1st"),
+              "A faction file loaded later - a user directory copy - must override the earlier subunit too");
+    }
+
+    @Test
+    void aSubunitDoesNotOverwriteAFactionThatHasItsOwnFile() {
+        Map<String, Faction2> factions = new HashMap<>();
+        SubunitRegistrar registrar = new SubunitRegistrar(factions);
+
+        Faction2 standaloneFaction = new Faction2();
+        standaloneFaction.setKey("OVR.1st");
+        factions.put("OVR.1st", standaloneFaction);
+
+        Faction2 parent = buildParentWithSubunit(new Faction2());
+        factions.put(parent.getKey(), parent);
+        registrar.registerSubunits(parent);
+
+        assertSame(standaloneFaction, factions.get("OVR.1st"),
+              "A faction with its own file must not be replaced by a subunit claiming the same key");
+    }
+
+    /**
+     * Builds a parent keyed {@code OVR} declaring the given faction as its {@code 1st} subunit, which the registrar
+     * will therefore register under {@code OVR.1st}.
+     */
+    private static Faction2 buildParentWithSubunit(Faction2 subunit) {
+        Faction2 parent = new Faction2();
+        parent.setKey("OVR");
+        parent.getSubunits().put("1st", subunit);
+        return parent;
+    }
+
+    private static void assertIterableContainsExactly(String expectedFallback, Faction2 faction) {
+        assertEquals(1, faction.getFallBackFactions().size(),
+              "Expected exactly one fallback faction on " + faction.getKey());
+        assertEquals(expectedFallback, faction.getFallBackFactions().iterator().next());
+    }
+}

--- a/megamek/unittests/megamek/common/universe/SubunitRegistrarTest.java
+++ b/megamek/unittests/megamek/common/universe/SubunitRegistrarTest.java
@@ -283,6 +283,32 @@ class SubunitRegistrarTest {
               "A faction with its own file must not be replaced by a subunit claiming the same key");
     }
 
+    @Test
+    void aSubunitDoesNotOverwriteAFactionFileThatLoadedAfterAnEarlierSubunit() {
+        Map<String, Faction2> factions = new HashMap<>();
+        SubunitRegistrar registrar = new SubunitRegistrar(factions);
+
+        // A command declares OVR.1st as a subunit.
+        Faction2 earlierParent = buildParentWithSubunit(new Faction2());
+        factions.put(earlierParent.getKey(), earlierParent);
+        registrar.registerSubunits(earlierParent);
+
+        // A faction with a file of its own then claims the same key. Factions2.loadFaction puts
+        // top-level factions in unconditionally, so this genuinely happens on the wrong file order.
+        Faction2 standaloneFaction = new Faction2();
+        standaloneFaction.setKey("OVR.1st");
+        factions.put("OVR.1st", standaloneFaction);
+
+        // A second command declaring the same subunit key must not displace that faction.
+        Faction2 laterParent = buildParentWithSubunit(new Faction2());
+        factions.put(laterParent.getKey(), laterParent);
+        registrar.registerSubunits(laterParent);
+
+        assertSame(standaloneFaction, factions.get("OVR.1st"),
+              "A faction with its own file must survive a later subunit claiming its key, "
+                    + "whatever order the files loaded in");
+    }
+
     /**
      * Builds a parent keyed {@code OVR} declaring the given faction as its {@code 1st} subunit, which the registrar
      * will therefore register under {@code OVR.1st}.


### PR DESCRIPTION
## Summary

Lets a command declare its subordinate formations inside its own file, so the St. Ives Lancers
and their seven regiments live in one `CC.SIL.yml` instead of eight separate files. Commands
without subunits are completely unaffected.

## Why

A large body of command data is arriving as parent formations with their regiments - the Lyran
Guards have forty-five, the Dieron Regulars forty-six. Giving every regiment its own file makes
the relationship invisible in the data and multiplies the file count by roughly seven. Declaring
them inline keeps the structure obvious to whoever edits the file next.

```yaml
key: CC.SIL
name: St. Ives Lancers
fallBackFactions:
  - CC.SIAC
subunits:
  "1":
    name: 1st St. Ives Lancers
    yearsActive:
      - start: 2300
```

Nesting is a convenience in the file only. MegaMek's runtime model stays a flat map, because a
regiment has to be selectable and generatable in its own right, so each subunit is registered as
a full faction under the composed key `CC.SIL.1`. Everything that consumes factions - the lobby,
RAT generation, MekHQ - sees one flat list and needs no knowledge of the nesting.

## Changes

1. `Faction2` - new `subunits` map, plus `isSubunit()` / `getParentCommand()` so callers can tell
   a regiment from a command. Both are `@JsonIgnore`, being derived from the file structure at
   load time rather than read from YAML, so they are never written back out.
2. `SubunitRegistrar` (new) - composes each subunit's key, applies inheritance, recurses for
   deeper nesting, and logs collisions. Kept out of `Factions2` so it can be unit-tested alone.
3. `Factions2` - holds one registrar for its lifetime and calls it from `loadFaction`.
4. `FactionRecord` - carries the subunit flag through to the RAT generator.
5. `ForceGeneratorOptionsView` - the sub-faction list now offers whole commands only. Without
   this, choosing a faction would list every regiment of every command it owns.

### What a subunit inherits

Only what it cannot resolve for itself. Anything it declares always wins.

- `fallBackFactions` defaults to the parent, which is what makes rating levels, formation sizes
  and the rank system resolve up the chain - those already recurse through the fallback factions.
- `tags` and `nameGenerator` are copied down when the subunit declares none, because
  `isClan()` and `getNameGenerator()` read their field directly with no fallback. Without this a
  Clan regiment would be treated as Inner Sphere and get a lance of four rather than a point of
  five.

A subunit may also spell out its own `key`, which lets imported data keep identifiers that do not
follow the parent's naming.

## Files Changed

- `megamek/src/megamek/common/universe/SubunitRegistrar.java` - new; the flattening logic
- `megamek/src/megamek/common/universe/Faction2.java` - `subunits`, `isSubunit()`,
  `getParentCommand()`, and package-private setters for the registrar
- `megamek/src/megamek/common/universe/Factions2.java` - registers subunits as each file loads
- `megamek/src/megamek/client/ratgenerator/FactionRecord.java` - carries the subunit flag
- `megamek/src/megamek/client/ui/dialogs/randomArmy/ForceGeneratorOptionsView.java` - excludes
  subunits from the sub-faction list
- `megamek/unittests/megamek/common/universe/SubunitRegistrarTest.java` - new; 17 tests
- `megamek/testresources/data/universe/factions/SUBUNIT_test.yml` - new; nested fixture

## Testing

- 17 new unit tests covering key composition, an explicitly declared key, inheritance and its
  precedence, nesting below the first level, the subunit markers, and both collision paths.
- Full `:megamek:test` suite green.
- Loaded a real merged corpus of 1,062 command and faction files through `Factions2`: 2,471
  factions registered, 1,409 of them subunits, with no file rejected. Spot-checked that
  `CC.SIL.1` resolves as "1st St. Ives Lancers" with parent `CC.SIL`, falls back to `CC.SIL`, and
  is active in 2400 from its own start year rather than its parent's.
- Run in a live client.

### Backwards compatibility

No existing file declares `subunits`, and a command without them is untouched: the map defaults
to empty, the registrar iterates nothing, and `saveToFile()` already uses `NON_EMPTY` inclusion,
so existing files round-trip byte-identically. Two tests pin this. Nothing is deprecated and no
public API changed - the additions are purely additive.

A subunit will not displace a faction that has its own file; it logs a warning and steps aside.
It will replace an earlier subunit registration, which is what lets a user-directory file
override shipped data the same way a whole faction file already does.

## What is NOT proven yet

- **No shipped data uses this yet.** The tests run against a fixture and against a locally
  assembled corpus; no file in mm-data declares `subunits` today, so this ships as capability
  ahead of the data that needs it.
- **The inheritance set is a judgement call.** `tags` and `nameGenerator` are copied down because
  they have no fallback path; if other fields turn out to need the same treatment, they are not
  covered here.
- **MekHQ is untouched.** It consumes the flat faction list and should be unaffected, but that is
  reasoning, not a test run against MekHQ.
