### PR TITLE
Fix: MML # 2288 Missing IndMek UMU and Deprecate MekJumpJets.java

### DIFF
--- a/megamek/src/megamek/common/equipment/MiscType.java
+++ b/megamek/src/megamek/common/equipment/MiscType.java
@@ -1844,7 +1844,6 @@ public class MiscType extends EquipmentType {
     // Advanced Mek/ProtoMek/Vehicular Motive Systems
     public static MiscType createJumpJet() {
         MiscType misc = new MiscType();
-
         misc.name = "Jump Jet";
         misc.setInternalName(EquipmentTypeLookup.JUMP_JET);
         misc.addLookupName("JumpJet");
@@ -1853,6 +1852,7 @@ public class MiscType extends EquipmentType {
         misc.tankSlots = 0;
         misc.flags = misc.flags.or(F_JUMP_JET, F_MEK_EQUIPMENT, MiscTypeFlag.S_STANDARD);
         misc.bv = 0;
+        misc.industrial = true;
         misc.rulesRefs = "225, TM";
         misc.techAdvancement.setTechBase(TechBase.ALL)
               .setISAdvancement(2464, 2471, 2500, DATE_NONE, DATE_NONE)
@@ -1869,7 +1869,6 @@ public class MiscType extends EquipmentType {
 
     public static MiscType createImprovedJumpJet() {
         MiscType misc = new MiscType();
-
         misc.name = "Improved Jump Jet";
         misc.setInternalName(EquipmentTypeLookup.IMPROVED_JUMP_JET);
         misc.addLookupName("IS Improved Jump Jet");
@@ -1897,10 +1896,9 @@ public class MiscType extends EquipmentType {
 
     public static MiscType createISPrototypeImprovedJumpJet() {
         MiscType misc = new MiscType();
-
         misc.name = "Prototype Improved Jump Jet";
         misc.setInternalName(EquipmentTypeLookup.PROTOTYPE_IMPROVED_JJ);
-        misc.shortName = "Prototype Imp. Jump Jet";
+        misc.shortName = "Proto. Imp. Jump Jet";
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticalSlots = 1;
         misc.tankSlots = 0;
@@ -1923,15 +1921,15 @@ public class MiscType extends EquipmentType {
 
     public static MiscType createISPrototypeJumpJet() {
         MiscType misc = new MiscType();
-
         misc.name = "Primitive Prototype Jump Jet";
         misc.setInternalName(EquipmentTypeLookup.PROTOTYPE_JUMP_JET);
-        misc.shortName = "Prototype Jump Jet";
+        misc.shortName = "Proto. Jump Jet";
         misc.tonnage = TONNAGE_VARIABLE;
         misc.criticalSlots = 1;
         misc.tankSlots = 0;
         misc.flags = misc.flags.or(F_JUMP_JET, F_MEK_EQUIPMENT, MiscTypeFlag.S_PROTOTYPE);
         misc.bv = 0;
+        misc.industrial = true;
         misc.techAdvancement.setTechBase(TechBase.ALL)
               .setISAdvancement(2464, DATE_NONE, DATE_NONE, 2471, DATE_NONE)
               .setISApproximate(true, false, false, true, false)
@@ -1947,7 +1945,6 @@ public class MiscType extends EquipmentType {
 
     public static MiscType createVehicularJumpJet() {
         MiscType misc = new MiscType();
-
         misc.name = "Jump Jet";
         misc.setInternalName(EquipmentTypeLookup.VEHICLE_JUMP_JET);
         misc.addLookupName("VJJ");
@@ -1970,7 +1967,6 @@ public class MiscType extends EquipmentType {
     }
 
     // TODO Protomek Jump Jets See IO, pg 35
-
     public static MiscType createProtomekJumpJet() {
         MiscType misc = new MiscType();
         misc.name = "Jump Jet";
@@ -2264,6 +2260,7 @@ public class MiscType extends EquipmentType {
         misc.criticalSlots = 1;
         misc.flags = misc.flags.or(F_UMU, F_MEK_EQUIPMENT);
         misc.bv = 0;
+        misc.industrial = true;
         misc.rulesRefs = "107, TO:AUE";
         // Tech Progression tweaked to combine IntOps with TRO Prototypes/3145 NTNU RS
         misc.techAdvancement.setTechBase(TechBase.ALL)

--- a/megamek/src/megamek/common/verifier/MekJumpJets.java
+++ b/megamek/src/megamek/common/verifier/MekJumpJets.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2005-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2005-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -41,6 +41,7 @@ import megamek.common.equipment.EquipmentType;
 import megamek.common.equipment.EquipmentTypeLookup;
 import megamek.common.units.Mek;
 
+@Deprecated(since = "0.51.0", forRemoval = true)
 public enum MekJumpJets {
     JJ_STANDARD(EquipmentTypeLookup.JUMP_JET, true, Mek.JUMP_STANDARD),
     JJ_IMPROVED(EquipmentTypeLookup.IMPROVED_JUMP_JET, false, Mek.JUMP_IMPROVED),
@@ -71,6 +72,7 @@ public enum MekJumpJets {
         return jumpType;
     }
 
+    @Deprecated(since = "0.51.0", forRemoval = true)
     public static List<EquipmentType> allJJs(boolean industrialOnly) {
         List<EquipmentType> retVal = new ArrayList<>();
         for (MekJumpJets jj : values()) {

--- a/megamek/src/megamek/common/verifier/MekJumpJets.java
+++ b/megamek/src/megamek/common/verifier/MekJumpJets.java
@@ -47,7 +47,7 @@ public enum MekJumpJets {
     JJ_IMPROVED(EquipmentTypeLookup.IMPROVED_JUMP_JET, false, Mek.JUMP_IMPROVED),
     JJ_PROTOTYPE(EquipmentTypeLookup.PROTOTYPE_JUMP_JET, true, Mek.JUMP_PROTOTYPE),
     JJ_PROTOTYPE_IMPROVED(EquipmentTypeLookup.PROTOTYPE_IMPROVED_JJ, false, Mek.JUMP_PROTOTYPE_IMPROVED),
-    JJ_UMU(EquipmentTypeLookup.MEK_UMU, false, Mek.JUMP_NONE);
+    JJ_UMU(EquipmentTypeLookup.MEK_UMU, true, Mek.JUMP_NONE);
 
     private final String internalName;
     private final boolean industrial;

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -421,7 +421,19 @@ public abstract class TestEntity implements TestEntityOption {
 
     public static List<EquipmentType> validJumpJets(long entityType, boolean industrial) {
         if ((entityType & Entity.ETYPE_MEK) != 0) {
-            return MekJumpJets.allJJs(industrial);
+            List<EquipmentType> jumpJets = Arrays.asList(
+                  EquipmentType.get(EquipmentTypeLookup.JUMP_JET),
+                  EquipmentType.get(EquipmentTypeLookup.IMPROVED_JUMP_JET),
+                  EquipmentType.get(EquipmentTypeLookup.PROTOTYPE_JUMP_JET),
+                  EquipmentType.get(EquipmentTypeLookup.PROTOTYPE_IMPROVED_JJ),
+                  EquipmentType.get(EquipmentTypeLookup.MEK_UMU)
+            );
+
+            if (industrial) {
+                return jumpJets.stream().filter(eq -> ((MiscType) eq).isIndustrial()).toList();
+            }
+
+            return jumpJets;
         } else if ((entityType & Entity.ETYPE_TANK) != 0) {
             return Collections.singletonList(EquipmentType.get(EquipmentTypeLookup.VEHICLE_JUMP_JET));
         } else if ((entityType & Entity.ETYPE_BATTLEARMOR) != 0) {

--- a/megamek/src/megamek/common/verifier/TestEntity.java
+++ b/megamek/src/megamek/common/verifier/TestEntity.java
@@ -430,10 +430,12 @@ public abstract class TestEntity implements TestEntityOption {
             );
 
             if (industrial) {
-                return jumpJets.stream().filter(eq -> ((MiscType) eq).isIndustrial()).toList();
+                return jumpJets.stream()
+                      .filter(eq -> (eq != null) && ((MiscType) eq).isIndustrial())
+                      .collect(Collectors.toCollection(ArrayList::new));
             }
 
-            return jumpJets;
+            return new ArrayList<>(jumpJets);
         } else if ((entityType & Entity.ETYPE_TANK) != 0) {
             return Collections.singletonList(EquipmentType.get(EquipmentTypeLookup.VEHICLE_JUMP_JET));
         } else if ((entityType & Entity.ETYPE_BATTLEARMOR) != 0) {


### PR DESCRIPTION
Fix https://github.com/MegaMek/megamek/issues/8756

Add industrial = true to MiscType jump jets and UMU where needed
Update jump jet short names to fit jump jet/UMU selector
Refactor TestEntity.validJumpJets() to not use MekJumpJets.allJJs()
Deprecate MekJumpJets due to its only usage being the now-removed usage of MekJumpJets.allJJs()