### PR TITLE
Add an optional build note under the version on the main menu

### DIFF
--- a/megamek/resources/Version.properties
+++ b/megamek/resources/Version.properties
@@ -43,3 +43,27 @@ patch=01
 # versions the whole suite. Only set it on the release branch the point release is cut from.
 #
 #revision=1
+#
+# Optional note about this build, shown on the main menu directly under the version number.
+#
+# Leave the line below commented out for an ordinary release: the main menu then looks exactly as it
+# always has. Set it to say something about a particular build - for example that it is a development
+# build, or that it is a hotfix for a specific problem - and that text appears under the version.
+#
+# Keep it to a short sentence or two: the text wraps to the width of the menu buttons, so a long note
+# pushes the buttons down the screen. Use plain ASCII only.
+#
+notes=Core Rules Release
+#
+# Colour of the note. One of: red, orange, yellow, green, blue, cyan, magenta, pink, white, black,
+# gray, lightgray, darkgray (grey is accepted as well). Leave it out and the note uses the same
+# warning colour the rest of MegaMek uses for things the player should notice. An unrecognised name
+# falls back to that warning colour and is reported in megamek.log.
+#
+notesColor=Red
+#
+# Point size of the note, between 6 and 72. Leave it out and the note is drawn at the same size as
+# the rest of the menu. A size outside that range falls back to the menu size and is reported in
+# megamek.log. Remember that a large size makes the note taller and pushes the buttons down.
+#
+notesFontSize=14

