### PR TITLE
Fix AIMatchRunner CSV dropping the wiped team's row (Fixes #8700)

### DIFF
--- a/megamek/src/megamek/utilities/ScenarioGameRunner.java
+++ b/megamek/src/megamek/utilities/ScenarioGameRunner.java
@@ -38,6 +38,7 @@ import java.io.File;
 import java.io.ObjectInputFilter;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -117,6 +118,17 @@ public class ScenarioGameRunner {
      */
     private final List<AbstractClient> connectedClients = new ArrayList<>();
 
+    /**
+     * The players as loaded from the scenario, captured before the game runs. The end-of-game standings are
+     * collected from this snapshot rather than from the live player list, because every bot disconnects itself
+     * when the VICTORY phase is announced ({@code BotClient#changePhase}) and the server then removes its player
+     * from the game entirely ({@code TWGameManager#disconnect}). That removal races the standings collection, so
+     * by the time standings are read a wiped (or even winning) team's player may already be gone - see issue #8700.
+     * {@code Game#removePlayer} only drops the list entry; these Player objects stay valid, and the server reuses
+     * them when the bot clients connect to claim their slots.
+     */
+    private final List<Player> playersAtGameStart;
+
     public ScenarioGameRunner(File scenarioFile) throws Exception {
         TWGameManager gameManager = new TWGameManager();
         Random random = new Random();
@@ -138,6 +150,7 @@ public class ScenarioGameRunner {
             server.setGame(game);
             scenario.applyDamage(gameManager);
             gameManager.calculatePlayerInitialCounts();
+            playersAtGameStart = List.copyOf(game.getPlayersList());
         } catch (Exception constructionFailure) {
             server.die();
             throw constructionFailure;
@@ -256,8 +269,10 @@ public class ScenarioGameRunner {
         } else {
             logger.error("Scenario game timed out");
         }
-        return new GameResult(finished, determineWinningTeam(watcherSlot.getTeam()), game.getCurrentRound(),
-              collectTeamStandings(watcherSlot.getTeam()));
+        return new GameResult(finished,
+              determineWinningTeam(game, playersAtGameStart, watcherSlot.getTeam()),
+              game.getCurrentRound(),
+              collectTeamStandings(game, playersAtGameStart, watcherSlot.getTeam()));
     }
 
     /**
@@ -265,14 +280,23 @@ public class ScenarioGameRunner {
      * are crippled), destroyed and fled counts, and Battle Value at start versus game end. Ejected crew entities
      * are skipped so a unit and its ejected pilot are not counted twice.
      *
-     * @param watcherTeam the team of the headless watcher, which is excluded
+     * <p>Teams and entity ownership are resolved through the game-start player snapshot, not the live player
+     * list: a bot whose side was wiped disconnects at VICTORY and its player is removed from the game, which
+     * would otherwise silently drop that team's standing entirely (issue #8700).</p>
+     *
+     * <p>Package-private and static so the wiped-team regression test can drive it without a live server.</p>
+     *
+     * @param game               the game to collect standings from
+     * @param playersAtGameStart every player as of game start, including any since removed
+     * @param watcherTeam        the team of the headless watcher, which is excluded
      *
      * @return one {@link TeamStanding} per combatant team, ordered by team id
      */
-    private List<TeamStanding> collectTeamStandings(int watcherTeam) {
+    static List<TeamStanding> collectTeamStandings(Game game, List<Player> playersAtGameStart, int watcherTeam) {
+        Map<Integer, Integer> teamByPlayerId = teamByPlayerId(playersAtGameStart);
         Map<Integer, TeamTally> tallies = new TreeMap<>();
 
-        for (Player player : game.getPlayersList()) {
+        for (Player player : playersAtGameStart) {
             if (player.getTeam() == watcherTeam) {
                 continue;
             }
@@ -283,7 +307,7 @@ public class ScenarioGameRunner {
         }
 
         for (Entity entity : game.getEntitiesVector()) {
-            TeamTally tally = tallyFor(tallies, entity, watcherTeam);
+            TeamTally tally = tallyFor(tallies, entity, teamByPlayerId, watcherTeam);
             if (tally == null) {
                 continue;
             }
@@ -298,7 +322,7 @@ public class ScenarioGameRunner {
         }
 
         for (Entity entity : game.getOutOfGameEntitiesVector()) {
-            TeamTally tally = tallyFor(tallies, entity, watcherTeam);
+            TeamTally tally = tallyFor(tallies, entity, teamByPlayerId, watcherTeam);
             if (tally == null) {
                 continue;
             }
@@ -324,32 +348,54 @@ public class ScenarioGameRunner {
 
     /**
      * Returns the tally the given entity counts toward, or {@code null} when it should not be counted:
-     * watcher-team and ownerless entities are not combatants, and ejected crew are not units.
+     * watcher-team entities and entities of unknown ownership are not combatants, and ejected crew are not
+     * units. Ownership is resolved by owner id against the game-start snapshot, because the owner's player
+     * may already have been removed from the game (see {@link #playersAtGameStart}).
      */
-    private @Nullable TeamTally tallyFor(Map<Integer, TeamTally> tallies, Entity entity, int watcherTeam) {
-        Player owner = entity.getOwner();
-        if ((owner == null) || (owner.getTeam() == watcherTeam) || (entity instanceof EjectedCrew)) {
+    private static @Nullable TeamTally tallyFor(Map<Integer, TeamTally> tallies, Entity entity,
+          Map<Integer, Integer> teamByPlayerId, int watcherTeam) {
+        Integer team = teamByPlayerId.get(entity.getOwnerId());
+        if ((team == null) || (team == watcherTeam) || (entity instanceof EjectedCrew)) {
             return null;
         }
-        return tallies.computeIfAbsent(owner.getTeam(), team -> new TeamTally());
+        return tallies.computeIfAbsent(team, teamId -> new TeamTally());
     }
 
     /**
      * Determines the winner as the sole combatant team with surviving units, ignoring the unit-less watcher.
+     * Entity ownership is resolved by owner id against the game-start snapshot, so a winner whose bot has
+     * already disconnected (and had its player removed) is not misreported as a draw.
      *
-     * @param watcherTeam the team of the headless watcher, which is excluded
+     * <p>Package-private and static so the wiped-team regression test can drive it without a live server.</p>
+     *
+     * @param game               the game to determine the winner of
+     * @param playersAtGameStart every player as of game start, including any since removed
+     * @param watcherTeam        the team of the headless watcher, which is excluded
      *
      * @return the sole surviving combatant team, or {@link Player#TEAM_NONE} if zero or more than one remain
      */
-    private int determineWinningTeam(int watcherTeam) {
+    static int determineWinningTeam(Game game, List<Player> playersAtGameStart, int watcherTeam) {
+        Map<Integer, Integer> teamByPlayerId = teamByPlayerId(playersAtGameStart);
         Set<Integer> survivingTeams = new TreeSet<>();
         for (Entity entity : game.getEntitiesVector()) {
-            Player owner = entity.getOwner();
-            if (!entity.isDestroyed() && (owner != null) && (owner.getTeam() != watcherTeam)) {
-                survivingTeams.add(owner.getTeam());
+            Integer team = teamByPlayerId.get(entity.getOwnerId());
+            if (!entity.isDestroyed() && (team != null) && (team != watcherTeam)) {
+                survivingTeams.add(team);
             }
         }
         return (survivingTeams.size() == 1) ? survivingTeams.iterator().next() : Player.TEAM_NONE;
+    }
+
+    /**
+     * Maps each game-start player's id to their team, for resolving entity ownership after a player has been
+     * removed from the game.
+     */
+    private static Map<Integer, Integer> teamByPlayerId(List<Player> playersAtGameStart) {
+        Map<Integer, Integer> teamByPlayerId = new HashMap<>();
+        for (Player player : playersAtGameStart) {
+            teamByPlayerId.put(player.getId(), player.getTeam());
+        }
+        return teamByPlayerId;
     }
 
     /**

--- a/megamek/unittests/megamek/utilities/ScenarioGameRunnerTest.java
+++ b/megamek/unittests/megamek/utilities/ScenarioGameRunnerTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.utilities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import megamek.common.Hex;
+import megamek.common.Player;
+import megamek.common.board.Board;
+import megamek.common.board.BoardType;
+import megamek.common.board.Coords;
+import megamek.common.enums.Gender;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.WeaponMounted;
+import megamek.common.game.Game;
+import megamek.common.interfaces.IEntityRemovalConditions;
+import megamek.common.options.OptionsConstants;
+import megamek.common.units.Aero;
+import megamek.common.units.AeroSpaceFighter;
+import megamek.common.units.Crew;
+import megamek.common.units.CrewType;
+import megamek.utilities.ScenarioGameRunner.TeamStanding;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for issue #8700: every bot disconnects itself when the VICTORY phase is announced, and the
+ * server then removes its player from the game entirely. That removal races the end-of-game standings
+ * collection, so a wiped team's player could already be gone when standings were read - and its CSV row
+ * silently vanished from the {@link AIMatchRunner} results. The standings must instead be collected from the
+ * game-start player snapshot.
+ */
+class ScenarioGameRunnerTest {
+
+    private static final int WATCHER_TEAM = 3;
+    private static final int WIPED_TEAM = 1;
+    private static final int WINNING_TEAM = 2;
+
+    private static final int WIPED_INITIAL_BV = 1000;
+    private static final int WINNER_INITIAL_BV = 900;
+
+    @BeforeAll
+    static void beforeAll() {
+        EquipmentType.initializeTypes();
+    }
+
+    /** The 2v2 duel from the issue, one round before the end: game state plus the game-start player snapshot. */
+    private record Duel(Game game, List<Player> playersAtGameStart, Player wipedPlayer, Player winningPlayer) {}
+
+    /**
+     * Builds the wipe from the issue's example: a watcher with no units, a wiped side whose two fighters are
+     * both in the graveyard, and a winning side with both fighters still on the board.
+     */
+    private static Duel buildFinishedDuel() {
+        Game game = new Game();
+        game.initializeRulesManager(OptionsConstants.RULES_CORE);
+        game.setBoard(smallGroundBoard());
+
+        Player watcher = new Player(0, "Watcher");
+        watcher.setTeam(WATCHER_TEAM);
+        game.addPlayer(0, watcher);
+
+        Player wipedPlayer = new Player(1, "PrincessSide");
+        wipedPlayer.setTeam(WIPED_TEAM);
+        wipedPlayer.setInitialEntityCount(2);
+        wipedPlayer.setInitialBV(WIPED_INITIAL_BV);
+        game.addPlayer(1, wipedPlayer);
+
+        Player winningPlayer = new Player(2, "CasparSide");
+        winningPlayer.setTeam(WINNING_TEAM);
+        winningPlayer.setInitialEntityCount(2);
+        winningPlayer.setInitialBV(WINNER_INITIAL_BV);
+        game.addPlayer(2, winningPlayer);
+
+        List<Player> playersAtGameStart = List.copyOf(game.getPlayersList());
+
+        fighter(game, 11, wipedPlayer, new Coords(0, 0));
+        fighter(game, 12, wipedPlayer, new Coords(1, 0));
+        fighter(game, 21, winningPlayer, new Coords(2, 2));
+        fighter(game, 22, winningPlayer, new Coords(3, 2));
+
+        // the wiped side's fighters are shot down, moving them to the graveyard
+        game.removeEntity(11, IEntityRemovalConditions.REMOVE_SALVAGEABLE);
+        game.removeEntity(12, IEntityRemovalConditions.REMOVE_SALVAGEABLE);
+
+        return new Duel(game, playersAtGameStart, wipedPlayer, winningPlayer);
+    }
+
+    private static void fighter(Game game, int id, Player owner, Coords position) {
+        AeroSpaceFighter fighter = new AeroSpaceFighter();
+        WeaponMounted laser = (WeaponMounted) WeaponMounted.createMounted(fighter,
+              EquipmentType.get("ISMediumLaser"));
+        try {
+            fighter.addEquipment(laser, Aero.LOC_NOSE, false);
+        } catch (Exception exception) {
+            throw new IllegalStateException(exception);
+        }
+        fighter.setCrew(new Crew(CrewType.SINGLE, "Test Pilot", 1, 4, 5, Gender.FEMALE, false, null));
+        fighter.setId(id);
+        fighter.setOwner(owner);
+        fighter.setPosition(position);
+        fighter.setAltitude(5);
+        fighter.setDeployed(true);
+        game.addEntity(fighter, false);
+    }
+
+    private static Board smallGroundBoard() {
+        Hex[] hexes = new Hex[25];
+        for (int index = 0; index < hexes.length; index++) {
+            hexes[index] = new Hex();
+        }
+        Board board = new Board(5, 5, hexes);
+        board.setBoardType(BoardType.GROUND);
+        return board;
+    }
+
+    private static TeamStanding standingOf(List<TeamStanding> standings, int team) {
+        for (TeamStanding standing : standings) {
+            if (standing.team() == team) {
+                return standing;
+            }
+        }
+        throw new AssertionError("No standing for team " + team + " in " + standings);
+    }
+
+    /**
+     * The regression itself: the wiped bot's player has been removed from the game (VICTORY-phase disconnect),
+     * but its team must still get a standing - with all units destroyed and no Battle Value remaining.
+     */
+    @Test
+    void wipedTeamKeepsItsStandingAfterItsPlayerIsRemoved() {
+        Duel duel = buildFinishedDuel();
+        int winnerRemainingBV = duel.winningPlayer().getBV();
+
+        duel.game().removePlayer(duel.wipedPlayer().getId());
+
+        List<TeamStanding> standings = ScenarioGameRunner.collectTeamStandings(duel.game(),
+              duel.playersAtGameStart(), WATCHER_TEAM);
+
+        assertEquals(2, standings.size(), "both combatant teams must have a standing: " + standings);
+        assertEquals(new TeamStanding(WIPED_TEAM, 2, 0, 0, 2, 0, WIPED_INITIAL_BV, 0),
+              standingOf(standings, WIPED_TEAM));
+        assertEquals(new TeamStanding(WINNING_TEAM, 2, 2, 0, 0, 0, WINNER_INITIAL_BV, winnerRemainingBV),
+              standingOf(standings, WINNING_TEAM));
+    }
+
+    /**
+     * The same race from the winner's side: if the winning bot's disconnect lands first, its surviving
+     * entities lose their live owner - the win must still be attributed instead of reporting a draw.
+     */
+    @Test
+    void winnerIsStillDeterminedAfterItsPlayerIsRemoved() {
+        Duel duel = buildFinishedDuel();
+
+        duel.game().removePlayer(duel.winningPlayer().getId());
+
+        assertEquals(WINNING_TEAM, ScenarioGameRunner.determineWinningTeam(duel.game(),
+              duel.playersAtGameStart(), WATCHER_TEAM));
+    }
+
+    /** The unraced case must keep producing exactly what it did before the fix. */
+    @Test
+    void standingsAndWinnerAreUnchangedWhenNoPlayerWasRemoved() {
+        Duel duel = buildFinishedDuel();
+
+        List<TeamStanding> standings = ScenarioGameRunner.collectTeamStandings(duel.game(),
+              duel.playersAtGameStart(), WATCHER_TEAM);
+
+        assertEquals(2, standings.size());
+        assertEquals(new TeamStanding(WIPED_TEAM, 2, 0, 0, 2, 0, WIPED_INITIAL_BV, 0),
+              standingOf(standings, WIPED_TEAM));
+        assertEquals(WINNING_TEAM, ScenarioGameRunner.determineWinningTeam(duel.game(),
+              duel.playersAtGameStart(), WATCHER_TEAM));
+    }
+}


### PR DESCRIPTION
Fixes #8700

## Summary
Games ending in a team wipe sometimes wrote only the surviving team's CSV row. Bots disconnect when the VICTORY phase is announced, the server then removes their player from the game, and the standings collector read the live player list - so the wiped team's row could vanish. Before 63fb78d1eb (merged two days after this was observed) a wiped bot left the game mid-match, making the loss near-deterministic; the VICTORY-phase race remains.

## Changes
- ScenarioGameRunner captures the player list once at game start and collects standings from that snapshot instead of the live list.
- Entity ownership is resolved by owner id against the snapshot, not Entity.getOwner(), so a removed player's graveyard units still count.
- determineWinningTeam gets the same treatment, so a winner whose bot disconnected first is not misreported as a draw.
- The two collectors are package-private static so the regression test can drive them without a live server. AIMatchRunner itself is unchanged.

## Testing
- New ScenarioGameRunnerTest, 3 tests. The wiped-team test was verified by reverting the fix: it fails against the old code.
- Headless 6-game guaranteed-wipe batch with the fix: every game produced 2 rows; all 3 true wipes show the wiped row with survivors=0 and bv_remaining=0, winner attributed.
- Full suite: 15,201 tests, 1 failure - AeroWeaponFireInfoProbeTest velocityPenaltyFiresOnALiveStyleRanking, which fails on unmodified main too.

## Not proven yet
- The pre-fix row loss was not reproduced end-to-end: a 5-game control on the old code kept both rows in all 3 wipes. Since 63fb78d1eb the race window is milliseconds, so the deterministic proof is the revert-verified unit test, not a live repro.
- The winner-misreported-as-draw side was not revert-verified: test-built entities keep the cached owner reference that masks it. Production entities lose that cache, which is why real rows vanished entirely.