### PR TITLE
Close #8796: Share the hex-click handling across attack phase displays

### DIFF
--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/AttackPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/AttackPhaseDisplay.java
@@ -32,9 +32,12 @@
  */
 package megamek.client.ui.panels.phaseDisplay;
 
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.List;
 
+import megamek.client.event.BoardViewEvent;
 import megamek.client.ui.clientGUI.ClientGUI;
 import megamek.client.ui.clientGUI.tooltip.EntityActionLog;
 import megamek.client.ui.dialogs.TurretFacingDialog;
@@ -441,5 +444,46 @@ public abstract class AttackPhaseDisplay extends ActionPhaseDisplay {
             setRotateTurretEnabled(!tank.hasNoTurret() && canTwistTurret);
             setRotateRearTurretEnabled(false);
         }
+    }
+
+    /**
+     * Applies the one board action a hex mouse event calls for: move the cursor while the player drags, select the
+     * hex on a plain left click.
+     * <p>
+     * Every attack phase display routes its mouse handling through this method so that a single click can select a
+     * hex only once. {@link megamek.client.ui.clientGUI.boardview.BoardView#select(megamek.common.board.Coords)}
+     * fires a hex-selected event every time it is called, even when the hex has not changed, and the displays
+     * answer that event by asking the player which unit in the hex to attack. A second selection for the same
+     * click therefore opens that target window twice (issue #8781).
+     * </p>
+     *
+     * @param event             the hex mouse event being handled
+     * @param twistModifierHeld {@code true} when the shift key is held and this display uses shift for torso twist,
+     *                          in which case the click twists and must not pick a target. Displays without torso
+     *                          twist pass {@code false}.
+     */
+    protected static void applyHexMouseAction(BoardViewEvent event, boolean twistModifierHeld) {
+        switch (event.getType()) {
+            case BoardViewEvent.BOARD_HEX_DRAGGED -> event.getBoardView().cursor(event.getCoords());
+            case BoardViewEvent.BOARD_HEX_CLICKED -> {
+                if (!twistModifierHeld && isPlainLeftClick(event)) {
+                    event.getBoardView().select(event.getCoords());
+                }
+            }
+            default -> {
+                // Every other board event is the display's own business.
+            }
+        }
+    }
+
+    /**
+     * @param event the hex mouse event being handled
+     *
+     * @return {@code true} if this is a left click with no ALT key. ALT belongs to the ruler
+     *       (RulerDialog.hexMoused) and the other mouse buttons have no targeting meaning on the board.
+     */
+    private static boolean isPlainLeftClick(BoardViewEvent event) {
+        return (event.getButton() == MouseEvent.BUTTON1)
+              && ((event.getModifiers() & InputEvent.ALT_DOWN_MASK) == 0);
     }
 }

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/FiringDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/FiringDisplay.java
@@ -2018,13 +2018,10 @@ public class FiringDisplay extends AttackPhaseDisplay implements ListSelectionLi
                 updateFlipArms(false);
                 torsoTwist(event.getCoords());
             }
-            event.getBoardView().cursor(event.getCoords());
         } else if (event.getType() == BoardViewEvent.BOARD_HEX_CLICKED) {
             twisting = false;
-            if (!event.isShiftHeld()) {
-                event.getBoardView().select(event.getCoords());
-            }
         }
+        applyHexMouseAction(event, event.isShiftHeld());
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/InfantryVsInfantryCombatDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/InfantryVsInfantryCombatDisplay.java
@@ -33,7 +33,6 @@
 package megamek.client.ui.panels.phaseDisplay;
 
 import java.awt.event.ActionEvent;
-import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -325,17 +324,8 @@ public class InfantryVsInfantryCombatDisplay extends AttackPhaseDisplay {
         //if (event.getCoords() != null) {
         //    clientgui.getBoardView().cursor(event.getCoords());
         //}
-        if (clientgui.getClient().isMyTurn()
-              && (event.getButton() == MouseEvent.BUTTON1)) {
-            if (event.getType() == BoardViewEvent.BOARD_HEX_DRAGGED) {
-                if (!event.getCoords().equals(
-                      event.getBoardView().getLastCursor())) {
-                    event.getBoardView().cursor(event.getCoords());
-                }
-            } else if (event.getType() == BoardViewEvent.BOARD_HEX_CLICKED) {
-                event.getBoardView().select(event.getCoords());
-            }
-        }
+        // This display has no torso twist, so the shift key never suppresses the selection.
+        applyHexMouseAction(event, false);
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/PhysicalDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/PhysicalDisplay.java
@@ -35,7 +35,6 @@ package megamek.client.ui.panels.phaseDisplay;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.InputEvent;
-import java.awt.event.MouseEvent;
 import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2078,18 +2077,10 @@ public class PhysicalDisplay extends AttackPhaseDisplay {
                     torsoTwist(event.getCoords());
                 }
             }
