### PR TITLE
Fix Split-S being offered when it would dive into the ground (Fixes #8699)

### DIFF
--- a/megamek/resources/megamek/client/messages.properties
+++ b/megamek/resources/megamek/client/messages.properties
@@ -3549,7 +3549,7 @@ ManeuverChoiceDialog.Immelman.requirements=Velocity >= 3, Altitude < 9
 ManeuverChoiceDialog.Immelman.thrustCost=4
 ManeuverChoiceDialog.Immelman.controlMod=+1
 ManeuverChoiceDialog.Immelman.effect=+2 altitude, face any direction
-ManeuverChoiceDialog.SplitS.requirements=Any velocity
+ManeuverChoiceDialog.SplitS.requirements=Any velocity, room to drop 2 altitudes above the terrain
 ManeuverChoiceDialog.SplitS.thrustCost=2
 ManeuverChoiceDialog.SplitS.controlMod=+2
 ManeuverChoiceDialog.SplitS.effect=-2 altitude, +1 velocity, face any direction
@@ -3579,6 +3579,7 @@ ManeuverChoiceDialog.VIFF.controlMod=+2
 ManeuverChoiceDialog.VIFF.effect=Stop forward momentum, +1 altitude
 ManeuverChoiceDialog.currentValue=(Current: {0})
 ManeuverChoiceDialog.currentValues=(Velocity: {0}, Altitude: {1})
+ManeuverChoiceDialog.currentAltitude=(Altitude: {0})
 ManeuverChoiceDialog.notVSTOL=(Not VSTOL)
 ManeuverChoiceDialog.thrustCostLabel=Thrust Cost
 ManeuverChoiceDialog.controlModLabel=Control Modifier

--- a/megamek/resources/megamek/client/messages_de.properties
+++ b/megamek/resources/megamek/client/messages_de.properties
@@ -1301,6 +1301,7 @@ ManeuverChoiceDialog.VIFF.controlMod=+2
 ManeuverChoiceDialog.VIFF.effect=Stoppt Vorw\u00E4rtsbewegung, +1 H\u00F6he
 ManeuverChoiceDialog.currentValue=(Aktuell: {0})
 ManeuverChoiceDialog.currentValues=(Geschwindigkeit: {0}, H\u00F6he: {1})
+ManeuverChoiceDialog.currentAltitude=(H\u00F6he: {0})
 ManeuverChoiceDialog.notVSTOL=(Kein VSTOL)
 ManeuverChoiceDialog.thrustCostLabel=Schubkosten
 ManeuverChoiceDialog.controlModLabel=Kontrollmodifikator

--- a/megamek/resources/megamek/client/messages_es.properties
+++ b/megamek/resources/megamek/client/messages_es.properties
@@ -4210,6 +4210,7 @@ ManeuverChoiceDialog.VIFF.controlMod=+2
 ManeuverChoiceDialog.VIFF.effect=Detiene impulso, +1 altitud
 ManeuverChoiceDialog.currentValue=(Actual: {0})
 ManeuverChoiceDialog.currentValues=(Velocidad: {0}, Altitud: {1})
+ManeuverChoiceDialog.currentAltitude=(Altitud: {0})
 ManeuverChoiceDialog.notVSTOL=(No es VSTOL)
 ManeuverChoiceDialog.thrustCostLabel=Coste de empuje
 ManeuverChoiceDialog.controlModLabel=Modificador de control

--- a/megamek/resources/megamek/client/messages_ru.properties
+++ b/megamek/resources/megamek/client/messages_ru.properties
@@ -2301,6 +2301,7 @@ ManeuverChoiceDialog.VIFF.controlMod=+2
 ManeuverChoiceDialog.VIFF.effect=\u041E\u0441\u0442\u0430\u043D\u043E\u0432\u043A\u0430, +1 \u0432\u044B\u0441\u043E\u0442\u0430
 ManeuverChoiceDialog.currentValue=(\u0422\u0435\u043A\u0443\u0449\u0435\u0435: {0})
 ManeuverChoiceDialog.currentValues=(\u0421\u043A\u043E\u0440\u043E\u0441\u0442\u044C: {0}, \u0412\u044B\u0441\u043E\u0442\u0430: {1})
+ManeuverChoiceDialog.currentAltitude=(\u0412\u044B\u0441\u043E\u0442\u0430: {0})
 ManeuverChoiceDialog.notVSTOL=(\u041D\u0435 VSTOL)
 ManeuverChoiceDialog.thrustCostLabel=\u0421\u0442\u043E\u0438\u043C\u043E\u0441\u0442\u044C \u0442\u044F\u0433\u0438
 ManeuverChoiceDialog.controlModLabel=\u041C\u043E\u0434\u0438\u0444\u0438\u043A\u0430\u0442\u043E\u0440 \u0443\u043F\u0440\u0430\u0432\u043B\u0435\u043D\u0438\u044F

--- a/megamek/src/megamek/client/ui/dialogs/phaseDisplay/ManeuverChoiceDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/phaseDisplay/ManeuverChoiceDialog.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2002-2004 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2004-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2004-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -320,7 +320,7 @@ public class ManeuverChoiceDialog extends JDialog implements ActionListener {
             checkboxes[type].setEnabled(canPerform);
             // Update tooltip to show current state using ManeuverType
             checkboxes[type].setToolTipText(
-                ManeuverType.getManeuverTooltip(type, canPerform, velocity, altitude, isVSTOL_CF));
+                ManeuverType.getManeuverTooltip(type, canPerform, velocity, altitude, ceiling, isVSTOL_CF));
         }
     }
 }

