### PR TITLE
Fix: Load Force Generator era parameters written under a retired faction code

### DIFF
--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -170,7 +170,11 @@ public class RATGenerator {
         modelIndex.clear();
         eraSet.clear();
         initialized = false;
-        initializing = false;
+        // Stay marked as initializing for the duration of the reload. getInstance() starts a loader thread whenever
+        // it finds both flags clear, and one started partway through a reload runs its own initialize() as soon as
+        // this one releases the lock. That second pass rebuilds every faction record but skips the era files, which
+        // are marked loaded by then, so the reloaded era parameters are replaced by empty ones.
+        initializing = true;
         initialize(dir);
     }
 
@@ -1655,22 +1659,7 @@ public class RATGenerator {
         for (int x = 0; x < nl.getLength(); x++) {
             Node mainNode = nl.item(x);
             if (mainNode.getNodeName().equalsIgnoreCase("factions")) {
-                for (int i = 0; i < mainNode.getChildNodes().getLength(); i++) {
-                    Node wn = mainNode.getChildNodes().item(i);
-                    if (wn.getNodeName().equalsIgnoreCase("faction")) {
-                        String fKey = wn.getAttributes().getNamedItem("key").getTextContent();
-                        if (fKey != null) {
-                            FactionRecord rec = factions.get(fKey);
-                            if (rec != null) {
-                                rec.loadEra(wn, era);
-                            } else {
-                                LOGGER.error("Faction {} not found in {}", fKey, file.getPath());
-                            }
-                        } else {
-                            LOGGER.error("Faction key not found in {}", file.getPath());
-                        }
-                    }
-                }
+                loadEraFactionParameters(mainNode, era, file);
             } else if (mainNode.getNodeName().equalsIgnoreCase("units")) {
                 for (int i = 0; i < mainNode.getChildNodes().getLength(); i++) {
                     Node wn = mainNode.getChildNodes().item(i);
@@ -1684,6 +1673,65 @@ public class RATGenerator {
         unitFileAvailabilityLoader.loadEra(era);
 
         notifyListenersEraLoaded();
+    }
+
+    /**
+     * Loads the per-era faction parameters - the Clan, Star League and Omni percentages, the tech margins, the salvage
+     * table and the weight distributions - from the {@code <factions>} section of an era file.
+     *
+     * <p>Faction codes are resolved through {@link #getFaction(String)} rather than by a direct lookup, so a block
+     * still written under a retired code loads into the faction that absorbed it. The availability tokens in the
+     * {@code <units>} section have always resolved that way, but this section did not, so a faction whose code was
+     * retired silently lost every parameter for the eras written under the old code and fell back on its parent
+     * faction's tech mix. Clan Goliath Scorpion is the live case: its blocks from 3082 on are written as {@code CEI}
+     * and then {@code SE}, both aliases of {@code CGS}.</p>
+     *
+     * <p>Two shipped era files name both the retired and the surviving code, so two blocks can resolve to the same
+     * faction. They are merged in document order and the later block wins for each field it sets, which is harmless
+     * while the overlapping values agree but would quietly discard data if they diverged. That case is logged rather
+     * than resolved here, because the fix belongs in the data.</p>
+     *
+     * @param factionsNode the {@code <factions>} element of an era file
+     * @param era          the era bucket being loaded
+     * @param file         the era file being read, named in the log messages so a bad block can be found
+     */
+    private void loadEraFactionParameters(Node factionsNode, int era, File file) {
+        Set<String> factionsAlreadyLoadedFromThisFile = new HashSet<>();
+        NodeList factionNodes = factionsNode.getChildNodes();
+
+        for (int index = 0; index < factionNodes.getLength(); index++) {
+            Node factionNode = factionNodes.item(index);
+            if (!factionNode.getNodeName().equalsIgnoreCase("faction")) {
+                continue;
+            }
+
+            Node keyAttribute = factionNode.getAttributes().getNamedItem("key");
+            if (keyAttribute == null) {
+                LOGGER.error("Faction key not found in {}", file.getPath());
+                continue;
+            }
+
+            String factionKey = keyAttribute.getTextContent();
+            FactionRecord factionRecord = getFaction(factionKey);
+            if (factionRecord == null) {
+                LOGGER.error("Faction {} not found in {}", factionKey, file.getPath());
+                continue;
+            }
+
+            String canonicalKey = factionRecord.getKey();
+            if (!canonicalKey.equals(factionKey)) {
+                LOGGER.debug("[FactionAlias] era {} parameters written as {} loaded into {}",
+                      era, factionKey, canonicalKey);
+            }
+
+            if (!factionsAlreadyLoadedFromThisFile.add(canonicalKey)) {
+                LOGGER.warn("[FactionAlias] {} in {} loads era {} parameters into {}, which an earlier block in the" +
+                            " same file already filled; the values set here replace it. Merge the two blocks in the" +
+                            " data to resolve this.", factionKey, file.getName(), era, canonicalKey);
+            }
+
+            factionRecord.loadEra(factionNode, era);
+        }
     }
 
     /**

--- a/megamek/src/megamek/client/ratgenerator/RATGenerator.java
+++ b/megamek/src/megamek/client/ratgenerator/RATGenerator.java
@@ -169,12 +169,13 @@ public class RATGenerator {
         chassisIndex.clear();
         modelIndex.clear();
         eraSet.clear();
-        initialized = false;
-        // Stay marked as initializing for the duration of the reload. getInstance() starts a loader thread whenever
-        // it finds both flags clear, and one started partway through a reload runs its own initialize() as soon as
-        // this one releases the lock. That second pass rebuilds every faction record but skips the era files, which
-        // are marked loaded by then, so the reloaded era parameters are replaced by empty ones.
+        // Stay marked as initializing for the duration of the reload, and set that before clearing initialized so the
+        // two flags are never both clear. getInstance() starts a loader thread whenever it finds them both clear, and
+        // one started partway through a reload runs its own initialize() as soon as this one releases the lock. That
+        // second pass rebuilds every faction record but skips the era files, which are marked loaded by then, so the
+        // reloaded era parameters are replaced by empty ones.
         initializing = true;
+        initialized = false;
         initialize(dir);
     }
 

--- a/megamek/testresources/data/forcegenerator/3050.xml
+++ b/megamek/testresources/data/forcegenerator/3050.xml
@@ -26,6 +26,16 @@
             <pctClan>0,0</pctClan>
             <pctSL>0,0</pctSL>
         </faction>
+        <!-- Written under the retired code RET, which resolves to SUC. This is the shape of the shipped 3082 to
+             3160 files, where Clan Goliath Scorpion's blocks are keyed CEI and then SE and no CGS block exists.
+             See RATGeneratorAliasedEraParametersTest. -->
+        <faction key='RET'>
+            <pctOmni>10,20,30,40,50</pctOmni>
+            <pctClan>11,21,31,41,51</pctClan>
+            <pctSL>89,79,69,59,49</pctSL>
+            <techMargin>7</techMargin>
+            <salvage pct='13'>LA:2</salvage>
+        </faction>
     </factions>
     <units>
         <chassis name='Archer' unitType='Mek'>

--- a/megamek/testresources/data/forcegenerator/3060.xml
+++ b/megamek/testresources/data/forcegenerator/3060.xml
@@ -26,6 +26,16 @@
             <pctClan>0,0</pctClan>
             <pctSL>0,0</pctSL>
         </faction>
+        <!-- Both the surviving and the retired code in one file, which is the shape of the shipped 3078 and 3131
+             files. The retired block sets only techMargin, so it must replace that one value and leave the rest of
+             the surviving block alone. See RATGeneratorAliasedEraParametersTest. -->
+        <faction key='SUC'>
+            <pctOmni>60,61,62,63,64</pctOmni>
+            <techMargin>4</techMargin>
+        </faction>
+        <faction key='RET'>
+            <techMargin>9</techMargin>
+        </faction>
     </factions>
     <units>
         <chassis name='Archer' unitType='Mek'>

--- a/megamek/testresources/data/universe/factions/SUCCESSOR_test.yml
+++ b/megamek/testresources/data/universe/factions/SUCCESSOR_test.yml
@@ -1,0 +1,33 @@
+# MegaMek Data (C) 2026 by The MegaMek Team is licensed under CC BY-NC-SA 4.0.
+# To view a copy of this license, visit https://creativecommons.org/licenses/by-nc-sa/4.0/
+#
+# NOTICE: The MegaMek organization is a non-profit group of volunteers
+# creating free software for the BattleTech community.
+#
+# MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+# of The Topps Company, Inc. All Rights Reserved.
+#
+# Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+# InMediaRes Productions, LLC.
+#
+# MechWarrior Copyright Microsoft Corporation. MegaMek Data was created under
+# Microsoft's "Game Content Usage Rules"
+# <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+# affiliated with Microsoft.
+key: SUC
+name: Successor Test Faction
+# Stands in for Clan Goliath Scorpion, whose era parameter blocks from 3082 on are still written under the
+# retired codes CEI and SE. RET has no faction file of its own, so an era block keyed RET has to resolve
+# here. No other test uses this faction, so its era parameters can be asserted exactly.
+aliases:
+  3050: RET
+yearsActive:
+  - start: 2807
+tags:
+  - CLAN
+ratingLevels:
+  - F
+  - D
+  - C
+  - B
+  - A

--- a/megamek/unittests/megamek/client/ratgenerator/ForceGeneratorTestFixture.java
+++ b/megamek/unittests/megamek/client/ratgenerator/ForceGeneratorTestFixture.java
@@ -102,10 +102,32 @@ final class ForceGeneratorTestFixture {
         }
 
         RATGenerator ratGenerator = RATGenerator.getInstance();
+        waitForBackgroundLoad(ratGenerator);
         ratGenerator.reloadFromDir(Configuration.forceGeneratorDir());
         ratGenerator.loadYear(era);
 
         return ratGenerator;
+    }
+
+    /**
+     * Waits for the background load started by {@link RATGenerator#getInstance()} to finish before the caller reloads
+     * from the test directory.
+     *
+     * <p>The first call to {@code getInstance()} in the test JVM spawns a loader thread. Reloading while it is still
+     * running leaves the two loads interleaved: the reload rebuilds the faction records and fills in their era
+     * parameters, then the background load rebuilds the records a second time and skips the era files, because the
+     * eras are marked loaded by then. The faction list and the unit availability indexes come out intact, so most
+     * tests never notice, but every faction's era parameters - its Clan, Star League and Omni percentages, margins
+     * and salvage - are lost, and the records handed back are not the ones the era files loaded into.</p>
+     *
+     * @param ratGenerator the Force Generator to wait on
+     *
+     * @throws InterruptedException if the wait is interrupted
+     */
+    private static void waitForBackgroundLoad(RATGenerator ratGenerator) throws InterruptedException {
+        while (!ratGenerator.isInitialized()) {
+            Thread.sleep(50);
+        }
     }
 
     /**

--- a/megamek/unittests/megamek/client/ratgenerator/ForceGeneratorTestFixture.java
+++ b/megamek/unittests/megamek/client/ratgenerator/ForceGeneratorTestFixture.java
@@ -70,6 +70,9 @@ final class ForceGeneratorTestFixture {
      */
     private static final List<String> CANON_TEST_UNITS = List.of("Archer ARC-2R", "Atlas AS7-D");
 
+    /** Generous enough for a cold CI machine building the unit cache, short enough not to stall a run. */
+    private static final long BACKGROUND_LOAD_TIMEOUT_MILLIS = 120_000;
+
     private ForceGeneratorTestFixture() {
     }
 
@@ -120,12 +123,21 @@ final class ForceGeneratorTestFixture {
      * tests never notice, but every faction's era parameters - its Clan, Star League and Omni percentages, margins
      * and salvage - are lost, and the records handed back are not the ones the era files loaded into.</p>
      *
+     * <p>Bounded, because a load that fails without ever setting the flag would otherwise hang the whole test run
+     * rather than fail one class.</p>
+     *
      * @param ratGenerator the Force Generator to wait on
      *
-     * @throws InterruptedException if the wait is interrupted
+     * @throws InterruptedException  if the wait is interrupted
+     * @throws IllegalStateException if the load has not finished within {@link #BACKGROUND_LOAD_TIMEOUT_MILLIS}
      */
     private static void waitForBackgroundLoad(RATGenerator ratGenerator) throws InterruptedException {
+        long giveUpAt = System.currentTimeMillis() + BACKGROUND_LOAD_TIMEOUT_MILLIS;
         while (!ratGenerator.isInitialized()) {
+            if (System.currentTimeMillis() >= giveUpAt) {
+                throw new IllegalStateException("Force Generator did not finish loading within "
+                      + BACKGROUND_LOAD_TIMEOUT_MILLIS + " ms; check the log for a load failure");
+            }
             Thread.sleep(50);
         }
     }

--- a/megamek/unittests/megamek/client/ratgenerator/ForceGeneratorTestFixture.java
+++ b/megamek/unittests/megamek/client/ratgenerator/ForceGeneratorTestFixture.java
@@ -36,6 +36,7 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Vector;
+import java.util.function.BooleanSupplier;
 
 import megamek.common.Configuration;
 import megamek.common.loaders.MekFileParser;
@@ -71,7 +72,7 @@ final class ForceGeneratorTestFixture {
     private static final List<String> CANON_TEST_UNITS = List.of("Archer ARC-2R", "Atlas AS7-D");
 
     /** Generous enough for a cold CI machine building the unit cache, short enough not to stall a run. */
-    private static final long BACKGROUND_LOAD_TIMEOUT_MILLIS = 120_000;
+    private static final long LOAD_TIMEOUT_MILLIS = 120_000;
 
     private ForceGeneratorTestFixture() {
     }
@@ -100,9 +101,7 @@ final class ForceGeneratorTestFixture {
         // Drop any cache another test class already built, so the test units are the ones that load
         resetMekSummaryCache();
         MekSummaryCache mekSummaryCache = MekSummaryCache.getInstance();
-        while (!mekSummaryCache.isInitialized()) {
-            Thread.sleep(50);
-        }
+        waitForLoad("Unit cache", mekSummaryCache::isInitialized);
 
         RATGenerator ratGenerator = RATGenerator.getInstance();
         waitForBackgroundLoad(ratGenerator);
@@ -123,20 +122,33 @@ final class ForceGeneratorTestFixture {
      * tests never notice, but every faction's era parameters - its Clan, Star League and Omni percentages, margins
      * and salvage - are lost, and the records handed back are not the ones the era files loaded into.</p>
      *
-     * <p>Bounded, because a load that fails without ever setting the flag would otherwise hang the whole test run
-     * rather than fail one class.</p>
-     *
      * @param ratGenerator the Force Generator to wait on
      *
      * @throws InterruptedException  if the wait is interrupted
-     * @throws IllegalStateException if the load has not finished within {@link #BACKGROUND_LOAD_TIMEOUT_MILLIS}
+     * @throws IllegalStateException if the load has not finished within {@link #LOAD_TIMEOUT_MILLIS}
      */
     private static void waitForBackgroundLoad(RATGenerator ratGenerator) throws InterruptedException {
-        long giveUpAt = System.currentTimeMillis() + BACKGROUND_LOAD_TIMEOUT_MILLIS;
-        while (!ratGenerator.isInitialized()) {
+        waitForLoad("Force Generator", ratGenerator::isInitialized);
+    }
+
+    /**
+     * Waits for an asynchronous load to report itself finished, giving up after {@link #LOAD_TIMEOUT_MILLIS}.
+     *
+     * <p>Bounded on purpose. Both singletons this fixture waits on load on their own threads, and one that fails
+     * without ever setting its flag would otherwise stall the whole test run instead of failing a single class.</p>
+     *
+     * @param whatIsLoading name of the thing being waited on, used in the failure message
+     * @param isLoaded      reports whether the load has finished
+     *
+     * @throws InterruptedException  if the wait is interrupted
+     * @throws IllegalStateException if the load has not finished in time
+     */
+    private static void waitForLoad(String whatIsLoading, BooleanSupplier isLoaded) throws InterruptedException {
+        long giveUpAt = System.currentTimeMillis() + LOAD_TIMEOUT_MILLIS;
+        while (!isLoaded.getAsBoolean()) {
             if (System.currentTimeMillis() >= giveUpAt) {
-                throw new IllegalStateException("Force Generator did not finish loading within "
-                      + BACKGROUND_LOAD_TIMEOUT_MILLIS + " ms; check the log for a load failure");
+                throw new IllegalStateException(whatIsLoading + " did not finish loading within "
+                      + LOAD_TIMEOUT_MILLIS + " ms; check the log for a load failure");
             }
             Thread.sleep(50);
         }

--- a/megamek/unittests/megamek/client/ratgenerator/RATGeneratorAliasedEraParametersTest.java
+++ b/megamek/unittests/megamek/client/ratgenerator/RATGeneratorAliasedEraParametersTest.java
@@ -52,7 +52,7 @@ import org.junit.jupiter.api.Test;
  * <p>It used to be looked up directly in the faction map, which by design holds no alias keys, so every block written
  * under a retired code was dropped with an error and the faction silently fell back on its parent's tech mix. Clan
  * Goliath Scorpion is the live case: it absorbed the Escorpion Imperio and the Scorpion Empire, and its blocks from
- * 3082 on are still keyed {@code CEI} and then {@code SE}, so it had no tuning of its own for six era buckets.</p>
+ * 3082 on are still keyed {@code CEI} and then {@code SE}, so it had no tuning of its own for seven era buckets.</p>
  *
  * <p>The test data mirrors both shapes the shipped files take. Era 3050 holds only the retired code, as 3082 through
  * 3160 do. Era 3060 holds the surviving and the retired code together, as 3078 and 3131 do.</p>

--- a/megamek/unittests/megamek/client/ratgenerator/RATGeneratorAliasedEraParametersTest.java
+++ b/megamek/unittests/megamek/client/ratgenerator/RATGeneratorAliasedEraParametersTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.ratgenerator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.Map;
+
+import megamek.client.ratgenerator.FactionRecord.TechCategory;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * An era file's {@code <factions>} section carries the per-era tuning for each faction: how much Clan and Star League
+ * tech it fields, its margins, and who it takes salvage from. Those blocks are keyed by faction code, and a code that
+ * has since been retired has to resolve to the faction that absorbed it.
+ *
+ * <p>It used to be looked up directly in the faction map, which by design holds no alias keys, so every block written
+ * under a retired code was dropped with an error and the faction silently fell back on its parent's tech mix. Clan
+ * Goliath Scorpion is the live case: it absorbed the Escorpion Imperio and the Scorpion Empire, and its blocks from
+ * 3082 on are still keyed {@code CEI} and then {@code SE}, so it had no tuning of its own for six era buckets.</p>
+ *
+ * <p>The test data mirrors both shapes the shipped files take. Era 3050 holds only the retired code, as 3082 through
+ * 3160 do. Era 3060 holds the surviving and the retired code together, as 3078 and 3131 do.</p>
+ */
+class RATGeneratorAliasedEraParametersTest {
+
+    /** Holds a block under the retired code only, with no block for the surviving faction. */
+    private static final int ERA_WITH_ONLY_THE_RETIRED_CODE = 3050;
+    /** Holds a block under each code, the surviving one first. */
+    private static final int ERA_WITH_BOTH_CODES = 3060;
+
+    /** The surviving faction, standing in for {@code CGS}. */
+    private static final String SURVIVING_FACTION = "SUC";
+    /** The retired code it absorbed, standing in for {@code CEI} and {@code SE}. */
+    private static final String RETIRED_FACTION_CODE = "RET";
+
+    /** Equipment rating to read the percentage lists at; the test faction declares the usual five levels. */
+    private static final int TOP_RATING = 4;
+
+    private static RATGenerator ratGenerator;
+
+    @BeforeAll
+    static void loadForceGeneratorFromTestData() throws Exception {
+        ratGenerator = ForceGeneratorTestFixture.loadFromTestData(ERA_WITH_ONLY_THE_RETIRED_CODE);
+        ratGenerator.loadYear(ERA_WITH_BOTH_CODES);
+    }
+
+    @AfterAll
+    static void clearSharedSingletons() throws Exception {
+        ForceGeneratorTestFixture.reset();
+    }
+
+    @Test
+    void aBlockWrittenUnderTheRetiredCodeTunesTheSurvivingFaction() {
+        FactionRecord survivingFaction = survivingFaction();
+        int era = ERA_WITH_ONLY_THE_RETIRED_CODE;
+
+        assertEquals(50, survivingFaction.getPctTech(TechCategory.OMNI, era, TOP_RATING),
+              "The Omni percentage from the retired code's block should have loaded into the surviving faction");
+        assertEquals(51, survivingFaction.getPctTech(TechCategory.CLAN, era, TOP_RATING),
+              "The Clan percentage from the retired code's block should have loaded into the surviving faction");
+        assertEquals(49, survivingFaction.getPctTech(TechCategory.IS_ADVANCED, era, TOP_RATING),
+              "The Star League percentage from the retired code's block should have loaded into the surviving"
+                    + " faction");
+    }
+
+    @Test
+    void theMarginsAndSalvageFromTheRetiredCodeLoadToo() {
+        FactionRecord survivingFaction = survivingFaction();
+        int era = ERA_WITH_ONLY_THE_RETIRED_CODE;
+
+        assertEquals(7, survivingFaction.getTechMargin(era),
+              "A tech margin that never loads reads back as zero, which is the bug this pins down");
+        assertEquals(13, survivingFaction.getPctSalvage(era),
+              "The salvage percentage from the retired code's block should have loaded");
+
+        Map<String, Integer> salvage = survivingFaction.getSalvage(era);
+        assertEquals(2, salvage.get("LA"), "The salvage table from the retired code's block should have loaded");
+    }
+
+    @Test
+    void theRetiredCodeIsNotItselfListedAsAFaction() {
+        boolean retiredCodeIsListed = ratGenerator.getFactionList()
+              .stream()
+              .anyMatch(factionRecord -> RETIRED_FACTION_CODE.equals(factionRecord.getKey()));
+
+        assertFalse(retiredCodeIsListed,
+              "Resolving the retired code must not add it to the faction list, or the same faction would be offered"
+                    + " to the player twice");
+        assertSame(survivingFaction(), ratGenerator.getFaction(RETIRED_FACTION_CODE),
+              "The retired code should resolve to the surviving faction");
+    }
+
+    @Test
+    void aRetiredBlockAlongsideTheSurvivingOneReplacesOnlyTheFieldsItSets() {
+        FactionRecord survivingFaction = survivingFaction();
+        int era = ERA_WITH_BOTH_CODES;
+
+        assertEquals(9, survivingFaction.getTechMargin(era),
+              "Both blocks set the tech margin, and the retired one is read second, so its value should stand");
+        assertEquals(64, survivingFaction.getPctTech(TechCategory.OMNI, era, TOP_RATING),
+              "The retired block sets no Omni percentage, so the surviving block's value must survive the merge");
+    }
+
+    private static FactionRecord survivingFaction() {
+        FactionRecord survivingFaction = ratGenerator.getFaction(SURVIVING_FACTION);
+        assertNotNull(survivingFaction, "Test data should provide faction " + SURVIVING_FACTION);
+        return survivingFaction;
+    }
+}


### PR DESCRIPTION
## What this changes

Clan Goliath Scorpion generated untuned forces from 3082 onwards. A 3145 Scorpion Empire force at
the top equipment rating should come out about 90% Clan tech, 10% Star League, with 10% of the force
salvaged from Clan Hell's Horses. None of that was applied, because the faction had no era
parameters loaded at all for seven era buckets.

Each Force Generator era file has two parts: a `<factions>` block holding the per-era tuning, and a
`<units>` section holding availability. Clan Goliath Scorpion absorbed the Escorpion Imperio and the
Scorpion Empire, so its blocks from 3082 on are still keyed `CEI` and then `SE`. The `<units>`
section already resolved retired codes through `getFaction()`, but the `<factions>` section looked
the code up directly in the faction map, which by design holds no alias keys. Every one of those
blocks was dropped with `Faction CEI not found in data/forcegenerator/3082.xml`, and the faction
fell back on its parent's tech mix.

While testing this, a second defect turned up. `reloadFromDir` cleared both the `initialized` and
`initializing` flags before reinitializing, so any `getInstance()` call during the reload started a
second loader thread. That thread rebuilt every faction record once the reload released the lock,
but skipped the era files because they were already marked loaded, leaving the records empty. Era
parameters could not survive a reload at all, which also affects the RAT Generator Editor.

## Testing

- New `RATGeneratorAliasedEraParametersTest`, four tests covering both shapes the shipped files
  take: an era holding only the retired code (like 3082 to 3160) and an era holding both the retired
  and surviving codes (like 3078 and 3131).
- Confirmed the new tests genuinely catch the bug by reverting the alias lookup on its own: three of
  the four fail, and pass again with it restored.
- Confirmed both halves of the fix are needed by reverting each independently. Neither alone makes
  the new tests pass.
- Read Clan Goliath Scorpion's era parameters back out of the Force Generator against the real
  shipped data, before and after. Every bucket from 3082 to 3160 previously came back empty, at tech
  margin 0 with no percentages. After the fix each carries its values: tech margin 3 at 3082 and
  3085, 6 at 3100, 12 at 3131, 15 at 3145, 16 at 3150 and 18 at 3160.
- Loaded the real data through the running Force Generator and read `megamek.log`. The
  `Faction CEI not found` and `Faction SE not found` errors are gone, and the new duplicate-block
  warning fires exactly twice, for the two files that legitimately name both codes.
- Generated Clan Goliath Scorpion 'Mek tables at 3100, 3145 and 3160, returning 214, 317 and 342
  entries, confirming availability still resolves.
- Full suite: 15291 tests, 8 skipped, 1 failure. That failure is
  `AeroWeaponFireInfoProbeTest.velocityPenaltyFiresOnALiveStyleRanking`, which fails identically on
  clean `main` with these changes stashed. It is unrelated and pre-existing.
- Checkstyle passes.

## What is not proven yet

- The Force Generator was never opened in the GUI. The values were read back through the real
  loading path rather than by generating a force from the menu.
- Nothing exercises the RAT Generator Editor, so the reload fix is proven by the parameters
  surviving a reload in the harness, not by using the editor.
- Two era files, 3078 and 3131, name both the retired and the surviving code. Their blocks are
  merged in document order and the later one wins for each field it sets. The overlapping values
  agree in the shipped data, so nothing changes today, but the merge order itself is not something a
  test pins down; it is logged instead, and the data fix is MegaMek/mm-data#525.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result
