### PR TITLE
fix: disallow loading of superheavy meks into standard mekbays (MM-8686)

### DIFF
--- a/megamek/src/megamek/common/bays/MekBay.java
+++ b/megamek/src/megamek/common/bays/MekBay.java
@@ -41,10 +41,12 @@ import megamek.common.TechAdvancement;
 import megamek.common.enums.AvailabilityValue;
 import megamek.common.enums.TechBase;
 import megamek.common.enums.TechRating;
+import megamek.common.units.EntityWeightClass;
 import megamek.common.units.Entity;
 import megamek.common.units.LandAirMek;
 import megamek.common.units.Mek;
 import megamek.common.units.QuadVee;
+
 
 /**
  * Represents a Transport Bay (TM p.239) for carrying Meks or LAMs aboard large spacecraft other units.
@@ -74,7 +76,7 @@ public final class MekBay extends UnitBay {
         boolean loadableLAM = (unit instanceof LandAirMek) && (unit.getConversionMode()
               == LandAirMek.CONV_MODE_MEK);
         boolean loadableOtherMek = (unit instanceof Mek) && !(unit instanceof QuadVee) && !(unit instanceof LandAirMek);
-        return (getUnused() >= 1) && (doors > loadedThisTurn) && (loadableLAM || loadableQuadVee || loadableOtherMek);
+        return (getUnused() >= 1) && (doors > loadedThisTurn) && !unit.isSuperHeavy() && (loadableLAM || loadableQuadVee || loadableOtherMek);
     }
 
     @Override


### PR DESCRIPTION
What it says in the description.