### PR TITLE
Fix #8685: Game would not load once artillery outlived the player who fired it

### DIFF
--- a/megamek/resources/megamek/common/messages.properties
+++ b/megamek/resources/megamek/common/messages.properties
@@ -668,6 +668,7 @@ BeastSize.large=Large
 BeastSize.very_large=Very Large
 BeastSize.monstrous=Monstrous
 ArtilleryMessage.drifted=Artillery drifted here from
+ArtilleryMessage.unknownFiringPlayer=an unknown battery
 BombMessage.drifted=Bomb drifted here from
 ### Weapon Handlers
 ArtilleryIndirectHomingHandler.HomingArtyMissChance=Homing shot locked on! (can miss on 3 or less)

--- a/megamek/src/megamek/common/weapons/ArtilleryHandlerHelper.java
+++ b/megamek/src/megamek/common/weapons/ArtilleryHandlerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -41,7 +41,10 @@ import java.util.Optional;
 import java.util.Vector;
 
 import megamek.common.LosEffects;
+import megamek.common.Messages;
+import megamek.common.Player;
 import megamek.common.Report;
+import megamek.common.actions.ArtilleryAttackAction;
 import megamek.common.annotations.Nullable;
 import megamek.common.board.Board;
 import megamek.common.board.Coords;
@@ -172,6 +175,26 @@ public final class ArtilleryHandlerHelper {
             }
         }
         return lastOnBoard;
+    }
+
+    /**
+     * Returns the name of the player who fired the given artillery attack, for use in the "fired by ..." text of a hex
+     * marker or report.
+     * <p>
+     * A round already in the air outlives its firer: by the rules it lands whether or not the firing unit survives, and
+     * a player whose last unit is destroyed can be dropped from the game while the round is still in flight. When that
+     * has happened the player can no longer be looked up, so a plain label is used instead of their name.</p>
+     *
+     * @param game   The game the attack belongs to
+     * @param attack The artillery attack whose firer is being named
+     *
+     * @return The firing player's name, or a generic label when that player is no longer in the game
+     */
+    public static String firingPlayerName(Game game, ArtilleryAttackAction attack) {
+        Player firingPlayer = game.getPlayer(attack.getPlayerId());
+        return (firingPlayer == null)
+              ? Messages.getString("ArtilleryMessage.unknownFiringPlayer")
+              : firingPlayer.getName();
     }
 
     private ArtilleryHandlerHelper() {}

--- a/megamek/src/megamek/common/weapons/handlers/CapitalLaserBayOrbitalBombardmentHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/CapitalLaserBayOrbitalBombardmentHandler.java
@@ -232,9 +232,16 @@ public class CapitalLaserBayOrbitalBombardmentHandler extends BayWeaponHandler {
         reports.addElement(report);
         Report.addNewline(reports);
 
+        // The incoming marker is meant for the firing player's team only. A null owner makes
+        // SpecialHexDisplay.isObscured() report the marker as visible to everyone, which would show the aim hex to the
+        // whole game under double-blind, so it is not drawn when the firer cannot be resolved - a team that has left
+        // the game has nobody left to warn.
         Player owner = game.getPlayer(aaa.getPlayerId());
+        if (owner == null) {
+            return;
+        }
         int landingRound = game.getRoundCount() + aaa.getTurnsTilHit();
-        String message = "Orbital Bombardment incoming, landing this round, fired by " + firingPlayerName(game, aaa);
+        String message = "Orbital Bombardment incoming, landing this round, fired by " + owner.getName();
         SpecialHexDisplay incomingMarker = SpecialHexDisplay.createIncomingFire(owner, landingRound, message);
         game.getBoard(target).addSpecialHexDisplay(target.getPosition(), incomingMarker);
     }

--- a/megamek/src/megamek/common/weapons/handlers/CapitalLaserBayOrbitalBombardmentHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/CapitalLaserBayOrbitalBombardmentHandler.java
@@ -35,6 +35,7 @@ package megamek.common.weapons.handlers;
 
 import static megamek.common.weapons.ArtilleryHandlerHelper.clearMines;
 import static megamek.common.weapons.ArtilleryHandlerHelper.findSpotter;
+import static megamek.common.weapons.ArtilleryHandlerHelper.firingPlayerName;
 import static megamek.common.weapons.ArtilleryHandlerHelper.isForwardObserver;
 
 import java.util.ArrayList;
