### PR TITLE
Support an optional fourth version component for point releases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,16 @@ subprojects {
     versionProperties.load(rootProject.file("megamek/resources/Version.properties").newDataInputStream())
     def processedVersion = String.format("%d.%02d.%02d", Integer.parseInt(versionProperties.getProperty("major")), Integer.parseInt(versionProperties.getProperty("minor")), Integer.parseInt(versionProperties.getProperty("patch")))
 
+    // Optional fourth component, present only for a special point release such as 0.51.0.1. See the comment in
+    // megamek/resources/Version.properties.
+    def revisionProperty = versionProperties.getProperty("revision")
+    if (revisionProperty != null && !revisionProperty.trim().isEmpty()) {
+        def parsedRevision = Integer.parseInt(revisionProperty.trim())
+        if (parsedRevision > 0) {
+            processedVersion = String.format("%s.%d", processedVersion, parsedRevision)
+        }
+    }
+
     if (project.hasProperty("extraVersion")) {
         processedVersion = String.format("%s-%s", processedVersion, project.getProperty('extraVersion'))
     }

--- a/megamek/resources/Version.properties
+++ b/megamek/resources/Version.properties
@@ -34,3 +34,12 @@
 major=0
 minor=51
 patch=01
+#
+# Optional fourth component, for a special point release that ships on top of an existing patch release
+# (for example 0.49.19.1). Ordinary releases do NOT have one: leave the line below commented out, and
+# comment it out again straight after the point release is tagged.
+#
+# Note that MekHQ and MegaMekLab read THIS file to version their own builds, so setting a revision here
+# versions the whole suite. Only set it on the release branch the point release is cut from.
+#
+#revision=1

--- a/megamek/src/megamek/MMLoggingConstants.java
+++ b/megamek/src/megamek/MMLoggingConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -60,7 +60,7 @@ public final class MMLoggingConstants {
 
     // region Version Constants
     public static final String VERSION_ERROR_CANNOT_PARSE_VERSION_FROM_STRING = "Cannot parse the version from %s. This may lead to severe issues that cannot be otherwise explained.";
-    public static final String VERSION_ILLEGAL_VERSION_FORMAT = "Version text %s is in an illegal version format. Versions should be in the format 'release.major.minor-SNAPSHOT', with the snapshot being an optional inclusion. This may lead to severe issues that cannot be otherwise explained.";
+    public static final String VERSION_ILLEGAL_VERSION_FORMAT = "Version text %s is in an illegal version format. Versions should be in the format 'major.minor.patch[.revision]-SNAPSHOT', with the revision and the snapshot both being optional inclusions. This may lead to severe issues that cannot be otherwise explained.";
     public static final String VERSION_FAILED_TO_PARSE_RELEASE = "Failed to parse the release value from Version text %s. This may lead to severe issues that cannot be otherwise explained.";
     public static final String VERSION_FAILED_TO_PARSE_MAJOR = "Failed to parse the major value from Version text %s. This may lead to severe issues that cannot be otherwise explained.";
     public static final String VERSION_FAILED_TO_PARSE_MINOR = "Failed to parse the minor value from Version text %s. This may lead to severe issues that cannot be otherwise explained.";

--- a/megamek/src/megamek/MMLoggingConstants.java
+++ b/megamek/src/megamek/MMLoggingConstants.java
@@ -60,7 +60,7 @@ public final class MMLoggingConstants {
 
     // region Version Constants
     public static final String VERSION_ERROR_CANNOT_PARSE_VERSION_FROM_STRING = "Cannot parse the version from %s. This may lead to severe issues that cannot be otherwise explained.";
-    public static final String VERSION_ILLEGAL_VERSION_FORMAT = "Version text %s is in an illegal version format. Versions should be in the format 'major.minor.patch[.revision]-SNAPSHOT', with the revision and the snapshot both being optional inclusions. This may lead to severe issues that cannot be otherwise explained.";
+    public static final String VERSION_ILLEGAL_VERSION_FORMAT = "Version text %s is in an illegal version format. Versions should be in the format 'major.minor.patch[.revision][-extra]', where the revision is an optional fourth number used by point releases and the extra is an optional suffix such as a snapshot or nightly build tag. This may lead to severe issues that cannot be otherwise explained.";
     public static final String VERSION_FAILED_TO_PARSE_RELEASE = "Failed to parse the release value from Version text %s. This may lead to severe issues that cannot be otherwise explained.";
     public static final String VERSION_FAILED_TO_PARSE_MAJOR = "Failed to parse the major value from Version text %s. This may lead to severe issues that cannot be otherwise explained.";
     public static final String VERSION_FAILED_TO_PARSE_MINOR = "Failed to parse the minor value from Version text %s. This may lead to severe issues that cannot be otherwise explained.";

--- a/megamek/src/megamek/Version.java
+++ b/megamek/src/megamek/Version.java
@@ -269,10 +269,16 @@ public final class Version implements Comparable<Version>, Serializable {
     }
 
     /**
+     * Sets the optional fourth version component.
+     *
+     * <p>A value at or below {@link #NO_REVISION} is stored as {@link #NO_REVISION}. Without that, a version
+     * built from malformed text such as {@code 0.51.0.-1} would render as though it had no revision while still
+     * comparing as lower than, and unequal to, the release it claims to be.</p>
+     *
      * @param revision the optional fourth version component, or {@link #NO_REVISION} for no revision
      */
     public void setRevision(final int revision) {
-        this.revision = revision;
+        this.revision = Math.max(revision, NO_REVISION);
     }
 
     /**

--- a/megamek/src/megamek/Version.java
+++ b/megamek/src/megamek/Version.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -46,6 +46,14 @@ import megamek.utilities.xml.MMXMLUtility;
 
 /**
  * This is used for versioning, and to track the current Version the suite is running at.
+ *
+ * <p>Versions are written as {@code major.minor.patch[.revision][-extra]}. The revision is an optional fourth
+ * component reserved for special point releases that ship on top of an existing patch release, such as
+ * {@code 0.49.19.1}. Ordinary releases have no revision at all, and both {@link #toString()} and the comparison
+ * methods behave exactly as they did before the component existed.</p>
+ *
+ * <p>Note that {@link #toString()} pads the minor and patch components to two digits, so the release labelled
+ * {@code v0.51.0.1} on GitHub renders here as {@code 0.51.00.1}.</p>
  */
 public final class Version implements Comparable<Version>, Serializable {
     // region Variable Declarations
@@ -56,9 +64,25 @@ public final class Version implements Comparable<Version>, Serializable {
     private static final ResourceBundle VERSION_BUNDLE = ResourceBundle.getBundle("Version");
     private static ResourceBundle EXTRA_VERSION_INFORMATION_BUNDLE = null;
 
+    /**
+     * The value {@link #getRevision()} reports when a version carries no fourth component, which is the case for
+     * every ordinary release.
+     *
+     * <p>Zero is deliberately used as the "absent" marker rather than a negative sentinel: a {@code Version}
+     * restored from an older save game or from an older client's network packet has no stored revision, and Java
+     * deserialization leaves such a field at zero. Treating zero as absent therefore keeps those versions reading
+     * exactly as they were written. It also means a hand-written {@code 0.51.0.0} is understood as plain
+     * {@code 0.51.0}, which is the same thing.</p>
+     */
+    public static final int NO_REVISION = 0;
+
+    /** Key of the optional revision entry in {@code Version.properties}. Absent for ordinary releases. */
+    private static final String REVISION_BUNDLE_KEY = "revision";
+
     private int major;
     private int minor;
     private int patch;
+    private int revision;
     private String extra;
     // endregion Variable Declarations
 
@@ -71,6 +95,7 @@ public final class Version implements Comparable<Version>, Serializable {
         setMajor(MathUtility.parseInt(VERSION_BUNDLE.getString("major")));
         setMinor(MathUtility.parseInt(VERSION_BUNDLE.getString("minor")));
         setPatch(MathUtility.parseInt(VERSION_BUNDLE.getString("patch")));
+        setRevision(readOptionalRevisionFromBundle());
 
         try {
             EXTRA_VERSION_INFORMATION_BUNDLE = ResourceBundle.getBundle("extraVersion");
@@ -95,7 +120,11 @@ public final class Version implements Comparable<Version>, Serializable {
         final String[] extraSplit = text.split("-", 2);
         final String[] versionSplit = extraSplit[0].split("\\.");
 
-        if ((extraSplit.length > 2) || (versionSplit.length < 3)) {
+        // Three components is the ordinary case; a fourth is the optional revision of a point release. Anything
+        // else is rejected rather than truncated, so a malformed version cannot silently become a valid one.
+        final boolean hasTooFewComponents = versionSplit.length < 3;
+        final boolean hasTooManyComponents = versionSplit.length > 4;
+        if (hasTooFewComponents || hasTooManyComponents) {
             final String message = String.format(MMLoggingConstants.VERSION_ILLEGAL_VERSION_FORMAT, text);
             LOGGER.fatalDialog(message, MMLoggingConstants.VERSION_PARSE_FAILURE);
             return;
@@ -104,11 +133,12 @@ public final class Version implements Comparable<Version>, Serializable {
         setMajor(MathUtility.parseInt(versionSplit[0]));
         setMinor(MathUtility.parseInt(versionSplit[1]));
         setPatch(MathUtility.parseInt(versionSplit[2]));
+        setRevision((versionSplit.length == 4) ? MathUtility.parseInt(versionSplit[3], NO_REVISION) : NO_REVISION);
         setExtra(extraSplit.length == 2 ? extraSplit[1] : null);
     }
 
     /**
-     * Sets the version.
+     * Sets the version. The resulting version has no revision component.
      *
      * @param major Major Version
      * @param minor Minor Version
@@ -119,10 +149,14 @@ public final class Version implements Comparable<Version>, Serializable {
         setMajor(major);
         setMinor(minor);
         setPatch(patch);
+        // The no-argument constructor above seeds the revision from Version.properties, which describes the
+        // running build rather than the version being constructed here. Clear it so that, on a point release,
+        // an explicitly built version is not silently promoted to that release's revision.
+        setRevision(NO_REVISION);
     }
 
     /**
-     * Sets the version.
+     * Sets the version. The resulting version has no revision component.
      *
      * @param major Major Version
      * @param minor Minor Version
@@ -133,10 +167,12 @@ public final class Version implements Comparable<Version>, Serializable {
         setMajor(MathUtility.parseInt(major, 0));
         setMinor(MathUtility.parseInt(minor, 50));
         setPatch(MathUtility.parseInt(patch, 5));
+        // See the note in the (int, int, int) constructor above.
+        setRevision(NO_REVISION);
     }
 
     /**
-     * Sets the version with Extra data.
+     * Sets the version with Extra data. The resulting version has no revision component.
      *
      * @param major Major Version
      * @param minor Minor Version
@@ -147,7 +183,57 @@ public final class Version implements Comparable<Version>, Serializable {
         this(major, minor, patch);
         setExtra(extra);
     }
+
+    /**
+     * Sets the version with an optional revision and Extra data.
+     *
+     * <p>This is the form used when rebuilding a version that was written to a file, where the revision is simply
+     * absent for anything produced by an ordinary release.</p>
+     *
+     * @param major    Major Version
+     * @param minor    Minor Version
+     * @param patch    Patch Version
+     * @param revision Optional fourth component of a point release, or {@code null} when there is none
+     * @param extra    Extra would be PR or nightly with git hash.
+     */
+    public Version(final String major, final String minor, final String patch, @Nullable final String revision,
+          @Nullable final String extra) {
+        this(major, minor, patch, extra);
+        setRevision((revision == null) ? NO_REVISION : MathUtility.parseInt(revision, NO_REVISION));
+    }
     // endregion Constructors
+
+    /**
+     * Reads the optional {@code revision} entry from {@code Version.properties}.
+     *
+     * <p>The key is absent for ordinary releases and is only added for a special point release such as
+     * {@code 0.49.19.1}, so a missing key is the expected case and is not reported as a problem.</p>
+     *
+     * @return the configured revision, or {@link #NO_REVISION} when the key is absent, blank or not a number
+     */
+    private static int readOptionalRevisionFromBundle() {
+        if (!VERSION_BUNDLE.containsKey(REVISION_BUNDLE_KEY)) {
+            return NO_REVISION;
+        }
+
+        final String configuredRevision = VERSION_BUNDLE.getString(REVISION_BUNDLE_KEY).trim();
+        if (configuredRevision.isEmpty()) {
+            return NO_REVISION;
+        }
+
+        final int parsedRevision = MathUtility.parseInt(configuredRevision, NO_REVISION);
+        if (parsedRevision <= NO_REVISION) {
+            LOGGER.warn(
+                  "[Version] Version.properties sets revision to '{}', which is not a positive number. "
+                        + "The build will be versioned without a fourth component. Remove the entry for an "
+                        + "ordinary release, or set it to a positive number for a point release.",
+                  configuredRevision);
+            return NO_REVISION;
+        }
+
+        LOGGER.debug("[Version] Optional revision component {} loaded from Version.properties", parsedRevision);
+        return parsedRevision;
+    }
 
     // region Getters
     public int getMajor() {
@@ -172,6 +258,29 @@ public final class Version implements Comparable<Version>, Serializable {
 
     public void setPatch(final int patch) {
         this.patch = patch;
+    }
+
+    /**
+     * @return the optional fourth version component, or {@link #NO_REVISION} when this version has none, which is
+     *       the case for every ordinary release
+     */
+    public int getRevision() {
+        return revision;
+    }
+
+    /**
+     * @param revision the optional fourth version component, or {@link #NO_REVISION} for no revision
+     */
+    public void setRevision(final int revision) {
+        this.revision = revision;
+    }
+
+    /**
+     * @return {@code true} if this version carries a fourth component, as a point release such as
+     *       {@code 0.49.19.1} does, otherwise {@code false}
+     */
+    public boolean hasRevision() {
+        return revision > NO_REVISION;
     }
 
     public String getExtra() {
@@ -256,24 +365,32 @@ public final class Version implements Comparable<Version>, Serializable {
 
     @Override
     public int compareTo(final Version other) {
-        // Check Release version
+        // Check the major version
         if (getMajor() > other.getMajor()) {
             return 1;
         } else if (getMajor() < other.getMajor()) {
             return -1;
         }
 
-        // Release version is equal, try with Major
+        // Major version is equal, try the minor version
         if (getMinor() > other.getMinor()) {
             return 1;
         } else if (getMinor() < other.getMinor()) {
             return -1;
         }
 
-        // Major version is also equal, try Minor
+        // Minor version is also equal, try the patch version
         if (getPatch() > other.getPatch()) {
             return 1;
         } else if (getPatch() < other.getPatch()) {
+            return -1;
+        }
+
+        // Patch version is also equal, try the optional revision. A version without one sorts below the point
+        // releases built on top of it, so 0.51.0 is lower than 0.51.0.1.
+        if (getRevision() > other.getRevision()) {
+            return 1;
+        } else if (getRevision() < other.getRevision()) {
             return -1;
         }
 
@@ -289,6 +406,7 @@ public final class Version implements Comparable<Version>, Serializable {
             return (getMajor() == other.getMajor() &&
                   getMinor() == other.getMinor() &&
                   getPatch() == other.getPatch() &&
+                  getRevision() == other.getRevision() &&
                   getExtra().equals(other.getExtra()));
         }
 
@@ -308,10 +426,11 @@ public final class Version implements Comparable<Version>, Serializable {
 
     @Override
     public String toString() {
-        return String.format("%d.%02d.%02d%s",
+        return String.format("%d.%02d.%02d%s%s",
               getMajor(),
               getMinor(),
               getPatch(),
+              (hasRevision() ? "." + getRevision() : ""),
               (!getExtra().isEmpty() ? "-" + getExtra() : ""));
     }
 }

--- a/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
@@ -856,38 +856,51 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         }
     }
 
-    private static Version getVersion(Node n) {
-        final NodeList nl = n.getChildNodes();
+    /**
+     * Rebuilds the {@link Version} a save game was written by, from the components stored in its version node.
+     *
+     * @param versionNode the save game's version node
+     *
+     * @return the version the save game was written by
+     */
+    private static Version getVersion(Node versionNode) {
+        final NodeList versionChildren = versionNode.getChildNodes();
         String major = null;
         String minor = null;
         String patch = null;
+        String revision = null;
         String extra = null;
-        for (int i = 0; i < nl.getLength(); i++) {
-            final Node n2 = nl.item(i);
-            if (n2.getNodeType() != Node.ELEMENT_NODE) {
+        for (int childIndex = 0; childIndex < versionChildren.getLength(); childIndex++) {
+            final Node versionComponent = versionChildren.item(childIndex);
+            if (versionComponent.getNodeType() != Node.ELEMENT_NODE) {
                 continue;
             }
 
-            switch (n2.getNodeName()) {
+            switch (versionComponent.getNodeName()) {
                 case "major":
-                    major = n2.getTextContent();
+                    major = versionComponent.getTextContent();
                     break;
                 case "minor":
-                    minor = n2.getTextContent();
+                    minor = versionComponent.getTextContent();
                     break;
                 case "patch":
-                    patch = n2.getTextContent();
+                    patch = versionComponent.getTextContent();
+                    break;
+                // Absent from saves written by an ordinary release, and by every release before the revision
+                // component existed.
+                case "revision":
+                    revision = versionComponent.getTextContent();
                     break;
                 case "snapshot":
                 case "extra":
-                    extra = n2.getTextContent();
+                    extra = versionComponent.getTextContent();
                     break;
                 default:
                     break;
             }
         }
 
-        return new Version(major, minor, patch, extra);
+        return new Version(major, minor, patch, revision, extra);
     }
 
     private void parsePlayerNames(final Node nodePlayers, final Vector<String> playerNames) {

--- a/megamek/unittests/megamek/VersionTest.java
+++ b/megamek/unittests/megamek/VersionTest.java
@@ -214,6 +214,25 @@ class VersionTest {
         assertNotEquals(versionWithoutExtra("0.51.0.1"), versionWithoutExtra("0.51.0"));
     }
 
+    @Test
+    void negativeRevisionFromMalformedTextIsNormalisedToNoRevision() {
+        // Without normalising, such a version would render as "0.51.00" while still sorting below, and being
+        // unequal to, the 0.51.0 it renders as.
+        Version malformedRevision = versionWithoutExtra("0.51.0.-1");
+        assertFalse(malformedRevision.hasRevision());
+        assertEquals(Version.NO_REVISION, malformedRevision.getRevision());
+        assertEquals("0.51.00", malformedRevision.toString());
+        assertEquals(versionWithoutExtra("0.51.0"), malformedRevision);
+    }
+
+    @Test
+    void negativeRevisionSetDirectlyIsNormalisedToNoRevision() {
+        Version ordinaryVersion = versionWithoutExtra("0.51.0");
+        ordinaryVersion.setRevision(-1);
+        assertFalse(ordinaryVersion.hasRevision());
+        assertEquals(Version.NO_REVISION, ordinaryVersion.getRevision());
+    }
+
     /**
      * Builds a version from its text form with the extra component explicitly cleared.
      *

--- a/megamek/unittests/megamek/VersionTest.java
+++ b/megamek/unittests/megamek/VersionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2021-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -35,6 +35,7 @@ package megamek;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.AfterEach;
@@ -126,5 +127,107 @@ class VersionTest {
     @Test
     void testToString() {
         assertEquals("1.50.05-test", version.toString());
+    }
+
+    @Test
+    void ordinaryVersionHasNoRevision() {
+        Version ordinaryVersion = versionWithoutExtra("0.51.0");
+        assertFalse(ordinaryVersion.hasRevision());
+        assertEquals(Version.NO_REVISION, ordinaryVersion.getRevision());
+    }
+
+    @Test
+    void ordinaryVersionRendersWithoutRevision() {
+        assertEquals("0.51.00", versionWithoutExtra("0.51.0").toString());
+    }
+
+    @Test
+    void pointReleaseParsesRevision() {
+        Version pointRelease = versionWithoutExtra("0.51.0.1");
+        assertTrue(pointRelease.hasRevision());
+        assertEquals(0, pointRelease.getMajor());
+        assertEquals(51, pointRelease.getMinor());
+        assertEquals(0, pointRelease.getPatch());
+        assertEquals(1, pointRelease.getRevision());
+    }
+
+    @Test
+    void pointReleaseRendersRevision() {
+        assertEquals("0.51.00.1", versionWithoutExtra("0.51.0.1").toString());
+    }
+
+    @Test
+    void pointReleaseKeepsRevisionAlongsideExtra() {
+        Version nightlyPointRelease = new Version("0.51.0.1-nightly");
+        assertEquals(1, nightlyPointRelease.getRevision());
+        assertEquals("nightly", nightlyPointRelease.getExtra());
+        assertEquals("0.51.00.1-nightly", nightlyPointRelease.toString());
+    }
+
+    @Test
+    void pointReleaseIsHigherThanTheReleaseItBuildsOn() {
+        assertTrue(new Version("0.51.0.1").isHigherThan(new Version("0.51.0")));
+        assertTrue(new Version("0.51.0").isLowerThan(new Version("0.51.0.1")));
+    }
+
+    @Test
+    void laterRevisionIsHigherThanEarlierRevision() {
+        assertTrue(new Version("0.51.0.2").isHigherThan(new Version("0.51.0.1")));
+    }
+
+    @Test
+    void revisionDoesNotOutrankTheNextPatchRelease() {
+        assertTrue(new Version("0.51.1").isHigherThan(new Version("0.51.0.9")));
+    }
+
+    @Test
+    void pointReleaseIsNotTheSameVersionAsTheReleaseItBuildsOn() {
+        assertFalse(versionWithoutExtra("0.51.0.1").is(versionWithoutExtra("0.51.0")));
+    }
+
+    @Test
+    void zeroRevisionIsTreatedAsNoRevision() {
+        // A save game or network packet written before the revision component existed restores the field as zero,
+        // so zero has to mean "no revision" for those to keep reading as the versions they were written by.
+        Version explicitZeroRevision = versionWithoutExtra("0.51.0.0");
+        assertFalse(explicitZeroRevision.hasRevision());
+        assertEquals("0.51.00", explicitZeroRevision.toString());
+        assertTrue(explicitZeroRevision.is(versionWithoutExtra("0.51.0")));
+    }
+
+    @Test
+    void revisionIsReadBackFromTheSavedComponents() {
+        Version savedPointRelease = new Version("0", "51", "0", "1", "");
+        assertEquals(1, savedPointRelease.getRevision());
+        assertEquals("0.51.00.1", savedPointRelease.toString());
+    }
+
+    @Test
+    void absentSavedRevisionYieldsNoRevision() {
+        Version savedOrdinaryRelease = new Version("0", "51", "0", null, "");
+        assertFalse(savedOrdinaryRelease.hasRevision());
+        assertEquals("0.51.00", savedOrdinaryRelease.toString());
+    }
+
+    @Test
+    void pointReleaseIsNotEqualToTheReleaseItBuildsOn() {
+        assertNotEquals(versionWithoutExtra("0.51.0.1"), versionWithoutExtra("0.51.0"));
+    }
+
+    /**
+     * Builds a version from its text form with the extra component explicitly cleared.
+     *
+     * <p>{@link Version#getExtra()} falls back to the running build's branch and git hash whenever the component
+     * is {@code null}, and continuous integration builds do populate that. Clearing it keeps the assertions above
+     * about the version number alone, whatever the build they run in.</p>
+     *
+     * @param text the version text to parse
+     *
+     * @return the parsed version, with no extra component
+     */
+    private static Version versionWithoutExtra(final String text) {
+        Version parsedVersion = new Version(text);
+        parsedVersion.setExtra("");
+        return parsedVersion;
     }
 }


### PR DESCRIPTION
## What this changes for you

Right now MegaMek cannot be given a version number like **0.51.0.1**. If you try, it quietly becomes 0.51.0 — the build would report itself as the release it was built on, name its tarball after that release, and happily swap save games with it.

Concretely: type `0.51.0.1` into the version and the parser splits it on the dots, reads the first three numbers, and drops the `.1` on the floor. There is no error and nothing in the log. `Version.java:96-107` checked only that there were *at least* three pieces, and `toString()` had no slot to print a fourth one.

This adds an optional fourth component so a special point release can have its own number. It is one line in `megamek/resources/Version.properties`:

```properties
major=0
minor=51
patch=01
#revision=1     <- uncomment for a point release, re-comment straight after
```

**Most releases will not have one, and that case is the one to care about.** With the line commented out, nothing changes at all — I built and ran it both ways and the version string is identical to before.

| | revision absent | `revision=1` |
|---|---|---|
| In-app / save games | `0.51.01` | `0.51.01.1` |
| Artifact | `MegaMek-0.51.01.tar.gz` | `MegaMek-0.51.01.1.tar.gz` |

Note the existing two-digit padding on the patch number is untouched, so a release tagged **`v0.51.0.1`** on GitHub reports itself in-game as **`0.51.00.1`**. That is the same label-vs-string gap we already have — today's `v0.51.0` reports itself as `0.51.00`.

A point release now counts as a genuinely different version: a 0.51.0.1 client gets the normal "illegal client version" dialog against a 0.51.0 server, and refuses 0.51.0 save games.

## Three decisions worth a reviewer's attention

**Zero means "no revision", not -1.** The 0.49.19.1-era code used -1 as the "absent" marker. I used zero deliberately. A `Version` restored from an older save game, or from an older client's network packet, has no stored revision, and Java deserialization leaves the new field at zero. Making zero mean "absent" is what lets those versions keep reading as exactly the versions they were written by, with no migration and no converter.

**The three-argument constructors had to be plugged.** They delegate to the no-argument constructor, which seeds itself from `Version.properties`. Left alone, on a 0.51.0.1 build *every* version parsed out of a save file would have inherited revision 1 from the running build — so a 0.51.0 save would have looked like a 0.51.0.1 save and loaded when it should not have. They now clear it explicitly.

**Over-long versions are now rejected instead of truncated.** Three or four components are accepted; anything else raises the existing parse-failure dialog rather than silently becoming a valid version. While in that guard I removed a dead clause — `text.split("-", 2)` can never return more than two pieces, so `extraSplit.length > 2` could never fire.

## Changes

1. `Version.java` — optional `revision` component: parsing, rendering, `compareTo`, `equals`, and a constructor for rebuilding a version from stored components. Fixed three stale comments in `compareTo` that still named the old release/major/minor fields.
2. `MegaMekGUI.java` — the save-game version reader learns the new element, so a point release recognises its own saves. Gave the method a JavaDoc and replaced its `n`/`nl`/`n2` locals with descriptive names while I was in it.
3. `MMLoggingConstants.java` — the malformed-version message documented a format that no longer matched the parser.
4. `Version.properties` — the commented-out key, plus a note that MekHQ and MegaMekLab read this same file.
5. `build.gradle` — appends the fourth component to the artifact version.

## Files Changed

- `megamek/src/megamek/Version.java` - the optional revision component
- `megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java` - save-game version reader
- `megamek/src/megamek/MMLoggingConstants.java` - corrected format message
- `megamek/resources/Version.properties` - the optional key and release-process notes
- `build.gradle` - artifact version
- `megamek/unittests/megamek/VersionTest.java` - 12 new tests

## Testing

Full `:megamek:test` suite green including checkstyle. `VersionTest` is 26 tests, 0 failures — 12 new ones covering parse, render, ordering, equality, the absent case, the zero-means-absent rule, and rebuilding from stored components.

Beyond unit tests, I set `revision=1` and ran the real application: it reported `MegaMek v0.51.01.1`. Reverted it and it reported `MegaMek v0.51.01`, byte-for-byte as before. `megamek.log` was clean, no ERROR or FATAL lines. Also confirmed MekHQ and MegaMekLab compile against this with a four-part version set.

## What is NOT proven yet

- **No game was played and no save game was round-tripped.** The version string generation is exercised in the real application, but the save-game refusal and the client/server handshake are reasoned from the code, not observed. Nobody has yet built a 0.51.0.1, saved from it, and tried to load that save in 0.51.0.
- **A 0.51.0 client handed a 0.51.0.1 save fails ugly.** `SerializationHelper` rejects unknown XML elements (see the comment at line 116). Saves now carry a `<revision>` element that today's released 0.51.0 has never seen, and 0.51.0 cannot see the fourth component to reject the save cleanly first — so it gets an XStream unknown-element error rather than a "wrong version" dialog. It does refuse, which is the safe direction, but it refuses badly. Nothing in this PR can fix that, since it needs a change in a build that already shipped. Worth a line in the release notes.
- **This file versions the whole suite.** MekHQ and MegaMekLab read this same `Version.properties`, so setting a revision here versions all three. For a MegaMek-only release, set it on the release branch, not on main.

## Companion PRs

- MekHQ: MegaMek/mekhq — same branch name
- MegaMekLab: MegaMek/megameklab — same branch name

Both are ten-line build-script changes so their artifact versions stay in lockstep. Neither needs a Java change.
