### PR TITLE
Spray an optional edition tag across the MegaMek logo on the splash screen

### DIFF
--- a/megamek/resources/Version.properties
+++ b/megamek/resources/Version.properties
@@ -67,3 +67,16 @@ notesColor=Red
 # megamek.log. Remember that a large size makes the note taller and pushes the buttons down.
 #
 notesFontSize=14
+#
+# Optional tag sprayed straight across the MegaMek logo on the splash artwork, in red spray-paint
+# lettering. This is separate from the note above, so the artwork and the menu can say different
+# things - or a build can have one without the other.
+#
+# Leave it out and the artwork is left clean. Keep it SHORT: it is sized to sit across the width of
+# the logo, so a long tag comes out small and cramped. Use plain ASCII only.
+#
+# The lettering needs the "Rubik Spray Paint" font, which ships in mm-data under
+# data/fonts/Rubik_Spray_Paint. If that font is missing the tag is still drawn, in the default font,
+# and a warning goes to megamek.log.
+#
+splashTag=Core Rules Edition

--- a/megamek/resources/Version.properties
+++ b/megamek/resources/Version.properties
@@ -80,3 +80,18 @@ notesFontSize=14
 # and a warning goes to megamek.log.
 #
 splashTag=Core Rules Edition
+#
+# Colour of the sprayed tag, from the same list of names as notesColor above: red, orange, yellow,
+# green, blue, cyan, magenta, pink, white, black, gray, lightgray, darkgray (grey is accepted too).
+# Leave it out and the tag is sprayed in red. An unrecognised name falls back to red and is reported
+# in megamek.log. Whichever colour is chosen is left slightly see-through, so the logo shows through
+# the paint.
+#
+#splashTagColor=red
+#
+# Angle the tag is sprayed at, in degrees. Zero is level. A NEGATIVE angle drops the left-hand end and
+# lifts the right-hand end; a POSITIVE angle does the opposite. Leave it out and the tag sits at -2.5,
+# just off level, which is enough to stop it reading as a tidy caption. Anything beyond -45 to 45 is
+# treated as a mistake, falls back to -2.5, and is reported in megamek.log.
+#
+#splashTagRotation=-2.5

