### PR TITLE
Fix Bombast Laser units being dropped from the unit cache (Fixes #8705)

### DIFF
--- a/megamek/src/megamek/common/weapons/lasers/innerSphere/ISBombastLaser.java
+++ b/megamek/src/megamek/common/weapons/lasers/innerSphere/ISBombastLaser.java
@@ -140,14 +140,25 @@ public class ISBombastLaser extends LaserWeapon {
         return (range <= AlphaStrikeElement.MEDIUM_RANGE) ? 1.02 : 0;
     }
     
+    /**
+     * A Bombast Laser is only explosive while it is holding a charge, so this needs a specific mount to answer for.
+     *
+     * @param mounted      the specific weapon mount to test, or {@code null} to ask about the weapon type in the
+     *                     abstract (as the AlphaStrike ENE conversion does)
+     * @param ignoreCharge unused for this weapon; the charge state is what decides the answer
+     *
+     * @return {@code true} if the given mount is currently carrying a charge that can detonate, otherwise
+     *       {@code false}
+     */
     @Override
-    public boolean isExplosive(Mounted<?> mounted, boolean ignoreCharge) {
-        if (mounted.getType().hasFlag(WeaponType.F_BOMBAST_LASER) &&
-              mounted.getChargeState().equals(ChargeLevel.CHARGED) &&
-              !mounted.isUsedThisRound()) {
-            // Bombast laser is only explosive when charged.
-            return true;
+    public boolean isExplosive(@Nullable Mounted<?> mounted, boolean ignoreCharge) {
+        if (mounted == null) {
+            // No mount to inspect means no charge state to read, and an uncharged Bombast Laser is not explosive.
+            return false;
         }
-        return false;
+        // Bombast laser is only explosive when charged.
+        return mounted.getType().hasFlag(WeaponType.F_BOMBAST_LASER) &&
+              mounted.getChargeState().equals(ChargeLevel.CHARGED) &&
+              !mounted.isUsedThisRound();
     }
 }

--- a/megamek/src/megamek/common/weapons/lasers/innerSphere/ISBombastLaser.java
+++ b/megamek/src/megamek/common/weapons/lasers/innerSphere/ISBombastLaser.java
@@ -49,7 +49,6 @@ import megamek.common.enums.Faction;
 import megamek.common.enums.TechBase;
 import megamek.common.enums.TechRating;
 import megamek.common.equipment.Mounted;
-import megamek.common.equipment.WeaponType;
 import megamek.common.game.Game;
 import megamek.common.loaders.EntityLoadingException;
 import megamek.common.weapons.handlers.AttackHandler;
@@ -72,7 +71,7 @@ public class ISBombastLaser extends LaserWeapon {
         setInternalName(name);
         addLookupName("IS Bombast Laser");
         addLookupName("ISBombastLaser");
-        String[] modeStrings = { "Damage 16", "Damage 12", "Damage 8"};
+        String[] modeStrings = { "Damage 16", "Damage 12", "Damage 8" };
         setModes(modeStrings);
         heat = 12;
         damage = 16;
@@ -128,18 +127,20 @@ public class ISBombastLaser extends LaserWeapon {
             return ToHitData.IMPOSSIBLE;
         } else if (!mounted.getChargeState().equals(ChargeLevel.CHARGED)) {
             switch (mounted.curMode().toString()) {
-                case "Damage 16": return modifier+2;
-                case "Damage 12": return modifier+1;
+                case "Damage 16":
+                    return modifier + 2;
+                case "Damage 12":
+                    return modifier + 1;
             }
-        } 
+        }
         return modifier;
     }
-    
+
     @Override
     public double getBattleForceDamage(int range, Mounted<?> fcs) {
         return (range <= AlphaStrikeElement.MEDIUM_RANGE) ? 1.02 : 0;
     }
-    
+
     /**
      * A Bombast Laser is only explosive while it is holding a charge, so this needs a specific mount to answer for.
      *
@@ -147,18 +148,16 @@ public class ISBombastLaser extends LaserWeapon {
      *                     abstract (as the AlphaStrike ENE conversion does)
      * @param ignoreCharge unused for this weapon; the charge state is what decides the answer
      *
-     * @return {@code true} if the given mount is currently carrying a charge that can detonate, otherwise
-     *       {@code false}
+     * @return {@code true} if the given mount is currently carrying a charge that can detonate, otherwise {@code false}
      */
     @Override
     public boolean isExplosive(@Nullable Mounted<?> mounted, boolean ignoreCharge) {
-        if (mounted == null) {
+        if (mounted == null || ignoreCharge) {
             // No mount to inspect means no charge state to read, and an uncharged Bombast Laser is not explosive.
             return false;
         }
         // Bombast laser is only explosive when charged.
-        return mounted.getType().hasFlag(WeaponType.F_BOMBAST_LASER) &&
-              mounted.getChargeState().equals(ChargeLevel.CHARGED) &&
+        return mounted.getChargeState().equals(ChargeLevel.CHARGED) &&
               !mounted.isUsedThisRound();
     }
 }

--- a/megamek/unittests/megamek/common/weapons/lasers/innerSphere/ISBombastLaserTest.java
+++ b/megamek/unittests/megamek/common/weapons/lasers/innerSphere/ISBombastLaserTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.weapons.lasers.innerSphere;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import megamek.common.enums.ChargeLevel;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.Mounted;
+import megamek.common.game.Game;
+import megamek.common.units.BipedMek;
+import megamek.common.units.Entity;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for {@link ISBombastLaser#isExplosive(Mounted, boolean)} (issue #8705).
+ *
+ * <p>The AlphaStrike ENE conversion asks a weapon type whether it is explosive without supplying a specific mount,
+ * passing {@code null} instead. {@link megamek.common.equipment.EquipmentType} handles that, but the Bombast Laser
+ * override used to dereference the parameter straight away, so every unit whose Bombast Laser was reached by that
+ * check threw a {@link NullPointerException} while the unit cache was being built and was dropped from the game
+ * entirely.</p>
+ */
+public class ISBombastLaserTest {
+
+    private static final String BOMBAST_LASER_INTERNAL_NAME = "Bombast Laser";
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    private static EquipmentType bombastLaserType() {
+        EquipmentType bombastLaser = EquipmentType.get(BOMBAST_LASER_INTERNAL_NAME);
+        assertNotNull(bombastLaser, "Bombast Laser should be a registered equipment type");
+        return bombastLaser;
+    }
+
+    private static Mounted<?> bombastLaserMount() {
+        Entity carrier = new BipedMek();
+        // Mounted.setUsedThisRound() reads the phase off the carrier's game, so the carrier needs one.
+        carrier.setGame(new Game());
+        Mounted<?> bombastLaser = Mounted.createMounted(carrier, bombastLaserType());
+        assertNotNull(bombastLaser, "Bombast Laser should be mountable");
+        return bombastLaser;
+    }
+
+    @Test
+    @DisplayName("Asking the type without a mount does not throw (issue #8705)")
+    void isExplosiveWithoutMountDoesNotThrow() {
+        EquipmentType bombastLaser = bombastLaserType();
+        assertDoesNotThrow(() -> bombastLaser.isExplosive(null),
+              "Asking a Bombast Laser whether it is explosive without a mount must not throw");
+    }
+
+    @Test
+    @DisplayName("A Bombast Laser with no mount to inspect is not explosive")
+    void isExplosiveWithoutMountIsFalse() {
+        assertFalse(bombastLaserType().isExplosive(null),
+              "A Bombast Laser with no charge state to read should not count as explosive");
+    }
+
+    @Test
+    @DisplayName("An uncharged Bombast Laser is not explosive")
+    void unchargedBombastLaserIsNotExplosive() {
+        Mounted<?> bombastLaser = bombastLaserMount();
+        bombastLaser.setChargeState(ChargeLevel.CHARGE_NONE);
+        assertFalse(bombastLaser.getType().isExplosive(bombastLaser),
+              "An uncharged Bombast Laser should not be explosive");
+    }
+
+    @Test
+    @DisplayName("A charged Bombast Laser is explosive")
+    void chargedBombastLaserIsExplosive() {
+        Mounted<?> bombastLaser = bombastLaserMount();
+        bombastLaser.setChargeState(ChargeLevel.CHARGED);
+        assertTrue(bombastLaser.getType().isExplosive(bombastLaser),
+              "A Bombast Laser holding a charge should be explosive");
+    }
+
+    @Test
+    @DisplayName("A charged Bombast Laser that already fired this round is not explosive")
+    void chargedBombastLaserFiredThisRoundIsNotExplosive() {
+        Mounted<?> bombastLaser = bombastLaserMount();
+        bombastLaser.setChargeState(ChargeLevel.CHARGED);
+        bombastLaser.setUsedThisRound(true);
+        assertFalse(bombastLaser.getType().isExplosive(bombastLaser),
+              "A Bombast Laser that has discharged into an attack should no longer be explosive");
+    }
+}


### PR DESCRIPTION
## What this fixes

Thirteen units that mount Bombast Lasers currently vanish from the game. They do not appear in the unit selector, so you cannot add them to a game, and the force generator and RAT loader then report them as missing units.

For example: search the unit selector for the Grasshopper GHR-7X on current `main` and it simply is not there. The Berserker BRZ-D4, Merlin MLN-SX, Uraeus UAE-7R, the four Bombast Turrets, both Claymores, the Lucifer III, the Seydlitz Starling and the Chalchiuhtotolin Support Tank all disappear the same way.

## Root Cause

When MegaMek builds its unit cache, each unit is run through an AlphaStrike conversion to work out whether it qualifies for ENE ("no explosive component"). That check asks each weapon *type*, in the abstract, whether it is explosive — it passes `null` where a specific installed weapon would normally go, because at that point it only cares about the equipment type, not a particular mount.

`EquipmentType.isExplosive(Mounted, boolean)` handles that `null` (EquipmentType.java:413). The Bombast Laser override, added in 7a5306eff2 on 10 Aug, did not — it dereferenced the parameter on its first line. The resulting `NullPointerException` was caught by the cache loader, recorded as "this unit failed to load", and the unit was thrown away.

Only *some* Bombast units were affected because the ENE check returns at the first explosive item it finds (ASSpecialAbilityConverter.java:128). A Bombast unit that also carries ammo or a Gauss rifle hits that first and returns before reaching the laser. Only the energy-heavy designs and the turrets actually failed.

## Changes

1. `ISBombastLaser.isExplosive(Mounted, boolean)` — added the missing `null` guard, returning `false` (a Bombast Laser with no mount to read has no charge state, and an uncharged one is not explosive). Marked the parameter `@Nullable` and documented the contract.
2. Rewrote the `if (...) { return true; } return false;` body as a single returned expression. Behaviour for a non-null mount is unchanged.
3. Added `ISBombastLaserTest` covering the null-mount case plus the charged / uncharged / already-fired arms, so the surviving behaviour is pinned too.

I deliberately kept the `hasFlag(F_BOMBAST_LASER)` check rather than dropping it as redundant, to keep the behaviour change strictly limited to the null case. Happy to remove it if reviewers prefer.

## Files Changed

- `megamek/src/megamek/common/weapons/lasers/innerSphere/ISBombastLaser.java` — null guard, `@Nullable`, JavaDoc
- `megamek/unittests/megamek/common/weapons/lasers/innerSphere/ISBombastLaserTest.java` — new regression test

## Testing

- The new test fails without the fix (`NullPointerException` on exactly the two null-mount cases) and passes with it.
- Verified end to end with a throwaway test that ran eight of the affected unit files (Grasshopper GHR-7X, Berserker BRZ-D4, Merlin MLN-SX, Uraeus UAE-7R, Seydlitz Starling, Bombast Turret (Quad), Chalchiuhtotolin Support Tank, Claymore V3) through `MekFileParser` and `ASConverter.convertForMekCache`. All eight throw before the fix and convert cleanly after it. That test is not committed — it read unit files from a scratch directory.
- Full `:megamek:test` suite green.

## A note for anyone trying to reproduce this

This was previously reported as #8692 and closed as a nightly data artifact. That conclusion was mistaken, and it is worth knowing why, because it will bite the next person.

The unit cache is only rebuilt when a *unit file* is newer than `units.cache` (MekSummaryCache.java:1217). Changing `ISBombastLaser.java` does not touch any unit file — so if you have a `units.cache` built before 10 Aug, those units keep being served from the stale cache and everything looks fine. A nightly install ships fresh data files, forces a rebuild, and the units disappear. To reproduce on a source build you must delete `megamek/data/mekfiles/units.cache` first.

## What is NOT proven yet

- **No in-game playtest.** I have verified that the affected units now load and convert, but I have not started a game, fielded a Bombast Laser unit and fired it. Charging and discharging behaviour is untouched by this change, but it has not been exercised by hand here.
- **`ignoreCharge` is still unused in this override.** The base class uses that parameter for capacitor handling; the Bombast version ignores it entirely, both before and after this change. That may well be intentional, but I have not verified it, and it is really a question for the original author. I left it alone rather than guess.
- This does not touch #8693 (Bombast laser not discharging on a miss), which is a separate bug.

Fixes #8705
