### PR TITLE
Fix the aero probe test crashing on an unstubbed aerospace focus order

### DIFF
--- a/megamek/unittests/megamek/client/bot/princess/AeroWeaponFireInfoProbeTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/AeroWeaponFireInfoProbeTest.java
@@ -147,6 +147,9 @@ class AeroWeaponFireInfoProbeTest {
         when(precognition.getECMInfo()).thenReturn(new ArrayList<>());
         when(princess.getPrecognition()).thenReturn(precognition);
         when(princess.getHonorUtil()).thenReturn(new HonorUtil());
+        // Unstubbed, Mockito hands back null and the ranker switches on it: calculateAerospaceMod reads
+        // the standing focus order to weight its two credit sets. A live Princess starts at AUTO.
+        when(princess.getAerospaceFocus()).thenReturn(AerospaceFocus.AUTO);
         return princess;
     }
 


### PR DESCRIPTION
## What this changes

One test in the aerospace probe suite crashes instead of running. `AeroWeaponFireInfoProbeTest.velocityPenaltyFiresOnALiveStyleRanking` throws a NullPointerException, because the test's Princess mock never stubs `getAerospaceFocus()` and path ranking then reads the bot's standing focus order as `null`.

Nothing is wrong with the bot itself. A live Princess starts at `AerospaceFocus.AUTO` and cannot hold `null`: the field is initialised to `AUTO`, and the only thing that changes it is the `/aerofocus` chat command, whose required enum argument throws during parsing before the command ever executes. This is also the only test that runs `calculateAerospaceMod` from end to end, which is why nothing else has reached the line. The fix is one more stub alongside the nine already in the same helper.

No issue filed - this turned up while looking at the failing test locally.

## Testing

- `AeroWeaponFireInfoProbeTest` now runs 6 tests, 0 skipped, 0 failures; on current main the same class fails with the NullPointerException.
- Re-ran the whole `megamek.client.bot.princess` package: 44 suites, 410 tests, 0 skipped, 0 failures.
- Ran `./gradlew :megamek:stageDataFiles` first, and used `--rerun`, so the unit-dependent tests actually executed rather than being skipped.
- No game was played, because no production code is touched.

## What is not proven yet

- CI will not exercise this fix. The `test` task does not depend on `stageDataFiles`, so `megamek/data` is empty, `MekSummaryCache` cannot find the Cheetah or the Stuka, and the `assumeTrue` guards skip all six tests in this class. It was verified locally with the data staged.
- That is the whole gap. There is no runtime behaviour to playtest here: the change is a single Mockito stub in a test fixture.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
