### PR TITLE
Fix: MML #2255 SC and JS Maximum Armor Points

### DIFF
--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -100,7 +100,7 @@ public class TestAdvancedAerospace extends TestAero {
      * @return The total number of armor points allowed to the vessel
      */
     public static int maxArmorPoints(Jumpship vessel) {
-        double pointsPerTon = ArmorType.forEntity(vessel).getPointsPerTon();
+        double pointsPerTon = ArmorType.forEntity(vessel).getPointsPerTon(vessel);
         int baseArmor = (int) (pointsPerTon * maxArmorWeight(vessel) + getSIBonusArmorPoints(vessel));
         if (vessel.isPrimitive()) {
             return (int) (baseArmor * 0.66);

--- a/megamek/src/megamek/common/verifier/TestSmallCraft.java
+++ b/megamek/src/megamek/common/verifier/TestSmallCraft.java
@@ -105,7 +105,7 @@ public class TestSmallCraft extends TestAero {
      * @return The total number of armor points allowed to the vessel
      */
     public static int maxArmorPoints(SmallCraft vessel) {
-        double pointsPerTon = ArmorType.forEntity(vessel).getPointsPerTon();
+        double pointsPerTon = ArmorType.forEntity(vessel).getPointsPerTon(vessel);
         int baseArmor = (int) (pointsPerTon * maxArmorWeight(vessel) + getSIBonusArmorPoints(vessel));
         if (vessel.isPrimitive()) {
             return (int) (baseArmor * 0.66);


### PR DESCRIPTION
Fix https://github.com/MegaMek/megameklab/issues/2255

Fix incorrect getPointsPerTon call in TestSmallCraft and TestAdvancedAerospace maxArmorPoints function, which was returning the fixed points per ton for BattleArmor instead of the correct variant points per ton for entities

Note for Reviewer: MERGE BEFORE https://github.com/MegaMek/megameklab/pull/2292