### PR TITLE
Move Report a Bug to the command strip as a SCRAM-coloured button

### DIFF
--- a/megamek/src/megamek/client/ui/clientGUI/BugReportDialog.java
+++ b/megamek/src/megamek/client/ui/clientGUI/BugReportDialog.java
@@ -33,31 +33,20 @@
 
 package megamek.client.ui.clientGUI;
 
-import java.awt.BasicStroke;
-import java.awt.Color;
-import java.awt.Component;
 import java.awt.Cursor;
 import java.awt.Dimension;
 import java.awt.Font;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.GridLayout;
-import java.awt.Insets;
-import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.awt.Window;
-import java.awt.geom.Area;
 import java.util.function.Supplier;
 import javax.swing.Action;
-import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
-import javax.swing.border.AbstractBorder;
 
 import megamek.MMConstants;
 import megamek.client.Client;
@@ -65,6 +54,7 @@ import megamek.client.ui.BugReportMessages;
 import megamek.client.ui.CopySystemDataAction;
 import megamek.client.ui.PackageBugReportAction;
 import megamek.client.ui.util.UIUtil;
+import megamek.client.ui.widget.HazardButton;
 import megamek.common.annotations.Nullable;
 import megamek.common.util.IssueReportUrl;
 
@@ -72,13 +62,6 @@ public class BugReportDialog {
 
     private static final int UNSCALED_WIDTH = 600;
     private static final BugReportMessages I18N = new BugReportMessages();
-
-    /** Hazard colours for the striped border around the reporting button. */
-    private static final Color HAZARD_YELLOW = new Color(255, 204, 0);
-    private static final Color HAZARD_RED = new Color(204, 34, 34);
-
-    /** Breathing room between the striped border and the button text. */
-    private static final int HAZARD_PADDING = 4;
 
     private static final int UNSCALED_REPORT_BUTTON_WIDTH = 260;
     private static final int UNSCALED_REPORT_BUTTON_HEIGHT = 48;
@@ -154,9 +137,7 @@ public class BugReportDialog {
      * @return the reporting button
      */
     private JButton createReportButton() {
-        JButton reportButton = new JButton(packageBugReportAction);
-        reportButton.setBorder(BorderFactory.createCompoundBorder(new HazardStripeBorder(),
-              BorderFactory.createEmptyBorder(HAZARD_PADDING, HAZARD_PADDING, HAZARD_PADDING, HAZARD_PADDING)));
+        JButton reportButton = new HazardButton(packageBugReportAction);
         reportButton.setFont(reportButton.getFont().deriveFont(Font.BOLD,
               reportButton.getFont().getSize2D() * REPORT_BUTTON_FONT_FACTOR));
         reportButton.setPreferredSize(new Dimension(UIUtil.scaleForGUI(UNSCALED_REPORT_BUTTON_WIDTH),
@@ -205,52 +186,6 @@ public class BugReportDialog {
         rootPanel.add(gatherFilesRow);
         rootPanel.add(repositoryRow);
         return rootPanel;
-    }
-
-    /**
-     * A border of diagonal yellow and red stripes, in the manner of hazard tape.
-     *
-     * <p>Used on the one button in this dialog that does something rather than opening a link, so that a player
-     * skimming ten similar-looking buttons cannot miss which one starts the job.</p>
-     */
-    private static class HazardStripeBorder extends AbstractBorder {
-
-        private final int thickness = UIUtil.scaleForGUI(5);
-
-        @Override
-        public void paintBorder(Component component, Graphics graphics, int x, int y, int width, int height) {
-            Graphics2D stripeGraphics = (Graphics2D) graphics.create();
-            try {
-                Area frame = new Area(new Rectangle(x, y, width, height));
-                frame.subtract(new Area(new Rectangle(x + thickness, y + thickness,
-                      width - (2 * thickness), height - (2 * thickness))));
-                stripeGraphics.clip(frame);
-                stripeGraphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-
-                stripeGraphics.setColor(HAZARD_YELLOW);
-                stripeGraphics.fillRect(x, y, width, height);
-
-                // Diagonals are drawn from off the left edge so that the stripes carry across the whole frame.
-                stripeGraphics.setColor(HAZARD_RED);
-                stripeGraphics.setStroke(new BasicStroke(thickness));
-                for (int offset = -height; offset < width; offset += thickness * 2) {
-                    stripeGraphics.drawLine(x + offset, y + height, x + offset + height, y);
-                }
-            } finally {
-                stripeGraphics.dispose();
-            }
-        }
-
-        @Override
-        public Insets getBorderInsets(Component component) {
-            return new Insets(thickness, thickness, thickness, thickness);
-        }
-
-        @Override
-        public Insets getBorderInsets(Component component, Insets insets) {
-            insets.set(thickness, thickness, thickness, thickness);
-            return insets;
-        }
     }
 
     private static class UrlButton extends JButton {

--- a/megamek/src/megamek/client/ui/clientGUI/BugReportDialog.java
+++ b/megamek/src/megamek/client/ui/clientGUI/BugReportDialog.java
@@ -42,6 +42,7 @@ import java.awt.GridLayout;
 import java.awt.Window;
 import java.util.function.Supplier;
 import javax.swing.Action;
+import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
@@ -54,7 +55,7 @@ import megamek.client.ui.BugReportMessages;
 import megamek.client.ui.CopySystemDataAction;
 import megamek.client.ui.PackageBugReportAction;
 import megamek.client.ui.util.UIUtil;
-import megamek.client.ui.widget.HazardButton;
+import megamek.client.ui.widget.HazardStripeBorder;
 import megamek.common.annotations.Nullable;
 import megamek.common.util.IssueReportUrl;
 
@@ -62,6 +63,9 @@ public class BugReportDialog {
 
     private static final int UNSCALED_WIDTH = 600;
     private static final BugReportMessages I18N = new BugReportMessages();
+
+    /** Breathing room between the striped border and the button text, in unscaled pixels. */
+    private static final int HAZARD_PADDING = 4;
 
     private static final int UNSCALED_REPORT_BUTTON_WIDTH = 260;
     private static final int UNSCALED_REPORT_BUTTON_HEIGHT = 48;
@@ -137,7 +141,10 @@ public class BugReportDialog {
      * @return the reporting button
      */
     private JButton createReportButton() {
-        JButton reportButton = new HazardButton(packageBugReportAction);
+        JButton reportButton = new JButton(packageBugReportAction);
+        int padding = UIUtil.scaleForGUI(HAZARD_PADDING);
+        reportButton.setBorder(BorderFactory.createCompoundBorder(new HazardStripeBorder(),
+              BorderFactory.createEmptyBorder(padding, padding, padding, padding)));
         reportButton.setFont(reportButton.getFont().deriveFont(Font.BOLD,
               reportButton.getFont().getSize2D() * REPORT_BUTTON_FONT_FACTOR));
         reportButton.setPreferredSize(new Dimension(UIUtil.scaleForGUI(UNSCALED_REPORT_BUTTON_WIDTH),

--- a/megamek/src/megamek/client/ui/clientGUI/CommandBarPanel.java
+++ b/megamek/src/megamek/client/ui/clientGUI/CommandBarPanel.java
@@ -37,28 +37,43 @@ import java.awt.BorderLayout;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 
+import megamek.client.Client;
+import megamek.client.ui.BugReportMessages;
 import megamek.client.ui.Messages;
 import megamek.client.ui.dialogs.BotCommands.BotCommandsPanel;
 import megamek.client.ui.util.UIUtil;
+import megamek.client.ui.widget.HazardButton;
 import megamek.client.ui.widget.MegaMekButton;
 import megamek.client.ui.widget.SkinSpecification;
+import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
 
 /**
  * The command strip that sits directly under the menu bar, above the board. It always ends in the Commands button,
- * which opens the game commands menu ({@link GameCommandsMenu}), and it is the strip the bot commands panel docks into
- * when the player has it set to Dock.
+ * which opens the game commands menu ({@link GameCommandsMenu}), followed by the Report a Bug button, and it is the
+ * strip the bot commands panel docks into when the player has it set to Dock.
  *
  * <p>Keeping the Commands button on a strip of its own, rather than on the bot commands panel, means it stays where
  * the player left it no matter how the bot commands panel is set: a player who commands no bots at all, and has the bot
  * panel switched off, still has the game commands one click away.</p>
+ *
+ * <p>The Report a Bug button is styled as a hazard-striped stop button so that a player who has just watched
+ * something go wrong can find it without reading the strip. It lives here rather than in the phase display's Done
+ * column because that column is already two buttons deep during the action phases, and a third row there cost board
+ * space in every phase.</p>
  */
 public class CommandBarPanel extends JPanel {
     private static final MMLogger LOGGER = MMLogger.create(CommandBarPanel.class);
 
+    private static final BugReportMessages BUG_REPORT_I18N = new BugReportMessages();
+
     /** The height of the strip, matching the docked layout of the bot commands panel it sits beside. */
     private static final int BAR_HEIGHT = 40;
-    private static final int COMMANDS_BUTTON_WIDTH = 160;
+    /** Narrower than it was before the Report a Bug button joined it, which is what pays for that button's width. */
+    private static final int COMMANDS_BUTTON_WIDTH = 110;
+    private static final int REPORT_BUG_BUTTON_WIDTH = 130;
+    /** The gap between the two buttons at the end of the strip. */
+    private static final int BUTTON_GAP = 2;
 
     private final ClientGUI clientGUI;
     private final MegaMekButton commandsButton;
@@ -80,7 +95,27 @@ public class CommandBarPanel extends JPanel {
         commandsButton.setToolTipText(Messages.getString("GameCommands.tooltip"));
         commandsButton.setPreferredSize(UIUtil.scaleForGUI(COMMANDS_BUTTON_WIDTH, BAR_HEIGHT));
         commandsButton.addActionListener(event -> showCommandsPopup());
-        add(commandsButton, BorderLayout.EAST);
+
+        HazardButton reportBugButton = new HazardButton(BUG_REPORT_I18N.get("package.reportBug"));
+        reportBugButton.setToolTipText(BUG_REPORT_I18N.get("package.reportBug.tooltip"));
+        reportBugButton.setPreferredSize(UIUtil.scaleForGUI(REPORT_BUG_BUTTON_WIDTH, BAR_HEIGHT));
+        reportBugButton.addActionListener(event -> BugReportDialog.showWithGameTools(clientGUI.getFrame(),
+              this::totalWarfareClient));
+
+        // Commands first, so it keeps the spot it had when it was alone, then Report a Bug on the far right.
+        JPanel endOfStrip = new JPanel(new BorderLayout(UIUtil.scaleForGUI(BUTTON_GAP), 0));
+        endOfStrip.setOpaque(false);
+        endOfStrip.add(commandsButton, BorderLayout.CENTER);
+        endOfStrip.add(reportBugButton, BorderLayout.EAST);
+        add(endOfStrip, BorderLayout.EAST);
+    }
+
+    /**
+     * @return the client of the running game when it is one whose save the bug report packager understands, otherwise
+     *       {@code null}; a Strategic BattleForce game, for instance, packages its logs alone
+     */
+    private @Nullable Client totalWarfareClient() {
+        return (clientGUI.getClient() instanceof Client totalWarfareClient) ? totalWarfareClient : null;
     }
 
     /**

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/StatusBarPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/StatusBarPhaseDisplay.java
@@ -59,11 +59,8 @@ import javax.swing.ToolTipManager;
 import javax.swing.border.EmptyBorder;
 
 import megamek.client.AbstractClient;
-import megamek.client.Client;
-import megamek.client.ui.BugReportMessages;
 import megamek.client.ui.GBC;
 import megamek.client.ui.Messages;
-import megamek.client.ui.clientGUI.BugReportDialog;
 import megamek.client.ui.clientGUI.GUIPreferences;
 import megamek.client.ui.clientGUI.IClientGUI;
 import megamek.client.ui.clientGUI.MegaMekGUI;
@@ -101,12 +98,10 @@ public abstract class StatusBarPhaseDisplay extends AbstractPhaseDisplay
     private static final String SBPD_KEY_CLEAR_BUTTON = "clearButton";
 
     /**
-     * How many buttons the Done column has to make room for: the Done button, the Skip button the action phases add
-     * below it, and the reporting button that sits under both in every phase.
+     * How many buttons the Done column has to make room for: the Done button, and the Skip button the action phases
+     * add below it.
      */
-    private static final int DONE_PANEL_ROWS = 3;
-
-    private static final BugReportMessages BUG_REPORT_I18N = new BugReportMessages();
+    private static final int DONE_PANEL_ROWS = 2;
 
     protected final IClientGUI clientGUI;
 
@@ -289,9 +284,6 @@ public abstract class StatusBarPhaseDisplay extends AbstractPhaseDisplay
         }
 
         var donePanel = setupDonePanel();
-        // Added here rather than in setupDonePanel() so that it stays below whatever the phase itself puts in the
-        // column: MovementDisplay and its relatives add a Skip button in their override.
-        addToDonePanel(donePanel, createReportBugButton());
 
         panButtons.add(buttonsPanel);
         panButtons.add(donePanel);
@@ -311,32 +303,6 @@ public abstract class StatusBarPhaseDisplay extends AbstractPhaseDisplay
         return donePanel;
     }
 
-    /**
-     * Creates the reporting button that sits at the bottom of the Done column in every phase.
-     *
-     * <p>The reporting tools are also on the menu bar, but a player who has just watched something go wrong is
-     * looking at the board, not at the menus, and by the time they have found the entry the game may have moved on.
-     * Keeping the button in the same place all game means it is always where they last saw it.</p>
-     *
-     * @return the reporting button, ready to be added to the Done column
-     */
-    private MegaMekButton createReportBugButton() {
-        MegaMekButton reportBugButton = new MegaMekButton(
-              "<html><b>" + BUG_REPORT_I18N.get("package.reportBug") + "</b></html>",
-              SkinSpecification.UIComponents.PhaseDisplayButton.getComp());
-        reportBugButton.setToolTipText(BUG_REPORT_I18N.get("package.reportBug.tooltip"));
-        reportBugButton.addActionListener(event -> BugReportDialog.showWithGameTools(clientGUI.getFrame(),
-              this::totalWarfareClient));
-        return reportBugButton;
-    }
-
-    /**
-     * @return the client of the running game when it is one whose save the bug report packager understands, otherwise
-     *       {@code null}; a Strategic BattleForce game, for instance, packages its logs alone
-     */
-    private @Nullable Client totalWarfareClient() {
-        return (clientGUI.getClient() instanceof Client totalWarfareClient) ? totalWarfareClient : null;
-    }
 
     protected void addToDonePanel(JPanel donePanel, JComponent item) {
         item.setPreferredSize(new Dimension(UIUtil.scaleForGUI(DONE_BUTTON_WIDTH), MIN_BUTTON_SIZE.height));

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/StatusBarPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/StatusBarPhaseDisplay.java
@@ -303,7 +303,6 @@ public abstract class StatusBarPhaseDisplay extends AbstractPhaseDisplay
         return donePanel;
     }
 
-
     protected void addToDonePanel(JPanel donePanel, JComponent item) {
         item.setPreferredSize(new Dimension(UIUtil.scaleForGUI(DONE_BUTTON_WIDTH), MIN_BUTTON_SIZE.height));
         butDone.setAlignmentX(LEFT_ALIGNMENT);

--- a/megamek/src/megamek/client/ui/widget/HazardButton.java
+++ b/megamek/src/megamek/client/ui/widget/HazardButton.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.client.ui.widget;
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.Shape;
+import java.awt.geom.RoundRectangle2D;
+import javax.swing.Action;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+
+import megamek.client.ui.util.UIUtil;
+
+/**
+ * A button styled like an emergency stop: a red face with bold yellow text, framed in yellow and red hazard stripes.
+ *
+ * <p>It is meant for the one control on a crowded strip that has to be findable at a glance by a player who has
+ * just watched something go wrong - the bug reporting button - and should not be used for anything routine, or the
+ * effect is lost.</p>
+ *
+ * <p>The face darkens while the mouse is over it and again while it is pressed, and fades to grey when the button is
+ * disabled, so it still reads as a button rather than a label.</p>
+ */
+public class HazardButton extends JButton {
+
+    private static final Color FACE = HazardStripeBorder.HAZARD_RED;
+    private static final Color FACE_HOVER = FACE.darker();
+    private static final Color FACE_PRESSED = FACE_HOVER.darker();
+    private static final Color FACE_DISABLED = new Color(120, 120, 120);
+    private static final Color TEXT = HazardStripeBorder.HAZARD_YELLOW;
+    private static final Color TEXT_DISABLED = new Color(200, 200, 200);
+
+    /** Breathing room between the striped border and the text, in unscaled pixels. */
+    private static final int PADDING = 3;
+    /** Radius of the face's rounded corners, in unscaled pixels. */
+    private static final int CORNER = 6;
+
+    private final HazardStripeBorder stripeBorder = new HazardStripeBorder();
+
+    /**
+     * @param text the button's label
+     */
+    public HazardButton(String text) {
+        super(text);
+        styleAsHazard();
+    }
+
+    /**
+     * @param action the action the button performs, which also supplies its label and tooltip
+     */
+    public HazardButton(Action action) {
+        super(action);
+        styleAsHazard();
+    }
+
+    private void styleAsHazard() {
+        setContentAreaFilled(false);
+        setFocusPainted(false);
+        setOpaque(false);
+        setRolloverEnabled(true);
+        setForeground(TEXT);
+        setFont(getFont().deriveFont(Font.BOLD));
+        int padding = UIUtil.scaleForGUI(PADDING);
+        setBorder(BorderFactory.createCompoundBorder(stripeBorder,
+              BorderFactory.createEmptyBorder(padding, padding, padding, padding)));
+    }
+
+    @Override
+    protected void paintComponent(Graphics graphics) {
+        Graphics2D faceGraphics = (Graphics2D) graphics.create();
+        try {
+            faceGraphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            faceGraphics.setColor(faceColor());
+            faceGraphics.fill(faceShape());
+        } finally {
+            faceGraphics.dispose();
+        }
+        setForeground(isEnabled() ? TEXT : TEXT_DISABLED);
+        super.paintComponent(graphics);
+    }
+
+    private Color faceColor() {
+        if (!isEnabled()) {
+            return FACE_DISABLED;
+        }
+        if (getModel().isPressed()) {
+            return FACE_PRESSED;
+        }
+        if (getModel().isRollover()) {
+            return FACE_HOVER;
+        }
+        return FACE;
+    }
+
+    /** @return the area inside the hazard stripes, with rounded corners so the red face does not fight the frame */
+    private Shape faceShape() {
+        var stripeInsets = stripeBorder.getBorderInsets(this);
+        int corner = UIUtil.scaleForGUI(CORNER);
+        return new RoundRectangle2D.Float(stripeInsets.left, stripeInsets.top,
+              getWidth() - stripeInsets.left - stripeInsets.right,
+              getHeight() - stripeInsets.top - stripeInsets.bottom, corner, corner);
+    }
+}

--- a/megamek/src/megamek/client/ui/widget/HazardButton.java
+++ b/megamek/src/megamek/client/ui/widget/HazardButton.java
@@ -76,6 +76,13 @@ public class HazardButton extends MegaMekButton {
     private boolean hidingTextForTint;
 
     /**
+     * The tinted face and frame, kept between repaints. Tinting walks every pixel, so it is done once per size and
+     * pressed state rather than on every hover or expose; the skin's own images do not change otherwise.
+     */
+    private final TintedImage tintedFace = new TintedImage();
+    private final TintedImage tintedFrame = new TintedImage();
+
+    /**
      * @param text the button's label
      */
     public HazardButton(String text) {
@@ -90,7 +97,7 @@ public class HazardButton extends MegaMekButton {
 
     @Override
     protected void paintComponent(Graphics graphics) {
-        paintTinted(graphics, super::paintComponent);
+        paintTinted(graphics, tintedFace, super::paintComponent);
 
         JLabel textLabel = new JLabel(super.getText(), SwingConstants.CENTER);
         textLabel.setSize(getSize());
@@ -101,7 +108,7 @@ public class HazardButton extends MegaMekButton {
 
     @Override
     protected void paintBorder(Graphics graphics) {
-        paintTinted(graphics, super::paintBorder);
+        paintTinted(graphics, tintedFrame, super::paintBorder);
     }
 
     private Color labelColor() {
@@ -112,17 +119,35 @@ public class HazardButton extends MegaMekButton {
     }
 
     /**
-     * Runs the given painter into an offscreen image, remaps every pixel onto the red ramp, and draws the result.
+     * Draws the tinted version of what the given painter paints, rebuilding it only when the button's size or pressed
+     * state has changed since it was last built.
      *
      * @param graphics the graphics to draw the tinted result on
-     * @param painter  the parent's painting step, handed an offscreen graphics
+     * @param cache    where the tinted image for this painter is kept between repaints
+     * @param painter  the parent's painting step, handed an offscreen graphics when a rebuild is needed
      */
-    private void paintTinted(Graphics graphics, Consumer<Graphics> painter) {
+    private void paintTinted(Graphics graphics, TintedImage cache, Consumer<Graphics> painter) {
         int width = getWidth();
         int height = getHeight();
         if ((width <= 0) || (height <= 0)) {
             return;
         }
+        if (!cache.matches(width, height, isPressed)) {
+            cache.update(renderTinted(width, height, painter), isPressed);
+        }
+        graphics.drawImage(cache.image, 0, 0, null);
+    }
+
+    /**
+     * Runs the given painter into a fresh offscreen image and remaps every pixel onto the hazard ramp.
+     *
+     * @param width   the button's current width
+     * @param height  the button's current height
+     * @param painter the parent's painting step
+     *
+     * @return the tinted image
+     */
+    private BufferedImage renderTinted(int width, int height, Consumer<Graphics> painter) {
         BufferedImage offscreen = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
         Graphics2D offscreenGraphics = offscreen.createGraphics();
         try {
@@ -138,7 +163,7 @@ public class HazardButton extends MegaMekButton {
             pixels[index] = tint(pixels[index]);
         }
         offscreen.setRGB(0, 0, width, height, pixels, 0, width);
-        graphics.drawImage(offscreen, 0, 0, null);
+        return offscreen;
     }
 
     /**
@@ -180,5 +205,21 @@ public class HazardButton extends MegaMekButton {
         }
         return (alpha << 24) | (Math.min(255, tintedRed) << 16) | (Math.min(255, tintedGreen) << 8)
               | Math.min(255, tintedBlue);
+    }
+
+    /** A tinted image together with the size and pressed state it was built for. */
+    private static class TintedImage {
+        private BufferedImage image;
+        private boolean pressed;
+
+        boolean matches(int width, int height, boolean isPressed) {
+            return (image != null) && (image.getWidth() == width) && (image.getHeight() == height)
+                  && (pressed == isPressed);
+        }
+
+        void update(BufferedImage newImage, boolean isPressed) {
+            image = newImage;
+            pressed = isPressed;
+        }
     }
 }

--- a/megamek/src/megamek/client/ui/widget/HazardButton.java
+++ b/megamek/src/megamek/client/ui/widget/HazardButton.java
@@ -37,102 +37,148 @@ import java.awt.Color;
 import java.awt.Font;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
-import java.awt.RenderingHints;
-import java.awt.Shape;
-import java.awt.geom.RoundRectangle2D;
-import javax.swing.Action;
-import javax.swing.BorderFactory;
-import javax.swing.JButton;
-
-import megamek.client.ui.util.UIUtil;
+import java.awt.image.BufferedImage;
+import java.io.Serial;
+import java.util.function.Consumer;
+import javax.swing.JLabel;
+import javax.swing.SwingConstants;
 
 /**
- * A button styled like an emergency stop: a red face with bold yellow text, framed in yellow and red hazard stripes.
+ * A phase display button in emergency-stop colours: the usual skinned frame and brushed face, but tinted red, with
+ * the label in bold yellow.
  *
  * <p>It is meant for the one control on a crowded strip that has to be findable at a glance by a player who has
  * just watched something go wrong - the bug reporting button - and should not be used for anything routine, or the
  * effect is lost.</p>
  *
- * <p>The face darkens while the mouse is over it and again while it is pressed, and fades to grey when the button is
- * disabled, so it still reads as a button rather than a label.</p>
+ * <p>The skin's own images are reused rather than copied and recoloured on disk: everything the parent paints,
+ * face and frame alike, is rendered to an offscreen image and each pixel is remapped by its brightness onto a
+ * dark-red to yellow ramp. That keeps the shape identical to the buttons beside it whatever skin is in use, and the
+ * pressed image darkens the red just as it darkens the grey.</p>
  */
-public class HazardButton extends JButton {
+public class HazardButton extends MegaMekButton {
 
-    private static final Color FACE = HazardStripeBorder.HAZARD_RED;
-    private static final Color FACE_HOVER = FACE.darker();
-    private static final Color FACE_PRESSED = FACE_HOVER.darker();
-    private static final Color FACE_DISABLED = new Color(120, 120, 120);
-    private static final Color TEXT = HazardStripeBorder.HAZARD_YELLOW;
-    private static final Color TEXT_DISABLED = new Color(200, 200, 200);
+    @Serial
+    private static final long serialVersionUID = 2817492054981104913L;
 
-    /** Breathing room between the striped border and the text, in unscaled pixels. */
-    private static final int PADDING = 3;
-    /** Radius of the face's rounded corners, in unscaled pixels. */
-    private static final int CORNER = 6;
+    private static final Color LABEL = new Color(255, 221, 0);
+    private static final Color LABEL_HOVER = new Color(255, 245, 150);
+    private static final Color LABEL_DISABLED = new Color(160, 110, 40);
 
-    private final HazardStripeBorder stripeBorder = new HazardStripeBorder();
+    /** Brightness at and above which the ramp starts bending from red towards yellow, for the bevel highlights. */
+    private static final float HIGHLIGHT_START = 0.7f;
+    /** How much redder than blue a source pixel has to be to count as part of the skin's warm-coloured frame. */
+    private static final int FRAME_WARMTH = 40;
+    /** Brightness multiplier for frame pixels, so the bevel reads as a bright yellow rather than a muddy one. */
+    private static final float FRAME_LIFT = 1.6f;
+
+    /** While this is set the parent paints no text, so that the label can be drawn in the hazard colour instead. */
+    private boolean hidingTextForTint;
 
     /**
      * @param text the button's label
      */
     public HazardButton(String text) {
-        super(text);
-        styleAsHazard();
-    }
-
-    /**
-     * @param action the action the button performs, which also supplies its label and tooltip
-     */
-    public HazardButton(Action action) {
-        super(action);
-        styleAsHazard();
-    }
-
-    private void styleAsHazard() {
-        setContentAreaFilled(false);
-        setFocusPainted(false);
-        setOpaque(false);
-        setRolloverEnabled(true);
-        setForeground(TEXT);
+        super(text, SkinSpecification.UIComponents.PhaseDisplayButton.getComp());
         setFont(getFont().deriveFont(Font.BOLD));
-        int padding = UIUtil.scaleForGUI(PADDING);
-        setBorder(BorderFactory.createCompoundBorder(stripeBorder,
-              BorderFactory.createEmptyBorder(padding, padding, padding, padding)));
+    }
+
+    @Override
+    public String getText() {
+        return hidingTextForTint ? "" : super.getText();
     }
 
     @Override
     protected void paintComponent(Graphics graphics) {
-        Graphics2D faceGraphics = (Graphics2D) graphics.create();
-        try {
-            faceGraphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-            faceGraphics.setColor(faceColor());
-            faceGraphics.fill(faceShape());
-        } finally {
-            faceGraphics.dispose();
-        }
-        setForeground(isEnabled() ? TEXT : TEXT_DISABLED);
-        super.paintComponent(graphics);
+        paintTinted(graphics, super::paintComponent);
+
+        JLabel textLabel = new JLabel(super.getText(), SwingConstants.CENTER);
+        textLabel.setSize(getSize());
+        textLabel.setFont(getFont().deriveFont(Font.BOLD));
+        textLabel.setForeground(labelColor());
+        textLabel.paint(graphics);
     }
 
-    private Color faceColor() {
+    @Override
+    protected void paintBorder(Graphics graphics) {
+        paintTinted(graphics, super::paintBorder);
+    }
+
+    private Color labelColor() {
         if (!isEnabled()) {
-            return FACE_DISABLED;
+            return LABEL_DISABLED;
         }
-        if (getModel().isPressed()) {
-            return FACE_PRESSED;
-        }
-        if (getModel().isRollover()) {
-            return FACE_HOVER;
-        }
-        return FACE;
+        return (isMousedOver || hasFocus()) ? LABEL_HOVER : LABEL;
     }
 
-    /** @return the area inside the hazard stripes, with rounded corners so the red face does not fight the frame */
-    private Shape faceShape() {
-        var stripeInsets = stripeBorder.getBorderInsets(this);
-        int corner = UIUtil.scaleForGUI(CORNER);
-        return new RoundRectangle2D.Float(stripeInsets.left, stripeInsets.top,
-              getWidth() - stripeInsets.left - stripeInsets.right,
-              getHeight() - stripeInsets.top - stripeInsets.bottom, corner, corner);
+    /**
+     * Runs the given painter into an offscreen image, remaps every pixel onto the red ramp, and draws the result.
+     *
+     * @param graphics the graphics to draw the tinted result on
+     * @param painter  the parent's painting step, handed an offscreen graphics
+     */
+    private void paintTinted(Graphics graphics, Consumer<Graphics> painter) {
+        int width = getWidth();
+        int height = getHeight();
+        if ((width <= 0) || (height <= 0)) {
+            return;
+        }
+        BufferedImage offscreen = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D offscreenGraphics = offscreen.createGraphics();
+        try {
+            hidingTextForTint = true;
+            painter.accept(offscreenGraphics);
+        } finally {
+            hidingTextForTint = false;
+            offscreenGraphics.dispose();
+        }
+
+        int[] pixels = offscreen.getRGB(0, 0, width, height, null, 0, width);
+        for (int index = 0; index < pixels.length; index++) {
+            pixels[index] = tint(pixels[index]);
+        }
+        offscreen.setRGB(0, 0, width, height, pixels, 0, width);
+        graphics.drawImage(offscreen, 0, 0, null);
+    }
+
+    /**
+     * Maps one ARGB pixel onto the hazard ramp by its brightness: shadows stay dark red, the face is red, and the
+     * brightest bevel highlights turn yellow. Alpha is kept, so transparent corners stay transparent.
+     *
+     * @param argb the source pixel
+     *
+     * @return the tinted pixel
+     */
+    static int tint(int argb) {
+        int alpha = (argb >>> 24) & 0xFF;
+        if (alpha == 0) {
+            return argb;
+        }
+        int red = (argb >> 16) & 0xFF;
+        int green = (argb >> 8) & 0xFF;
+        int blue = argb & 0xFF;
+        float brightness = ((0.299f * red) + (0.587f * green) + (0.114f * blue)) / 255f;
+
+        int tintedRed;
+        int tintedGreen;
+        int tintedBlue;
+        if ((red - blue) > FRAME_WARMTH) {
+            // The skin draws its bevel and corner pieces in warm orange; those become the yellow of the frame.
+            float lift = Math.min(1f, brightness * FRAME_LIFT);
+            tintedRed = Math.round(120 + (135 * lift));
+            tintedGreen = Math.round(90 + (130 * lift));
+            tintedBlue = 0;
+        } else {
+            // Everything else - the brushed grey face and its shadows - becomes the red of the face.
+            tintedRed = Math.round(70 + (185 * brightness));
+            tintedGreen = Math.round(10 + (30 * brightness));
+            tintedBlue = Math.round(5 + (15 * brightness));
+            if (brightness > HIGHLIGHT_START) {
+                float highlight = (brightness - HIGHLIGHT_START) / (1f - HIGHLIGHT_START);
+                tintedGreen = Math.round(tintedGreen + (highlight * 180));
+            }
+        }
+        return (alpha << 24) | (Math.min(255, tintedRed) << 16) | (Math.min(255, tintedGreen) << 8)
+              | Math.min(255, tintedBlue);
     }
 }

--- a/megamek/src/megamek/client/ui/widget/HazardStripeBorder.java
+++ b/megamek/src/megamek/client/ui/widget/HazardStripeBorder.java
@@ -49,15 +49,15 @@ import megamek.client.ui.util.UIUtil;
 /**
  * A border of diagonal yellow and red stripes, in the manner of hazard tape.
  *
- * <p>It marks the one control in a group that does something the player should not press by accident, or should be
- * able to find in a hurry: the bug reporting button, which sits beside nine link buttons in its dialog and beside the
- * bot and game command buttons above the board.</p>
+ * <p>It marks the one control in a group that the player should be able to find in a hurry: the bug reporting button
+ * in its dialog, which sits beside nine buttons that only open a link. Its in-game counterpart on the command strip
+ * is a {@link HazardButton}, which carries the same colours on the phase display skin instead.</p>
  */
 public class HazardStripeBorder extends AbstractBorder {
 
-    /** The yellow of the stripes, also used as the text colour on a {@link HazardButton}. */
+    /** The yellow of the stripes. */
     public static final Color HAZARD_YELLOW = new Color(255, 204, 0);
-    /** The red of the stripes, also used as the face colour of a {@link HazardButton}. */
+    /** The red of the stripes. */
     public static final Color HAZARD_RED = new Color(204, 34, 34);
 
     private static final int UNSCALED_THICKNESS = 5;

--- a/megamek/src/megamek/client/ui/widget/HazardStripeBorder.java
+++ b/megamek/src/megamek/client/ui/widget/HazardStripeBorder.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.client.ui.widget;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.geom.Area;
+import javax.swing.border.AbstractBorder;
+
+import megamek.client.ui.util.UIUtil;
+
+/**
+ * A border of diagonal yellow and red stripes, in the manner of hazard tape.
+ *
+ * <p>It marks the one control in a group that does something the player should not press by accident, or should be
+ * able to find in a hurry: the bug reporting button, which sits beside nine link buttons in its dialog and beside the
+ * bot and game command buttons above the board.</p>
+ */
+public class HazardStripeBorder extends AbstractBorder {
+
+    /** The yellow of the stripes, also used as the text colour on a {@link HazardButton}. */
+    public static final Color HAZARD_YELLOW = new Color(255, 204, 0);
+    /** The red of the stripes, also used as the face colour of a {@link HazardButton}. */
+    public static final Color HAZARD_RED = new Color(204, 34, 34);
+
+    private static final int UNSCALED_THICKNESS = 5;
+
+    private final int thickness;
+
+    /** Creates a border of the standard stripe width. */
+    public HazardStripeBorder() {
+        this(UNSCALED_THICKNESS);
+    }
+
+    /**
+     * @param unscaledThickness the stripe width in unscaled pixels; the GUI scale is applied here
+     */
+    public HazardStripeBorder(int unscaledThickness) {
+        thickness = UIUtil.scaleForGUI(unscaledThickness);
+    }
+
+    @Override
+    public void paintBorder(Component component, Graphics graphics, int x, int y, int width, int height) {
+        Graphics2D stripeGraphics = (Graphics2D) graphics.create();
+        try {
+            Area frame = new Area(new Rectangle(x, y, width, height));
+            frame.subtract(new Area(new Rectangle(x + thickness, y + thickness,
+                  width - (2 * thickness), height - (2 * thickness))));
+            stripeGraphics.clip(frame);
+            stripeGraphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+
+            stripeGraphics.setColor(HAZARD_YELLOW);
+            stripeGraphics.fillRect(x, y, width, height);
+
+            // Diagonals are drawn from off the left edge so that the stripes carry across the whole frame.
+            stripeGraphics.setColor(HAZARD_RED);
+            stripeGraphics.setStroke(new BasicStroke(thickness));
+            for (int offset = -height; offset < width; offset += thickness * 2) {
+                stripeGraphics.drawLine(x + offset, y + height, x + offset + height, y);
+            }
+        } finally {
+            stripeGraphics.dispose();
+        }
+    }
+
+    @Override
+    public Insets getBorderInsets(Component component) {
+        return new Insets(thickness, thickness, thickness, thickness);
+    }
+
+    @Override
+    public Insets getBorderInsets(Component component, Insets insets) {
+        insets.set(thickness, thickness, thickness, thickness);
+        return insets;
+    }
+}

--- a/megamek/src/megamek/client/ui/widget/HazardStripeBorder.java
+++ b/megamek/src/megamek/client/ui/widget/HazardStripeBorder.java
@@ -70,10 +70,11 @@ public class HazardStripeBorder extends AbstractBorder {
     }
 
     /**
-     * @param unscaledThickness the stripe width in unscaled pixels; the GUI scale is applied here
+     * @param unscaledThickness the stripe width in unscaled pixels; the GUI scale is applied here, and the result is
+     *                          never less than one pixel, since the stripe loop steps by the thickness
      */
     public HazardStripeBorder(int unscaledThickness) {
-        thickness = UIUtil.scaleForGUI(unscaledThickness);
+        thickness = Math.max(1, UIUtil.scaleForGUI(unscaledThickness));
     }
 
     @Override

--- a/megamek/unittests/megamek/client/ui/widget/HazardButtonTest.java
+++ b/megamek/unittests/megamek/client/ui/widget/HazardButtonTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.client.ui.widget;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Color;
+
+import org.junit.jupiter.api.Test;
+
+class HazardButtonTest {
+
+    @Test
+    void transparentPixelsStayTransparent() {
+        int transparent = new Color(0, 0, 0, 0).getRGB();
+        assertEquals(transparent, HazardButton.tint(transparent));
+    }
+
+    @Test
+    void greyFacePixelsBecomeRed() {
+        Color tinted = new Color(HazardButton.tint(new Color(90, 90, 90).getRGB()), true);
+        assertTrue(tinted.getRed() > (2 * tinted.getGreen()), "red should dominate, was " + tinted);
+        assertTrue(tinted.getRed() > (2 * tinted.getBlue()), "red should dominate, was " + tinted);
+        assertEquals(255, tinted.getAlpha());
+    }
+
+    @Test
+    void darkerGreyGivesDarkerRed() {
+        Color shadow = new Color(HazardButton.tint(new Color(40, 40, 40).getRGB()), true);
+        Color face = new Color(HazardButton.tint(new Color(120, 120, 120).getRGB()), true);
+        assertTrue(shadow.getRed() < face.getRed(), "shadow " + shadow + " should be darker than face " + face);
+    }
+
+    @Test
+    void warmFramePixelsBecomeYellow() {
+        // The skin's bevel is orange: much more red than blue.
+        Color tinted = new Color(HazardButton.tint(new Color(200, 120, 60).getRGB()), true);
+        assertTrue(tinted.getGreen() > 150, "yellow needs strong green, was " + tinted);
+        assertTrue(tinted.getRed() >= tinted.getGreen(), "yellow keeps red at least as strong, was " + tinted);
+        assertEquals(0, tinted.getBlue());
+    }
+}

--- a/megamek/unittests/megamek/client/ui/widget/HazardStripeBorderTest.java
+++ b/megamek/unittests/megamek/client/ui/widget/HazardStripeBorderTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.client.ui.widget;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.image.BufferedImage;
+import javax.swing.JPanel;
+
+import megamek.client.ui.util.UIUtil;
+import org.junit.jupiter.api.Test;
+
+class HazardStripeBorderTest {
+
+    private static final int WIDTH = 120;
+    private static final int HEIGHT = 40;
+
+    @Test
+    void insetsMatchTheScaledStripeWidth() {
+        int expected = UIUtil.scaleForGUI(5);
+        HazardStripeBorder border = new HazardStripeBorder();
+
+        Insets insets = border.getBorderInsets(new JPanel());
+        assertEquals(new Insets(expected, expected, expected, expected), insets);
+
+        Insets reused = border.getBorderInsets(new JPanel(), new Insets(99, 99, 99, 99));
+        assertEquals(new Insets(expected, expected, expected, expected), reused);
+    }
+
+    @Test
+    void paintsTheFrameAndLeavesTheInsideAlone() {
+        BufferedImage image = new BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D graphics = image.createGraphics();
+        Color untouched = new Color(1, 2, 3);
+        graphics.setColor(untouched);
+        graphics.fillRect(0, 0, WIDTH, HEIGHT);
+
+        HazardStripeBorder border = new HazardStripeBorder();
+        border.paintBorder(new JPanel(), graphics, 0, 0, WIDTH, HEIGHT);
+        graphics.dispose();
+
+        // The frame itself is painted in the hazard colours...
+        Color corner = new Color(image.getRGB(1, 1), true);
+        assertNotEquals(untouched, corner);
+        assertTrue(corner.equals(HazardStripeBorder.HAZARD_YELLOW) || corner.equals(HazardStripeBorder.HAZARD_RED)
+              || isBlendOfHazardColors(corner), "corner pixel should be a hazard colour, was " + corner);
+
+        // ...and the area inside the stripes is left for the component to paint.
+        assertEquals(untouched, new Color(image.getRGB(WIDTH / 2, HEIGHT / 2), true));
+    }
+
+    /** Antialiasing can land a pixel between the two stripe colours; red and green channels stay in their range. */
+    private static boolean isBlendOfHazardColors(Color color) {
+        return (color.getRed() >= HazardStripeBorder.HAZARD_RED.getRed())
+              && (color.getGreen() >= HazardStripeBorder.HAZARD_RED.getGreen())
+              && (color.getGreen() <= HazardStripeBorder.HAZARD_YELLOW.getGreen())
+              && (color.getBlue() <= HazardStripeBorder.HAZARD_RED.getBlue());
+    }
+}

--- a/megamek/unittests/megamek/client/ui/widget/HazardStripeBorderTest.java
+++ b/megamek/unittests/megamek/client/ui/widget/HazardStripeBorderTest.java
@@ -64,6 +64,17 @@ class HazardStripeBorderTest {
     }
 
     @Test
+    void aZeroThicknessIsClampedToOnePixelSoPaintingTerminates() {
+        HazardStripeBorder border = new HazardStripeBorder(0);
+        assertEquals(new Insets(1, 1, 1, 1), border.getBorderInsets(new JPanel()));
+
+        BufferedImage image = new BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D graphics = image.createGraphics();
+        border.paintBorder(new JPanel(), graphics, 0, 0, WIDTH, HEIGHT);
+        graphics.dispose();
+    }
+
+    @Test
     void paintsTheFrameAndLeavesTheInsideAlone() {
         BufferedImage image = new BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_INT_ARGB);
         Graphics2D graphics = image.createGraphics();


### PR DESCRIPTION
## Summary

Follow-up to #8722. The in-game Report a Bug button sat at the bottom of the Done column in the ordinary phase-display skin. The player feedback was almost all negative to the location this PR moves it. It now sits at the right end of the command strip, after Commands, styled as an emergency-stop button so a player who has just watched something go wrong can find it without reading the strip.

<img width="473" height="136" alt="image" src="https://github.com/user-attachments/assets/4328225e-17a5-4e9b-8236-3f8fd1390758" />


## Changes

- The command strip under the menu bar now ends in `Commands | Report a Bug`. Commands shrinks from 160 to 110 wide to pay for most of the new button; the docked bot command buttons share the rest evenly.
- Report a Bug has the same skinned frame and notched corners as the Commands button beside it, tinted red with a yellow bevel and a bold yellow label. Pressing it darkens the red the way pressing Commands darkens the grey.
- The tint is applied to whatever the current skin paints, per pixel, so no recoloured image files are added and a custom skin still gets a matching button.
- The big button in the bug report helper dialog is unchanged in look; its hazard-stripe border moved to a shared class.
- The Done column is back to two rows (Done, plus Skip in the phases that have one).
- New `HazardButton` (a `MegaMekButton` subclass) and `HazardStripeBorder` widgets carry the look. The border was a private class inside `BugReportDialog`; it is shared now.

## Testing

- `HazardButtonTest` (4 new tests): transparent pixels stay transparent, grey face pixels come out red and darker grey darker, warm bevel pixels come out yellow.
- `HazardStripeBorderTest` (2 new tests): insets match the scaled stripe width; the border paints the frame and leaves the inside untouched.
- `GameCommandsMenuTest` (8) still passes; compile, checkstyle and javadoc clean.
- The strip was rendered headlessly at 1400 px and 1000 px window widths. At 1000 px the bot buttons are 89 px wide and their labels still fit.
- Checked in game: the strip layout and button sizes were confirmed in a live game. The first version was a flat red button; it was sent back for not matching Commands, and the skinned version replaced it.

## Not proven yet

- The skinned version has been rendered headlessly next to Commands but not yet seen in a live game.
- GUI scale above 100% has only been checked by reading the code (every pixel value goes through `UIUtil.scaleForGUI`), not by eye.
- The disabled look of the button has not been seen; nothing disables it today.
- Only the default skin has been rendered. The warm-versus-grey split that decides yellow from red is tuned to its images; a custom skin with a grey bevel would get an all-red button, which is still readable.
