### PR TITLE
Fixes #8747 - TAG/Offboard phase activated for thunderbolts

### DIFF
--- a/megamek/src/megamek/common/actions/compute/ComputeTargetToHitMods.java
+++ b/megamek/src/megamek/common/actions/compute/ComputeTargetToHitMods.java
@@ -41,15 +41,22 @@ import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
 import megamek.common.battleArmor.BattleArmor;
 import megamek.common.compute.Compute;
-import megamek.common.moves.ClimbingHelper;
 import megamek.common.compute.ComputeSideTable;
 import megamek.common.enums.AimingMode;
 import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.equipment.WeaponType;
 import megamek.common.game.Game;
+import megamek.common.moves.ClimbingHelper;
 import megamek.common.options.OptionsConstants;
-import megamek.common.units.*;
+import megamek.common.units.ConvInfantry;
+import megamek.common.units.Entity;
+import megamek.common.units.IAero;
+import megamek.common.units.Infantry;
+import megamek.common.units.InfantryMount;
+import megamek.common.units.MekWarrior;
+import megamek.common.units.SmallCraft;
+import megamek.common.units.Targetable;
 
 public class ComputeTargetToHitMods {
 
@@ -86,7 +93,7 @@ public class ComputeTargetToHitMods {
           WeaponMounted weapon, AmmoType ammoType, EnumSet<AmmoType.Munitions> munition, boolean isArtilleryDirect,
           boolean isArtilleryIndirect, boolean isAttackerInfantry, boolean exchangeSwarmTarget, boolean isIndirect,
           boolean isPointBlankShot, boolean usesAmmo) {
-    
+
         if (attacker == null || target == null) {
             // Can't handle these attacks without a valid attacker and target
             return toHit;
@@ -176,7 +183,9 @@ public class ComputeTargetToHitMods {
                       && (entityTarget.getTaggedBy() != WeaponAttackAction.UNASSIGNED)
                       && (ammoType != null)
                       && ammoType.getAmmoType().isAnyOf(AmmoType.AmmoTypeEnum.LRM, AmmoType.AmmoTypeEnum.LRM_IMP,
-                      AmmoType.AmmoTypeEnum.MML, AmmoType.AmmoTypeEnum.NLRM, AmmoType.AmmoTypeEnum.MEK_MORTAR)
+                      AmmoType.AmmoTypeEnum.MML, AmmoType.AmmoTypeEnum.NLRM, AmmoType.AmmoTypeEnum.MEK_MORTAR,
+                      AmmoType.AmmoTypeEnum.TBOLT_5, AmmoType.AmmoTypeEnum.TBOLT_10, AmmoType.AmmoTypeEnum.TBOLT_15,
+                      AmmoType.AmmoTypeEnum.TBOLT_10)
                       && munition.contains(AmmoType.Munitions.M_SEMIGUIDED);
 
                 if (!attacker.isConventionalInfantry() && !hasActiveProbeImmunity) {
@@ -387,7 +396,7 @@ public class ComputeTargetToHitMods {
 
         return toHit;
     }
-    
+
     private static boolean createsSensorShadow(Entity target, Entity other) {
         return !other.isEnemyOf(target)
               && other.isLargeCraft()

--- a/megamek/src/megamek/common/game/Game.java
+++ b/megamek/src/megamek/common/game/Game.java
@@ -241,10 +241,10 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
     private Map<String, BehaviorSettings> botSettings = new HashMap<>();
 
     /**
-     * Which AI implementation the most recent bot connected under each name was, alongside {@link #botSettings}.
-     * Rides the savegame so a loaded game can restore each seat with the same kind of bot it held, rather than
-     * guessing. Absent ({@code null}) in games saved before this was recorded - read it through
-     * {@link #getBotTypes()}, which heals that.
+     * Which AI implementation the most recent bot connected under each name was, alongside {@link #botSettings}. Rides
+     * the savegame so a loaded game can restore each seat with the same kind of bot it held, rather than guessing.
+     * Absent ({@code null}) in games saved before this was recorded - read it through {@link #getBotTypes()}, which
+     * heals that.
      */
     private Map<String, AIType> botTypes = new HashMap<>();
 
@@ -327,7 +327,7 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
             rulesManager = new CoreRulesManager();
         }
     }
-    
+
     /**
      * Returns the map of hex locations being cleared by saws to turns remaining. Used by the board view to render cut
      * indicators and tooltips.
@@ -505,7 +505,7 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
                 initializeRulesManager(OptionsConstants.RULES_CORE);
             } else if (!rules_system.stringValue().equals(loadedOption)) {
                 initializeRulesManager(rules_system.stringValue());
-            } 
+            }
             processGameEvent(new GameSettingsChangeEvent(this));
         }
     }
@@ -633,7 +633,11 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
                       (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.LRM_IMP) ||
                       (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.MML) ||
                       (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.NLRM) ||
-                      (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.MEK_MORTAR)) {
+                      (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.MEK_MORTAR) ||
+                      (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.TBOLT_5) ||
+                      (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.TBOLT_10) ||
+                      (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.TBOLT_15) ||
+                      (ammoType.getAmmoType() == AmmoType.AmmoTypeEnum.TBOLT_20)) {
                     return true;
                 }
 
@@ -1380,7 +1384,8 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
                 case Targetable.TYPE_HEX_CLEAR, Targetable.TYPE_HEX_IGNITE, Targetable.TYPE_HEX_BOMB,
                      Targetable.TYPE_MINEFIELD_DELIVER, Targetable.TYPE_FLARE_DELIVER, Targetable.TYPE_HEX_EXTINGUISH,
                      Targetable.TYPE_HEX_ARTILLERY, Targetable.TYPE_HEX_SCREEN, Targetable.TYPE_HEX_AERO_BOMB,
-                     Targetable.TYPE_SATURATION, Targetable.TYPE_HEX_TAG -> new HexTarget(HexTarget.idToLocation(targetId), targetType);
+                     Targetable.TYPE_SATURATION, Targetable.TYPE_HEX_TAG ->
+                      new HexTarget(HexTarget.idToLocation(targetId), targetType);
 
                 case Targetable.TYPE_FUEL_TANK, Targetable.TYPE_FUEL_TANK_IGNITE, Targetable.TYPE_BUILDING,
                      Targetable.TYPE_BLDG_IGNITE, Targetable.TYPE_BLDG_TAG -> {
@@ -2648,6 +2653,7 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
 
     /**
      * Remove displacement attacks that were added previously
+     *
      * @param ea
      */
     public void removeDisplacementAttack(AttackAction ea) {
@@ -2715,12 +2721,12 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
         }
         if (pendingDisplacementAttacks == null) {
             pendingDisplacementAttacks = new Vector<>();
-        } 
-        if (!pendingDisplacementAttacks.isEmpty()){
+        }
+        if (!pendingDisplacementAttacks.isEmpty()) {
             // Reverse traverse the pendingDisplacementAttacks, otherwise when we remove things, it causes problems
-            for (int attack = (pendingDisplacementAttacks.size()-1); attack >= 0; attack--) {
+            for (int attack = (pendingDisplacementAttacks.size() - 1); attack >= 0; attack--) {
                 AttackAction pendingAttack = pendingDisplacementAttacks.get(attack);
-                if (pendingAttack == null) { continue; }
+                if (pendingAttack == null) {continue;}
                 if (pendingAttack instanceof RamAttackAction) {
                     addRam(pendingAttack);
                     pendingDisplacementAttacks.remove(attack);
@@ -2731,7 +2737,7 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
             }
         }
     }
-    
+
     /**
      * Adds a pending ramming attack to the list for this phase.
      *
@@ -2802,7 +2808,7 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
      */
     public ArrayList<PilotingRollData> getPSRsForEntity(Entity entity) {
         ArrayList<PilotingRollData> rollsForEntity = new ArrayList<>();
-        
+
         for (PilotingRollData psr : pilotingRolls) {
             if (psr.getEntityId() == entity.getId()) {
                 rollsForEntity.add(psr);
@@ -2810,11 +2816,11 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
         }
         return rollsForEntity;
     }
-        
+
     public void removePSRsByArray(ArrayList<PilotingRollData> psrList) {
         pilotingRolls.removeAll(psrList);
     }
-    
+
     /**
      * Resets the PSR list for a given entity.
      */
@@ -3905,9 +3911,9 @@ public final class Game extends AbstractGame implements Serializable, PlanetaryC
     }
 
     /**
-     * @return which AI implementation the most recent bot connected under each player name was, as an
-     *       unmodifiable view; never {@code null} - games saved before the types were recorded read as an
-     *       empty map. Record entries through {@link #recordBotType(String, AIType)}.
+     * @return which AI implementation the most recent bot connected under each player name was, as an unmodifiable
+     *       view; never {@code null} - games saved before the types were recorded read as an empty map. Record entries
+     *       through {@link #recordBotType(String, AIType)}.
      */
     public Map<String, AIType> getBotTypes() {
         return Collections.unmodifiableMap(ensureBotTypes());


### PR DESCRIPTION
## What this changes

Fixes #8747 Thunderbolts now activate TAG for the offboard phase. Thunderbolts can be fired indirectly, they can fire at a tagged target, they can use semiguided now as well. This means fix the thunderbolts so TAG activates.

## Testing

Tested in game, tag now activates for them

## What is not proven yet

nothing

- [ X ] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [ X ] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
