### PR TITLE
Fix #8676: DFA attacker never landed when its target left the game

### DIFF
--- a/megamek/src/megamek/server/totalWarfare/MovePathHandler.java
+++ b/megamek/src/megamek/server/totalWarfare/MovePathHandler.java
@@ -2911,13 +2911,15 @@ class MovePathHandler extends AbstractTWRuleHandler {
                         // log the error, then put some defaults in for the DFA and proceed as if the
                         // target had been moved/destroyed
                     } else {
+                        // A DFA step only carries a target position when the target hex was picked in a dialog, so
+                        // report the hex the step lands in instead - that is the one the player is looking at.
                         String errorMessage = "Illegal DFA by " + entity.getDisplayName()
-                              + " against non-existent entity at " + step.getTargetPosition();
+                              + " against non-existent entity at " + step.getPosition();
                         gameManager.sendServerChat(errorMessage);
                         logger.error(errorMessage);
                         targetID = Entity.NONE;
-                        // doesn't really matter, DFA processing will cut out early if target resolves
-                        // as null
+                        // The physical phase lands the attacker in the target hex as if the target had been
+                        // destroyed, so the unit still comes down even though the attack does nothing.
                         targetType = Targetable.TYPE_ENTITY;
                     }
 

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -16913,12 +16913,26 @@ public class TWGameManager extends AbstractGameManager {
             return;
         }
 
+        if (lastEntityId != daa.getEntityId()) {
+            // who is making the attack
+            Report attackerReport = new Report(4005);
+            attackerReport.subject = ae.getId();
+            attackerReport.addDesc(ae);
+            addReport(attackerReport);
+        }
+
         Board board = game.getBoard(ae);
         final Hex aeHex = game.getHexOf(ae);
         final Hex teHex = board.getHex(daa.getTargetPos());
         final Targetable target = game.getTarget(daa.getTargetType(), daa.getTargetId());
 
+        // The target is no longer in the game at all - it was removed between the declaration in the movement phase
+        // and this attack being resolved, most often destroyed by artillery or an ammo explosion during the weapon
+        // attack phase. The attacker still has to come down, so land it exactly as for a target that was destroyed
+        // but is still on the board. Returning here left the attacker at DFA elevation with a stale displacement
+        // attack, so it never landed.
         if (target == null) {
+            landDfaAttackerOnGoneTarget(ae, daa, aeHex, teHex);
             return;
         }
 