--- a/megamek/src/megamek/Version.java
+++ b/megamek/src/megamek/Version.java
@@ -91,6 +91,23 @@ public final class Version implements Comparable<Version>, Serializable {
     /** Key of the optional tag sprayed across the MegaMek logo on the splash art. Absent for ordinary releases. */
     private static final String SPLASH_TAG_BUNDLE_KEY = "splashTag";
 
+    /** Key of the optional colour name the splash tag is sprayed in. Absent unless a splash tag sets one. */
+    private static final String SPLASH_TAG_COLOR_BUNDLE_KEY = "splashTagColor";
+
+    /** Key of the optional angle, in degrees, the splash tag is sprayed at. Absent unless a splash tag sets one. */
+    private static final String SPLASH_TAG_ROTATION_BUNDLE_KEY = "splashTagRotation";
+
+    /** The angle the splash tag is sprayed at when it does not ask for one: very slightly off level. */
+    public static final double DEFAULT_SPLASH_TAG_ROTATION = -2.5;
+
+    /**
+     * Bounds accepted for a configured splash tag angle. Anything past this is treated as a mistake rather than
+     * an intention, since a tag turned much further than this stops reading as paint on a sign and starts
+     * running off the artwork.
+     */
+    private static final double MINIMUM_SPLASH_TAG_ROTATION = -45.0;
+    private static final double MAXIMUM_SPLASH_TAG_ROTATION = 45.0;
+
     /**
      * The value {@link #getBuildNotesFontSize()} reports when no point size is configured, meaning the build note
      * is drawn at whatever size the rest of the menu uses.
@@ -118,6 +135,8 @@ public final class Version implements Comparable<Version>, Serializable {
     private static final String BUILD_NOTES_COLOR_NAME = readOptionalEntryFromBundle(NOTES_COLOR_BUNDLE_KEY);
     private static final int BUILD_NOTES_FONT_SIZE = readOptionalNotesFontSizeFromBundle();
     private static final String SPLASH_TAG = readOptionalEntryFromBundle(SPLASH_TAG_BUNDLE_KEY);
+    private static final String SPLASH_TAG_COLOR_NAME = readOptionalEntryFromBundle(SPLASH_TAG_COLOR_BUNDLE_KEY);
+    private static final double SPLASH_TAG_ROTATION = readOptionalSplashTagRotationFromBundle();
 
     private int major;
     private int minor;
@@ -323,6 +342,36 @@ public final class Version implements Comparable<Version>, Serializable {
     }
 
     /**
+     * Reads the optional {@code splashTagRotation} entry from {@code Version.properties}.
+     *
+     * @return the configured angle in degrees, or {@link #DEFAULT_SPLASH_TAG_ROTATION} when the key is absent,
+     *       blank, not a number, or turned further than makes sense on the artwork
+     */
+    private static double readOptionalSplashTagRotationFromBundle() {
+        final String configuredRotation = readOptionalEntryFromBundle(SPLASH_TAG_ROTATION_BUNDLE_KEY);
+        if (configuredRotation == null) {
+            return DEFAULT_SPLASH_TAG_ROTATION;
+        }
+
+        final double parsedRotation = MathUtility.parseDouble(configuredRotation, Double.NaN);
+        final boolean isNotANumber = Double.isNaN(parsedRotation);
+        final boolean isTurnedTooFar = (parsedRotation < MINIMUM_SPLASH_TAG_ROTATION)
+              || (parsedRotation > MAXIMUM_SPLASH_TAG_ROTATION);
+        if (isNotANumber || isTurnedTooFar) {
+            LOGGER.warn("[Version] Version.properties sets splashTagRotation to '{}', which is not an angle "
+                        + "between {} and {} degrees. The splash tag will be sprayed at {} degrees instead.",
+                  configuredRotation,
+                  MINIMUM_SPLASH_TAG_ROTATION,
+                  MAXIMUM_SPLASH_TAG_ROTATION,
+                  DEFAULT_SPLASH_TAG_ROTATION);
+            return DEFAULT_SPLASH_TAG_ROTATION;
+        }
+
+        LOGGER.debug("[Version] Splash tag angle {} degrees loaded from Version.properties", parsedRotation);
+        return parsedRotation;
+    }
+
+    /**
      * Reads an optional entry from {@code Version.properties}, treating an absent key and a blank value alike.
      *
      * @param bundleKey the key to read
@@ -421,6 +470,30 @@ public final class Version implements Comparable<Version>, Serializable {
      */
     public static boolean hasSplashTag() {
         return SPLASH_TAG != null;
+    }
+
+    /**
+     * Returns the colour the splash tag asks to be sprayed in, as the plain name written in
+     * {@code Version.properties} rather than as a colour object, for the same reason as
+     * {@link #getBuildNotesColorName()}: this class is also used well away from the user interface.
+     *
+     * @return the configured colour name, or {@code null} when the tag did not ask for a particular colour
+     */
+    public static @Nullable String getSplashTagColorName() {
+        return SPLASH_TAG_COLOR_NAME;
+    }
+
+    /**
+     * Returns the angle, in degrees, the splash tag is sprayed at.
+     *
+     * <p>Zero is level. A negative angle drops the left-hand end and lifts the right-hand end; a positive angle
+     * does the opposite. This follows the screen's own sense of rotation, where the vertical axis points
+     * downwards.</p>
+     *
+     * @return the configured angle, or {@link #DEFAULT_SPLASH_TAG_ROTATION} when the tag did not ask for one
+     */
+    public static double getSplashTagRotation() {
+        return SPLASH_TAG_ROTATION;
     }
 
     // region Getters

--- a/megamek/src/megamek/Version.java
+++ b/megamek/src/megamek/Version.java
@@ -88,6 +88,9 @@ public final class Version implements Comparable<Version>, Serializable {
     /** Key of the optional point size the build note is drawn at. Absent unless a build note sets one. */
     private static final String NOTES_FONT_SIZE_BUNDLE_KEY = "notesFontSize";
 
+    /** Key of the optional tag sprayed across the MegaMek logo on the splash art. Absent for ordinary releases. */
+    private static final String SPLASH_TAG_BUNDLE_KEY = "splashTag";
+
     /**
      * The value {@link #getBuildNotesFontSize()} reports when no point size is configured, meaning the build note
      * is drawn at whatever size the rest of the menu uses.
@@ -114,6 +117,7 @@ public final class Version implements Comparable<Version>, Serializable {
     private static final String BUILD_NOTES = readOptionalNotesFromBundle();
     private static final String BUILD_NOTES_COLOR_NAME = readOptionalEntryFromBundle(NOTES_COLOR_BUNDLE_KEY);
     private static final int BUILD_NOTES_FONT_SIZE = readOptionalNotesFontSizeFromBundle();
+    private static final String SPLASH_TAG = readOptionalEntryFromBundle(SPLASH_TAG_BUNDLE_KEY);
 
     private int major;
     private int minor;
@@ -396,6 +400,27 @@ public final class Version implements Comparable<Version>, Serializable {
      */
     public static boolean hasBuildNotesFontSize() {
         return BUILD_NOTES_FONT_SIZE != NO_NOTES_FONT_SIZE;
+    }
+
+    /**
+     * Returns the short tag this build sprays across the MegaMek logo on the splash art, such as the name of the
+     * edition it is celebrating.
+     *
+     * <p>This is separate from {@link #getBuildNotes()} so that the artwork and the menu can say different
+     * things, or so that a build can have one without the other.</p>
+     *
+     * @return the splash tag, or {@code null} when this build has none, which is the case for every ordinary
+     *       release
+     */
+    public static @Nullable String getSplashTag() {
+        return SPLASH_TAG;
+    }
+
+    /**
+     * @return {@code true} if this build has a tag to spray across the splash art, otherwise {@code false}
+     */
+    public static boolean hasSplashTag() {
+        return SPLASH_TAG != null;
     }
 
     // region Getters

--- a/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
@@ -41,6 +41,7 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.awt.font.GlyphVector;
 import java.awt.image.VolatileImage;
 import java.io.File;
 import java.io.FileInputStream;
@@ -102,6 +103,7 @@ import megamek.client.ui.dialogs.scenario.ScenarioChooserDialog;
 import megamek.client.ui.dialogs.unitSelectorDialogs.MainMenuUnitBrowserDialog;
 import megamek.client.ui.enums.DialogResult;
 import megamek.client.ui.panels.skinEditor.SkinEditorMainGUIPanel;
+import megamek.client.ui.util.FontHandler;
 import megamek.client.ui.util.MegaMekController;
 import megamek.client.ui.util.UIUtil;
 import megamek.client.ui.widget.MegaMekButton;
@@ -159,6 +161,54 @@ public class MegaMekGUI implements IPreferenceChangeListener {
     private static final String FILENAME_ICON_48X48 = "megamek-icon-48x48.png";
     private static final String FILENAME_ICON_256X256 = "megamek-icon-256x256.png";
 
+    /** Family name of the spray-paint font the splash tag is drawn in. Ships in mm-data under data/fonts. */
+    private static final String SPRAY_PAINT_FONT_FAMILY = "Rubik Spray Paint";
+
+    /** Colour of the sprayed splash tag: a strong red, left see-through enough that the logo shows through it. */
+    private static final Color SPLASH_TAG_COLOR = new Color(198, 26, 26, 232);
+
+    /** Colour outlining the sprayed tag, which lifts the red clear of the light wordmark underneath it. */
+    private static final Color SPLASH_TAG_OUTLINE_COLOR = new Color(0, 0, 0, 225);
+
+    /**
+     * Thickness of that outline, as a fraction of the tag's font size, so the outline stays in proportion at
+     * every window size instead of turning into a heavy blob on a small launcher.
+     */
+    private static final double SPLASH_TAG_OUTLINE_WIDTH_FRACTION = 0.085;
+
+    /** How far off level the sprayed tag sits, in degrees, so it does not read as a tidy interface caption. */
+    private static final double SPLASH_TAG_TILT_DEGREES = -2.5;
+
+    /** Fraction of the logo's width the sprayed tag spans, leaving it a little narrower than the logo itself. */
+    private static final double SPLASH_TAG_WIDTH_FRACTION_OF_LOGO = 0.92;
+
+    /**
+     * How far down the logo image the MegaMek wordmark plate sits, as a fraction of the image's height.
+     *
+     * <p>The logo artwork is a tall composite: a 'Mek standing above the wordmark plate, with the plate filling
+     * only the bottom quarter or so of the image. The tag belongs across the wordmark, so centring it on the
+     * image as a whole would put it up on the 'Mek instead. Measuring the artwork, the plate runs from about
+     * three-quarters of the way down to the bottom edge; the tag sits low on that plate, overlapping the bottom
+     * of the lettering, which is where a tag sprayed across a sign tends to land.</p>
+     */
+    private static final double LOGO_WORDMARK_CENTRE_FRACTION = 0.93;
+
+    /**
+     * The tallest the tag's lettering may be, as a fraction of the logo's height, so that it stays on the
+     * wordmark plate.
+     *
+     * <p>Without this, a very short tag would be blown up to span the width of the logo and end up taller than
+     * the plate it is supposed to be sprayed across. This applies at every window size, because the tag is sized
+     * from the logo and the logo is sized from the window.</p>
+     */
+    private static final double SPLASH_TAG_MAX_HEIGHT_FRACTION_OF_LOGO = 0.17;
+
+    /** Size the tag is measured at before being scaled to fit; large enough that the measurement is accurate. */
+    private static final float SPLASH_TAG_REFERENCE_FONT_SIZE = 100f;
+
+    /** Size the tag's font is created at. The real size is derived from the artwork's width when painting. */
+    private static final int SPLASH_TAG_PLACEHOLDER_FONT_SIZE = 12;
+
     private JFrame frame;
     private IClient client;
     private Server server;
@@ -166,6 +216,8 @@ public class MegaMekGUI implements IPreferenceChangeListener {
     private CommonSettingsDialog settingsDialog;
     private ManagedVolatileImage logoImage;
     private ManagedVolatileImage medalImage;
+    /** Font the splash tag is sprayed in, or {@code null} when this build has no tag to spray. */
+    private Font splashTagFont;
     private TipOfTheDay tipOfTheDay;
     private AbstractRandomArmyDialog randomArmyDialog;
     private NetworkInformationDialog networkInformationDialog;
@@ -280,7 +332,14 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         return targetMedalWidth;
     }
 
-    private void drawLogo(Graphics2D g2d, int panelWidth, int panelHeight, int targetMedalWidth, int padding) {
+    /**
+     * Draws the MegaMek logo in the bottom-right of the splash artwork.
+     *
+     * @return the area the logo was drawn into, so that the splash tag can be sprayed across it, or {@code null}
+     *       when the image was not ready to draw
+     */
+    private @Nullable Rectangle drawLogo(Graphics2D g2d, int panelWidth, int panelHeight, int targetMedalWidth,
+          int padding) {
         VolatileImage image = logoImage.getImage();
         if (image.getWidth(null) > 0 && image.getHeight(null) > 0) {
             double logoWidthScalePercent = 0.25; // Logo width as 25% of panel width
@@ -305,7 +364,9 @@ public class MegaMekGUI implements IPreferenceChangeListener {
             if (logoY < 0) {logoY = 0;}
 
             g2d.drawImage(image, logoX, logoY, targetLogoWidth, targetLogoHeight, null);
+            return new Rectangle(logoX, logoY, targetLogoWidth, targetLogoHeight);
         }
+        return null;
     }
 
     /**
@@ -373,6 +434,7 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         Image splashImage = getImage(FILENAME_MEGAMEK_SPLASH);
         logoImage = new ManagedVolatileImage(getImage(FILENAME_LOGO), Transparency.TRANSLUCENT);
         medalImage = new ManagedVolatileImage(getImage(FILENAME_MEDAL), Transparency.TRANSLUCENT);
+        splashTagFont = loadSplashTagFont();
         Dimension splashPanelPreferredSize = calculateSplashPanelPreferredSize(scaledMonitorSize, splashImage);
         // This is an empty panel that will contain the splash image
         // Draw background, border, and children first
@@ -467,6 +529,137 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         frame.pack();
         // center window in screen
         frame.setLocationRelativeTo(null);
+    }
+
+    /**
+     * Works out which font this build's splash tag is sprayed in, and how big it should be, given the width of
+     * the artwork it is being painted onto.
+     *
+     * <p>The tag is sized to sit across the width of the MegaMek logo above it, so it stays in proportion however
+     * large the window is. A short tag therefore comes out big and bold, and a long one comes out smaller, which
+     * is why {@code Version.properties} asks for a short one.</p>
+     *
+     * @param graphics   the graphics context the tag will be painted with, used to measure the lettering
+     * @param panelWidth the width in pixels of the splash artwork
+     *
+     * @return the font to spray the tag in, already at the right size, or {@code null} when this build has no tag
+     */
+    private @Nullable Font deriveSplashTagFont(Graphics2D graphics, Rectangle logoBounds) {
+        if (splashTagFont == null) {
+            return null;
+        }
+
+        String splashTag = Version.getSplashTag();
+
+        // Measure at a reference size and scale from there, which is one measurement instead of a search.
+        Font referenceFont = splashTagFont.deriveFont(SPLASH_TAG_REFERENCE_FONT_SIZE);
+        FontMetrics referenceMetrics = graphics.getFontMetrics(referenceFont);
+        int referenceWidth = referenceMetrics.stringWidth(splashTag);
+        int referenceHeight = referenceMetrics.getAscent() - referenceMetrics.getDescent();
+        if ((referenceWidth <= 0) || (referenceHeight <= 0)) {
+            return null;
+        }
+
+        // Size the tag to span the logo, then pull it back if that would make it taller than the wordmark plate,
+        // which is what happens with a very short tag.
+        double targetTagWidth = logoBounds.width * SPLASH_TAG_WIDTH_FRACTION_OF_LOGO;
+        double maximumTagHeight = logoBounds.height * SPLASH_TAG_MAX_HEIGHT_FRACTION_OF_LOGO;
+        double sizeThatFitsWidth = SPLASH_TAG_REFERENCE_FONT_SIZE * targetTagWidth / referenceWidth;
+        double sizeThatFitsHeight = SPLASH_TAG_REFERENCE_FONT_SIZE * maximumTagHeight / referenceHeight;
+
+        float sprayedFontSize = (float) Math.min(sizeThatFitsWidth, sizeThatFitsHeight);
+        if (sprayedFontSize < 1f) {
+            return null;
+        }
+
+        return splashTagFont.deriveFont(sprayedFontSize);
+    }
+
+    /**
+     * Sprays this build's tag straight across the MegaMek logo, the way a tag gets put on a wall.
+     *
+     * <p>It is drawn in red outlined in black, tilted very slightly off level and left a little see-through so
+     * the logo shows through it, which is what makes it read as paint on top of the picture rather than as
+     * another caption belonging to the interface. The black outline is what keeps the red readable where it
+     * crosses the pale lettering of the wordmark.</p>
+     *
+     * @param graphics   the graphics context to paint into
+     * @param logoBounds the area the logo occupies, or {@code null} when the logo was not drawn
+     */
+    private void drawSplashTag(Graphics2D graphics, @Nullable Rectangle logoBounds) {
+        if (logoBounds == null) {
+            return;
+        }
+
+        Font sizedSplashTagFont = deriveSplashTagFont(graphics, logoBounds);
+        if (sizedSplashTagFont == null) {
+            return;
+        }
+
+        String splashTag = Version.getSplashTag();
+        FontMetrics tagMetrics = graphics.getFontMetrics(sizedSplashTagFont);
+        int tagWidth = tagMetrics.stringWidth(splashTag);
+
+        // Centred across the logo, and down it at the height the wordmark sits at
+        int tagX = logoBounds.x + ((logoBounds.width - tagWidth) / 2);
+        int lettersHeight = tagMetrics.getAscent() - tagMetrics.getDescent();
+        int wordmarkCentreY = logoBounds.y + (int) (logoBounds.height * LOGO_WORDMARK_CENTRE_FRACTION);
+        int tagY = wordmarkCentreY + (lettersHeight / 2);
+
+        Graphics2D tagGraphics = (Graphics2D) graphics.create();
+        try {
+            tagGraphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            tagGraphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                  RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+            tagGraphics.rotate(Math.toRadians(SPLASH_TAG_TILT_DEGREES),
+                  tagX + (tagWidth / 2.0),
+                  tagY - (tagMetrics.getAscent() / 2.0));
+
+            // The lettering is outlined in black and then filled in red, rather than simply drawn, so that it
+            // stands clear of the pale wordmark it is sprayed across.
+            GlyphVector tagGlyphs = sizedSplashTagFont.createGlyphVector(tagGraphics.getFontRenderContext(),
+                  splashTag);
+            Shape tagOutline = tagGlyphs.getOutline(tagX, tagY);
+
+            float outlineWidth = (float) Math.max(1.0,
+                  sizedSplashTagFont.getSize2D() * SPLASH_TAG_OUTLINE_WIDTH_FRACTION);
+            tagGraphics.setStroke(new BasicStroke(outlineWidth, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+            tagGraphics.setColor(SPLASH_TAG_OUTLINE_COLOR);
+            tagGraphics.draw(tagOutline);
+
+            tagGraphics.setColor(SPLASH_TAG_COLOR);
+            tagGraphics.fill(tagOutline);
+        } finally {
+            tagGraphics.dispose();
+        }
+    }
+
+    /**
+     * Loads the font the splash tag is sprayed in, once, when the menu is built.
+     *
+     * <p>Doing this here rather than while painting keeps the decision, and the log line explaining it, out of a
+     * method that runs on every repaint.</p>
+     *
+     * @return the spray-paint font, a plain fallback when that font is not installed, or {@code null} when this
+     *       build has no tag to spray
+     */
+    private static @Nullable Font loadSplashTagFont() {
+        if (!Version.hasSplashTag()) {
+            LOGGER.debug("[SplashTag] Version.properties sets no splashTag entry - the artwork is left clean");
+            return null;
+        }
+
+        String splashTag = Version.getSplashTag();
+        if (!FontHandler.getAvailableFonts().contains(SPRAY_PAINT_FONT_FAMILY)) {
+            LOGGER.warn("[SplashTag] The '{}' font is not installed, so '{}' cannot be sprayed and will be "
+                        + "painted in the default font instead. Check that mm-data has been staged.",
+                  SPRAY_PAINT_FONT_FAMILY,
+                  splashTag);
+            return new Font(Font.SANS_SERIF, Font.BOLD, SPLASH_TAG_PLACEHOLDER_FONT_SIZE);
+        }
+
+        LOGGER.info("[SplashTag] Spraying '{}' onto the splash artwork in {}", splashTag, SPRAY_PAINT_FONT_FAMILY);
+        return new Font(SPRAY_PAINT_FONT_FAMILY, Font.PLAIN, SPLASH_TAG_PLACEHOLDER_FONT_SIZE);
     }
 
     /**
@@ -645,7 +838,10 @@ public class MegaMekGUI implements IPreferenceChangeListener {
                     targetMedalWidth = drawMedal(g2d, panelWidth, panelHeight, padding);
 
                     // Draw logoImage
-                    drawLogo(g2d, panelWidth, panelHeight, targetMedalWidth, padding);
+                    Rectangle logoBounds = drawLogo(g2d, panelWidth, panelHeight, targetMedalWidth, padding);
+
+                    // Spray the splash tag across the logo
+                    drawSplashTag(g2d, logoBounds);
                 } finally {
                     g2d.dispose();
                 }

--- a/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
@@ -42,6 +42,7 @@ import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.font.GlyphVector;
+import java.awt.geom.Rectangle2D;
 import java.awt.image.VolatileImage;
 import java.io.File;
 import java.io.FileInputStream;
@@ -164,8 +165,11 @@ public class MegaMekGUI implements IPreferenceChangeListener {
     /** Family name of the spray-paint font the splash tag is drawn in. Ships in mm-data under data/fonts. */
     private static final String SPRAY_PAINT_FONT_FAMILY = "Rubik Spray Paint";
 
-    /** Colour of the sprayed splash tag: a strong red, left see-through enough that the logo shows through it. */
-    private static final Color SPLASH_TAG_COLOR = new Color(198, 26, 26, 232);
+    /** Colour the splash tag is sprayed in when it does not name one: a strong red. */
+    private static final Color SPLASH_TAG_DEFAULT_COLOR = new Color(198, 26, 26);
+
+    /** How solid the sprayed tag is, out of 255. Short of opaque, so the logo shows through the paint. */
+    private static final int SPLASH_TAG_ALPHA = 232;
 
     /** Colour outlining the sprayed tag, which lifts the red clear of the light wordmark underneath it. */
     private static final Color SPLASH_TAG_OUTLINE_COLOR = new Color(0, 0, 0, 225);
@@ -175,9 +179,6 @@ public class MegaMekGUI implements IPreferenceChangeListener {
      * every window size instead of turning into a heavy blob on a small launcher.
      */
     private static final double SPLASH_TAG_OUTLINE_WIDTH_FRACTION = 0.085;
-
-    /** How far off level the sprayed tag sits, in degrees, so it does not read as a tidy interface caption. */
-    private static final double SPLASH_TAG_TILT_DEGREES = -2.5;
 
     /** Fraction of the logo's width the sprayed tag spans, leaving it a little narrower than the logo itself. */
     private static final double SPLASH_TAG_WIDTH_FRACTION_OF_LOGO = 0.92;
@@ -218,6 +219,8 @@ public class MegaMekGUI implements IPreferenceChangeListener {
     private ManagedVolatileImage medalImage;
     /** Font the splash tag is sprayed in, or {@code null} when this build has no tag to spray. */
     private Font splashTagFont;
+    /** Colour the splash tag is sprayed in, worked out once when the menu is built. */
+    private Color splashTagColor = SPLASH_TAG_DEFAULT_COLOR;
     private TipOfTheDay tipOfTheDay;
     private AbstractRandomArmyDialog randomArmyDialog;
     private NetworkInformationDialog networkInformationDialog;
@@ -435,6 +438,7 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         logoImage = new ManagedVolatileImage(getImage(FILENAME_LOGO), Transparency.TRANSLUCENT);
         medalImage = new ManagedVolatileImage(getImage(FILENAME_MEDAL), Transparency.TRANSLUCENT);
         splashTagFont = loadSplashTagFont();
+        splashTagColor = resolveSplashTagColor();
         Dimension splashPanelPreferredSize = calculateSplashPanelPreferredSize(scaledMonitorSize, splashImage);
         // This is an empty panel that will contain the splash image
         // Draw background, border, and children first
@@ -540,7 +544,7 @@ public class MegaMekGUI implements IPreferenceChangeListener {
      * is why {@code Version.properties} asks for a short one.</p>
      *
      * @param graphics   the graphics context the tag will be painted with, used to measure the lettering
-     * @param panelWidth the width in pixels of the splash artwork
+     * @param logoBounds the area the logo occupies, which the tag is sized against
      *
      * @return the font to spray the tag in, already at the right size, or {@code null} when this build has no tag
      */
@@ -551,11 +555,14 @@ public class MegaMekGUI implements IPreferenceChangeListener {
 
         String splashTag = Version.getSplashTag();
 
-        // Measure at a reference size and scale from there, which is one measurement instead of a search.
+        // Measure at a reference size and scale from there, which is one measurement instead of a search. The
+        // measurement is of the painted lettering itself rather than of the font's ascent and descent, because
+        // those describe what the font could draw rather than what this particular tag does draw.
         Font referenceFont = splashTagFont.deriveFont(SPLASH_TAG_REFERENCE_FONT_SIZE);
-        FontMetrics referenceMetrics = graphics.getFontMetrics(referenceFont);
-        int referenceWidth = referenceMetrics.stringWidth(splashTag);
-        int referenceHeight = referenceMetrics.getAscent() - referenceMetrics.getDescent();
+        Rectangle2D referenceInk = referenceFont.createGlyphVector(graphics.getFontRenderContext(), splashTag)
+              .getVisualBounds();
+        double referenceWidth = referenceInk.getWidth();
+        double referenceHeight = referenceInk.getHeight();
         if ((referenceWidth <= 0) || (referenceHeight <= 0)) {
             return null;
         }
@@ -597,28 +604,30 @@ public class MegaMekGUI implements IPreferenceChangeListener {
         }
 
         String splashTag = Version.getSplashTag();
-        FontMetrics tagMetrics = graphics.getFontMetrics(sizedSplashTagFont);
-        int tagWidth = tagMetrics.stringWidth(splashTag);
-
-        // Centred across the logo, and down it at the height the wordmark sits at
-        int tagX = logoBounds.x + ((logoBounds.width - tagWidth) / 2);
-        int lettersHeight = tagMetrics.getAscent() - tagMetrics.getDescent();
-        int wordmarkCentreY = logoBounds.y + (int) (logoBounds.height * LOGO_WORDMARK_CENTRE_FRACTION);
-        int tagY = wordmarkCentreY + (lettersHeight / 2);
 
         Graphics2D tagGraphics = (Graphics2D) graphics.create();
         try {
             tagGraphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
             tagGraphics.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
                   RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-            tagGraphics.rotate(Math.toRadians(SPLASH_TAG_TILT_DEGREES),
-                  tagX + (tagWidth / 2.0),
-                  tagY - (tagMetrics.getAscent() / 2.0));
 
-            // The lettering is outlined in black and then filled in red, rather than simply drawn, so that it
-            // stands clear of the pale wordmark it is sprayed across.
+            // Measure the painted lettering, so that centring it uses where the paint actually lands rather than
+            // where the font says its tallest and lowest characters could reach.
             GlyphVector tagGlyphs = sizedSplashTagFont.createGlyphVector(tagGraphics.getFontRenderContext(),
                   splashTag);
+            Rectangle2D tagInk = tagGlyphs.getVisualBounds();
+
+            // Centred across the logo, and down it at the height the wordmark sits at
+            int tagX = logoBounds.x + (int) ((logoBounds.width - tagInk.getWidth()) / 2 - tagInk.getX());
+            int wordmarkCentreY = logoBounds.y + (int) (logoBounds.height * LOGO_WORDMARK_CENTRE_FRACTION);
+            int tagY = wordmarkCentreY - (int) (tagInk.getY() + (tagInk.getHeight() / 2));
+
+            tagGraphics.rotate(Math.toRadians(Version.getSplashTagRotation()),
+                  tagX + tagInk.getCenterX(),
+                  wordmarkCentreY);
+
+            // The lettering is outlined and then filled, rather than simply drawn, so that it stands clear of the
+            // pale wordmark it is sprayed across.
             Shape tagOutline = tagGlyphs.getOutline(tagX, tagY);
 
             float outlineWidth = (float) Math.max(1.0,
@@ -627,11 +636,38 @@ public class MegaMekGUI implements IPreferenceChangeListener {
             tagGraphics.setColor(SPLASH_TAG_OUTLINE_COLOR);
             tagGraphics.draw(tagOutline);
 
-            tagGraphics.setColor(SPLASH_TAG_COLOR);
+            tagGraphics.setColor(splashTagColor);
             tagGraphics.fill(tagOutline);
         } finally {
             tagGraphics.dispose();
         }
+    }
+
+    /**
+     * Works out what colour to spray the splash tag in, the same way the build note's colour is chosen: by the
+     * plain colour name written in {@code Version.properties}.
+     *
+     * <p>A tag that names no colour, or names one that is not recognised, is sprayed in red. Whichever colour is
+     * used is left slightly see-through so the logo shows through the paint.</p>
+     *
+     * @return the colour to spray the tag in, never {@code null}
+     */
+    private static Color resolveSplashTagColor() {
+        String configuredColorName = Version.getSplashTagColorName();
+        if (configuredColorName == null) {
+            LOGGER.debug("[SplashTag] No splashTagColor set - the tag is sprayed in red");
+            return UIUtil.addAlpha(SPLASH_TAG_DEFAULT_COLOR, SPLASH_TAG_ALPHA);
+        }
+
+        Color namedColor = colorForName(configuredColorName);
+        if (namedColor == null) {
+            LOGGER.warn("[SplashTag] Version.properties sets splashTagColor to '{}', which is not a colour name "
+                        + "MegaMek knows. The tag will be sprayed in red instead.", configuredColorName);
+            return UIUtil.addAlpha(SPLASH_TAG_DEFAULT_COLOR, SPLASH_TAG_ALPHA);
+        }
+
+        LOGGER.debug("[SplashTag] Splash tag colour set to {}", configuredColorName);
+        return UIUtil.addAlpha(namedColor, SPLASH_TAG_ALPHA);
     }
 
     /**


### PR DESCRIPTION
## Summary

MegaMek can now say which edition a build is, right on the artwork: a short tag sprayed straight
across the MegaMek logo in red spray-paint lettering, outlined in black so it stays readable over the
pale wordmark underneath.

It follows the `notes=` entry added in #8710, and is driven the same way. Put this in
`megamek/resources/Version.properties`:

```properties
splashTag=Core Rules Edition
```

and "Core Rules Edition" appears sprayed across the logo, tilted slightly off level. Leave the entry
out and the artwork is exactly as it is today.

It is deliberately a **separate** entry from `notes=`, so the artwork and the menu can say different
things - this build says "Core Rules Release" in the menu and "Core Rules Edition" on the logo - or a
build can have one without the other.

**This PR ships the tag switched on**, labelling the build as the Core Rules Edition.

<img width="1285" height="926" alt="image" src="https://github.com/user-attachments/assets/8084dfc0-00bc-4b20-b7c7-b49711e4da56" />


## The font

The lettering uses the **Rubik Spray Paint** font, under the SIL Open Font License 1.1. It is already
on `MegaMek/mm-data` main at `data/fonts/Rubik_Spray_Paint/`, holding `RubikSprayPaint-Regular.ttf` and
`OFL.txt`, laid out the same way as `Anta/` and `Jura/`. MegaMek registers everything under
`data/fonts` automatically, so there is no loader change here.

If the font is ever missing - an un-staged or stale data directory - the tag is still drawn, in the
default font, and a warning naming the missing font goes to `megamek.log`. It degrades rather than
breaks.

## Changes

1. **A new optional `splashTag` entry in `Version.properties`**, documented in the file next to
   `notes`.
2. **`Version` reads it**, alongside the other optional entries, reusing the same
   "absent or blank means nothing configured" handling. Everything added is `static`, so nothing
   changes about how a `Version` travels in a packet or a save game.
3. **`MegaMekGUI` paints it** onto the splash artwork: it loads the font once when the menu is built,
   then sizes and places the tag against the logo each time the artwork is drawn.
4. **`drawLogo` now returns the rectangle it drew into**, which is what the tag is positioned against.
   Its drawing behaviour is unchanged.

### Two things worth knowing for review

**The tag is placed against the wordmark plate, not the middle of the logo image.** The obvious
approach - centre the tag on the logo - puts it up on the 'Mek's legs, because `mm-logo.png` is a tall
composite: a 'Mek standing above the wordmark plate, with the plate filling only the bottom quarter or
so. Profiling the image's transparency, the plate is the full-width band running from about
three-quarters of the way down to the bottom edge, so the tag is placed against that band instead.

**The tag is capped by height as well as width.** Sizing it purely to span the logo's width means a
short tag gets a huge font - "BETA" would come out taller than the plate it is supposed to be sprayed
across. The size is therefore the smaller of "fits the width" and "fits the plate's height".

Everything is derived from the logo's own rectangle, which is itself derived from the window size, so
the placement holds at any launcher size rather than being tuned to one screen.

## Files Changed

- `megamek/resources/Version.properties` - the new entry, documented, with the Core Rules Edition tag
  set
- `megamek/src/megamek/Version.java` - reads it; `getSplashTag()` and `hasSplashTag()`
- `megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java` - loads the font, sizes and sprays the tag,
  and `drawLogo` now reports where it drew

## Testing

- `compileJava`, `compileTestJava`, `VersionTest` (31/31) and checkstyle all clean.
- Run in-game repeatedly while settling the look. The final version was checked against a clean
  `megamek.log`: no ERROR, FATAL or null-pointer entries, and the expected
  `[SplashTag] Spraying 'Core Rules Edition' onto the splash artwork in Rubik Spray Paint` line.
- The placement was worked out by measuring the logo image's transparency per row to find where the
  wordmark plate actually sits, rather than by eye.
- The sizing and placement were then checked numerically across launcher widths of 800, 1024, 1280,
  1600, 1920, 2560 and 3200 pixels, and across tags from 4 to 35 characters ("BETA" through "The
  Twenty Fifth Anniversary Edition"). In every combination the tag lands on the plate and stays inside
  the artwork, with between 7 and 46 pixels to spare at the bottom.

## What is NOT proven yet

- **No automated test covers the tag.** The checks above were done with a throwaway harness, not a
  committed test. Making the sizing testable would mean pulling it out of the painting code; I am happy
  to do that if reviewers would rather have it guarded.
- **Only run at the default GUI scale and the default window size** for the visual check. The numeric
  check above covers other sizes, but I have only *looked* at one.
- **Only run with one skin.** The tag is painted onto the splash artwork rather than onto a skinned
  component, so a skin should not affect it - but that is reasoning, not something I have tried.
- **The font has not been through a release build.** It works from a staged data directory, and it is
  on mm-data main; I have not confirmed it survives packaging into a distributed build.
