### PR TITLE
Fix WARN stack trace per weapon and ammo bin on every phase change (Fixes #8741)

### DIFF
--- a/megamek/src/megamek/common/equipment/Mounted.java
+++ b/megamek/src/megamek/common/equipment/Mounted.java
@@ -526,7 +526,8 @@ public class Mounted<T extends EquipmentType> implements Serializable, RoundUpda
 
         jammed = jammedThisPhase;
 
-        if (type.hasFlag(MiscType.F_SHIELD) && Game.rulesManager.getRulesPhysical().phaseChangeShield() &&
+        if ((type instanceof MiscType) && type.hasFlag(MiscType.F_SHIELD) &&
+              Game.rulesManager.getRulesPhysical().phaseChangeShield() &&
               !this.curMode().equals(MiscType.S_NO_SHIELD)) {
             if (!this.getEntity().isCharging() || phase.isEnd()) {
                 this.setMode(MiscType.S_NO_SHIELD);


### PR DESCRIPTION
Fixes #8741

## Summary

Every phase change, `Mounted.newPhase()` asked every mounted item - weapons and ammo included - the MiscType-only question `hasFlag(MiscType.F_SHIELD)`. The type-safety tripwires in `WeaponType.hasFlag()` and `AmmoType.hasFlag()` correctly flag that mistyped call, logging a WARN with a full stack trace once per weapon and ammo bin per phase change. A short two-Mek test game produced 72 stack traces.

## Changes

- The shield check is now guarded with `(type instanceof MiscType)`, matching the five sibling guards already in the same class. The mistyped call already returned false, so game behavior is unchanged - only the log noise goes away.
- The `hasFlag()` tripwires are NOT modified; they are working as intended and stay as protection against future mistyped flag checks.

## Testing

- `compileJava`, `checkstyleMain`, and `javadoc` all pass; the `Mounted` test classes pass.
- Live before/after on a hosted game: 42 WeaponType and 30 AmmoType "Incorrect flag check" WARNs before the fix; zero after, verified by advancing through the same phases.

## Not proven yet

- Everything claimed above is verified, including the in-game before/after check.