--- a/megamek/src/megamek/common/ManeuverType.java
+++ b/megamek/src/megamek/common/ManeuverType.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2008-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2008-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -102,7 +102,9 @@ public class ManeuverType {
             case MAN_IMMELMAN:
                 return (velocity >= 3) && (altitude < 9);
             case MAN_SPLIT_S:
-                return (altitude + 2) > ceiling;
+                // Loses two altitudes (TW p.85), so there must be room below: the unit has to end
+                // strictly above the terrain ceiling (0 on ground maps, where altitude 0 is the ground)
+                return (altitude - 2) > ceiling;
             case MAN_BARREL_ROLL:
                 return velocity >= 2;
             case MAN_SIDE_SLIP_LEFT:
@@ -178,12 +180,13 @@ public class ManeuverType {
      * @param canPerform Whether the maneuver can currently be performed
      * @param velocity   Current unit velocity
      * @param altitude   Current unit altitude
+     * @param ceiling    Terrain ceiling altitude below the unit (0 on ground maps)
      * @param isVSTOL_CF Whether the entity is a VSTOL with Improved Avionics
      *
      * @return HTML-formatted tooltip string
      */
     public static String getManeuverTooltip(int type, boolean canPerform, int velocity, int altitude,
-          boolean isVSTOL_CF) {
+          int ceiling, boolean isVSTOL_CF) {
         StringBuilder tooltip = new StringBuilder("<HTML><BODY>");
 
         // Maneuver name header
@@ -218,6 +221,12 @@ public class ManeuverType {
                     if ((velocity < 3) || (altitude >= 9)) {
                         tooltip.append(" ").append(MessageFormat.format(
                               Messages.getString("ManeuverChoiceDialog.currentValues"), velocity, altitude));
+                    }
+                    break;
+                case MAN_SPLIT_S:
+                    if ((altitude - 2) <= ceiling) {
+                        tooltip.append(" ").append(MessageFormat.format(
+                              Messages.getString("ManeuverChoiceDialog.currentAltitude"), altitude));
                     }
                     break;
                 case MAN_BARREL_ROLL:

--- a/megamek/src/megamek/common/pathfinder/AeroGroundDoctrinePathFinder.java
+++ b/megamek/src/megamek/common/pathfinder/AeroGroundDoctrinePathFinder.java
@@ -188,9 +188,8 @@ public class AeroGroundDoctrinePathFinder extends AeroGroundPathFinder {
         }
 
         // Split-S: 2 thrust, +2 control - down two altitudes, any facing, velocity up one. Offensive only:
-        // dive out of the dead zone onto an enemy below. Guarded to keep two levels of air below, because
-        // the engine's own legality check reads (altitude + 2) > ceiling, which permits a Split-S from
-        // altitude 2 straight into the ground.
+        // dive out of the dead zone onto an enemy below. The altitude guard matches the engine legality
+        // check (must end above the ground after dropping 2), kept explicit here as defense-in-depth.
         if (canPerform(ManeuverType.MAN_SPLIT_S, velocity, altitude, board, start)
               && (altitude - 2 >= AerospaceGeometry.MINIMUM_ALTITUDE)
               && (2 <= maxThrust)) {

--- a/megamek/unittests/megamek/client/ui/dialogs/phaseDisplay/ManeuverChoiceDialogTest.java
+++ b/megamek/unittests/megamek/client/ui/dialogs/phaseDisplay/ManeuverChoiceDialogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 - The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -87,7 +87,8 @@ class ManeuverChoiceDialogTest {
     void testAllManeuversHaveTooltips() {
         // Test that all maneuvers have valid tooltips
         for (int type = 0; type < ManeuverType.MAN_SIZE; type++) {
-            String tooltip = ManeuverType.getManeuverTooltip(type, true, TEST_VELOCITY, TEST_ALTITUDE, false);
+            String tooltip = ManeuverType.getManeuverTooltip(type, true, TEST_VELOCITY, TEST_ALTITUDE,
+                  TEST_CEILING, false);
             assertNotNull(tooltip, ManeuverType.getTypeName(type) + " tooltip should not be null");
             assertFalse(tooltip.isEmpty(), ManeuverType.getTypeName(type) + " tooltip should not be empty");
             assertTrue(tooltip.contains("<HTML>"),
@@ -114,6 +115,8 @@ class ManeuverChoiceDialogTest {
               "Current value format should exist");
         assertResourceExists("ManeuverChoiceDialog.currentValues",
               "Current values (plural) format should exist");
+        assertResourceExists("ManeuverChoiceDialog.currentAltitude",
+              "Current altitude format should exist");
         assertResourceExists("ManeuverChoiceDialog.notVSTOL",
               "Not VSTOL message should exist");
     }
@@ -273,6 +276,7 @@ class ManeuverChoiceDialogTest {
               true,
               TEST_VELOCITY,
               TEST_ALTITUDE,
+              TEST_CEILING,
               false);
         assertTrue(loopTooltip.contains("Thrust Cost") || loopTooltip.contains("thrust"),
               "Loop tooltip should contain thrust cost information");
@@ -282,6 +286,7 @@ class ManeuverChoiceDialogTest {
               true,
               TEST_VELOCITY,
               TEST_ALTITUDE,
+              TEST_CEILING,
               false);
         assertTrue(hammerheadTooltip5.contains("5"),
               "Hammerhead tooltip at velocity 5 should show cost of 5");
@@ -290,6 +295,7 @@ class ManeuverChoiceDialogTest {
               true,
               10,
               TEST_ALTITUDE,
+              TEST_CEILING,
               false);
         assertTrue(hammerheadTooltip10.contains("10"),
               "Hammerhead tooltip at velocity 10 should show cost of 10");
@@ -299,11 +305,13 @@ class ManeuverChoiceDialogTest {
               true,
               TEST_VELOCITY,
               TEST_ALTITUDE,
+              TEST_CEILING,
               false);
         assertTrue(viffTooltip5.contains("7"),
               "VIFF tooltip at velocity 5 should show cost of 7 (velocity + 2)");
 
-        String viffTooltip10 = ManeuverType.getManeuverTooltip(ManeuverType.MAN_VIFF, true, 10, TEST_ALTITUDE, false);
+        String viffTooltip10 = ManeuverType.getManeuverTooltip(ManeuverType.MAN_VIFF, true, 10, TEST_ALTITUDE,
+              TEST_CEILING, false);
         assertTrue(viffTooltip10.contains("12"),
               "VIFF tooltip at velocity 10 should show cost of 12 (velocity + 2)");
     }
@@ -318,6 +326,7 @@ class ManeuverChoiceDialogTest {
               true,
               TEST_VELOCITY,
               TEST_ALTITUDE,
+              TEST_CEILING,
               false);
         assertTrue(loopTooltip.contains("Control") || loopTooltip.contains("Mod"),
               "Loop tooltip should contain control modifier information");
@@ -327,6 +336,7 @@ class ManeuverChoiceDialogTest {
               true,
               TEST_VELOCITY,
               TEST_ALTITUDE,
+              TEST_CEILING,
               false);
         assertTrue(sideSlipNonVSTOL.contains("+0") || sideSlipNonVSTOL.contains("0"),
               "Side Slip tooltip for non-VSTOL should show +0 modifier");
@@ -335,6 +345,7 @@ class ManeuverChoiceDialogTest {
               true,
               TEST_VELOCITY,
               TEST_ALTITUDE,
+              TEST_CEILING,
               true);
         assertTrue(sideSlipVSTOL.contains("-1"),
               "Side Slip tooltip for VSTOL should show -1 modifier");
@@ -344,6 +355,7 @@ class ManeuverChoiceDialogTest {
               true,
               TEST_VELOCITY,
               TEST_ALTITUDE,
+              TEST_CEILING,
               false);
         assertTrue(hammerheadTooltip.contains("3") || hammerheadTooltip.contains("+3"),
               "Hammerhead tooltip should show +3 control modifier");
@@ -352,9 +364,26 @@ class ManeuverChoiceDialogTest {
               true,
               TEST_VELOCITY,
               TEST_ALTITUDE,
+              TEST_CEILING,
               false);
         assertTrue(halfRollTooltip.contains("-1"),
               "Half Roll tooltip should show -1 control modifier");
+    }
+
+    /**
+     * Test that an unavailable Split-S tooltip explains itself by showing the current altitude (issue #8699).
+     */
+    @Test
+    void testSplitSTooltipShowsAltitudeWhenUnavailable() {
+        // Altitude 2 over a ground map (ceiling 0): a Split-S would end in the ground
+        String splitSTooltip = ManeuverType.getManeuverTooltip(ManeuverType.MAN_SPLIT_S,
+              false,
+              TEST_VELOCITY,
+              2,
+              0,
+              false);
+        assertTrue(splitSTooltip.contains("Altitude: 2"),
+              "Unavailable Split-S tooltip should show the current altitude");
     }
 
     /**

--- a/megamek/unittests/megamek/common/ManeuverTypeTest.java
+++ b/megamek/unittests/megamek/common/ManeuverTypeTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Vector;
+
+import megamek.common.board.Board;
+import megamek.common.moves.MovePath;
+import megamek.common.moves.MoveStep;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the legality checks for aerospace special maneuvers (TW p.85). A Split-S loses two altitudes, so it is only
+ * legal when the unit ends strictly above the terrain ceiling below it (regression test for issue #8699, where the
+ * check read {@code (altitude + 2) > ceiling} and offered a Split-S straight into the ground).
+ */
+class ManeuverTypeTest {
+
+    private static final int GROUND_MAP_CEILING = 0;
+    private static final boolean NOT_VTOL = false;
+    private static final int MANEUVER_AT_MOVE_START = 0;
+
+    private Board board;
+    private MovePath movePath;
+
+    @BeforeEach
+    void setUp() {
+        board = mock(Board.class);
+        movePath = mock(MovePath.class);
+        when(movePath.getStepVector()).thenReturn(new Vector<MoveStep>());
+    }
+
+    private boolean canPerform(int maneuverType, int velocity, int altitude, int ceiling) {
+        return ManeuverType.canPerform(maneuverType, velocity, altitude, ceiling, NOT_VTOL,
+              MANEUVER_AT_MOVE_START, board, movePath);
+    }
+
+    @Test
+    @DisplayName("Split-S from altitude 2 over a ground map would end in the ground and is illegal")
+    void splitSAtAltitudeTwoOverGroundMapIsIllegal() {
+        assertFalse(canPerform(ManeuverType.MAN_SPLIT_S, 3, 2, GROUND_MAP_CEILING),
+              "Split-S from altitude 2 ends at altitude 0 - in the ground");
+    }
+
+    @Test
+    @DisplayName("Split-S from altitude 1 over a ground map would end below the ground and is illegal")
+    void splitSAtAltitudeOneOverGroundMapIsIllegal() {
+        assertFalse(canPerform(ManeuverType.MAN_SPLIT_S, 3, 1, GROUND_MAP_CEILING),
+              "Split-S from altitude 1 ends below altitude 0");
+    }
+
+    @Test
+    @DisplayName("Split-S from altitude 3 over a ground map ends at altitude 1 and is legal")
+    void splitSAtAltitudeThreeOverGroundMapIsLegal() {
+        assertTrue(canPerform(ManeuverType.MAN_SPLIT_S, 3, 3, GROUND_MAP_CEILING),
+              "Split-S from altitude 3 ends at altitude 1, the minimum legal flight altitude");
+    }
+
+    @Test
+    @DisplayName("Split-S from altitude 5 over a ground map is legal")
+    void splitSAtAltitudeFiveOverGroundMapIsLegal() {
+        assertTrue(canPerform(ManeuverType.MAN_SPLIT_S, 3, 5, GROUND_MAP_CEILING));
+    }
+
+    @Test
+    @DisplayName("Split-S ending exactly at a low-altitude hex ceiling is illegal")
+    void splitSEndingAtTerrainCeilingIsIllegal() {
+        // Low-altitude map hex with terrain reaching altitude 3: ending AT the ceiling is a collision,
+        // matching the strictly-above convention used when flying into a hex (MoveStep)
+        assertFalse(canPerform(ManeuverType.MAN_SPLIT_S, 3, 5, 3),
+              "Ending at the hex ceiling altitude is a terrain collision");
+    }
+
+    @Test
+    @DisplayName("Split-S ending above a low-altitude hex ceiling is legal")
+    void splitSEndingAboveTerrainCeilingIsLegal() {
+        assertTrue(canPerform(ManeuverType.MAN_SPLIT_S, 3, 6, 3));
+    }
+
+    @Test
+    @DisplayName("Immelmann still requires velocity 3+ and headroom below altitude 9")
+    void immelmannChecksAreUnchanged() {
+        assertTrue(canPerform(ManeuverType.MAN_IMMELMAN, 3, 2, GROUND_MAP_CEILING));
+        assertFalse(canPerform(ManeuverType.MAN_IMMELMAN, 2, 2, GROUND_MAP_CEILING),
+              "Immelmann needs velocity 3 or more");
+        assertFalse(canPerform(ManeuverType.MAN_IMMELMAN, 3, 9, GROUND_MAP_CEILING),
+              "Immelmann climbs 2 and needs to start below altitude 9");
+    }
+}


### PR DESCRIPTION
Fixes #8699

## Summary
The Split-S legality check read `(altitude + 2) > ceiling`. A Split-S loses two altitudes (TW p.85), so the check needs room below, not headroom above. On ground maps the UI passes ceiling 0, so the check passed at every altitude and the maneuver dialog offered a Split-S straight into the ground. The dialog check is the only gate, because the maneuver adds forced DOWN steps that skip normal step legality.

## Changes
- The check is now `(altitude - 2) > ceiling`, mirroring the Immelmann headroom check one case above. Strict `>` matches the engine rule that flying at a hex ceiling altitude is a collision (MoveStep).
- When Split-S is greyed out, its tooltip now shows the current altitude. It was the only maneuver with no unavailable-reason indicator. The requirements line now mentions the room-below rule (new i18n key, English only).
- `getManeuverTooltip` gained a ceiling parameter for that indicator (one caller).
- The bot pathfinder comment that documented this engine bug as a workaround is updated; its own guard stays as defense-in-depth.

## Testing
- New `ManeuverTypeTest` (7 tests): Split-S illegal at altitudes 1 and 2 over a ground map, legal at 3 and 5, illegal ending exactly at a low-altitude hex ceiling, legal above it, plus an Immelmann-unchanged guard.
- Verified by reverting the fix: exactly the three too-low tests fail with the old check restored.
- `ManeuverChoiceDialogTest` updated for the new parameter, plus a resource-key check and an unavailable-tooltip test. All 22 tests pass; checkstyle and javadoc clean.
- Manual in-game test: on a ground map, Split-S is greyed out at altitude 2 with the altitude shown in the tooltip, and offered again at altitude 3+.

## Not proven yet
- Nothing outstanding. The legality change, the tooltip indicator, and the in-game dialog behavior are all verified.