### PR TITLE
Fix spurious 'Unexpected null last step' ERROR on empty move paths (Fixes #8714)

### DIFF
--- a/megamek/src/megamek/server/totalWarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalWarfare/MovePathHandler.java
@@ -1091,17 +1091,11 @@ class MovePathHandler extends AbstractTWRuleHandler {
         }
 
         // if we ran with destroyed hip or gyro, we need a psr
-        MoveStep lastStep = md.getLastStep();
-        if (lastStep != null) {
-            rollTarget = entity.checkRunningWithDamage(overallMoveType, lastStep.getDistance());
-            if (rollTarget.getValue() != TargetRoll.CHECK_FALSE && entity.canFall()) {
-                gameManager.doSkillCheckInPlace(entity, rollTarget);
-            }
-        } else {
-            logger.error("Unexpected null last step! Entity: {}; MoveType: {}; md: {}", entity.getId(),
-                  overallMoveType, md);
+        rollTarget = entity.checkRunningWithDamage(overallMoveType, md.getHexesMoved());
+        if (rollTarget.getValue() != TargetRoll.CHECK_FALSE && entity.canFall()) {
+            gameManager.doSkillCheckInPlace(entity, rollTarget);
         }
-        
+
         // if we moved a hex with a destroyed leg, but it was not a run
         rollTarget = Game.rulesManager.getRulesPSR().checkWalkWithLegDestroyed(entity,
               overallMoveType, md.getHexesMoved());


### PR DESCRIPTION
Fixes #8714

## Summary

Whenever a unit ended the movement phase without moving (Done with no destination, or `/skip`), the host's log got an ERROR line from `MovePathHandler`. The null guard added in 2b6dd54bbc fixed a real NPE from 90b986700a but logged the normal empty-path case at ERROR severity. A zero-step move is ordinary, not an error.

## Changes

- The ran-with-damaged-hip-or-gyro check now passes `md.getHexesMoved()` instead of null-checking `getLastStep()` and logging when it is null. `getHexesMoved()` is the same value with a built-in null guard returning 0.
- Distance 0 returns CHECK_FALSE under both TW and Core rules, so the game outcome is unchanged - only the log line is gone. This matches the client-side nag in `SharedUtility` and the destroyed-leg check on the next lines.

## Testing

- `compileJava`, `checkstyleMain`, and `javadoc` all pass; `MovePathHandlerClimbingTest` passes.
- Live repro on a hosted game: before the fix, pressing Done on an unmoved Mek wrote the ERROR line; after the fix, the same repro writes nothing.
- The `/skip` trigger was also re-tested in-game after the fix: game brought to the movement phase, `/skip` issued, log stayed clean.

## Not proven yet

- Everything claimed above is verified: both triggers (Done without moving, `/skip`) were reproduced live before and after the fix.