### PR TITLE
Fix #8687: Follow the Leader ammo is missing its 3046 reintroduction date

### DIFF
--- a/megamek/src/megamek/common/equipment/AmmoType.java
+++ b/megamek/src/megamek/common/equipment/AmmoType.java
@@ -707,7 +707,7 @@ public class AmmoType extends EquipmentType {
           Munitions.M_FOLLOW_THE_LEADER,
           new TechAdvancement(TechBase.IS).setTechRating(TechRating.E)
                 .setAvailability(AvailabilityValue.F, AvailabilityValue.F, AvailabilityValue.F, AvailabilityValue.F)
-                .setISAdvancement(2750, DATE_NONE, DATE_NONE, 2770, DATE_NONE)
+                .setISAdvancement(2750, DATE_NONE, DATE_NONE, 2770, 3046)
                 .setISApproximate(true, false, false, true, false)
                 .setPrototypeFactions(Faction.TH)
                 .setReintroductionFactions(Faction.FS, Faction.LC)
@@ -3932,10 +3932,10 @@ public class AmmoType extends EquipmentType {
 
     /**
      * Create a new techAdvancement that uses: 1. the more restrictive tech base 2. the more-restrictive of all faction
-     * tech advancements 3. the later of all intro dates, 4. the earlier of all extinction dates, 5. the smaller of all
-     * prototype / production / reintroduction faction lists, 6. the greater of all extinction faction lists, 7. the
-     * higher static tech level, 8. the rarer availability level 9. the higher TechRating score given two other
-     * TechAdvancements.
+     * tech advancements 3. the later of all intro dates, 4. the earlier of all extinction dates, 5. the later of all
+     * reintroduction dates, 6. the smaller of all prototype / production / reintroduction faction lists, 7. the
+     * greater of all extinction faction lists, 8. the higher static tech level, 9. the rarer availability level 10.
+     * the higher TechRating score given two other TechAdvancements.
      *
      * @param base TechAdvancement of base ammo type being modified
      * @param mod  TechAdvancement of the mod/mutator; currently only Incendiary
@@ -3954,8 +3954,7 @@ public class AmmoType extends EquipmentType {
         // Advancement - later takes precendent except for extinction, but -1 trumps all
         for (AdvancementPhase phase : List.of(AdvancementPhase.PROTOTYPE,
               AdvancementPhase.PRODUCTION,
-              AdvancementPhase.COMMON,
-              AdvancementPhase.REINTRODUCED)) {
+              AdvancementPhase.COMMON)) {
             combination.setISAdvancement(phase,
                   laterOrUnsetYear(base.getISAdvancement(phase), mod.getISAdvancement(phase)));
             combination.setISApproximate(phase, (base.getISApproximate(phase) || mod.getISApproximate(phase)));
@@ -3965,13 +3964,31 @@ public class AmmoType extends EquipmentType {
         }
 
         // Extinction dates: earlier non-"-1" value wins
-        AdvancementPhase phase = AdvancementPhase.EXTINCT;
-        combination.setISAdvancement(phase, earlierNotUnsetYear(base.getISAdvancement(phase),
-              mod.getISAdvancement(phase)));
-        combination.setISApproximate(phase, (base.getISApproximate(phase) || mod.getISApproximate(phase)));
-        combination.setClanAdvancement(phase, earlierNotUnsetYear(base.getClanAdvancement(phase),
-              mod.getClanAdvancement(phase)));
-        combination.setClanApproximate(phase, (base.getClanApproximate(phase) || mod.getClanApproximate(phase)));
+        AdvancementPhase extinctionPhase = AdvancementPhase.EXTINCT;
+        combination.setISAdvancement(extinctionPhase, earlierNotUnsetYear(base.getISAdvancement(extinctionPhase),
+              mod.getISAdvancement(extinctionPhase)));
+        combination.setISApproximate(extinctionPhase,
+              (base.getISApproximate(extinctionPhase) || mod.getISApproximate(extinctionPhase)));
+        combination.setClanAdvancement(extinctionPhase, earlierNotUnsetYear(base.getClanAdvancement(extinctionPhase),
+              mod.getClanAdvancement(extinctionPhase)));
+        combination.setClanApproximate(extinctionPhase,
+              (base.getClanApproximate(extinctionPhase) || mod.getClanApproximate(extinctionPhase)));
+
+        // Reintroduction dates: later non-"-1" value wins. This has to follow the same "a set date wins over an
+        // unset one" rule as extinction above: the combination inherits an extinction date from whichever side went
+        // extinct, so it must inherit that side's reintroduction date too, or the combined munition would stay
+        // extinct forever.
+        AdvancementPhase reintroductionPhase = AdvancementPhase.REINTRODUCED;
+        combination.setISAdvancement(reintroductionPhase,
+              laterNotUnsetYear(base.getISAdvancement(reintroductionPhase),
+                    mod.getISAdvancement(reintroductionPhase)));
+        combination.setISApproximate(reintroductionPhase,
+              (base.getISApproximate(reintroductionPhase) || mod.getISApproximate(reintroductionPhase)));
+        combination.setClanAdvancement(reintroductionPhase,
+              laterNotUnsetYear(base.getClanAdvancement(reintroductionPhase),
+                    mod.getClanAdvancement(reintroductionPhase)));
+        combination.setClanApproximate(reintroductionPhase,
+              (base.getClanApproximate(reintroductionPhase) || mod.getClanApproximate(reintroductionPhase)));
 
         // Faction lists - eugh.
         Set<Faction> bProto = base.getPrototypeFactions();
@@ -4038,6 +4055,24 @@ public class AmmoType extends EquipmentType {
             }
         }
         return left;
+    }
+
+    /**
+     * Determine the later of two years for purposes of setting the reintroduction year of modified munitions.
+     *
+     * @param left  Left year
+     * @param right Right year
+     *
+     * @return Higher year that is not {@code DATE_NONE}, that is, the unset value of -1, or -1 if both are unset.
+     */
+    private static int laterNotUnsetYear(int left, int right) {
+        if (left == DATE_NONE) {
+            return right;
+        } else if (right == DATE_NONE) {
+            return left;
+        } else {
+            return Math.max(left, right);
+        }
     }
 
     /**

--- a/megamek/unittests/megamek/common/equipment/FollowTheLeaderAmmoTechAdvancementTest.java
+++ b/megamek/unittests/megamek/common/equipment/FollowTheLeaderAmmoTechAdvancementTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.equipment;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import megamek.common.enums.Faction;
+import megamek.common.enums.TechBase;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for the Inner Sphere Follow The Leader missile ammunition, which was lost with the fall of the Star
+ * League and recovered by the Federated Suns and the Lyran Commonwealth in 3046 (Interstellar Operations: Alternate
+ * Eras, 3rd printing, Heavy Weapons Ammunition table, p. 55).
+ *
+ * @see <a href="https://github.com/MegaMek/megamek/issues/8687">MegaMek issue #8687</a>
+ */
+class FollowTheLeaderAmmoTechAdvancementTest {
+
+    private static final int REINTRODUCTION_YEAR = 3046;
+
+    private static List<AmmoType> innerSphereFollowTheLeaderAmmo;
+
+    @BeforeAll
+    static void collectInnerSphereFollowTheLeaderAmmo() {
+        EquipmentType.initializeTypes();
+        innerSphereFollowTheLeaderAmmo = EquipmentType.allTypes()
+              .stream()
+              .filter(AmmoType.class::isInstance)
+              .map(AmmoType.class::cast)
+              .filter(ammoType -> ammoType.getMunitionType().contains(AmmoType.Munitions.M_FOLLOW_THE_LEADER))
+              .filter(ammoType -> ammoType.getTechBase() == TechBase.IS)
+              .toList();
+    }
+
+    @Test
+    void innerSphereFollowTheLeaderAmmoExists() {
+        assertFalse(innerSphereFollowTheLeaderAmmo.isEmpty(),
+              "No Inner Sphere Follow The Leader ammunition was created at all");
+    }
+
+    @Test
+    void innerSphereFollowTheLeaderAmmoIsReintroducedIn3046() {
+        for (AmmoType ammoType : innerSphereFollowTheLeaderAmmo) {
+            assertEquals(REINTRODUCTION_YEAR,
+                  ammoType.getReintroductionDate(false),
+                  ammoType.getName() + " should be reintroduced in " + REINTRODUCTION_YEAR);
+        }
+    }
+
+    /**
+     * The Federated Suns and the Lyran Commonwealth recover the munition in 3046; every other Inner Sphere faction has
+     * to wait the standard ten years, so it is still extinct for them in 3050.
+     */
+    @Test
+    void followTheLeaderAmmoIsAvailableToItsReintroductionFactionsFirst() {
+        for (AmmoType ammoType : innerSphereFollowTheLeaderAmmo) {
+            assertFalse(ammoType.isExtinct(3050, false, Faction.FS),
+                  ammoType.getName() + " should be available to the Federated Suns in 3050");
+            assertFalse(ammoType.isExtinct(3050, false, Faction.LC),
+                  ammoType.getName() + " should be available to the Lyran Commonwealth in 3050");
+            assertTrue(ammoType.isExtinct(3050, false, Faction.DC),
+                  ammoType.getName() + " should still be extinct for the Draconis Combine in 3050");
+            assertFalse(ammoType.isExtinct(3060, false, Faction.DC),
+                  ammoType.getName() + " should be available to the Draconis Combine in 3060");
+        }
+    }
+
+    /**
+     * Before the reintroduction date was recorded, the munition was extinct forever after 2770 - the bug reported in
+     * issue #8687.
+     */
+    @Test
+    void followTheLeaderAmmoIsNotPermanentlyExtinct() {
+        for (AmmoType ammoType : innerSphereFollowTheLeaderAmmo) {
+            assertTrue(ammoType.isExtinct(3000, false),
+                  ammoType.getName() + " should be extinct in 3000, before its reintroduction");
+            assertFalse(ammoType.isExtinct(3050, false),
+                  ammoType.getName() + " should no longer be extinct in 3050");
+        }
+    }
+}


### PR DESCRIPTION
## What this changes

Follow the Leader missile ammunition could not be used in any campaign after 2770. Build a 3050 Federated Suns force, give a unit an LRM 15, and the Follow the Leader load is simply missing from the ammo list. MegaMek had the munition's 2770 extinction date but not the 3046 reintroduction that Interstellar Operations: Alternate Eras, 3rd printing gives it (Heavy Weapons Ammunition table, p. 55), and a munition that goes extinct with no reintroduction date is gone for good.

Adding the date exposed the same fault one layer down, in the code that merges tech records to build the incendiary ammo variants. It kept whichever extinction date was actually set, but discarded the reintroduction date if either side lacked one - and plain incendiary rounds never went extinct, so they have no such date. Every incendiary mix of a once-lost munition was therefore stranded as permanently extinct. Fixing that brings back the incendiary mixes of Follow the Leader (3046), Artemis-capable (3035), Narc-capable (3035), Swarm (3048), Thunder (3052), Fragmentation (3054) and Clan Improved LRM ammo (3080), across LRM, Improved LRM, MML LRM-mode and Enhanced LRM launchers. Magnetic Pulse and Listen-Kill have no reintroduction year in the tables and correctly stay extinct.

Fixes #8687

## Testing

`FollowTheLeaderAmmoTechAdvancementTest` is new. It sweeps every registered Inner Sphere Follow the Leader ammo type rather than naming one, so the LRM, Enhanced LRM, MML and incendiary variants are all covered. It checks the 3046 reintroduction date, that the munition is extinct in 3000 and usable again in 3050, that the Federated Suns and the Lyran Commonwealth have it in 3050, and that the Draconis Combine does not until 3060.

That test is what caught the incendiary merge fault - it failed on "LRM 5 Follow the Leader w/ Incendiary Ammo" when only the date had been fixed. The list of munitions the merge fix restores, above, came from dumping every generated incendiary ammo type with its extinction and reintroduction dates, so those years are measured rather than inferred.

Full MegaMek suite: 15202 tests, one failure - `AeroWeaponFireInfoProbeTest.velocityPenaltyFiresOnALiveStyleRanking`, a null `AerospaceFocus` in Princess's aerospace path ranker. It fails identically with this change stashed, so it is pre-existing on main and unrelated. Checkstyle and javadoc are clean.

Also tested in game and the ammo behaves as expected.

## What is not proven yet

Only the Follow the Leader dates were checked against the book. The other six munitions keep whatever reintroduction year their own entries already held. The merge fix stops those years being thrown away, it does not vouch for them being right.

The Clan Follow the Leader entry was deliberately left alone. It has no extinction date at all, so this bug never touched it, but it does list the Federated Suns and the Lyran Commonwealth as reintroduction factions with no reintroduction date to go with them - dead data that nothing reads today. Whether the Clan row in the same table needs its own correction has not been checked.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result
