### PR TITLE
Fix VTOL beast infantry unable to move over deep water (Fixes #8707)

### DIFF
--- a/megamek/src/megamek/common/units/ConvInfantry.java
+++ b/megamek/src/megamek/common/units/ConvInfantry.java
@@ -1842,9 +1842,13 @@ public class ConvInfantry extends Infantry {
                       !getMovementMode().isUMUInfantry() &&
                       !getMovementMode().isSubmarine() &&
                       !getMovementMode().isVTOL();
-            } else {
-                return hex.terrainLevel(Terrains.WATER) > mount.maxWaterDepth();
             }
+            // A flying mount above the surface is not in the water; only a beast at or below the
+            // surface is bound by its maximum water depth (TW p.54 VTOL movement, TO:AUE p.106)
+            if (currElevation > 0) {
+                return false;
+            }
+            return hex.terrainLevel(Terrains.WATER) > mount.maxWaterDepth();
         }
         return false;
     }

--- a/megamek/src/megamek/server/totalWarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalWarfare/MovePathHandler.java
@@ -268,6 +268,23 @@ class MovePathHandler extends AbstractTWRuleHandler {
         addReport(elevatorReport);
     }
 
+    /**
+     * VTOL-capable creatures must spend 1 MP per turn, even if remaining stationary (TW p.54). An airborne
+     * beast-mounted platoon (e.g. Branth) that holds its hex therefore still counts as having walked: its movement
+     * type becomes {@link EntityMovementType#MOVE_VTOL_WALK} and it records 1 MP spent.
+     *
+     * @param entity the entity whose movement was just processed
+     *
+     * @return {@code true} if the entity is airborne VTOL beast-mounted infantry that did not move this turn
+     */
+    static boolean mustSpendStationaryFlightMP(Entity entity) {
+        return (entity instanceof ConvInfantry beastInfantry)
+              && (beastInfantry.getMount() != null)
+              && beastInfantry.getMount().movementMode().isVTOL()
+              && entity.isAirborneVTOLorWIGE()
+              && (entity.moved == EntityMovementType.MOVE_NONE);
+    }
+
     void processMovement() {
         // TacOps Climbing: check if a climbing/dangling entity lost its climbing ability
         // due to actuator damage since last turn (TO:AR p.20)
@@ -1061,6 +1078,10 @@ class MovePathHandler extends AbstractTWRuleHandler {
             }
         } else {
             entity.underwaterRounds = 0;
+        }
+        if (mustSpendStationaryFlightMP(entity)) {
+            entity.moved = EntityMovementType.MOVE_VTOL_WALK;
+            entity.mpUsed = Math.max(entity.mpUsed, 1);
         }
         entity.setClimbMode(curClimbMode);
         if (!sideslipped && !fellDuringMovement && !crashedDuringMovement

--- a/megamek/src/megamek/server/totalWarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalWarfare/MovePathHandler.java
@@ -269,9 +269,11 @@ class MovePathHandler extends AbstractTWRuleHandler {
     }
 
     /**
-     * VTOL-capable creatures must spend 1 MP per turn, even if remaining stationary (TW p.54). An airborne
-     * beast-mounted platoon (e.g. Branth) that holds its hex therefore still counts as having walked: its movement
-     * type becomes {@link EntityMovementType#MOVE_VTOL_WALK} and it records 1 MP spent.
+     * Checks whether the TW p.54 rule applies that VTOL-capable creatures must spend 1 MP per turn, even if
+     * remaining stationary. This is a pure check with no side effects: when it returns {@code true}, the caller
+     * ({@code processMovement()}) converts the entity's movement type to
+     * {@link EntityMovementType#MOVE_VTOL_WALK} and records 1 MP spent, so an airborne beast-mounted platoon
+     * (e.g. Branth) that holds its hex still counts as having walked.
      *
      * @param entity the entity whose movement was just processed
      *

--- a/megamek/unittests/megamek/common/moves/VtolBeastInfantryWaterMovementTest.java
+++ b/megamek/unittests/megamek/common/moves/VtolBeastInfantryWaterMovementTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.moves;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import megamek.common.GameBoardTestCase;
+import megamek.common.board.Coords;
+import megamek.common.enums.MoveStepType;
+import megamek.common.units.ConvInfantry;
+import megamek.common.units.Crew;
+import megamek.common.units.CrewType;
+import megamek.common.units.InfantryMount;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Water movement tests for VTOL beast-mounted infantry (e.g. Branth, TO:AUE p.106). A flying mount above the surface
+ * is not in the water, so depth-1+ water hexes must not be prohibited terrain for it while airborne; its maximum
+ * water depth only binds it at or below the surface (TW p.54 VTOL movement). Regression tests for MegaMek issue
+ * #8707, where Branth platoons over deep water were unable to move at all and could not path across water.
+ */
+public class VtolBeastInfantryWaterMovementTest extends GameBoardTestCase {
+
+    static {
+        // Land - depth 1 water - land, in one column; units start at 0101 facing south
+        initializeBoard("BOARD_1x3_WATER_CROSSING", """
+              size 1 3
+              hex 0101 0 "" ""
+              hex 0102 0 "water:1" ""
+              hex 0103 0 "" ""
+              end""");
+
+        // All water, in one column: depth 1 then depth 2
+        initializeBoard("BOARD_1x2_ALL_WATER", """
+              size 1 2
+              hex 0101 0 "water:1" ""
+              hex 0102 0 "water:2" ""
+              end""");
+    }
+
+    /**
+     * Creates a Branth-mounted platoon: VTOL movement mode, 6 VTOL MP, maximum water depth 0.
+     */
+    private ConvInfantry createBranthInfantry() {
+        ConvInfantry infantry = new ConvInfantry();
+        infantry.setId(7);
+        infantry.setSquadSize(5);
+        infantry.setSquadCount(4);
+        infantry.autoSetInternal();
+        infantry.setMount(InfantryMount.BRANTH);
+
+        Crew crew = new Crew(CrewType.INFANTRY_CREW);
+        crew.setGunnery(4, crew.getCrewType().getGunnerPos());
+        crew.setPiloting(5, crew.getCrewType().getPilotPos());
+        crew.setName("Branth Test Crew", 0);
+        infantry.setCrew(crew);
+
+        return infantry;
+    }
+
+    /**
+     * Creates a Camel-mounted platoon: ground movement mode, maximum water depth 0.
+     */
+    private ConvInfantry createCamelInfantry() {
+        ConvInfantry infantry = new ConvInfantry();
+        infantry.setId(8);
+        infantry.setSquadSize(5);
+        infantry.setSquadCount(4);
+        infantry.autoSetInternal();
+        infantry.setMount(InfantryMount.CAMEL);
+
+        Crew crew = new Crew(CrewType.INFANTRY_CREW);
+        crew.setGunnery(4, crew.getCrewType().getGunnerPos());
+        crew.setPiloting(5, crew.getCrewType().getPilotPos());
+        crew.setName("Camel Test Crew", 0);
+        infantry.setCrew(crew);
+
+        return infantry;
+    }
+
+    @Test
+    @DisplayName("Deep water is not prohibited terrain for a Branth platoon flying above the surface")
+    void deepWaterNotProhibitedWhileAirborne() {
+        setBoard("BOARD_1x2_ALL_WATER");
+        ConvInfantry branth = createBranthInfantry();
+        getGame().addEntity(branth);
+
+        assertFalse(branth.isLocationProhibited(new Coords(0, 0), 0, 2),
+              "Branth flying at elevation 2 over depth 1 water should not be prohibited");
+        assertFalse(branth.isLocationProhibited(new Coords(0, 1), 0, 1),
+              "Branth flying at elevation 1 over depth 2 water should not be prohibited");
+    }
+
+    @Test
+    @DisplayName("Deep water is still prohibited for a Branth platoon at or below the surface")
+    void deepWaterProhibitedAtOrBelowSurface() {
+        setBoard("BOARD_1x2_ALL_WATER");
+        ConvInfantry branth = createBranthInfantry();
+        getGame().addEntity(branth);
+
+        assertTrue(branth.isLocationProhibited(new Coords(0, 0), 0, 0),
+              "Branth at the surface of depth 1 water should be prohibited (max water depth 0)");
+        assertTrue(branth.isLocationProhibited(new Coords(0, 0), 0, -1),
+              "Submerged Branth should be prohibited (max water depth 0)");
+    }
+
+    @Test
+    @DisplayName("Deep water is still prohibited for a ground beast regardless of the fix")
+    void deepWaterProhibitedForGroundBeast() {
+        setBoard("BOARD_1x2_ALL_WATER");
+        ConvInfantry camel = createCamelInfantry();
+        getGame().addEntity(camel);
+
+        assertTrue(camel.isLocationProhibited(new Coords(0, 0), 0, 0),
+              "Camel in depth 1 water should be prohibited (max water depth 0)");
+    }
+
+    @Test
+    @DisplayName("Branth platoon can fly across a deep water hex")
+    void branthCanFlyAcrossDeepWater() {
+        setBoard("BOARD_1x3_WATER_CROSSING");
+        ConvInfantry branth = createBranthInfantry();
+
+        // Lift off from land, cross the depth 1 water hex, end over land
+        MovePath movePath = getMovePathFor(branth, 0, null,
+              MoveStepType.UP, MoveStepType.FORWARDS, MoveStepType.FORWARDS);
+
+        assertTrue(movePath.isMoveLegal(),
+              "Branth platoon should be able to fly across a depth 1 water hex (issue #8707)");
+    }
+
+    @Test
+    @DisplayName("Branth platoon hovering over deep water can move")
+    void branthOverDeepWaterCanMove() {
+        setBoard("BOARD_1x2_ALL_WATER");
+        ConvInfantry branth = createBranthInfantry();
+
+        // Starts airborne over depth 1 water, moves to the next water hex
+        MovePath movePath = getMovePathFor(branth, 2, null, MoveStepType.FORWARDS);
+
+        assertTrue(movePath.isMoveLegal(),
+              "Branth platoon airborne over deep water should be able to move (issue #8707)");
+    }
+
+    @Test
+    @DisplayName("Branth platoon still cannot land in deep water")
+    void branthCannotLandInDeepWater() {
+        setBoard("BOARD_1x2_ALL_WATER");
+        ConvInfantry branth = createBranthInfantry();
+
+        // Starts airborne over depth 1 water and tries to descend to the surface
+        MovePath movePath = getMovePathFor(branth, 2, null, MoveStepType.DOWN, MoveStepType.DOWN);
+
+        assertFalse(movePath.isMoveLegal(),
+              "Branth platoon should not be able to land on deep water (max water depth 0)");
+    }
+}

--- a/megamek/unittests/megamek/server/totalWarfare/MovePathHandlerStationaryFlightTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/MovePathHandlerStationaryFlightTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.server.totalWarfare;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import megamek.common.equipment.EquipmentType;
+import megamek.common.units.ConvInfantry;
+import megamek.common.units.EntityMovementMode;
+import megamek.common.units.EntityMovementType;
+import megamek.common.units.InfantryMount;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the TW p.54 rule that VTOL-capable creatures must spend 1 MP per turn even if remaining stationary: an
+ * airborne beast-mounted platoon (e.g. Branth) that holds its hex is converted from MOVE_NONE to MOVE_VTOL_WALK at the
+ * end of movement processing. Ground beasts, grounded flying beasts and unmounted VTOL infantry (microlites) are not
+ * affected. Part of the fix for MegaMek issue #8707.
+ */
+class MovePathHandlerStationaryFlightTest {
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    private ConvInfantry createBranthInfantry() {
+        ConvInfantry infantry = new ConvInfantry();
+        infantry.setMount(InfantryMount.BRANTH);
+        return infantry;
+    }
+
+    @Test
+    @DisplayName("Airborne Branth platoon that did not move must spend its stationary flight MP")
+    void airborneBranthHoldingStillMustSpend() {
+        ConvInfantry branth = createBranthInfantry();
+        branth.setElevation(2);
+        branth.moved = EntityMovementType.MOVE_NONE;
+
+        assertTrue(MovePathHandler.mustSpendStationaryFlightMP(branth),
+              "An airborne Branth platoon that holds its hex must still spend 1 MP (TW p.54)");
+    }
+
+    @Test
+    @DisplayName("Grounded Branth platoon that did not move spends nothing")
+    void groundedBranthHoldingStillSpendsNothing() {
+        ConvInfantry branth = createBranthInfantry();
+        branth.setElevation(0);
+        branth.moved = EntityMovementType.MOVE_NONE;
+
+        assertFalse(MovePathHandler.mustSpendStationaryFlightMP(branth),
+              "A Branth platoon on the ground is not flying and spends no MP while stationary");
+    }
+
+    @Test
+    @DisplayName("Airborne Branth platoon that already moved is left alone")
+    void airborneBranthThatMovedIsLeftAlone() {
+        ConvInfantry branth = createBranthInfantry();
+        branth.setElevation(2);
+        branth.moved = EntityMovementType.MOVE_VTOL_WALK;
+
+        assertFalse(MovePathHandler.mustSpendStationaryFlightMP(branth),
+              "A Branth platoon that already moved needs no stationary MP conversion");
+    }
+
+    @Test
+    @DisplayName("Ground beast mount is not affected")
+    void groundBeastNotAffected() {
+        ConvInfantry camel = new ConvInfantry();
+        camel.setMount(InfantryMount.CAMEL);
+        camel.moved = EntityMovementType.MOVE_NONE;
+
+        assertFalse(MovePathHandler.mustSpendStationaryFlightMP(camel),
+              "A ground beast mount is not a VTOL-capable creature");
+    }
+
+    @Test
+    @DisplayName("Unmounted VTOL infantry (microlite) is not affected")
+    void microliteNotAffected() {
+        ConvInfantry microlite = new ConvInfantry();
+        microlite.setMicrolite(true);
+        microlite.setMovementMode(EntityMovementMode.VTOL);
+        microlite.setElevation(2);
+        microlite.moved = EntityMovementType.MOVE_NONE;
+
+        assertFalse(MovePathHandler.mustSpendStationaryFlightMP(microlite),
+              "The TW p.54 stationary MP rule applies to VTOL-capable creatures, not microlite platoons");
+    }
+}


### PR DESCRIPTION
Fixes #8707

## Summary

Beast-mounted VTOL infantry (Branth platoons) over depth 1+ water could not move at all, and could not end movement over any water hex. `ConvInfantry.isLocationProhibited` applied the mount's maximum water depth to every water hex without looking at the unit's elevation, so a platoon flying at elevation 4 was treated as if it were swimming. VTOL vehicles already make this check elevation-aware; this brings beast mounts in line. Per request, the PR also implements the TW p.54 rule that VTOL-capable creatures spend 1 MP per turn even when stationary.

## Changes

- A flying mount above the surface is no longer blocked by deep water; at or below the surface the maximum water depth check is unchanged (`ConvInfantry`).
- TW p.54: an airborne beast platoon that holds its hex now counts as having walked (`MOVE_VTOL_WALK`, 1 MP used), so it takes the +1 attacker movement modifier instead of getting a free stationary turn. Grounded beasts, ground mounts and microlite platoons are unaffected (`MovePathHandler`).
- The high altitude map half of the TW p.54 footnote does not apply: MegaMek has no high altitude map.

## Testing

- 11 new unit tests. Two fail with the fix reverted: the airborne prohibition check and moving while hovering over deep water. The rest guard unchanged behavior: at or below the surface still prohibited, ground beasts (Camel) unchanged, landing on deep water still illegal, and the stationary MP rule's gating (airborne vs grounded vs already moved vs ground mount vs microlite).
- Verified in game on the reporter's savegame: the four Branth platoons stuck over the lake can move again.
- Existing suites pass: InfantryMovement, InfantryPoweredFlightMovement, MountainInfantryMovement, ConvInfantryVtolMovement, InfantryGliderWings. checkstyle and javadoc clean.

## Not proven yet

- The fly-across-water path test also passes on the old code (through-movement over prohibited hexes was already allowed for flying units; only ending there was blocked), so it guards intended behavior rather than proving the fix.
- The +1 attacker movement modifier from the stationary MP rule is unit-tested but was not visually confirmed in a game's to-hit breakdown.
- A beast reduced to 0 MP while airborne (weather, gravity) is not addressed; by the rules it likely could not stay aloft. Out of scope here.