@@ -16962,38 +16976,11 @@ public class TWGameManager extends AbstractGameManager {
 
         final int direction = ae.getFacing();
 
-        if (lastEntityId != daa.getEntityId()) {
-            // who is making the attack
-            r = new Report(4005);
-            r.subject = ae.getId();
-            r.addDesc(ae);
-            addReport(r);
-        }
-
         // Check if the target isn't dead, if it is, exit
         if (targetEntity != null &&
               target.getTargetType() == Targetable.TYPE_ENTITY &&
               (targetEntity.isDestroyed() || targetEntity.isDoomed() || targetEntity.getCrew().isDead())) {
-            r = new Report(4245);
-            r.subject = ae.getId();
-            r.indent();
-            addReport(r);
-
-            if (ae.isProne()) {
-                // attacker prone during weapons phase
-                addReport(doEntityFall(ae, daa.getTargetPos(), 2, 3, ae.getBasePilotingRoll(), false, false));
-
-            } else {
-                // same effect as successful DFA
-                ae.setElevation(ae.calcElevation(aeHex, teHex, 0, false));
-                addReport(doEntityDisplacement(ae,
-                      ae.getPosition(),
-                      daa.getTargetPos(),
-                      new PilotingRollData(ae.getId(), Game.rulesManager.getRulesPSR().getSuccessfulDFAModifier(),
-                            "executed death from above")));
-            }
-            // entity isn't DFA-ing anymore
-            ae.setDisplacementAttack(null);
+            landDfaAttackerOnGoneTarget(ae, daa, aeHex, teHex);
             return;
         }
 
@@ -17267,6 +17254,42 @@ public class TWGameManager extends AbstractGameManager {
         if ((target instanceof Mek mek) && mek.isIndustrial()) {
             mek.setCheckForCrit(true);
         }
+    }
+
+    /**
+     * Lands a death from above attacker whose target is not there to be hit any more, either because it was destroyed
+     * while still on the board or because it has been removed from the game entirely. The attack does no damage, but
+     * the attacker still comes down in the target's hex and rolls to stay standing, which is the same result as a
+     * successful death from above (TW p. 148).
+     *
+     * @param attacker    the unit that declared the death from above
+     * @param dfaAttack   the declared attack, whose target position is the hex the attacker comes down in
+     * @param attackerHex the hex the attacker is jumping from
+     * @param targetHex   the hex the attacker comes down in
+     */
+    private void landDfaAttackerOnGoneTarget(Entity attacker, DfaAttackAction dfaAttack, Hex attackerHex,
+          Hex targetHex) {
+        Report report = new Report(4245);
+        report.subject = attacker.getId();
+        report.indent();
+        addReport(report);
+
+        if (attacker.isProne()) {
+            // attacker prone during weapons phase
+            addReport(doEntityFall(attacker, dfaAttack.getTargetPos(), 2, 3, attacker.getBasePilotingRoll(), false,
+                  false));
+        } else {
+            // same effect as successful DFA
+            attacker.setElevation(attacker.calcElevation(attackerHex, targetHex, 0, false));
+            addReport(doEntityDisplacement(attacker,
+                  attacker.getPosition(),
+                  dfaAttack.getTargetPos(),
+                  new PilotingRollData(attacker.getId(),
+                        Game.rulesManager.getRulesPSR().getSuccessfulDFAModifier(),
+                        "executed death from above")));
+        }
+        // entity isn't DFA-ing anymore
+        attacker.setDisplacementAttack(null);
     }
 
     /**

--- a/megamek/unittests/megamek/server/totalWarfare/TWGameManagerDfaMissingTargetTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/TWGameManagerDfaMissingTargetTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.server.totalWarfare;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Field;
+import java.util.Vector;
+
+import megamek.common.Hex;
+import megamek.common.PhysicalResult;
+import megamek.common.Player;
+import megamek.common.actions.DfaAttackAction;
+import megamek.common.board.Board;
+import megamek.common.board.Coords;
+import megamek.common.enums.GamePhase;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.game.Game;
+import megamek.common.rolls.PilotingRollData;
+import megamek.common.units.Entity;
+import megamek.common.units.Targetable;
+import megamek.testUtilities.MMTestUtilities;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for a death from above whose target is gone by the time the physical phase resolves it.
+ *
+ * <p>A DFA is declared in the movement phase but resolved in the physical phase, so anything that removes the target
+ * in between - artillery landing on the hex, an ammo explosion - leaves the attack with nothing to hit. The attacker
+ * still has to come down. Before this fix the server returned as soon as the target failed to resolve, so the Mek was
+ * left at DFA elevation with a stale displacement attack and never landed.</p>
+ */
+class TWGameManagerDfaMissingTargetTest {
+
+    private static final int ATTACKER_ID = 5;
+    private static final int TARGET_ID = 6;
+    private static final int MISSING_TARGET_ID = 99;
+
+    private static final Coords ATTACKER_POSITION = new Coords(1, 1);
+    private static final Coords TARGET_POSITION = new Coords(1, 2);
+
+    private TWGameManager gameManager;
+    private Game game;
+    private Entity attacker;
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void setUp() throws ReflectiveOperationException {
+        game = new Game();
+        game.setBoard(flatBoard(4, 4));
+
+        Player player = new Player(0, "Attacker");
+        player.setTeam(1);
+        game.addPlayer(0, player);
+
+        attacker = MMTestUtilities.getEntityForUnitTesting("Shadow Hawk SHD-5D", false);
+        assertNotNull(attacker, "Attacking unit could not be loaded");
+        attacker.setId(ATTACKER_ID);
+        attacker.setOwner(player);
+        game.addEntity(attacker);
+        attacker.setPosition(ATTACKER_POSITION);
+        attacker.setFacing(3);
+        // The movement phase leaves a DFA attacker one level above the target hex; landing it again is what the
+        // physical phase is responsible for.
+        attacker.setElevation(1);
+
+        game.setPhase(GamePhase.PHYSICAL);
+
+        gameManager = mock(TWGameManager.class);
+        doCallRealMethod().when(gameManager).setGame(any());
+        doCallRealMethod().when(gameManager).resolvePhysicalAttacks();
+        gameManager.setGame(game);
+        givePhysicalResultList(gameManager);
+    }
+
+    /**
+     * A mocked manager skips field initialization, so hand it the physical result list its real constructor would
+     * have built.
+     */
+    private static void givePhysicalResultList(TWGameManager manager) throws ReflectiveOperationException {
+        Field physicalResults = TWGameManager.class.getDeclaredField("physicalResults");
+        physicalResults.setAccessible(true);
+        physicalResults.set(manager, new Vector<PhysicalResult>());
+    }
+
+    /** A board of the given size with plain level 0 hexes. */
+    private static Board flatBoard(int width, int height) {
+        Hex[] hexes = new Hex[width * height];
+        for (int hex = 0; hex < hexes.length; hex++) {
+            hexes[hex] = new Hex();
+        }
+        return new Board(width, height, hexes);
+    }
+
+    /** Declares a death from above by the attacker against the given target id, as the movement phase would. */
+    private void declareDeathFromAbove(int targetId) {
+        DfaAttackAction deathFromAbove = new DfaAttackAction(ATTACKER_ID,
+              Targetable.TYPE_ENTITY,
+              targetId,
+              TARGET_POSITION);
+        attacker.setDisplacementAttack(deathFromAbove);
+        game.addDisplacementAttack(deathFromAbove);
+    }
+
+    /** Asserts that the attacker was brought down in the target hex and is no longer flagged as making a DFA. */
+    private void assertAttackerLanded() {
+        verify(gameManager).doEntityDisplacement(eq(attacker),
+              eq(ATTACKER_POSITION),
+              eq(TARGET_POSITION),
+              any(PilotingRollData.class));
+        assertFalse(attacker.isMakingDfa(), "Attacker is still flagged as making a death from above");
+    }
+
+    @Test
+    void attackerLandsWhenTargetIsNoLongerInTheGame() {
+        declareDeathFromAbove(MISSING_TARGET_ID);
+
+        gameManager.resolvePhysicalAttacks();
+
+        assertAttackerLanded();
+    }
+
+    @Test
+    void attackerLandsWhenTargetWasDestroyedButIsStillOnTheBoard() {
+        Entity target = MMTestUtilities.getEntityForUnitTesting("Locust LCT-1V", false);
+        assertNotNull(target, "Target unit could not be loaded");
+        Player enemy = new Player(1, "Defender");
+        enemy.setTeam(2);
+        game.addPlayer(1, enemy);
+        target.setId(TARGET_ID);
+        target.setOwner(enemy);
+        game.addEntity(target);
+        target.setPosition(TARGET_POSITION);
+        target.setDestroyed(true);
+
+        declareDeathFromAbove(TARGET_ID);
+
+        gameManager.resolvePhysicalAttacks();
+
+        assertAttackerLanded();
+    }
+}


### PR DESCRIPTION
## What this changes

A Mek that death-from-aboves a unit which is then killed before the attack resolves now lands in the target hex and rolls to stay standing, instead of being left hanging at DFA elevation. Artillery is the usual cause: the DFA is declared in the movement phase, the shell lands in the weapon attack phase, and the DFA resolves in the physical phase with nothing left to hit. The server used to drop the attack silently at that point - no report, no piloting roll, and the attacker kept its displacement attack, so it still counted as making a DFA in later rounds.

Fixes #8676

## Testing

Verified in game. A Phoenix Hawk PXH-1D death-from-aboved a target that was destroyed before the physical phase. It now comes down, rolls to stay standing, and a failed roll resolves as an ordinary fall:

```
Death from above deals no damage as the target has been destroyed.
Phoenix Hawk PXH-1D (MobileHammer) is displaced into hex 0708.
Phoenix Hawk PXH-1D (MobileHammer) must make 1 piloting skill roll(s) (executed death from above).
      The base target is 4.
      Roll #1 :needs 6, rolls 5 : falls.
Phoenix Hawk PXH-1D (MobileHammer) falls on its front, suffering 5 damage.
```

`TWGameManagerDfaMissingTargetTest` (new): a DFA declared against a unit that is no longer in the game now displaces the attacker into the target hex with the successful-DFA piloting roll and clears the displacement attack. That test fails with the fix reverted. A second test asserts the same outcome for the pre-existing "target destroyed but still on the board" branch, which is there to guard the extraction of the shared landing code.

Full `:megamek:test`, `checkstyleMain` and `javadoc` all pass, with no pre-existing failures.

## What is not proven yet

The prone-attacker leg of the landing takes a different path (`doEntityFall` rather than a displacement). Neither the in-game check nor the tests exercise it; it is the same call the destroyed-target branch already made before this change.

The reporter's log line came from the movement phase, which means their target was already gone when the move packet reached the server - a client/server race on target removal rather than the artillery timing above. That path was not reproduced. It ends in the same place: `MovePathHandler` already substitutes `Entity.NONE`, and the physical phase now lands the unit rather than dropping it.

---
- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
