### PR TITLE
PR: Add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!-- TITLE: start with "Fix:" for a bug fix, or "PR:" for a feature or improvement.
+     Release notes are generated automatically from PR titles. -->
+
+## What this changes
+
+<!-- The effect someone actually sees, in plain language. One or two sentences is fine. -->
+
+Fixes #
+
+## Testing
+
+<!-- What you ran. Unit tests? Did you play a game and exercise this path?
+     Once it has been tested in game, add the "AI ready for Review" label. -->
+
+## What is not proven yet
+
+<!-- What you did not test, or could not. "Nothing" is a valid answer - say so explicitly. -->
+
+---
+
+- [ ] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
+- [ ] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
+- [ ] Tests added or updated, if this implements a rule or changes game state
+- [ ] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
+- [ ] If AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have
+      verified the result ([AI tool guidelines](https://github.com/MegaMek/megamek/wiki/Guidelines-for-Developer%E2%80%90Led-AI-Tool-Usage-in-MegaMek))

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,18 @@
 <!-- The effect someone actually sees, in plain language. One or two sentences is fine. -->
 
 <!-- Keep this line as well as the number in the title. GitHub only closes an issue from a
-     keyword in the description - a number in the title alone does not close anything. -->
+     keyword in the description - a number in the title alone does not close anything.
+
+     Any of these close an issue when this merges:
+         Close / Closes / Closed
+         Fix / Fixes / Fixed
+         Resolve / Resolves / Resolved
+
+     Closing more than one needs the keyword repeated in front of each number:
+         Fixes #1234, fixes #5678          closes both
+         Fixes #1234, #5678                closes only #1234
+
+     For an issue in another repository, qualify it: Fixes MegaMek/mekhq#1234 -->
 Fixes #
 
 ## Testing

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,19 @@
-<!-- TITLE: start with "Fix:" for a bug fix, or "PR:" for a feature or improvement.
-     Release notes are generated automatically from PR titles. -->
+<!-- TITLE: include the issue number, and start with "Fix" for a bug fix or "Close" for
+     anything else:
+
+         Fix #1234: Cheese has the wrong colour gradient
+         Close #1234: Added 6 new cheese gradients
+
+     More than one issue is fine: "Close #111, #5329: Added unit history tracking".
+     Release notes are generated automatically from pull request titles, so the title is
+     what players end up reading. -->
 
 ## What this changes
 
 <!-- The effect someone actually sees, in plain language. One or two sentences is fine. -->
 
+<!-- Keep this line as well as the number in the title. GitHub only closes an issue from a
+     keyword in the description - a number in the title alone does not close anything. -->
 Fixes #
 
 ## Testing

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -42,5 +42,21 @@ Fixes #
 - [ ] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
 - [ ] Tests added or updated, if this implements a rule or changes game state
 - [ ] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
-- [ ] If AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have
-      verified the result ([AI tool guidelines](https://github.com/MegaMek/megamek/wiki/Guidelines-for-Developer%E2%80%90Led-AI-Tool-Usage-in-MegaMek))
+- [ ] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
+      explain and have verified the result
+
+<!-- ABOUT THAT LAST BOX, IF YOU ARE NOT ON THE DEV TEAM:
+
+     Only active members of the dev team may use AI tools on contributions. That is not a judgement
+     on your work. A developer carries the history of why the codebase is the way it is, and an AI
+     tool starts without any of it every single session - the developer is what makes the difference.
+
+     Contributions you have written yourself are very welcome, and you do not need to be on the dev
+     team to send one:
+     https://github.com/MegaMek/megamek/wiki/Creating-a-Pull-Request-%28PR%29-as-an-Outside-Contributor
+
+     Generative AI art is never accepted, from anyone. A pull request containing it will be rejected.
+
+     Full policy:
+     https://github.com/MegaMek/megamek/wiki/Guidelines-for-Developer%E2%80%90Led-AI-Tool-Usage-in-MegaMek -->
+


### PR DESCRIPTION
## What this changes

MegaMek has no pull request template, so the box is empty when you open a PR. This adds one. It is a prompt, not a gate - GitHub has no required fields for pull requests, so anything here can be deleted by the author.

The content is taken from what the project already asks for rather than from a generic checklist. Three things it addresses, each measured against the last 50 merged PRs:

**The title convention is documented but almost unused.** `Commit-Procedures` on the wiki says titles start with `Fix:` for a bug fix or `PR:` for a feature, because release notes are generated automatically from PR titles. Four of the last fifty MegaMek PRs did that. Release notes are currently being built from titles like "F_PHYSICAL_WEAPON". The reminder is the first thing in the template, in a comment, because a template cannot set the title itself.

**Only five of the last fifty linked an issue** with a closing keyword, so issues are not closing themselves. `Fixes #` now sits directly under the summary.

**AI disclosure is project policy.** The wiki's AI tool guidelines require that any PR involving AI tools be labelled, and that the submitting developer be able to explain and verify the result. The checklist says so and links the page.

## Testing

Rendered the Markdown to check the comment blocks disappear and the checklist renders as checkboxes. The template cannot be seen in the pull request composer until it is on the default branch, which is the same constraint the issue templates had.

## What is not proven yet

Whether it actually helps. That is the point of trying it in MegaMek alone before MegaMekLab, MekHQ and mm-data - if it turns out to be noise, or people delete it wholesale, it is one file to revise or remove.

The four checklist items are drawn from what reviewers have been flagging, but the list is deliberately short. A long checklist gets ticked without being read, which is exactly why the mandatory Discord confirmation came out of the bug report form.

Two related corrections are worth making separately, since they are wiki edits rather than repository changes: the AI guidelines name labels called "AI Code" and "AI Data" which do not exist - the real ones are `AI Assisted Development` and `AI ready for Review` - and the outside contributor page still tells people to target the `master` branch.