-            event.getBoardView().cursor(event.getCoords());
         } else if (event.getType() == BoardViewEvent.BOARD_HEX_CLICKED) {
             twisting = false;
-            // Only a plain left click picks a target: shift is torso twist, ALT feeds the ruler
-            // (RulerDialog.hexMoused), and the other mouse buttons have no targeting meaning here. The firing
-            // and targeting phases already ignore those clicks.
-            boolean plainLeftClick = (event.getButton() == MouseEvent.BUTTON1)
-                  && ((event.getModifiers() & InputEvent.ALT_DOWN_MASK) == 0);
-            if (!shiftHeld && plainLeftClick) {
-                event.getBoardView().select(event.getCoords());
-            }
         }
+        applyHexMouseAction(event, shiftHeld);
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/PointblankShotDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/PointblankShotDisplay.java
@@ -778,7 +778,7 @@ public class PointblankShotDisplay extends FiringDisplay {
     // BoardListener
     //
     @Override
-    public void hexMoused(BoardViewEvent b) {
+    public void hexMoused(BoardViewEvent event) {
         // Are we ignoring events?
         if (isIgnoringEvents()) {
             return;
@@ -786,28 +786,25 @@ public class PointblankShotDisplay extends FiringDisplay {
 
         // ignore buttons other than 1
         if (!clientgui.isProcessingPointblankShot()
-              || ((b.getButton() != MouseEvent.BUTTON1))) {
+              || ((event.getButton() != MouseEvent.BUTTON1))) {
             return;
         }
         // control pressed means a line of sight check.
         // added ALT_MASK by kenn
-        if (((b.getModifiers() & InputEvent.CTRL_DOWN_MASK) != 0)
-              || ((b.getModifiers() & InputEvent.ALT_DOWN_MASK) != 0)) {
+        if (((event.getModifiers() & InputEvent.CTRL_DOWN_MASK) != 0)
+              || ((event.getModifiers() & InputEvent.ALT_DOWN_MASK) != 0)) {
             return;
         }
 
-        if (b.getType() == BoardViewEvent.BOARD_HEX_DRAGGED) {
-            if (b.isShiftHeld() || twisting) {
+        if (event.getType() == BoardViewEvent.BOARD_HEX_DRAGGED) {
+            if (event.isShiftHeld() || twisting) {
                 updateFlipArms(false);
-                torsoTwist(b.getCoords());
+                torsoTwist(event.getCoords());
             }
-            b.getBoardView().cursor(b.getCoords());
-        } else if (b.getType() == BoardViewEvent.BOARD_HEX_CLICKED) {
+        } else if (event.getType() == BoardViewEvent.BOARD_HEX_CLICKED) {
             twisting = false;
-            if (!b.isShiftHeld()) {
-                b.getBoardView().select(b.getCoords());
-            }
         }
+        applyHexMouseAction(event, event.isShiftHeld());
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/PreEndDeclarationsDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/PreEndDeclarationsDisplay.java
@@ -33,7 +33,6 @@
 package megamek.client.ui.panels.phaseDisplay;
 
 import java.awt.event.ActionEvent;
-import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -463,17 +462,8 @@ public class PreEndDeclarationsDisplay extends AttackPhaseDisplay {
         //if (event.getCoords() != null) {
         //    clientgui.getBoardView().cursor(event.getCoords());
         //}
-        if (clientgui.getClient().isMyTurn()
-              && (event.getButton() == MouseEvent.BUTTON1)) {
-            if (event.getType() == BoardViewEvent.BOARD_HEX_DRAGGED) {
-                if (!event.getCoords().equals(
-                      event.getBoardView().getLastCursor())) {
-                    event.getBoardView().cursor(event.getCoords());
-                }
-            } else if (event.getType() == BoardViewEvent.BOARD_HEX_CLICKED) {
-                event.getBoardView().select(event.getCoords());
-            }
-        }
+        // This display has no torso twist, so the shift key never suppresses the selection.
+        applyHexMouseAction(event, false);
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/TargetingPhaseDisplay.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/TargetingPhaseDisplay.java
@@ -1105,7 +1105,7 @@ public class TargetingPhaseDisplay extends AttackPhaseDisplay implements ListSel
     // BoardListener
     //
     @Override
-    public void hexMoused(BoardViewEvent b) {
+    public void hexMoused(BoardViewEvent event) {
         // Are we ignoring events?
         if (isIgnoringEvents()) {
             return;
@@ -1113,34 +1113,31 @@ public class TargetingPhaseDisplay extends AttackPhaseDisplay implements ListSel
 
         // ignore buttons other than 1
         if (!clientgui.getClient().isMyTurn()
-              || ((b.getButton() != MouseEvent.BUTTON1))) {
+              || ((event.getButton() != MouseEvent.BUTTON1))) {
             return;
         }
         // control pressed means a line of sight check.
         // added ALT_MASK by kenn
-        if (((b.getModifiers() & InputEvent.CTRL_DOWN_MASK) != 0)
-              || ((b.getModifiers() & InputEvent.ALT_DOWN_MASK) != 0)) {
+        if (((event.getModifiers() & InputEvent.CTRL_DOWN_MASK) != 0)
+              || ((event.getModifiers() & InputEvent.ALT_DOWN_MASK) != 0)) {
             return;
         }
         // check for shifty goodness
-        if (shiftHeld == ((b.getModifiers() & InputEvent.SHIFT_DOWN_MASK) == 0)) {
-            shiftHeld = (b.getModifiers() & InputEvent.SHIFT_DOWN_MASK) != 0;
+        if (shiftHeld == ((event.getModifiers() & InputEvent.SHIFT_DOWN_MASK) == 0)) {
+            shiftHeld = (event.getModifiers() & InputEvent.SHIFT_DOWN_MASK) != 0;
         }
 
-        if (b.getType() == BoardViewEvent.BOARD_HEX_DRAGGED) {
+        if (event.getType() == BoardViewEvent.BOARD_HEX_DRAGGED) {
             if (shiftHeld || twisting) {
                 if ((currentEntity() != null) && !currentEntity().getAlreadyTwisted()) {
                     updateFlipArms(false);
-                    torsoTwist(b.getCoords());
+                    torsoTwist(event.getCoords());
                 }
             }
-            b.getBoardView().cursor(b.getCoords());
-        } else if (b.getType() == BoardViewEvent.BOARD_HEX_CLICKED) {
+        } else if (event.getType() == BoardViewEvent.BOARD_HEX_CLICKED) {
             twisting = false;
-            if (!shiftHeld) {
-                b.getBoardView().select(b.getCoords());
-            }
         }
+        applyHexMouseAction(event, shiftHeld);
     }
 
     @Override

--- a/megamek/unittests/megamek/client/ui/panels/phaseDisplay/AttackPhaseDisplayHexMouseActionTest.java
+++ b/megamek/unittests/megamek/client/ui/panels/phaseDisplay/AttackPhaseDisplayHexMouseActionTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.client.ui.panels.phaseDisplay;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
+
+import megamek.client.event.BoardViewEvent;
+import megamek.client.ui.clientGUI.boardview.BoardView;
+import megamek.common.board.Coords;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link AttackPhaseDisplay#applyHexMouseAction(BoardViewEvent, boolean)}, the single place an attack phase
+ * display turns a hex mouse event into a board action.
+ * <p>
+ * The rule these tests protect: one click selects the hex at most once. A second selection fires a second
+ * hex-selected event, and the displays answer that by opening the target window again (issue #8781).
+ * </p>
+ */
+@DisplayName("AttackPhaseDisplay hex mouse action")
+class AttackPhaseDisplayHexMouseActionTest {
+
+    private static final Coords CLICKED_HEX = new Coords(5, 10);
+
+    private BoardView boardView;
+
+    @BeforeEach
+    void setUp() {
+        boardView = mock(BoardView.class);
+    }
+
+    private BoardViewEvent hexEvent(int eventType, int modifiers, int mouseButton) {
+        BoardViewEvent event = mock(BoardViewEvent.class);
+        when(event.getType()).thenReturn(eventType);
+        when(event.getCoords()).thenReturn(CLICKED_HEX);
+        when(event.getModifiers()).thenReturn(modifiers);
+        when(event.getButton()).thenReturn(mouseButton);
+        when(event.getBoardView()).thenReturn(boardView);
+        return event;
+    }
+
+    @Test
+    @DisplayName("A left click selects the clicked hex exactly once")
+    void leftClickSelectsTheHexOnce() {
+        BoardViewEvent leftClick = hexEvent(BoardViewEvent.BOARD_HEX_CLICKED, 0, MouseEvent.BUTTON1);
+
+        AttackPhaseDisplay.applyHexMouseAction(leftClick, false);
+
+        verify(boardView, times(1)).select(CLICKED_HEX);
+        verify(boardView, never()).cursor(any());
+    }
+
+    @Test
+    @DisplayName("A drag moves the cursor and never selects")
+    void dragOnlyMovesTheCursor() {
+        BoardViewEvent drag = hexEvent(BoardViewEvent.BOARD_HEX_DRAGGED, 0, MouseEvent.BUTTON1);
+
+        AttackPhaseDisplay.applyHexMouseAction(drag, false);
+
+        verify(boardView, times(1)).cursor(CLICKED_HEX);
+        verify(boardView, never()).select(any());
+    }
+
+    @Test
+    @DisplayName("A click does not select while the torso twist modifier is held")
+    void twistModifierSuppressesSelection() {
+        BoardViewEvent shiftClick = hexEvent(BoardViewEvent.BOARD_HEX_CLICKED,
+              InputEvent.SHIFT_DOWN_MASK,
+              MouseEvent.BUTTON1);
+
+        AttackPhaseDisplay.applyHexMouseAction(shiftClick, true);
+
+        verify(boardView, never()).select(any());
+    }
+
+    @Test
+    @DisplayName("An ALT click leaves the hex alone for the ruler")
+    void altClickDoesNotSelect() {
+        BoardViewEvent altClick = hexEvent(BoardViewEvent.BOARD_HEX_CLICKED,
+              InputEvent.ALT_DOWN_MASK,
+              MouseEvent.BUTTON1);
+
+        AttackPhaseDisplay.applyHexMouseAction(altClick, false);
+
+        verify(boardView, never()).select(any());
+    }
+
+    @Test
+    @DisplayName("A middle click does not select")
+    void middleClickDoesNotSelect() {
+        BoardViewEvent middleClick = hexEvent(BoardViewEvent.BOARD_HEX_CLICKED, 0, MouseEvent.BUTTON2);
+
+        AttackPhaseDisplay.applyHexMouseAction(middleClick, false);
+
+        verify(boardView, never()).select(any());
+    }
+
+    @Test
+    @DisplayName("Board events that are not a click or a drag touch neither cursor nor selection")
+    void otherEventsAreIgnored() {
+        BoardViewEvent popup = hexEvent(BoardViewEvent.BOARD_HEX_POPUP, 0, MouseEvent.BUTTON3);
+
+        AttackPhaseDisplay.applyHexMouseAction(popup, false);
+
+        verify(boardView, never()).select(any());
+        verify(boardView, never()).cursor(any());
+    }
+}


### PR DESCRIPTION
## What this changes

Nothing changes for the player in the phases you use most. This is the guard that stops #8781 from happening again.

Six attack phase displays each kept their own copy of the code that turns a hex click into a board action: move the cursor while dragging, select the hex on a plain left click. Copies drift, and one had - `PhysicalDisplay` had grown a second copy of the click half, so one click selected the hex twice and the target window opened twice. They now all call one shared method, `AttackPhaseDisplay.applyHexMouseAction()`.

Two behaviour changes come with it, both in the pre-end declarations and infantry-vs-infantry displays, which were the two out of step with the rest:

- An ALT click no longer selects a hex there. ALT belongs to the ruler, and the other phases already ignore it.
- A drag with a button other than the left one now moves the cursor, as it does in the other phases.

Closes #8796

## Testing

New test `AttackPhaseDisplayHexMouseActionTest`, six cases: a left click selects exactly once, a drag only moves the cursor, and shift, ALT and middle clicks select nothing. The shared method is static and takes the event, so no Swing is built and it runs headless.

The test was checked by putting the bug back. With a second `select()` call added and the click guard dropped, three of the six cases fail; with the code as it stands, all six pass.

Clicked through in game after the refactor: the physical and weapon attack phases still pick a target once, and the two displays whose behaviour changed - pre-end declarations and infantry-vs-infantry - behave correctly.

`./gradlew :megamek:test`, `checkstyleMain` and `javadoc` are green.

## What is not proven yet

Nothing about the behaviour itself. The test covers the shared method, and every affected phase has been clicked through in game.

#8795 has merged, so this now targets `main` and the normal checks are running.

---
- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