@@ -155,7 +156,7 @@ public class CapitalLaserBayOrbitalBombardmentHandler extends BayWeaponHandler {
             report = new Report(3203).subject(subjectId).add(numWeaponsHit).add(target.getPosition().getBoardNum());
             reports.addElement(report);
             String message = "Orbital Bombardment by %s hit here on round %d (this hex is now an auto-hit)"
-                  .formatted(owner().getName(), game.getRoundCount());
+                  .formatted(firingPlayerName(game, attackAction), game.getRoundCount());
 
             board.addSpecialHexDisplay(target.getPosition(),
                   new SpecialHexDisplay(SpecialHexDisplay.Type.ARTILLERY_HIT, game.getRoundCount(), owner(), message));
@@ -166,7 +167,7 @@ public class CapitalLaserBayOrbitalBombardmentHandler extends BayWeaponHandler {
             // We're only going to display one missed shot hex on the board, at the intended target
             // Any drifted shots will be indicated at their end points
             String message = "Orbital Bombardment by %s missed here on round %d"
-                  .formatted(owner().getName(), game.getRoundCount());
+                  .formatted(firingPlayerName(game, attackAction), game.getRoundCount());
             board.addSpecialHexDisplay(target.getPosition(),
                   SpecialHexDisplay.createArtyMiss(owner(), game.getRoundCount(), message));
 
@@ -233,7 +234,7 @@ public class CapitalLaserBayOrbitalBombardmentHandler extends BayWeaponHandler {
 
         Player owner = game.getPlayer(aaa.getPlayerId());
         int landingRound = game.getRoundCount() + aaa.getTurnsTilHit();
-        String message = "Orbital Bombardment incoming, landing this round, fired by " + owner.getName();
+        String message = "Orbital Bombardment incoming, landing this round, fired by " + firingPlayerName(game, aaa);
         SpecialHexDisplay incomingMarker = SpecialHexDisplay.createIncomingFire(owner, landingRound, message);
         game.getBoard(target).addSpecialHexDisplay(target.getPosition(), incomingMarker);
     }

--- a/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryBayWeaponDistantFireHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryBayWeaponDistantFireHandler.java
@@ -173,7 +173,7 @@ public class ArtilleryBayWeaponDistantFireHandler extends AmmoBayWeaponHandler {
                 artyMsg = "Artillery bay fire Incoming, landing on round "
                       + (game.getRoundCount() + aaa.getTurnsTilHit())
                       + ", fired by "
-                      + game.getPlayer(aaa.getPlayerId()).getName();
+                      + ArtilleryHandlerHelper.firingPlayerName(game, aaa);
                 game.getBoard(aaa.getTarget(game).getBoardId()).addSpecialHexDisplay(
                       aaa.getTarget(game).getPosition(),
                       new SpecialHexDisplay(
@@ -390,7 +390,7 @@ public class ArtilleryBayWeaponDistantFireHandler extends AmmoBayWeaponHandler {
             targetHex = game.getBoard(target.getBoardId()).getHex(targetPos);
             heights.add((targetHex != null) ? game.getBoard(target.getBoardId()).getHex(targetPos).getLevel() : 0);
             artyMsg = "Artillery hit here on round " + game.getRoundCount()
-                  + ", fired by " + game.getPlayer(aaa.getPlayerId()).getName()
+                  + ", fired by " + ArtilleryHandlerHelper.firingPlayerName(game, aaa)
                   + " (this hex is now an auto-hit)";
             game.getBoard(target.getBoardId()).addSpecialHexDisplay(targetPos,
                   new SpecialHexDisplay(SpecialHexDisplay.Type.ARTILLERY_HIT,
@@ -405,7 +405,7 @@ public class ArtilleryBayWeaponDistantFireHandler extends AmmoBayWeaponHandler {
             // Any drifted shots will be indicated at their end points
             artyMsg = "Bay Artillery missed here on round "
                   + game.getRoundCount() + ", by "
-                  + game.getPlayer(aaa.getPlayerId()).getName();
+                  + ArtilleryHandlerHelper.firingPlayerName(game, aaa);
             SpecialHexDisplay bayMissMarker = new SpecialHexDisplay(SpecialHexDisplay.Type.ARTILLERY_MISS,
                   game.getRoundCount(), game.getPlayer(aaa.getPlayerId()), artyMsg);
             game.getBoard().addSpecialHexDisplay(originalPosition, bayMissMarker);

--- a/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryBayWeaponDistantFireHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryBayWeaponDistantFireHandler.java
@@ -43,6 +43,7 @@ import java.util.Vector;
 
 import megamek.common.Hex;
 import megamek.common.LosEffects;
+import megamek.common.Player;
 import megamek.common.Report;
 import megamek.common.SpecialHexDisplay;
 import megamek.common.ToHitData;
@@ -170,17 +171,25 @@ public class ArtilleryBayWeaponDistantFireHandler extends AmmoBayWeaponHandler {
                 Report.addNewline(vPhaseReport);
                 handledAmmoAndReport = true;
 
-                artyMsg = "Artillery bay fire Incoming, landing on round "
-                      + (game.getRoundCount() + aaa.getTurnsTilHit())
-                      + ", fired by "
-                      + ArtilleryHandlerHelper.firingPlayerName(game, aaa);
-                game.getBoard(aaa.getTarget(game).getBoardId()).addSpecialHexDisplay(
-                      aaa.getTarget(game).getPosition(),
-                      new SpecialHexDisplay(
-                            SpecialHexDisplay.Type.ARTILLERY_INCOMING, game
-                            .getRoundCount() + aaa.getTurnsTilHit(),
-                            game.getPlayer(aaa.getPlayerId()), artyMsg,
-                            SpecialHexDisplay.SHD_VISIBLE_TO_TEAM));
+                // The incoming marker is meant for the firing player's team only. A null owner makes
+                // SpecialHexDisplay.isObscured() report the marker as visible to everyone, which would show the aim
+                // hex to the whole game under double-blind, so it is not drawn when the firer cannot be resolved -
+                // a team that has left the game has nobody left to warn.
+                Player firingPlayer = game.getPlayer(aaa.getPlayerId());
+                if (firingPlayer != null) {
+                    Targetable incomingTarget = aaa.getTarget(game);
+                    int landingRound = game.getRoundCount() + aaa.getTurnsTilHit();
+                    artyMsg = "Artillery bay fire Incoming, landing on round "
+                          + landingRound
+                          + ", fired by "
+                          + firingPlayer.getName();
+                    game.getBoard(incomingTarget.getBoardId()).addSpecialHexDisplay(
+                          incomingTarget.getPosition(),
+                          new SpecialHexDisplay(
+                                SpecialHexDisplay.Type.ARTILLERY_INCOMING, landingRound,
+                                firingPlayer, artyMsg,
+                                SpecialHexDisplay.SHD_VISIBLE_TO_TEAM));
+                }
             }
             // if this is the last targeting phase before we hit,
             // make it so the firing entity is announced in the

--- a/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryWeaponDistantFireHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryWeaponDistantFireHandler.java
@@ -43,6 +43,7 @@ import megamek.client.ui.Messages;
 import megamek.common.Hex;
 import megamek.common.HexTarget;
 import megamek.common.LosEffects;
+import megamek.common.Player;
 import megamek.common.Report;
 import megamek.common.SpecialHexDisplay;
 import megamek.common.SpecialHexDisplay.Type;
@@ -123,7 +124,6 @@ public class ArtilleryWeaponDistantFireHandler extends AmmoWeaponHandler {
         if (!cares(phase)) {
             return true;
         }
-        String artyMsg;
         ArtilleryAttackAction artilleryAttackAction = (ArtilleryAttackAction) weaponAttackAction;
         if (phase.isTargeting()) {
             if (!handledAmmoAndReport) {
@@ -144,17 +144,23 @@ public class ArtilleryWeaponDistantFireHandler extends AmmoWeaponHandler {
                 // "Shot, over" - the battery announces the round is on the way, characterised by fire type
                 reportShot();
 
-                artyMsg = "Artillery fire Incoming, landing on round "
-                      + (game.getRoundCount() + artilleryAttackAction.getTurnsTilHit())
-                      + ", fired by "
-                      + ArtilleryHandlerHelper.firingPlayerName(game, artilleryAttackAction);
-                if (artilleryAttackAction.getTarget(game) != null) {
-                    game.getBoard(artilleryAttackAction.getTarget(game).getBoardId()).addSpecialHexDisplay(
-                          artilleryAttackAction.getTarget(game).getPosition(),
+                // The incoming marker is meant for the firing player's team only. A null owner makes
+                // SpecialHexDisplay.isObscured() report the marker as visible to everyone, which would show the aim
+                // hex to the whole game under double-blind, so it is not drawn when the firer cannot be resolved -
+                // a team that has left the game has nobody left to warn.
+                Player firingPlayer = game.getPlayer(artilleryAttackAction.getPlayerId());
+                Targetable incomingTarget = artilleryAttackAction.getTarget(game);
+                if ((firingPlayer != null) && (incomingTarget != null)) {
+                    int landingRound = game.getRoundCount() + artilleryAttackAction.getTurnsTilHit();
+                    String artyMsg = "Artillery fire Incoming, landing on round "
+                          + landingRound
+                          + ", fired by "
+                          + firingPlayer.getName();
+                    game.getBoard(incomingTarget.getBoardId()).addSpecialHexDisplay(
+                          incomingTarget.getPosition(),
                           new SpecialHexDisplay(
-                                Type.ARTILLERY_INCOMING, game
-                                .getRoundCount() + artilleryAttackAction.getTurnsTilHit(),
-                                game.getPlayer(artilleryAttackAction.getPlayerId()), artyMsg,
+                                Type.ARTILLERY_INCOMING, landingRound,
+                                firingPlayer, artyMsg,
                                 SpecialHexDisplay.SHD_VISIBLE_TO_TEAM));
                 }
             }

--- a/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryWeaponDistantFireHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/artillery/ArtilleryWeaponDistantFireHandler.java
@@ -147,7 +147,7 @@ public class ArtilleryWeaponDistantFireHandler extends AmmoWeaponHandler {
                 artyMsg = "Artillery fire Incoming, landing on round "
                       + (game.getRoundCount() + artilleryAttackAction.getTurnsTilHit())
                       + ", fired by "
-                      + game.getPlayer(artilleryAttackAction.getPlayerId()).getName();
+                      + ArtilleryHandlerHelper.firingPlayerName(game, artilleryAttackAction);
                 if (artilleryAttackAction.getTarget(game) != null) {
                     game.getBoard(artilleryAttackAction.getTarget(game).getBoardId()).addSpecialHexDisplay(
                           artilleryAttackAction.getTarget(game).getPosition(),
@@ -591,7 +591,7 @@ public class ArtilleryWeaponDistantFireHandler extends AmmoWeaponHandler {
                 String artyMsg = "Artillery hit here on round " +
                       game.getRoundCount() +
                       ", fired by " +
-                      game.getPlayer(aaa.getPlayerId()).getName() +
+                      ArtilleryHandlerHelper.firingPlayerName(game, aaa) +
                       " (this hex is now an auto-hit)";
                 game.getBoard()
                       .addSpecialHexDisplay(targetPos,
@@ -623,7 +623,7 @@ public class ArtilleryWeaponDistantFireHandler extends AmmoWeaponHandler {
 
                     String artyMsg = "Artillery missed here on round "
                           + game.getRoundCount() + ", by "
-                          + game.getPlayer(aaa.getPlayerId()).getName()
+                          + ArtilleryHandlerHelper.firingPlayerName(game, aaa)
                           + (driftedOffTarget ? ", drifted to " + targetPos.getBoardNum() : ", landed on target");
                     SpecialHexDisplay missMarker = new SpecialHexDisplay(Type.ARTILLERY_MISS,
                           game.getRoundCount(),
@@ -657,7 +657,7 @@ public class ArtilleryWeaponDistantFireHandler extends AmmoWeaponHandler {
 
                 String artyMsg = "Artillery missed here on round "
                       + game.getRoundCount() + ", by "
-                      + game.getPlayer(aaa.getPlayerId()).getName()
+                      + ArtilleryHandlerHelper.firingPlayerName(game, aaa)
                       + ", drifted off the board";
                 SpecialHexDisplay missMarker = new SpecialHexDisplay(Type.ARTILLERY_MISS,
                       game.getRoundCount(),

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -28304,18 +28304,22 @@ public class TWGameManager extends AbstractGameManager {
     /**
      * Creates a packet containing off board artillery attacks
      */
-    Packet createArtilleryPacket(Player p) {
+    Packet createArtilleryPacket(Player viewingPlayer) {
         Vector<ArtilleryAttackAction> v = new Vector<>();
         List<EnemyArtilleryInbound> enemyInbound = new ArrayList<>();
-        int team = p.getTeam();
+        int team = viewingPlayer.getTeam();
         for (Enumeration<AttackHandler> i = game.getAttacks(); i.hasMoreElements(); ) {
             WeaponHandler wh = (WeaponHandler) i.nextElement();
             if (wh.weaponAttackAction instanceof ArtilleryAttackAction aaa) {
-                boolean ownOrAllied = (aaa.getPlayerId() == p.getId())
-                      || ((team != Player.TEAM_NONE) && (team == game.getPlayer(aaa.getPlayerId()).getTeam()));
-                if (ownOrAllied || p.canIgnoreDoubleBlind() || p.isArtilleryRevealAll()) {
+                // A round already in the air outlives its firer: a player whose last unit is destroyed can be
+                // dropped from the game while the round is still in flight, so the firer may no longer be
+                // present. An unknown firer counts as nobody's ally.
+                Player firingPlayer = game.getPlayer(aaa.getPlayerId());
+                boolean ownOrAllied = (aaa.getPlayerId() == viewingPlayer.getId())
+                      || ((firingPlayer != null) && (team != Player.TEAM_NONE) && (team == firingPlayer.getTeam()));
+                if (ownOrAllied || viewingPlayer.canIgnoreDoubleBlind() || viewingPlayer.isArtilleryRevealAll()) {
                     v.addElement(aaa);
-                } else if (enemyArtilleryRoundIsKnownTo(aaa, p)) {
+                } else if (enemyArtilleryRoundIsKnownTo(aaa, viewingPlayer)) {
                     // The player knows an enemy round is inbound (its firing is announced in the report) but not its
                     // target hex or munition - send only a redacted summary so the Rounds-in-Air window can list it with
                     // "Unknown" target/warhead, without ever sending the aim point to the client.

--- a/megamek/unittests/megamek/common/weapons/ArtilleryHandlerHelperTest.java
+++ b/megamek/unittests/megamek/common/weapons/ArtilleryHandlerHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,6 +32,7 @@
  */
 package megamek.common.weapons;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -42,6 +43,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Optional;
 
+import megamek.common.Messages;
+import megamek.common.Player;
+import megamek.common.actions.ArtilleryAttackAction;
 import megamek.common.game.Game;
 import megamek.common.options.OptionsConstants;
 import megamek.common.units.Entity;
@@ -182,5 +186,33 @@ class ArtilleryHandlerHelperTest {
         boolean getsBonus = !(spotter instanceof Infantry)
               && spotter.hasAbility(OptionsConstants.MD_COMM_IMPLANT);
         assertFalse(getsBonus, "Entity without comm implant should not get bonus");
+    }
+
+    /**
+     * A round already in the air outlives its firer, so the player who fired it may have been dropped from the game by
+     * the time it lands (issue #8685). Naming that firer must fall back to a label rather than throwing.
+     */
+    @Test
+    void firingPlayerName_whenPlayerHasLeftTheGame_returnsALabel() {
+        Game game = mock(Game.class);
+        ArtilleryAttackAction attack = mock(ArtilleryAttackAction.class);
+        when(attack.getPlayerId()).thenReturn(2);
+        when(game.getPlayer(2)).thenReturn(null);
+
+        assertEquals(Messages.getString("ArtilleryMessage.unknownFiringPlayer"),
+              ArtilleryHandlerHelper.firingPlayerName(game, attack));
+    }
+
+    /**
+     * Test that a firer still in the game is named normally.
+     */
+    @Test
+    void firingPlayerName_whenPlayerIsStillInTheGame_returnsTheirName() {
+        Game game = mock(Game.class);
+        ArtilleryAttackAction attack = mock(ArtilleryAttackAction.class);
+        when(attack.getPlayerId()).thenReturn(2);
+        when(game.getPlayer(2)).thenReturn(new Player(2, "Independent Base Defenses"));
+
+        assertEquals("Independent Base Defenses", ArtilleryHandlerHelper.firingPlayerName(game, attack));
     }
 }

--- a/megamek/unittests/megamek/common/weapons/ArtilleryIncomingMarkerTest.java
+++ b/megamek/unittests/megamek/common/weapons/ArtilleryIncomingMarkerTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.weapons;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Vector;
+
+import megamek.common.Hex;
+import megamek.common.Player;
+import megamek.common.Report;
+import megamek.common.SpecialHexDisplay;
+import megamek.common.ToHitData;
+import megamek.common.actions.ArtilleryAttackAction;
+import megamek.common.board.Board;
+import megamek.common.board.Coords;
+import megamek.common.enums.GamePhase;
+import megamek.common.equipment.AmmoType;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.EquipmentTypeLookup;
+import megamek.common.equipment.Mounted;
+import megamek.common.exceptions.LocationFullException;
+import megamek.common.game.Game;
+import megamek.common.loaders.EntityLoadingException;
+import megamek.common.options.GameOptions;
+import megamek.common.options.PilotOptions;
+import megamek.common.units.BipedMek;
+import megamek.common.units.Crew;
+import megamek.common.units.CrewType;
+import megamek.common.units.Mek;
+import megamek.common.weapons.handlers.artillery.ArtilleryWeaponDistantFireHandler;
+import megamek.server.Server;
+import megamek.server.totalWarfare.TWGameManager;
+import megamek.utils.ServerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the "incoming artillery" hex marker raised when a fire mission is declared (issue #8685, PR review).
+ *
+ * <p>That marker is created with {@link SpecialHexDisplay#SHD_VISIBLE_TO_TEAM}, so only the firing player's team is
+ * meant to see the hex being aimed at. {@link SpecialHexDisplay#isObscured(Player)} returns {@code false} for a marker
+ * with no owner, and the server filters on exactly that call before sending markers to a client - so a marker built
+ * with a null owner would be broadcast to every player, showing the aim point to the enemy under double-blind. The
+ * handler therefore does not raise the marker at all when the firing player cannot be resolved.</p>
+ */
+class ArtilleryIncomingMarkerTest {
+
+    private static final int BOARD_WIDTH = 16;
+    private static final int BOARD_HEIGHT = 17;
+
+    private Player attackingPlayer;
+    private Player defendingPlayer;
+    private TWGameManager gameManager;
+    private Game game;
+    private Server server;
+    private Board board;
+
+    @BeforeAll
+    static void beforeAll() {
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void setUp() throws IOException {
+        attackingPlayer = new Player(0, "Independent Base Defenses");
+        defendingPlayer = new Player(1, "Dust Devils");
+        gameManager = new TWGameManager();
+        game = gameManager.getGame();
+        game.createVictoryConditions();
+        game.addPlayer(attackingPlayer.getId(), attackingPlayer);
+        game.addPlayer(defendingPlayer.getId(), defendingPlayer);
+
+        game.setOptions(new GameOptions());
+
+        Hex[] hexes = new Hex[BOARD_WIDTH * BOARD_HEIGHT];
+        for (int index = 0; index < hexes.length; index++) {
+            hexes[index] = new Hex();
+        }
+        board = new Board(BOARD_WIDTH, BOARD_HEIGHT, hexes);
+        game.setBoard(board);
+
+        server = ServerFactory.createServer(gameManager);
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.die();
+    }
+
+    private Mek createMek(String chassis, Player owner, Coords position) {
+        Mek mek = new BipedMek();
+        mek.setGame(game);
+        mek.setChassis(chassis);
+        mek.setModel("Test");
+
+        Crew crew = new Crew(CrewType.SINGLE);
+        crew.setGunnery(4, crew.getCrewType().getGunnerPos());
+        crew.setPiloting(5, crew.getCrewType().getPilotPos());
+        crew.setName("Gunner", 0);
+        crew.setOptions(new PilotOptions());
+        mek.setCrew(crew);
+
+        mek.setId(game.getNextEntityId());
+        game.addEntity(mek);
+        mek.setOwner(owner);
+        mek.setDeployed(true);
+        mek.setPosition(position);
+        return mek;
+    }
+
+    /** Builds a Thumper-armed attacker, a target, and the handler for a fire mission between them. */
+    private ArtilleryWeaponDistantFireHandler declareFireMission(Coords targetPosition) throws LocationFullException, EntityLoadingException {
+        Mek attacker = createMek("Bombard", attackingPlayer, new Coords(1, 1));
+        Mounted<?> thumper = attacker.addEquipment(EquipmentType.get(EquipmentTypeLookup.THUMPER_ARTY),
+              Mek.LOC_CENTER_TORSO);
+        AmmoType thumperAmmo = (AmmoType) EquipmentType.get("ISThumperAmmo");
+        Mounted<?> ammoBin = attacker.addEquipment(thumperAmmo, Mek.LOC_CENTER_TORSO);
+        thumper.setLinked(ammoBin);
+
+        Mek defender = createMek("Marauder", defendingPlayer, targetPosition);
+
+        ArtilleryAttackAction attack = new ArtilleryAttackAction(attacker.getId(),
+              defender.getTargetType(),
+              defender.getId(),
+              attacker.getEquipmentNum(thumper),
+              game);
+
+        ToHitData toHit = new ToHitData();
+        toHit.addModifier(4, "Gunnery Skill");
+        return new ArtilleryWeaponDistantFireHandler(toHit, attack, game, gameManager);
+    }
+
+    private boolean hasIncomingMarkerAt(Coords coords) {
+        Collection<SpecialHexDisplay> markers = board.getSpecialHexDisplay(coords);
+        if (markers == null) {
+            return false;
+        }
+        for (SpecialHexDisplay marker : markers) {
+            if (marker.getType() == SpecialHexDisplay.Type.ARTILLERY_INCOMING) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Test
+    void incomingMarkerIsRaisedWhenTheFiringPlayerIsInTheGame() throws LocationFullException, EntityLoadingException {
+        Coords targetPosition = new Coords(8, 8);
+        ArtilleryWeaponDistantFireHandler handler = declareFireMission(targetPosition);
+
+        game.setPhase(GamePhase.TARGETING);
+        handler.handle(GamePhase.TARGETING, new Vector<Report>());
+
+        assertTrue(hasIncomingMarkerAt(targetPosition),
+              "A fire mission from a player still in the game should warn that team");
+    }
+
+    @Test
+    void noIncomingMarkerIsRaisedWhenTheFiringPlayerHasLeftTheGame() throws LocationFullException, EntityLoadingException {
+        Coords targetPosition = new Coords(8, 8);
+        ArtilleryWeaponDistantFireHandler handler = declareFireMission(targetPosition);
+
+        // The firing player is dropped from the game, as happens when their last unit is destroyed while a round is
+        // still in flight. A team-visible marker with no owner would be sent to everyone, revealing the aim hex.
+        game.removePlayer(attackingPlayer.getId());
+
+        game.setPhase(GamePhase.TARGETING);
+        handler.handle(GamePhase.TARGETING, new Vector<Report>());
+
+        assertFalse(hasIncomingMarkerAt(targetPosition),
+              "A marker with no owner is visible to every player, so none should be raised at all");
+    }
+}

--- a/megamek/unittests/megamek/server/totalWarfare/TWGameManagerArtilleryPacketTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/TWGameManagerArtilleryPacketTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.server.totalWarfare;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Vector;
+
+import megamek.common.Player;
+import megamek.common.actions.ArtilleryAttackAction;
+import megamek.common.game.Game;
+import megamek.common.net.packets.Packet;
+import megamek.common.options.OptionsConstants;
+import megamek.common.weapons.handlers.WeaponHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for issue #8685: a game could not be loaded once an artillery round outlived the player who fired
+ * it.
+ *
+ * <p>A round already in the air lands whether or not the firing unit survives, so it stays in the attack list. When
+ * that unit was its owner's last one, the player can be dropped from the game while the round is still in flight,
+ * leaving an attack stamped with a player id that no longer resolves. Every connecting client asked the server which
+ * rounds were friendly, that lookup returned {@code null}, and the connection was closed - so every player was kicked
+ * off and the game could not advance.</p>
+ */
+class TWGameManagerArtilleryPacketTest {
+
+    private static final int VIEWING_PLAYER_ID = 0;
+    private static final int DEPARTED_PLAYER_ID = 2;
+    private static final int ALLY_PLAYER_ID = 1;
+    private static final int SHARED_TEAM = 1;
+
+    private TWGameManager gameManager;
+    private Game game;
+    private Player viewingPlayer;
+
+    @BeforeEach
+    void setUp() {
+        gameManager = new TWGameManager();
+        game = gameManager.getGame();
+        viewingPlayer = new Player(VIEWING_PLAYER_ID, "Dust Devils");
+        viewingPlayer.setTeam(SHARED_TEAM);
+        game.addPlayer(VIEWING_PLAYER_ID, viewingPlayer);
+        game.initializeRulesManager(OptionsConstants.RULES_CORE);
+    }
+
+    /** Adds an in-flight artillery attack fired by the given player id, as a loaded save would hold it. */
+    private void addInFlightArtilleryAttack(int firingPlayerId) {
+        ArtilleryAttackAction attack = mock(ArtilleryAttackAction.class);
+        when(attack.getPlayerId()).thenReturn(firingPlayerId);
+        WeaponHandler handler = mock(WeaponHandler.class);
+        handler.weaponAttackAction = attack;
+        game.addAttack(handler);
+    }
+
+    @Test
+    void artilleryPacketIsBuiltWhenTheFiringPlayerHasLeftTheGame() {
+        addInFlightArtilleryAttack(DEPARTED_PLAYER_ID);
+
+        Packet packet = assertDoesNotThrow(() -> gameManager.createArtilleryPacket(viewingPlayer));
+
+        assertNotNull(packet);
+    }
+
+    @Test
+    void aRoundFromADepartedPlayerIsNotTreatedAsFriendly() {
+        addInFlightArtilleryAttack(DEPARTED_PLAYER_ID);
+
+        Packet packet = gameManager.createArtilleryPacket(viewingPlayer);
+
+        // A firer that cannot be resolved has no team, so the round must not be sent as one of the viewer's own.
+        assertTrue(friendlyAttacksIn(packet).isEmpty());
+    }
+
+    @Test
+    void aRoundFromASurvivingTeammateIsStillSentInFull() {
+        Player ally = new Player(ALLY_PLAYER_ID, "Federated Commonwealth Alliance Additional Force");
+        ally.setTeam(SHARED_TEAM);
+        game.addPlayer(ALLY_PLAYER_ID, ally);
+        addInFlightArtilleryAttack(ALLY_PLAYER_ID);
+
+        Packet packet = gameManager.createArtilleryPacket(viewingPlayer);
+
+        assertEquals(1, friendlyAttacksIn(packet).size());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Vector<ArtilleryAttackAction> friendlyAttacksIn(Packet packet) {
+        return (Vector<ArtilleryAttackAction>) packet.getObject(0);
+    }
+}


### PR DESCRIPTION
## What this changes

A game could no longer be loaded once an artillery round outlived the player who fired it. Every client that tried to connect was disconnected straight away, so nobody could rejoin and the game could not advance. It now loads and plays on, and the round lands as the rules say it should.

This happens when a bot's last unit is destroyed with a shell still in the air. The player is dropped from the game, but the round stays in the attack list stamped with their id. Anything that then asked "who fired this" got nothing back and threw. The fix makes that question safe to ask: an unknown firer counts as nobody's ally, and the hex marker says "an unknown battery" instead of naming a player.

The reported crash was one of eleven places with the same unguarded lookup. Fixing only the reported one would have moved the problem, not removed it: the round in the reporter's save lands on the very next off-board phase, and the code that draws its landing marker had the same flaw.

Fixes #8685

## Testing

Full suite green: 15,390 tests, 0 failures, 0 errors, 8 skipped. `checkstyleMain` and `javadoc` both clean.

Three new tests in `TWGameManagerArtilleryPacketTest` cover the packet built for a connecting client, and two in `ArtilleryHandlerHelperTest` cover naming the firer. Two of the packet tests were verified by reverting the fix - they fail with the reporter's exact NullPointerException. The third, a round fired by a teammate who is still alive, passes with and without the fix, which is what shows the guard did not break the normal path.

A second commit skips the "incoming artillery" hex marker when the firer cannot be resolved, after review. That marker is team-visible, and `SpecialHexDisplay.isObscured()` treats a null owner as visible to everyone, so building one without an owner would show the aim hex to the whole game under double-blind. `ArtilleryIncomingMarkerTest` drives a real handler against a real board and checks both directions; it is revert-verified. The state is not reachable today - all three sites sit behind a once-only "just declared" flag that is never reset - so this is hardening, not a second defect.

The reporter's save was read directly to confirm the diagnosis rather than infer it: the player map holds ids 0, 1, 3, 4 and 5, and the attack list holds an in-flight Thumper from entity 143 stamped with player id 2, who is not in that map.

## What is not proven yet

The reporter's save has not been loaded in a running game. The unit tests reproduce the crash and show it is gone, but the end-to-end path of loading `base_assault.sav` and watching the Thumper land has not been walked.

The bay artillery and orbital bombardment paths were changed alongside the ground artillery ones because they share the same flaw. They are covered by the helper's unit tests and they compile, but no game has been played through either of those weapons with a departed firer.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
