### PR TITLE
Fix: Escalating failure table started at 2+, corrected so it no longer does this.

### DIFF
--- a/megamek/src/megamek/common/rules/RulesCharts.java
+++ b/megamek/src/megamek/common/rules/RulesCharts.java
@@ -48,12 +48,11 @@ public abstract class RulesCharts {
     public int escalatingFailure(int count) {
         // For each count after 5, the number is 11+
         return switch (count) {
-            case 0 -> 2;
-            case 1 -> 3;
-            case 2 -> 5;
-            case 3 -> 7;
-            case 4 -> 10;
-            default -> 11;
+            case 0 -> 3;
+            case 1 -> 5;
+            case 2 -> 7;
+            case 3 -> 10;
+            default-> 11;
         };
     }
 


### PR DESCRIPTION
## What this changes

Fixes the new escalating failure table, previously this started at 2 for the first failure check, ensuring it could never fail. Updated the switch statement to start from 3+ as intended.

## Testing
## What is not proven yet
I had issues getting Gradle to work so I could not test it. But as this is a simple change to a single switch case I feel this could be acceptable.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [ ] Tests added or updated, if this implements a rule or changes game state
- [ ] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
