### PR TITLE
Stop prefilling a bug report field that no longer exists

### DIFF
--- a/megamek/src/megamek/client/ui/PackageBugReportAction.java
+++ b/megamek/src/megamek/client/ui/PackageBugReportAction.java
@@ -340,7 +340,7 @@ public class PackageBugReportAction extends AbstractAction {
      */
     private static void openIssueForm(File archiveFile) {
         copyToClipboard(archiveFile);
-        String issueFormUrl = IssueReportUrl.forIssueForm(IssueReportUrl.MEGAMEK_ISSUES_URL, archiveFile.getName());
+        String issueFormUrl = IssueReportUrl.forIssueForm(IssueReportUrl.MEGAMEK_ISSUES_URL);
         LOGGER.info("[BugReport] Opening the issue form for {}", archiveFile.getName());
         UIUtil.browse(issueFormUrl);
     }

--- a/megamek/src/megamek/client/ui/clientGUI/BugReportDialog.java
+++ b/megamek/src/megamek/client/ui/clientGUI/BugReportDialog.java
@@ -171,7 +171,7 @@ public class BugReportDialog {
      * @return a button opening that repository's issue form with the environment fields already filled in
      */
     private static UrlButton prefilledIssueButton(String labelKey, String issuesUrl) {
-        return new UrlButton(I18N.get(labelKey), IssueReportUrl.forIssueForm(issuesUrl, null), issuesUrl);
+        return new UrlButton(I18N.get(labelKey), IssueReportUrl.forIssueForm(issuesUrl), issuesUrl);
     }
 
     /**

--- a/megamek/src/megamek/common/util/IssueReportUrl.java
+++ b/megamek/src/megamek/common/util/IssueReportUrl.java
@@ -39,7 +39,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.StringJoiner;
 
-import jakarta.annotation.Nullable;
 import megamek.SuiteConstants;
 import megamek.logging.MMLogger;
 
@@ -72,7 +71,6 @@ public final class IssueReportUrl {
     private static final String FIELD_VERSION = "custom-megamek-version";
     private static final String FIELD_OPERATING_SYSTEM = "operating-system";
     private static final String FIELD_JAVA_VERSION = "java-version";
-    private static final String FIELD_ATTACHED_FILES = "attached-files";
 
     /** The suite's repositories disable blank issues, so the template has to be named explicitly. */
     private static final String TEMPLATE_PARAMETER = "template=bug_report.yml";
@@ -81,7 +79,7 @@ public final class IssueReportUrl {
     private static final String CHOOSER_PATH = "/issues/new/choose";
     private static final String FORM_PATH = "/issues/new";
 
-    /** Kept well inside what browsers and GitHub accept, so a long note can never break the link. */
+    /** Kept well inside what browsers and GitHub accept, so the link can never be broken by its own length. */
     private static final int MAX_URL_LENGTH = 6000;
 
     /** The issue links of the three repositories that share the suite bug report template. */
@@ -94,18 +92,15 @@ public final class IssueReportUrl {
     /**
      * Builds a prefilled issue-form URL for one of the repositories that uses the suite bug report template.
      *
-     * <p>If including the attachment note would push the URL past {@link #MAX_URL_LENGTH}, the note is dropped; if
-     * the URL is still too long without it, the plain issue-chooser link is returned instead. A truncated URL is
-     * never produced, since that would land the player on a 404.</p>
+     * <p>If the URL would exceed {@link #MAX_URL_LENGTH} the plain issue-chooser link is returned instead. A
+     * truncated URL is never produced, since that would land the player on a 404.</p>
      *
      * @param repositoryIssuesUrl the repository's issue link, in either the {@code /issues/new/choose} or
      *                            {@code /issues/new} form
-     * @param attachmentNote      a note naming the bug report archive the player just built, or {@code null} when no
-     *                            archive has been created yet
      *
      * @return a URL that opens the issue form with the environment fields populated
      */
-    public static String forIssueForm(String repositoryIssuesUrl, @Nullable String attachmentNote) {
+    public static String forIssueForm(String repositoryIssuesUrl) {
         String formUrl = repositoryIssuesUrl.endsWith(CHOOSER_PATH)
               ? repositoryIssuesUrl.substring(0, repositoryIssuesUrl.length() - CHOOSER_PATH.length()) + FORM_PATH
               : repositoryIssuesUrl;
@@ -114,19 +109,8 @@ public final class IssueReportUrl {
         fields.put(FIELD_VERSION, SuiteConstants.VERSION.toString());
         fields.put(FIELD_OPERATING_SYSTEM, operatingSystemDescription());
         fields.put(FIELD_JAVA_VERSION, javaVersionDescription());
-        if ((attachmentNote != null) && !attachmentNote.isBlank()) {
-            fields.put(FIELD_ATTACHED_FILES, attachmentNote);
-        }
 
         String candidateUrl = assemble(formUrl, fields);
-        if (candidateUrl.length() <= MAX_URL_LENGTH) {
-            return candidateUrl;
-        }
-
-        LOGGER.debug("[BugReport] Prefilled issue URL was {} characters; dropping the attachment note",
-              candidateUrl.length());
-        fields.remove(FIELD_ATTACHED_FILES);
-        candidateUrl = assemble(formUrl, fields);
         if (candidateUrl.length() <= MAX_URL_LENGTH) {
             return candidateUrl;
         }

--- a/megamek/src/megamek/common/util/IssueReportUrl.java
+++ b/megamek/src/megamek/common/util/IssueReportUrl.java
@@ -92,8 +92,8 @@ public final class IssueReportUrl {
     /**
      * Builds a prefilled issue-form URL for one of the repositories that uses the suite bug report template.
      *
-     * <p>If the URL would exceed {@link #MAX_URL_LENGTH} the plain issue-chooser link is returned instead. A
-     * truncated URL is never produced, since that would land the player on a 404.</p>
+     * <p>If the URL would exceed {@link #MAX_URL_LENGTH} the link is returned exactly as it was given, with no
+     * prefilled fields. A truncated URL is never produced, since that would land the player on a 404.</p>
      *
      * @param repositoryIssuesUrl the repository's issue link, in either the {@code /issues/new/choose} or
      *                            {@code /issues/new} form
@@ -116,7 +116,7 @@ public final class IssueReportUrl {
         }
 
         LOGGER.warn("[BugReport] Could not build a prefilled issue URL within {} characters; "
-              + "falling back to the plain issue chooser", MAX_URL_LENGTH);
+              + "falling back to {} unchanged", MAX_URL_LENGTH, repositoryIssuesUrl);
         return repositoryIssuesUrl;
     }
 

--- a/megamek/unittests/megamek/common/util/IssueReportUrlTest.java
+++ b/megamek/unittests/megamek/common/util/IssueReportUrlTest.java
@@ -45,7 +45,7 @@ class IssueReportUrlTest {
 
     @Test
     void prefillsTheThreeRequiredEnvironmentFields() {
-        String url = IssueReportUrl.forIssueForm(MEGAMEK_ISSUES, null);
+        String url = IssueReportUrl.forIssueForm(MEGAMEK_ISSUES);
 
         assertTrue(url.contains("custom-megamek-version="), url);
         assertTrue(url.contains("operating-system="), url);
@@ -54,7 +54,7 @@ class IssueReportUrlTest {
 
     @Test
     void namesTheTemplateBecauseTheRepositoriesDisableBlankIssues() {
-        String url = IssueReportUrl.forIssueForm(MEGAMEK_ISSUES, null);
+        String url = IssueReportUrl.forIssueForm(MEGAMEK_ISSUES);
 
         assertTrue(url.contains("template=bug_report.yml"), url);
         assertTrue(url.startsWith("https://github.com/MegaMek/megamek/issues/new?"), url);
@@ -67,55 +67,42 @@ class IssueReportUrlTest {
      */
     @Test
     void neverSetsTheLabelsParameter() {
-        String url = IssueReportUrl.forIssueForm(MEGAMEK_ISSUES, "attach bug-report.zip");
+        String url = IssueReportUrl.forIssueForm(MEGAMEK_ISSUES);
 
         assertFalse(url.contains("labels="), "a labels parameter would 404 for non-maintainers: " + url);
     }
 
-    @Test
-    void includesTheAttachmentNoteWhenOneIsGiven() {
-        String url = IssueReportUrl.forIssueForm(MEGAMEK_ISSUES, "Please attach MegaMek-BugReport.zip");
-
-        assertTrue(url.contains("attached-files="), url);
-        assertTrue(url.contains("MegaMek-BugReport.zip"), url);
-    }
-
-    @Test
-    void omitsTheAttachmentFieldWhenThereIsNoNote() {
-        String url = IssueReportUrl.forIssueForm(MEGAMEK_ISSUES, null);
-
-        assertFalse(url.contains("attached-files="), url);
-    }
-
+    /** Both the operating system and Java descriptions are built with spaces in them on every platform. */
     @Test
     void encodesValuesSoSpacesCannotBreakTheUrl() {
-        String url = IssueReportUrl.forIssueForm(MEGAMEK_ISSUES, "a note with spaces");
+        String url = IssueReportUrl.forIssueForm(MEGAMEK_ISSUES);
 
         assertFalse(url.contains(" "), "an unencoded space would truncate the link: " + url);
     }
 
     @Test
     void acceptsARepositoryUrlThatIsAlreadyInFormRatherThanChooserShape() {
-        String url = IssueReportUrl.forIssueForm("https://github.com/MegaMek/mekhq/issues/new", null);
+        String url = IssueReportUrl.forIssueForm("https://github.com/MegaMek/mekhq/issues/new");
 
         assertTrue(url.startsWith("https://github.com/MegaMek/mekhq/issues/new?"), url);
         assertFalse(url.contains("/choose"), url);
     }
 
+    /**
+     * The bug report form now takes files through an {@code upload} element named {@code report-files}, which no
+     * query parameter can fill. The old {@code attached-files} text field no longer exists in any of the templates.
+     */
     @Test
-    void dropsTheAttachmentNoteRatherThanEmittingAnOverlongUrl() {
-        String overlongNote = "z".repeat(10_000);
+    void neverSetsTheRetiredAttachmentField() {
+        String url = IssueReportUrl.forIssueForm(MEGAMEK_ISSUES);
 
-        String url = IssueReportUrl.forIssueForm(MEGAMEK_ISSUES, overlongNote);
-
-        assertFalse(url.contains("attached-files="), "the note should have been dropped, not truncated");
-        assertTrue(url.contains("custom-megamek-version="), "the required fields should survive: " + url);
+        assertFalse(url.contains("attached-files="), "that field was retired when the templates were reworked: " + url);
     }
 
     @Test
     void buildsTheSameFieldSetForEverySuiteRepository() {
-        String megaMekUrl = IssueReportUrl.forIssueForm(MEGAMEK_ISSUES, null);
-        String mekHqUrl = IssueReportUrl.forIssueForm("https://github.com/MegaMek/mekhq/issues/new/choose", null);
+        String megaMekUrl = IssueReportUrl.forIssueForm(MEGAMEK_ISSUES);
+        String mekHqUrl = IssueReportUrl.forIssueForm("https://github.com/MegaMek/mekhq/issues/new/choose");
 
         assertEquals(queryStringOf(megaMekUrl), queryStringOf(mekHqUrl),
               "the three suite repositories share identical issue-form field ids");


### PR DESCRIPTION
## What was broken

Nothing a player would notice, which is why this is small. When the Report a Bug packager opens the issue form it was writing the archive's file name into a form field called `attached-files`. That field no longer exists: #8733 replaced it with an `upload` element named `report-files`, and a file input cannot be filled from a query parameter at all.

So the program has been sending a parameter that names nothing. It is harmless - GitHub ignores a parameter for a field that does not exist, which I checked against the live form before the templates were reworked - but it is dead code that will quietly confuse the next person who reads it.

## Changes

- `forIssueForm` now takes only the repository URL. The `attachmentNote` parameter, the `attached-files` field id, and the fallback that dropped the note to keep the URL under the length limit all went with it, since that fallback existed solely to protect the note.
- `PackageBugReportAction` and `BugReportDialog` updated for the one-argument call. The dialog was already passing `null`.
- The three tests covering the note are replaced by one that asserts `attached-files` never reappears in a generated URL, so this cannot be reintroduced by accident.

The three environment field ids are untouched. Those are still live, still filled in by the program, and still must never be renamed.

## Testing

`compileJava`, `compileTestJava` and the `IssueReportUrl` and `BugReportBundle` test classes all pass.

The behaviour this removes was verified on the live form rather than assumed. Before the templates were reworked I loaded MegaMek's issue form with a deliberately junk parameter and confirmed the form rendered normally with the real prefills intact. After #8733 merged I loaded it again: the `upload` element renders, the issue type is applied, the version prefill still lands, and the retired `attached-files` parameter does nothing.

## What is NOT proven yet

Nothing outstanding. This removes a code path rather than adding one, and the remaining prefill was confirmed working against the live form after the template change.

Worth recording from that same check, since it was the open question on #8733: the upload element's drop zone reads "Paste, drop, or click to add files", so the packager's Copy File button and its automatic clipboard copy still work as intended.
