### PR TITLE
Fix #8781: Target selection window opened twice for one hex click

### DIFF
--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/PhysicalDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/PhysicalDisplay.java
@@ -35,6 +35,7 @@ package megamek.client.ui.panels.phaseDisplay;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
 import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2080,7 +2081,12 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
             event.getBoardView().cursor(event.getCoords());
         } else if (event.getType() == BoardViewEvent.BOARD_HEX_CLICKED) {
             twisting = false;
-            if (!shiftHeld) {
+            // Only a plain left click picks a target: shift is torso twist, ALT feeds the ruler
+            // (RulerDialog.hexMoused), and the other mouse buttons have no targeting meaning here. The firing
+            // and targeting phases already ignore those clicks.
+            boolean plainLeftClick = (event.getButton() == MouseEvent.BUTTON1)
+                  && ((event.getModifiers() & InputEvent.ALT_DOWN_MASK) == 0);
+            if (!shiftHeld && plainLeftClick) {
                 event.getBoardView().select(event.getCoords());
             }
         }

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/PhysicalDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/PhysicalDisplay.java
@@ -35,7 +35,6 @@ package megamek.client.ui.panels.phaseDisplay;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
-import java.awt.event.MouseEvent;
 import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2069,6 +2068,9 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
         if (shiftHeld == ((event.getModifiers() & InputEvent.SHIFT_DOWN_MASK) == 0)) {
             shiftHeld = (event.getModifiers() & InputEvent.SHIFT_DOWN_MASK) != 0;
         }
+        // Select the hex exactly once per click. BoardView.select() always fires a hex-selected event, even when
+        // the hex has not changed, and hexSelected() answers it by asking the player which unit in the hex to
+        // attack. A second select() for the same click therefore opens that target dialog a second time.
         if (event.getType() == BoardViewEvent.BOARD_HEX_DRAGGED) {
             if ((shiftHeld || twisting) && isMyTurn() && Game.rulesManager.getRulesUnits().getPhysicalTwistEnabled()) {
                 if ((currentEntity() != null) && !currentEntity().getAlreadyTwisted()) {
@@ -2079,17 +2081,6 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
         } else if (event.getType() == BoardViewEvent.BOARD_HEX_CLICKED) {
             twisting = false;
             if (!shiftHeld) {
-                event.getBoardView().select(event.getCoords());
-            }
-        }
-        if (clientgui.getClient().isMyTurn()
-              && (event.getButton() == MouseEvent.BUTTON1)) {
-            if (event.getType() == BoardViewEvent.BOARD_HEX_DRAGGED) {
-                if (!event.getCoords().equals(
-                      event.getBoardView().getLastCursor())) {
-                    event.getBoardView().cursor(event.getCoords());
-                }
-            } else if (event.getType() == BoardViewEvent.BOARD_HEX_CLICKED) {
                 event.getBoardView().select(event.getCoords());
             }
         }


### PR DESCRIPTION
## What this changes

Clicking a hex that holds more than one attackable unit now opens the "choose a target" window once instead of twice. Before, you picked a target, the window closed, and an identical second window opened straight away. Whatever you answered the second time replaced your first pick, and cancelling it left you with no target at all.

Shift-clicking a hex no longer opens that window either. Shift is torso twist, and the click handler already meant to skip target selection while it is held. Middle-clicking and ALT-clicking no longer open it either: ALT belongs to the ruler, and the firing and targeting phases already ignore both.

Fixes #8781

## Testing

Tested in game with two units sharing a hex: the window now appears once in the physical attack phase, and once in the weapon attack phase.

The middle-click and ALT-click guard came later, from Copilot review feedback. That was tested in game too: neither click opens the target window now.

`./gradlew :megamek:test` is green, as are `compileJava`, `compileTestJava`, `checkstyleMain` and `javadoc`. No unit test was added. The bug lives in the Swing event chain (`BoardView.select()` -> `hexSelected()`), which needs a live board view and a real mouse event; the test suite has no harness for that.

## What is not proven yet

Nothing guards this automatically. Each attack phase display writes its own click handling, so a future edit that adds a second `select()` call for one click would bring the second window back, and only clicking in a game would show it. A follow-up that moves the shared click handling into `AttackPhaseDisplay`, with a unit test over the decision it makes, would close that gap.

---
- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [ ] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
