### PR TITLE
Fix #8788: Battle Armor sorted into the wrong weight class in the unit selector and RAT Generator

### DIFF
--- a/megamek/src/megamek/common/loaders/MekSummaryCache.java
+++ b/megamek/src/megamek/common/loaders/MekSummaryCache.java
@@ -913,7 +913,7 @@ public class MekSummaryCache {
         if (ms.isSupport()) {
             ms.setWeightClass(EntityWeightClass.getSupportWeightClass(ms.getTons(), ms.getUnitSubType()));
         } else {
-            double weightClassWeight = ms.isBattleArmor() ? ms.getSuitWeight() : ms.getTons();
+            double weightClassWeight = e.isBattleArmor() ? ms.getSuitWeight() : ms.getTons();
             ms.setWeightClass(EntityWeightClass.getWeightClass(weightClassWeight, ms.getUnitType()));
         }
 

--- a/megamek/unittests/megamek/common/loaders/BattleArmorSummaryWeightClassTest.java
+++ b/megamek/unittests/megamek/common/loaders/BattleArmorSummaryWeightClassTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.loaders;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.File;
+
+import megamek.common.equipment.EquipmentType;
+import megamek.common.units.EntityWeightClass;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression test for <a href="https://github.com/MegaMek/megamek/issues/8788">#8788</a>: the unit cache classed every
+ * Battle Armor squad by its squad transport weight (4-6 tons) instead of its suit weight, so nearly all of them landed
+ * in Assault. The summary must carry the weight class of the suit.
+ */
+class BattleArmorSummaryWeightClassTest {
+
+    private static final String UNIT_DIR = "testresources/megamek/common/units/";
+
+    @BeforeAll
+    static void beforeAll() {
+        EquipmentType.initializeTypes();
+    }
+
+    @Test
+    void powerArmorLightSquadIsUltraLight() {
+        assertEquals(EntityWeightClass.WEIGHT_ULTRA_LIGHT, weightClassOf("Aerie PA(L) (Sqd4).blk"));
+    }
+
+    @Test
+    void mediumSuitSquadIsMedium() {
+        assertEquals(EntityWeightClass.WEIGHT_MEDIUM, weightClassOf("Elemental BA [Laser] (Sqd5).blk"));
+    }
+
+    @Test
+    void heavySuitSquadIsHeavy() {
+        assertEquals(EntityWeightClass.WEIGHT_HEAVY, weightClassOf("Black Wolf BA (ER Pulse) (Sqd5).blk"));
+    }
+
+    @Test
+    void mekStillUsesItsTonnage() {
+        assertEquals(EntityWeightClass.WEIGHT_ASSAULT, weightClassOf("Atlas AS7-D.mtf"));
+    }
+
+    private static int weightClassOf(String fileName) {
+        MekSummary summary = MekSummaryCache.getSummaryFromFile(new File(UNIT_DIR + fileName));
+        assertNotNull(summary, "Summary should be built for " + fileName);
+        return summary.getWeightClass();
+    }
+}


### PR DESCRIPTION
## What this changes

Battle Armor now sorts into the right weight class in the unit selector and the RAT Generator. Before, nearly every squad landed in Assault because the unit cache classed it by squad transport weight (4 to 6 tons) instead of suit weight; the only squads that escaped were the five one-trooper designs, whose 1 ton squad weight sits exactly on the Medium limit.

The cache chose between suit weight and tonnage with `ms.isBattleArmor()`. `MekSummary` has no such method of its own; it inherits one from the Alpha Strike interface, and the Alpha Strike type it reads is still `UNKNOWN` at that point because it is set about 230 lines later in the same method. The fix asks the `Entity` instead, which is in scope and always knows. The stored suit weight was already correct.

Fixes #8788

## Testing

New `BattleArmorSummaryWeightClassTest` builds summaries from existing test resources: Aerie PA(L) is Ultra Light, Elemental is Medium, Black Wolf is Heavy, and an Atlas AS7-D is Assault as the control for the non-Battle-Armor path. All three Battle Armor cases fail with the fix reverted (each reports Assault); all four pass with it.

Tested in game: after rebuilding the unit cache, the unit selector's Heavy and Medium filters list the expected suits and Assault shrinks to the real 2-ton designs.

`checkstyleMain`, `checkstyleTest` and `javadoc` are clean.

## What is not proven yet

The fix only applies when a unit is rescanned. An existing `units.cache` built before this change keeps the old values until the data files change or the cache is rebuilt. A fresh release install rescans naturally; a jar-only update does not. Bumping `MekSummary.serialVersionUID` would force a one-time rebuild for everyone and is not included here.

The RAT Generator was not exercised in game; it reads the same cached value as the selector, so the fix reaches it by construction.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result