--- a/megamek/src/megamek/Version.java
+++ b/megamek/src/megamek/Version.java
@@ -79,6 +79,42 @@ public final class Version implements Comparable<Version>, Serializable {
     /** Key of the optional revision entry in {@code Version.properties}. Absent for ordinary releases. */
     private static final String REVISION_BUNDLE_KEY = "revision";
 
+    /** Key of the optional build note entry in {@code Version.properties}. Absent for ordinary releases. */
+    private static final String NOTES_BUNDLE_KEY = "notes";
+
+    /** Key of the optional colour name the build note is drawn in. Absent unless a build note sets one. */
+    private static final String NOTES_COLOR_BUNDLE_KEY = "notesColor";
+
+    /** Key of the optional point size the build note is drawn at. Absent unless a build note sets one. */
+    private static final String NOTES_FONT_SIZE_BUNDLE_KEY = "notesFontSize";
+
+    /**
+     * The value {@link #getBuildNotesFontSize()} reports when no point size is configured, meaning the build note
+     * is drawn at whatever size the rest of the menu uses.
+     */
+    public static final int NO_NOTES_FONT_SIZE = 0;
+
+    /**
+     * Bounds accepted for a configured build note point size. A size outside these is treated as a mistake and
+     * ignored, because a note at 2 points is unreadable and one at 400 points would push the menu buttons off the
+     * bottom of the screen.
+     */
+    private static final int MINIMUM_NOTES_FONT_SIZE = 6;
+    private static final int MAXIMUM_NOTES_FONT_SIZE = 72;
+
+    /**
+     * The free-text note about this particular build, or {@code null} when the build carries none, which is the
+     * case for every ordinary release.
+     *
+     * <p>This describes the build the code is running as, not any one {@code Version} object, so it is read once
+     * at class load and is deliberately not part of a version's identity: it takes no part in {@link #toString()},
+     * {@link #compareTo(Version)} or {@link #equals(Object)}, and is never sent to another client. The colour and
+     * point size below are the presentation of that same note and are read the same way.</p>
+     */
+    private static final String BUILD_NOTES = readOptionalNotesFromBundle();
+    private static final String BUILD_NOTES_COLOR_NAME = readOptionalEntryFromBundle(NOTES_COLOR_BUNDLE_KEY);
+    private static final int BUILD_NOTES_FONT_SIZE = readOptionalNotesFontSizeFromBundle();
+
     private int major;
     private int minor;
     private int patch;
@@ -233,6 +269,133 @@ public final class Version implements Comparable<Version>, Serializable {
 
         LOGGER.debug("[Version] Optional revision component {} loaded from Version.properties", parsedRevision);
         return parsedRevision;
+    }
+
+    /**
+     * Reads the optional {@code notes} entry from {@code Version.properties}.
+     *
+     * <p>The key is absent for ordinary releases and is only filled in when a build needs to say something about
+     * itself on the main menu, so a missing key is the expected case and is not reported as a problem.</p>
+     *
+     * @return the configured build note, or {@code null} when the key is absent or blank
+     */
+    private static @Nullable String readOptionalNotesFromBundle() {
+        final String configuredNotes = readOptionalEntryFromBundle(NOTES_BUNDLE_KEY);
+        if (configuredNotes == null) {
+            return null;
+        }
+
+        LOGGER.info("[Version] Build note loaded from Version.properties: {}", configuredNotes);
+        return configuredNotes;
+    }
+
+    /**
+     * Reads the optional {@code notesFontSize} entry from {@code Version.properties}.
+     *
+     * @return the configured point size, or {@link #NO_NOTES_FONT_SIZE} when the key is absent, blank, not a
+     *       number, or outside the sizes that make sense on the menu
+     */
+    private static int readOptionalNotesFontSizeFromBundle() {
+        final String configuredFontSize = readOptionalEntryFromBundle(NOTES_FONT_SIZE_BUNDLE_KEY);
+        if (configuredFontSize == null) {
+            return NO_NOTES_FONT_SIZE;
+        }
+
+        final int parsedFontSize = MathUtility.parseInt(configuredFontSize, NO_NOTES_FONT_SIZE);
+        final boolean isTooSmall = parsedFontSize < MINIMUM_NOTES_FONT_SIZE;
+        final boolean isTooLarge = parsedFontSize > MAXIMUM_NOTES_FONT_SIZE;
+        if (isTooSmall || isTooLarge) {
+            LOGGER.warn(
+                  "[Version] Version.properties sets notesFontSize to '{}', which is not a point size between "
+                        + "{} and {}. The build note will be shown at the menu's ordinary size instead.",
+                  configuredFontSize,
+                  MINIMUM_NOTES_FONT_SIZE,
+                  MAXIMUM_NOTES_FONT_SIZE);
+            return NO_NOTES_FONT_SIZE;
+        }
+
+        LOGGER.debug("[Version] Build note point size {} loaded from Version.properties", parsedFontSize);
+        return parsedFontSize;
+    }
+
+    /**
+     * Reads an optional entry from {@code Version.properties}, treating an absent key and a blank value alike.
+     *
+     * @param bundleKey the key to read
+     *
+     * @return the trimmed value, or {@code null} when the key is absent or its value is blank
+     */
+    private static @Nullable String readOptionalEntryFromBundle(final String bundleKey) {
+        if (!VERSION_BUNDLE.containsKey(bundleKey)) {
+            return null;
+        }
+
+        final String normalizedEntry = normalizeOptionalEntry(VERSION_BUNDLE.getString(bundleKey));
+        if (normalizedEntry == null) {
+            LOGGER.debug("[Version] Version.properties has a {} entry, but it is blank; it is ignored", bundleKey);
+        }
+
+        return normalizedEntry;
+    }
+
+    /**
+     * Trims a configured entry and reduces an empty one to {@code null}, so that callers have a single "there is
+     * nothing configured" case to handle rather than also having to allow for whitespace.
+     *
+     * @param configuredEntry the raw value of the entry, or {@code null} when there is none
+     *
+     * @return the trimmed value, or {@code null} when there is nothing there
+     */
+    static @Nullable String normalizeOptionalEntry(final @Nullable String configuredEntry) {
+        if (configuredEntry == null) {
+            return null;
+        }
+
+        final String trimmedEntry = configuredEntry.trim();
+        return trimmedEntry.isEmpty() ? null : trimmedEntry;
+    }
+
+    /**
+     * Returns the free-text note this build was released with, such as a warning that it is a development build.
+     *
+     * @return the build note, or {@code null} when this build has none, which is the case for every ordinary
+     *       release
+     */
+    public static @Nullable String getBuildNotes() {
+        return BUILD_NOTES;
+    }
+
+    /**
+     * @return {@code true} if this build was released with a note to show the player, otherwise {@code false}
+     */
+    public static boolean hasBuildNotes() {
+        return BUILD_NOTES != null;
+    }
+
+    /**
+     * Returns the colour the build note asks to be drawn in, as the plain name written in
+     * {@code Version.properties} rather than as a colour object, because this class is also used well away from
+     * the user interface.
+     *
+     * @return the configured colour name, or {@code null} when the note did not ask for a particular colour
+     */
+    public static @Nullable String getBuildNotesColorName() {
+        return BUILD_NOTES_COLOR_NAME;
+    }
+
+    /**
+     * @return the point size the build note asks to be drawn at, or {@link #NO_NOTES_FONT_SIZE} when it did not
+     *       ask for a particular size
+     */
+    public static int getBuildNotesFontSize() {
+        return BUILD_NOTES_FONT_SIZE;
+    }
+
+    /**
+     * @return {@code true} if the build note asks for a particular point size, otherwise {@code false}
+     */
+    public static boolean hasBuildNotesFontSize() {
+        return BUILD_NOTES_FONT_SIZE != NO_NOTES_FONT_SIZE;
     }
 
     // region Getters

--- a/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
@@ -52,6 +52,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.Vector;
 import java.util.zip.GZIPInputStream;
@@ -60,6 +61,7 @@ import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
+import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import javax.swing.ToolTipManager;
 import javax.swing.UIManager;
@@ -140,6 +142,7 @@ import megamek.server.Server;
 import megamek.server.sbf.SBFGameManager;
 import megamek.server.totalWarfare.TWGameManager;
 import megamek.utilities.xml.MMXMLUtility;
+import org.apache.commons.text.StringEscapeUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -398,6 +401,9 @@ public class MegaMekGUI implements IPreferenceChangeListener {
             minButtonDim = textDim;
         }
 
+        // Most builds carry no note, in which case this is null and the menu is laid out exactly as before.
+        JLabel buildNotesLabel = createBuildNotesLabel(minButtonDim.width);
+
         hostB.setPreferredSize(minButtonDim);
         connectB.setPreferredSize(minButtonDim);
         botB.setPreferredSize(minButtonDim);
@@ -441,7 +447,7 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         c.gridheight = 1;
         c.gridx = 1;
         c.gridy = 0;
-        addBag(labVersion, gridBagLayout, c);
+        addBag(stackBuildNotesUnderVersion(labVersion, buildNotesLabel), gridBagLayout, c);
         c.gridy++;
         addBag(hostB, gridBagLayout, c);
         c.gridy++;
@@ -461,6 +467,157 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         frame.pack();
         // center window in screen
         frame.setLocationRelativeTo(null);
+    }
+
+    /**
+     * Puts the build note immediately under the version number, as one block sharing a single row of the menu.
+     *
+     * <p>Giving the note a menu row of its own would let the layout spread the two apart, leaving the note
+     * stranded halfway down the gap above the buttons. Keeping them in one row instead means the pair sits
+     * together where the version number alone used to be.</p>
+     *
+     * @param versionLabel    the version label, which is what a build with no note shows on its own
+     * @param buildNotesLabel the build note to tuck under it, or {@code null} when this build has no note
+     *
+     * @return the version label itself when there is no note, otherwise the two of them stacked together
+     */
+    private static JComponent stackBuildNotesUnderVersion(JLabel versionLabel, @Nullable JLabel buildNotesLabel) {
+        if (buildNotesLabel == null) {
+            return versionLabel;
+        }
+
+        JPanel versionPanel = new JPanel(new GridBagLayout());
+        versionPanel.setOpaque(false);
+
+        GridBagConstraints versionConstraints = new GridBagConstraints();
+        versionConstraints.fill = GridBagConstraints.HORIZONTAL;
+        versionConstraints.weightx = 1.0;
+        versionConstraints.gridx = 0;
+        versionConstraints.gridy = 0;
+        versionPanel.add(versionLabel, versionConstraints);
+
+        versionConstraints.gridy = 1;
+        versionPanel.add(buildNotesLabel, versionConstraints);
+
+        return versionPanel;
+    }
+
+    /**
+     * Creates the label that shows this build's note on the main menu, directly under the version number.
+     *
+     * <p>Almost every build has nothing to say for itself, so the usual result is {@code null} and the menu is
+     * built exactly as it always was. A note only exists when {@code Version.properties} carries a non-blank
+     * {@code notes} entry, which is how a build is flagged as something other than an ordinary release.</p>
+     *
+     * <p>The note is drawn in bold so that it reads as a notice about the build rather than as part of the
+     * version string, and it wraps at the width of the menu buttons so that a note longer than one line stays
+     * inside the column instead of being cut off. Its colour and point size come from {@code Version.properties}
+     * alongside the text itself; a note that asks for neither is drawn in the usual warning colour at the menu's
+     * ordinary size.</p>
+     *
+     * @param wrapWidth the width in pixels at which the note wraps, which is the menu button width
+     *
+     * @return the label to place under the version label, or {@code null} when this build has no note
+     */
+    private @Nullable JLabel createBuildNotesLabel(int wrapWidth) {
+        if (!Version.hasBuildNotes()) {
+            LOGGER.debug("[BuildNotes] Version.properties sets no notes entry - main menu shows no build note");
+            return null;
+        }
+
+        String buildNotes = Version.getBuildNotes();
+        LOGGER.debug("[BuildNotes] Showing build note on the main menu, wrapping at {} pixels: {}",
+              wrapWidth,
+              buildNotes);
+
+        // The note is free text from Version.properties, so it is escaped before going into the HTML that gives
+        // the label its wrapping. A single-cell table of a fixed pixel width is used rather than a CSS width,
+        // because Swing scales CSS pixel lengths by about a third and the note would then be wider than the
+        // buttons it sits above. The table is stripped of its padding, spacing and border for the same reason.
+        String escapedBuildNotes = StringEscapeUtils.escapeHtml4(buildNotes);
+        JLabel buildNotesLabel = new JLabel("<html><table cellpadding='0' cellspacing='0' border='0'>" +
+              "<tr><td width='" +
+              wrapWidth +
+              "' align='center'><b>" +
+              escapedBuildNotes +
+              "</b></td></tr></table></html>", JLabel.CENTER);
+        buildNotesLabel.setForeground(resolveBuildNotesColor());
+        applyBuildNotesFontSize(buildNotesLabel);
+        return buildNotesLabel;
+    }
+
+    /**
+     * Works out what colour to draw the build note in.
+     *
+     * <p>A note that names no colour, or names one that is not recognised, is drawn in the same warning colour
+     * the rest of the interface uses for things the player should notice.</p>
+     *
+     * @return the colour to draw the build note in, never {@code null}
+     */
+    private Color resolveBuildNotesColor() {
+        Color warningColor = GUIPreferences.getInstance().getWarningColor();
+        String configuredColorName = Version.getBuildNotesColorName();
+        if (configuredColorName == null) {
+            LOGGER.debug("[BuildNotes] No notesColor set - the build note uses the warning colour");
+            return warningColor;
+        }
+
+        Color namedColor = colorForName(configuredColorName);
+        if (namedColor == null) {
+            LOGGER.warn("[BuildNotes] Version.properties sets notesColor to '{}', which is not a colour name "
+                        + "MegaMek knows. The build note will use the warning colour instead.",
+                  configuredColorName);
+            return warningColor;
+        }
+
+        LOGGER.debug("[BuildNotes] Build note colour set to {}", configuredColorName);
+        return namedColor;
+    }
+
+    /**
+     * Maps a colour name written in {@code Version.properties} to the colour it stands for.
+     *
+     * @param colorName the configured colour name, in any mix of upper and lower case
+     *
+     * @return the matching colour, or {@code null} when the name is not one of the recognised colours
+     */
+    private static @Nullable Color colorForName(String colorName) {
+        return switch (colorName.toLowerCase(Locale.ROOT)) {
+            case "red" -> Color.RED;
+            case "orange" -> Color.ORANGE;
+            case "yellow" -> Color.YELLOW;
+            case "green" -> Color.GREEN;
+            case "blue" -> Color.BLUE;
+            case "cyan" -> Color.CYAN;
+            case "magenta" -> Color.MAGENTA;
+            case "pink" -> Color.PINK;
+            case "white" -> Color.WHITE;
+            case "black" -> Color.BLACK;
+            case "gray", "grey" -> Color.GRAY;
+            case "lightgray", "lightgrey" -> Color.LIGHT_GRAY;
+            case "darkgray", "darkgrey" -> Color.DARK_GRAY;
+            default -> null;
+        };
+    }
+
+    /**
+     * Resizes the build note to the point size it asked for, leaving it at the menu's ordinary size when it asked
+     * for none.
+     *
+     * <p>The configured size is put through the GUI scale, so that a note stays in proportion with the menu
+     * around it for a player who runs MegaMek scaled up or down.</p>
+     *
+     * @param buildNotesLabel the build note label to resize
+     */
+    private static void applyBuildNotesFontSize(JLabel buildNotesLabel) {
+        if (!Version.hasBuildNotesFontSize()) {
+            LOGGER.debug("[BuildNotes] No notesFontSize set - the build note uses the menu's ordinary size");
+            return;
+        }
+
+        int buildNotesFontSize = Version.getBuildNotesFontSize();
+        LOGGER.debug("[BuildNotes] Build note point size set to {}", buildNotesFontSize);
+        buildNotesLabel.setFont(buildNotesLabel.getFont().deriveFont(UIUtil.scaleForGUI((float) buildNotesFontSize)));
     }
 
     private RawImagePanel getRawImagePanel(Image splashImage, Dimension splashPanelPreferredSize) {

--- a/megamek/unittests/megamek/VersionTest.java
+++ b/megamek/unittests/megamek/VersionTest.java
@@ -36,6 +36,7 @@ package megamek;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.AfterEach;
@@ -231,6 +232,24 @@ class VersionTest {
         ordinaryVersion.setRevision(-1);
         assertFalse(ordinaryVersion.hasRevision());
         assertEquals(Version.NO_REVISION, ordinaryVersion.getRevision());
+    }
+
+    @Test
+    void absentOptionalEntryYieldsNothing() {
+        assertNull(Version.normalizeOptionalEntry(null));
+    }
+
+    @Test
+    void blankOptionalEntryYieldsNothing() {
+        // A notes entry left in place but emptied out must read as "no note" rather than as an empty line on the
+        // main menu.
+        assertNull(Version.normalizeOptionalEntry(""));
+        assertNull(Version.normalizeOptionalEntry("   "));
+    }
+
+    @Test
+    void optionalEntryIsTrimmed() {
+        assertEquals("Development build", Version.normalizeOptionalEntry("  Development build  "));
     }
 
     /**


### PR DESCRIPTION
## Summary

Open MegaMek today and the start-up screen tells you the version and nothing else. There is no way to
say "this one is the Core Rules release" or "this is a development build, don't take it to a
tournament" without changing code and rebuilding.

This adds one optional line of text under the version number, controlled from `Version.properties`.

Here is the whole of it. Put these three lines in `megamek/resources/Version.properties`:

```properties
notes=Core Rules Release
notesColor=Red
notesFontSize=14
```

Start MegaMek, and "Core Rules Release" appears in red, just under "MegaMek v0.51.01" and just above
the "Start a New Game" button. Comment the three lines out and the start-up screen goes back to
exactly what it looks like now.

**This PR ships that note switched on**, labelling the build as the Core Rules Release. That is
deliberate, not a leftover test value.

The colour is a plain name: red, orange, yellow, green, blue, cyan, magenta, pink, white, black, gray,
lightgray or darkgray. Capitals and the "grey" spelling are both fine. The size is a point size
between 6 and 72. Leave either one out and the note uses MegaMek's usual warning colour at the usual
menu size.

## Changes

1. **Three new optional entries in `Version.properties`** - `notes`, `notesColor`, `notesFontSize` -
   each documented in the file itself, next to the existing `revision` entry.
2. **`Version` reads them.** The note describes the build, not any particular version number, so it
   stays out of a version's identity: it does not appear in `toString()`, it plays no part in
   comparing or equalling two versions, and it is never sent to another player. Everything added here
   is `static`, so nothing changes about how a `Version` travels in a packet or a save game.
3. **`MegaMekGUI` puts it on the screen**, working out the colour and size and placing the note under
   the version label.
4. **A typo cannot break the start-up screen.** Write `notesColor=puce` or `notesFontSize=200` and the
   note falls back to the default and writes a line in `megamek.log` naming what was wrong. The menu
   still comes up.

### Two things that did not work, in case they look odd in review

**The note could not simply be given its own row in the menu.** That was the obvious approach and it
looked wrong: the note ended up floating in the middle of the empty space, nowhere near the version
number it belongs to. The cause is that every row in that column is set to take an equal share of the
leftover height, so a row of its own became a tall row with the text centred in it. The note and the
version label now sit together in a single row, which keeps them tucked up against each other. When
there is no note, that same code hands back the plain version label, which is why an ordinary build
comes out byte-for-byte as before.

**The obvious way to make long text wrap made the note too wide.** Asking for a 250-pixel wrap width
in the usual way produced a label 325 pixels wide - visibly wider than the buttons above and below it.
Swing quietly enlarges those width values by about a third. Sizing a table cell instead gives exactly
the width asked for; measured at 100, 250 and 400 pixels, the label came out 100, 250 and 400.

The point size is put through `UIUtil.scaleForGUI`, so a player running MegaMek scaled up or down gets
a note in proportion with the rest of the menu.

## Files Changed

- `megamek/resources/Version.properties` - the three new entries, documented, with the Core Rules
  Release note filled in
- `megamek/src/megamek/Version.java` - reads and sanity-checks them
- `megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java` - builds the note and places it under the
  version label
- `megamek/unittests/megamek/VersionTest.java` - covers an entry that is missing, blank, or padded with
  spaces

## Testing

- `VersionTest` passes, 31 of 31. `compileJava`, `compileTestJava` and checkstyle are clean.
- Played through it on this branch with current `main` merged in: the note comes up in the right place,
  all seven menu buttons still fit, and `megamek.log` has no ERROR, FATAL or null-pointer entries for
  the session.
- Filled all three entries in for real and read them back to confirm the file is being picked up
  (`notesColor=Red` came back as `Red`, `notesFontSize=14` as `14`), then set `notesFontSize=200` and
  confirmed it falls back to the normal size instead of producing a giant note.
- The wrapping was measured rather than eyeballed, which is the only reason the width problem above was
  caught.

## What is NOT proven yet

- **Only run at the default GUI scale.** The scaling call is the same one the rest of the interface
  uses, but I have not started MegaMek at 1.5x or 0.75x to look at it.
- **Only run with the default skin.** The colours are fixed values, so on a pale skin a note set to
  white or yellow would be hard to read. Nothing stops a bad choice.
- **Only run with a short note.** Longer text wraps correctly when measured, but I have not looked at a
  two- or three-line note on screen, and every extra line pushes the menu buttons further down.
- **No automated test covers the note as it is drawn.** The tests cover reading the entries out of the
  file. The colour lookup and the label itself were checked by running MegaMek and looking at it, not
  by an assertion, so a future change could move the note without failing a test.
