### PR TITLE
Skip inaccessible user directory paths

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialog.java
@@ -4065,7 +4065,7 @@ public class CommonSettingsDialog extends AbstractButtonDialog
             try {
                   Files.walkFileTree(path.toPath(), filteredFileVisitor(fileEnding, result));
         } catch (IOException e) {
-            logger.warn("Error while reading {} files from {}", fileEnding, path);
+                  logger.warn(e, "Error while reading {} files from {}", fileEnding, path);
         }
             return result;
       }
@@ -4082,14 +4082,16 @@ public class CommonSettingsDialog extends AbstractButtonDialog
 
                   @Override
                   public FileVisitResult visitFileFailed(Path file, IOException exception) {
-                        logger.warn("Unable to access {} while searching for {} files; skipping it.", file, fileEnding);
+                        logger.warn(exception, "Unable to access {} while searching for {} files; skipping it.", file,
+                                fileEnding);
                         return FileVisitResult.CONTINUE;
                   }
 
                   @Override
                   public FileVisitResult postVisitDirectory(Path directory, IOException exception) {
                         if (exception != null) {
-                              logger.warn("Unable to finish reading {} while searching for {} files; skipping it.", directory,
+                              logger.warn(exception,
+                                      "Unable to finish reading {} while searching for {} files; skipping it.", directory,
                                       fileEnding);
                         }
                         return FileVisitResult.CONTINUE;

--- a/megamek/src/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialog.java
@@ -33,8 +33,6 @@
  */
 package megamek.client.ui.dialogs.buttonDialogs;
 
-import static java.util.stream.Collectors.toList;
-
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Container;
@@ -49,10 +47,12 @@ import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
-import java.util.stream.Stream;
 import javax.swing.*;
 import javax.swing.UIManager.LookAndFeelInfo;
 import javax.swing.border.EmptyBorder;
@@ -4061,13 +4061,41 @@ public class CommonSettingsDialog extends AbstractButtonDialog
             logger.warn("Path {} does not exist.", path);
             return new ArrayList<>();
         }
-        try (Stream<Path> entries = Files.walk(path.toPath())) {
-            return entries.map(Objects::toString).filter(name -> name.endsWith(fileEnding)).collect(toList());
+            List<String> result = new ArrayList<>();
+            try {
+                  Files.walkFileTree(path.toPath(), filteredFileVisitor(fileEnding, result));
         } catch (IOException e) {
             logger.warn("Error while reading {} files from {}", fileEnding, path);
-            return new ArrayList<>();
         }
-    }
+            return result;
+      }
+
+      static SimpleFileVisitor<Path> filteredFileVisitor(String fileEnding, List<String> result) {
+            return new SimpleFileVisitor<>() {
+                  @Override
+                  public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) {
+                        if (file.toString().endsWith(fileEnding)) {
+                              result.add(file.toString());
+                        }
+                        return FileVisitResult.CONTINUE;
+                  }
+
+                  @Override
+                  public FileVisitResult visitFileFailed(Path file, IOException exception) {
+                        logger.warn("Unable to access {} while searching for {} files; skipping it.", file, fileEnding);
+                        return FileVisitResult.CONTINUE;
+                  }
+
+                  @Override
+                  public FileVisitResult postVisitDirectory(Path directory, IOException exception) {
+                        if (exception != null) {
+                              logger.warn("Unable to finish reading {} while searching for {} files; skipping it.", directory,
+                                      fileEnding);
+                        }
+                        return FileVisitResult.CONTINUE;
+                  }
+            };
+      }
 
     /**
      * Shows a file chooser for selecting a user directory and sets the given text field to the result if one was

--- a/megamek/unittests/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialogFileSearchTest.java
+++ b/megamek/unittests/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialogFileSearchTest.java
@@ -23,7 +23,7 @@
  * of The Topps Company, Inc. All Rights Reserved.
  *
  * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
- * InMediaRes Productions LLC.
+ * InMediaRes Productions, LLC.
  *
  * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
  * Microsoft's "Game Content Usage Rules"

--- a/megamek/unittests/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialogFileSearchTest.java
+++ b/megamek/unittests/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialogFileSearchTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.ui.dialogs.buttonDialogs;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CommonSettingsDialogFileSearchTest {
+    @TempDir
+    private Path tempDirectory;
+
+    @Test
+    void recursiveSearchReturnsMatchingFiles() throws IOException {
+        Path nestedDirectory = Files.createDirectories(tempDirectory.resolve("nested"));
+        Path rootMatch = Files.createFile(tempDirectory.resolve("root.xml"));
+        Path nestedMatch = Files.createFile(nestedDirectory.resolve("nested.xml"));
+        Files.createFile(nestedDirectory.resolve("ignored.txt"));
+
+        List<String> matches = CommonSettingsDialog.filteredFilesWithSubDirs(tempDirectory.toFile(), ".xml");
+
+        assertEquals(Set.of(rootMatch.toString(), nestedMatch.toString()), Set.copyOf(matches));
+    }
+
+    @Test
+    void recursiveSearchContinuesAfterAccessFailure() throws IOException {
+        List<String> matches = new ArrayList<>();
+        SimpleFileVisitor<Path> visitor = CommonSettingsDialog.filteredFileVisitor(".ttf", matches);
+        Path protectedDirectory = tempDirectory.resolve("protected");
+        AccessDeniedException accessDenied = new AccessDeniedException(protectedDirectory.toString());
+        Path readableFont = Files.createFile(tempDirectory.resolve("readable.ttf"));
+        BasicFileAttributes attributes = Files.readAttributes(readableFont, BasicFileAttributes.class);
+
+        assertEquals(FileVisitResult.CONTINUE, visitor.visitFileFailed(protectedDirectory, accessDenied));
+        assertEquals(FileVisitResult.CONTINUE, visitor.visitFile(readableFont, attributes));
+
+        assertEquals(List.of(readableFont.toString()), matches);
+    }
+}


### PR DESCRIPTION
## Summary

- replace lazy recursive file streaming with a file visitor that handles access failures during traversal
- log and skip protected files or directories while continuing to load readable custom fonts, scenarios, and skins
- add focused coverage for recursive filtering and continuing after an access-denied entry

## Verification

- `:megamek:test --tests "megamek.client.ui.dialogs.buttonDialogs.CommonSettingsDialogFileSearchTest"`
- `:megamek:checkstyleMain :megamek:checkstyleTest`
- live MekHQ startup with `UserDir=C:\Windows`; protected paths including `appcompat\AIDD` were logged and skipped, and startup continued without `UncheckedIOException`

Closes #8695

Companion to MegaMek/mekhq#9765, which closes MegaMek/mekhq#9745. The startup crash was discovered during that issue's manual verification.