### PR TITLE
Fix #8778: Scenario factions without a camo get their player color's camouflage

### DIFF
--- a/megamek/src/megamek/common/scenario/ScenarioV2.java
+++ b/megamek/src/megamek/common/scenario/ScenarioV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2024-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -409,6 +409,11 @@ public class ScenarioV2 implements Scenario {
                 } else {
                     player.setCamouflage(new Camouflage(new File(camoPath)));
                 }
+            } else {
+                // like lobby-created players (Server.addNewPlayer), a faction without a camo of its own
+                // gets its player color's camouflage - otherwise every faction renders with the same
+                // default camo and the sides cannot be told apart on the board
+                player.setCamouflage(Camouflage.of(player.getColour()));
             }
 
             teamId = playerNode.has(PARAM_TEAM) ? playerNode.get(PARAM_TEAM).intValue() : teamId + 1;

--- a/megamek/unittests/megamek/common/scenario/ScenarioV2PlayerCamoTest.java
+++ b/megamek/unittests/megamek/common/scenario/ScenarioV2PlayerCamoTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.scenario;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
+
+import megamek.common.Player;
+import megamek.common.game.IGame;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Scenario factions that declare no camo of their own must receive their player color's camouflage, the same
+ * way lobby-created players do - otherwise every faction renders with the identical default camo and the sides
+ * cannot be told apart on the board (found live in a Princess-versus-Princess objectives playtest, #8778).
+ * Factions that do declare a camo must keep it.
+ */
+class ScenarioV2PlayerCamoTest {
+
+    @Test
+    void factionsWithoutACamoGetTheirPlayerColorCamouflage() throws Exception {
+        IGame game = loadScenario("testresources/data/scenarios/test_setups/AeroDuelGroundMap.mms");
+
+        Set<String> seenCamoNames = new HashSet<>();
+        for (Player player : game.getPlayersList()) {
+            assertTrue(player.getCamouflage().isColourCamouflage(),
+                  player.getName() + " should have a color camouflage, not the default");
+            assertEquals(player.getColour().name(), player.getCamouflage().getFilename(),
+                  player.getName() + "'s camo should match their player color");
+            seenCamoNames.add(player.getCamouflage().getFilename());
+        }
+        assertEquals(game.getPlayersList().size(), seenCamoNames.size(),
+              "every faction should look different on the board");
+    }
+
+    @Test
+    void factionsWithTheirOwnCamoKeepIt() throws Exception {
+        IGame game = loadScenario("testresources/data/scenarios/test_setups/AeroScen.mms");
+
+        for (Player player : game.getPlayersList()) {
+            assertFalse(player.getCamouflage().isColourCamouflage(),
+                  player.getName() + "'s scenario-declared camo must not be replaced");
+        }
+    }
+
+    private IGame loadScenario(String path) throws Exception {
+        File scenarioFile = new File(path);
+        assertTrue(scenarioFile.exists(), "missing test fixture: " + scenarioFile.getAbsolutePath());
+        return new ScenarioLoader(scenarioFile).load().createGame();
+    }
+}

--- a/megamek/unittests/megamek/common/scenario/ScenarioV2PlayerCamoTest.java
+++ b/megamek/unittests/megamek/common/scenario/ScenarioV2PlayerCamoTest.java
@@ -54,7 +54,7 @@ class ScenarioV2PlayerCamoTest {
 
     @Test
     void factionsWithoutACamoGetTheirPlayerColorCamouflage() throws Exception {
-        IGame game = loadScenario("testresources/data/scenarios/test_setups/AeroDuelGroundMap.mms");
+        IGame game = loadScenario("testresources/data/scenarios/test_setups/AeroGroundAttackRun.mms");
 
         Set<String> seenCamoNames = new HashSet<>();
         for (Player player : game.getPlayersList()) {


### PR DESCRIPTION
## What this changes

Run any V2 scenario whose factions do not declare a `camo:` key - the shipped Princess evaluation scenarios, for example - and every unit on the board renders with the same default camouflage, so the sides cannot be told apart while playing. The player colors themselves were always assigned correctly (minimap, chat names); only the unit sprites were indistinguishable. Scenario factions without a camo now receive their player color's camouflage, exactly the way lobby-created players always have (the same fallback `Server.addNewPlayer` applies), so a Princess-versus-Princess scenario shows blue units against red. Factions that declare their own `camo:` keep it unchanged. The change is one fallback branch in `ScenarioV2.createPlayers`.

Fixes #8778

## Testing

- Two regression tests in `ScenarioV2PlayerCamoTest`: a camo-less fixture scenario must give every faction a distinct color camouflage matching its player color, and a fixture with declared camos must keep them.
- compile and checkstyle green.

## What is not proven yet

- Not yet relaunched in-game on this branch; the failure itself was observed live in a Princess-versus-Princess scenario and the fix path is covered by the tests above.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result
