### PR TITLE
Fix bug report template applying no label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,7 +5,7 @@ description: >
   on the Discord that there is an issue and not working as intended.
 title: "[Issue]"
 labels:
-  - bug
+  - Bug
 
 body:
   - type: textarea


### PR DESCRIPTION
## Root Cause

`bug_report.yml` declares its label as `bug`, but the repository's label is named `Bug`. The declared name does not match an existing label, so GitHub applies nothing and does not report an error. Bug reports opened through the issue form have therefore been arriving with no label at all.

The RFE template declares `(RFE) Enhancement`, which matches an existing label exactly, and that one works as intended - which is what makes this easy to miss.

## Evidence

Recent issues filed through the bug report form, with the labels they arrived with:

| Issue | Reporter | Labels |
|---|---|---|
| #8620 | Tecmes | none |
| #8652 | Tecmes | none |
| #8685 | AlexOldenburger | none |
| #8686 | radar6510 | none |
| #8673 | TenkawaBC | none |
| #8462 | TenkawaBC | none |
| #8476 | Shazrael | none |
| #8399 | BTSS88 | none |
| #8367 | BTSS88 | none |
| #8342 | Nick11012 | none |
| #7879 | SimonLandmine | none |
| #8433 | Rethid | none |

Twelve of the fourteen most recent form-filed reports arrived unlabelled. The two that do carry `Bug` (#8348, #8027) appear to have been labelled by hand afterwards; there is no labelling workflow in `.github/workflows/`.

By contrast #8709, filed through the RFE form, arrived with `(RFE) Enhancement` applied automatically.

## Changes

1. `.github/ISSUE_TEMPLATE/bug_report.yml` - declare the label as `Bug` so it matches the repository's label exactly.

## Files Changed

- `.github/ISSUE_TEMPLATE/bug_report.yml` - one line

## Testing

Not directly testable before merge: a template's labels only take effect for issues opened after it lands on the default branch. Worth confirming on the first bug report filed after this merges.

Verified beforehand that `Bug` exists in this repository as an exact string, so the new declaration matches.

## Notes

Found while working on #8722, which adds an in-game bug report helper. It is a separate concern from that PR, so it is split out here rather than riding along.

Two related observations for the maintainers, neither addressed here:

- **MekHQ has the identical mismatch.** Its `bug_report.yml` also declares `bug` while its label is `Bug`. The same one-line fix applies there.
- **MegaMekLab has no `Bug` label at all.** Its template declares `bug`, but the repository has no bug label of any spelling, so the label would have to be created before the template could reference one. That is a repository administration decision rather than a template fix.

The roughly twelve unlabelled reports listed above could also be backfilled if that is worth doing.
