### PR TITLE
Fix #8775: Princess abandoned Meks that were only temporarily overheated

### DIFF
--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -3143,16 +3143,28 @@ public class Princess extends BotClient {
         }
 
         final int dissipation = mover.getHeatCapacityWithWater();
+        return canJumpClear(mover, dissipation) || (dissipation > recurringHeat(mover, false));
+    }
 
-        // Heat never reduces jump MP, so a unit with working jets can leave under its own power - as long
-        // as it can afford the jump heat on top of everything else it is already gaining. A prone Mek does
-        // not get this: it has to stand up first, and standing needs walking MP it does not have.
-        if (!mover.isProne() && (0 < mover.getAnyTypeMaxJumpMP())
-              && (dissipation > recurringHeat(mover, true) + mover.getJumpHeat(CHEAPEST_JUMP_DISTANCE))) {
-            return true;
-        }
-
-        return dissipation > recurringHeat(mover, false);
+    /**
+     * Whether a heat-stalled unit can leave its hex by jumping rather than waiting to cool.
+     * <p>
+     * Heat never reduces jump MP, so a unit with working jets can move under its own power even at zero
+     * walking MP - as long as it can afford the jump's heat on top of everything else it is already
+     * gaining. Jumping also leaves any fire behind, which is why the recurring heat here excludes it. A
+     * prone Mek does not get this route: it has to stand up first, and standing needs walking MP it does
+     * not have.
+     * </p>
+     *
+     * @param mover       the unit being assessed
+     * @param dissipation the unit's heat dissipation per turn
+     *
+     * @return {@code true} if jumping one hex is sustainable for this unit
+     */
+    private boolean canJumpClear(final Entity mover, final int dissipation) {
+        return !mover.isProne()
+              && (0 < mover.getAnyTypeMaxJumpMP())
+              && (dissipation > recurringHeat(mover, true) + mover.getJumpHeat(CHEAPEST_JUMP_DISTANCE));
     }
 
     /**
@@ -3338,11 +3350,23 @@ public class Princess extends BotClient {
                 // it can still shed, in which case it moves again in a turn or two and is worth keeping.
                 if (isImmobilized(entity) && entity.isEjectionPossible()) {
                     if (canRecoverMobility(entity)) {
-                        LOGGER.info("{} cannot move but will recover: sinks {} against {} recurring heat."
-                                    + " Not abandoning it.",
-                              entity.getDisplayName(),
-                              entity.getHeatCapacityWithWater(),
-                              recurringHeat(entity, false));
+                        // Name the route that saved it, so the printed numbers always back the claim: a
+                        // unit jumping clear of a fire is not out-sinking the heat it is standing in.
+                        final int dissipation = entity.getHeatCapacityWithWater();
+                        if (canJumpClear(entity, dissipation)) {
+                            LOGGER.info("{} cannot walk but can jump clear: sinks {} against {} recurring"
+                                        + " heat plus {} jump heat. Not abandoning it.",
+                                  entity.getDisplayName(),
+                                  dissipation,
+                                  recurringHeat(entity, true),
+                                  entity.getJumpHeat(CHEAPEST_JUMP_DISTANCE));
+                        } else {
+                            LOGGER.info("{} cannot move but will cool: sinks {} against {} recurring heat."
+                                        + " Not abandoning it.",
+                                  entity.getDisplayName(),
+                                  dissipation,
+                                  recurringHeat(entity, false));
+                        }
                     } else {
                         msg = entity.getDisplayName() + " is immobile. Abandoning unit.";
                         LOGGER.info(msg);

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -113,6 +113,34 @@ public class Princess extends BotClient {
     private static final int MAX_OVERHEAT_AMS = 14;
 
     /**
+     * Heat a unit standing in a burning hex gains every turn, halved for a Mek with intact
+     * heat-dissipating armor. Mirrors the fire check in the server's {@code HeatResolver}.
+     */
+    private static final int FIRE_HEAT_PER_TURN = 5;
+
+    /**
+     * Heat an active Nova CEWS adds every turn. There is no shared constant for any of the four values
+     * below; each mirrors the literal the server's {@code HeatResolver} charges.
+     */
+    private static final int NOVA_CEWS_HEAT_PER_TURN = 2;
+
+    /** Heat an active Null Signature System adds every turn. */
+    private static final int NULL_SIGNATURE_HEAT_PER_TURN = 10;
+
+    /** Heat an active Void Signature System adds every turn. */
+    private static final int VOID_SIGNATURE_HEAT_PER_TURN = 10;
+
+    /** Heat an active Chameleon Light Polarization Shield adds every turn. */
+    private static final int CHAMELEON_SHIELD_HEAT_PER_TURN = 6;
+
+    /**
+     * Number of jump MP priced when asking whether a heat-stalled unit can afford to jump clear. One hex
+     * is the cheapest jump that gets a unit moving again, and Princess chooses the path, so this is the
+     * least the unit could commit to rather than the jump it would most likely make.
+     */
+    private static final int CHEAPEST_JUMP_DISTANCE = 1;
+
+    /**
      * Highest target number to consider when not aiming at the head on an immobile Mek
      */
     private static final int SHUTDOWN_MAX_TARGET_NUMBER = 12;
@@ -3076,6 +3104,122 @@ public class Princess extends BotClient {
         }
     }
 
+    /**
+     * Whether a unit that cannot move right now is expected to move again under its own power.
+     * <p>
+     * Movement lost to damage is gone for the rest of the battle, but movement lost to heat comes back as
+     * soon as the unit cools: heat costs a unit one MP for every five heat points, so a Mek walking 5 has
+     * nothing left at 25 heat and walks again the moment it drops back to 24. A unit in that state is
+     * stalled, not finished, and abandoning it throws away a working machine.
+     * </p><p>
+     * A stalled unit has two ways out and only needs one of them. It can stand still and let its heat
+     * sinks win, which they do whenever they out-dissipate the heat that arrives every turn no matter what
+     * the pilot chooses to do. Or, if it still has working jump jets, it can jump clear - which leaves any
+     * fire behind but costs jump heat instead. Both comparisons are strictly greater: a unit whose sinks
+     * exactly match its incoming heat holds that heat forever and never moves again.
+     * </p>
+     *
+     * @param mover the unit {@link #isImmobilized(Entity)} has reported as unable to move
+     *
+     * @return {@code true} if the unit is expected to move again without help
+     */
+    boolean canRecoverMobility(final Entity mover) {
+        // Only heat is temporary. A unit that still has movement points was called immobilized for some
+        // other reason - prone with poor odds of standing, or bogged down - and no amount of cooling
+        // changes that, so it is not this method's business.
+        if (0 < mover.getRunMP()) {
+            return false;
+        }
+
+        // The core rules already measure this with heat ignored, so anything it catches is damage rather
+        // than temperature: legs gone, gyro destroyed, or prone with no walking MP left to stand on.
+        if (mover.isPermanentlyImmobilized(true)) {
+            return false;
+        }
+
+        // A unit that does not track heat did not lose its movement to heat, so there is nothing to wait out.
+        if (Entity.DOES_NOT_TRACK_HEAT == mover.getHeatCapacity()) {
+            return false;
+        }
+
+        final int dissipation = mover.getHeatCapacityWithWater();
+
+        // Heat never reduces jump MP, so a unit with working jets can leave under its own power - as long
+        // as it can afford the jump heat on top of everything else it is already gaining. A prone Mek does
+        // not get this: it has to stand up first, and standing needs walking MP it does not have.
+        if (!mover.isProne() && (0 < mover.getAnyTypeMaxJumpMP())
+              && (dissipation > recurringHeat(mover, true) + mover.getJumpHeat(CHEAPEST_JUMP_DISTANCE))) {
+            return true;
+        }
+
+        return dissipation > recurringHeat(mover, false);
+    }
+
+    /**
+     * Heat this unit gains every turn whatever its pilot decides to do. Weapon heat and movement heat are
+     * choices and are therefore left out, and so is stealth armor: {@code BotClient.toggleStealth()}
+     * already switches that off in the end phase once a unit passes roughly 13 to 19 heat, so a
+     * heat-stalled unit has shed it before this question is ever asked.
+     * <p>
+     * What is left is engine criticals, a burning hex the unit cannot walk out of, and the concealment
+     * systems no bot code touches: Null Signature, Void Signature, Chameleon Light Polarization Shield
+     * and Nova CEWS. Their heat really does keep arriving. See MegaMek/megamek#8802, which proposes
+     * folding them into the same end-phase utility that handles stealth armor.
+     * </p>
+     *
+     * @param mover          the unit being assessed
+     * @param leavingThisHex {@code true} when the unit is about to jump out of its current hex, which
+     *                       means any fire it is standing in stops being its problem
+     *
+     * @return heat points added per turn that the pilot cannot avoid
+     */
+    int recurringHeat(final Entity mover, final boolean leavingThisHex) {
+        int recurring = mover.getEngineCritHeat();
+
+        if (!leavingThisHex && isStandingInFire(mover)) {
+            int fireHeat = FIRE_HEAT_PER_TURN;
+            if ((mover instanceof Mek mek) && mek.hasIntactHeatDissipatingArmor()) {
+                fireHeat /= 2;
+            }
+            recurring += fireHeat;
+        }
+
+        if (mover.isNullSigOn()) {
+            recurring += NULL_SIGNATURE_HEAT_PER_TURN;
+        }
+
+        if (mover.isVoidSigOn()) {
+            recurring += VOID_SIGNATURE_HEAT_PER_TURN;
+        }
+
+        if (mover.isChameleonShieldOn()) {
+            recurring += CHAMELEON_SHIELD_HEAT_PER_TURN;
+        }
+
+        if (mover.hasActiveNovaCEWS()) {
+            recurring += NOVA_CEWS_HEAT_PER_TURN;
+        }
+
+        return recurring;
+    }
+
+    /**
+     * Whether this unit is taking heat from a fire in its own hex. Mirrors the fire check in the server's
+     * heat resolver, including the requirement that the fire started on an earlier turn.
+     *
+     * @param mover the unit being assessed
+     *
+     * @return {@code true} if the unit's hex is burning and the unit is low enough to be burned by it
+     */
+    private boolean isStandingInFire(final Entity mover) {
+        if (!mover.tracksHeat() || (0 != mover.getAltitude()) || (1 < mover.getElevation())) {
+            return false;
+        }
+
+        final Hex hex = getGame().getHex(mover.getPosition(), mover.getBoardId());
+        return (null != hex) && hex.containsTerrain(Terrains.FIRE) && (0 < hex.getFireTurn());
+    }
+
     boolean isImmobilized(final Entity mover) {
         if (mover.isImmobile() && !mover.isShutDown()) {
             LOGGER.info("Is truly immobile.");
@@ -3190,14 +3334,23 @@ public class Princess extends BotClient {
                     return mp;
                 }
 
-                // If we want to flee, but cannot, eject the crew.
+                // If we want to flee but cannot, eject the crew - unless the unit is only stopped by heat
+                // it can still shed, in which case it moves again in a turn or two and is worth keeping.
                 if (isImmobilized(entity) && entity.isEjectionPossible()) {
-                    msg = entity.getDisplayName() + " is immobile. Abandoning unit.";
-                    LOGGER.info(msg);
-                    sendChat(msg, Level.ERROR);
-                    final MovePath mp = new MovePath(game, entity);
-                    mp.addStep(MoveStepType.EJECT);
-                    return mp;
+                    if (canRecoverMobility(entity)) {
+                        LOGGER.info("{} cannot move but will recover: sinks {} against {} recurring heat."
+                                    + " Not abandoning it.",
+                              entity.getDisplayName(),
+                              entity.getHeatCapacityWithWater(),
+                              recurringHeat(entity, false));
+                    } else {
+                        msg = entity.getDisplayName() + " is immobile. Abandoning unit.";
+                        LOGGER.info(msg);
+                        sendChat(msg, Level.ERROR);
+                        final MovePath mp = new MovePath(game, entity);
+                        mp.addStep(MoveStepType.EJECT);
+                        return mp;
+                    }
                 }
             }
 

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -1294,4 +1294,250 @@ class PrincessTest {
             verify(path).addStep(MoveStepType.EVADE);
         }
     }
+
+    /**
+     * Regression tests for {@link Princess#canRecoverMobility(Entity)} (issue #8775): a Mek whose
+     * movement has been eaten by heat is stalled, not finished, and its crew must not be ejected while
+     * its heat sinks are still winning. The numbers come from the units in the reporter's game log.
+     */
+    @Nested
+    class CanRecoverMobilityTests {
+
+        private Game mockGame;
+        private Hex mockHex;
+
+        @BeforeEach
+        void setUpGate() {
+            mockGame = mock(Game.class);
+            mockHex = mock(Hex.class);
+            when(mockHex.containsTerrain(Terrains.FIRE)).thenReturn(false);
+            when(mockGame.getHex(any(Coords.class), anyInt())).thenReturn(mockHex);
+            doReturn(mockGame).when(mockPrincess).getGame();
+            when(mockPrincess.canRecoverMobility(any(Entity.class))).thenCallRealMethod();
+            when(mockPrincess.recurringHeat(any(Entity.class), anyBoolean())).thenCallRealMethod();
+        }
+
+        /**
+         * A heat-stalled Mek with the given dissipation and engine damage: standing, no jump jets, no
+         * stealth armor, no Nova CEWS, and a hex that is not burning.
+         */
+        private Mek stalledMek(int heatCapacity, int engineCritHeat) {
+            Mek mockMek = mock(BipedMek.class);
+            when(mockMek.isPermanentlyImmobilized(true)).thenReturn(false);
+            when(mockMek.getRunMP()).thenReturn(0);
+            when(mockMek.getHeatCapacity()).thenReturn(heatCapacity);
+            when(mockMek.getHeatCapacityWithWater()).thenReturn(heatCapacity);
+            when(mockMek.getEngineCritHeat()).thenReturn(engineCritHeat);
+            when(mockMek.isProne()).thenReturn(false);
+            when(mockMek.getAnyTypeMaxJumpMP()).thenReturn(0);
+            when(mockMek.isNullSigOn()).thenReturn(false);
+            when(mockMek.isVoidSigOn()).thenReturn(false);
+            when(mockMek.isChameleonShieldOn()).thenReturn(false);
+            when(mockMek.hasActiveNovaCEWS()).thenReturn(false);
+            when(mockMek.tracksHeat()).thenReturn(true);
+            when(mockMek.getAltitude()).thenReturn(0);
+            when(mockMek.getElevation()).thenReturn(0);
+            when(mockMek.getPosition()).thenReturn(new Coords(5, 5));
+            when(mockMek.getBoardId()).thenReturn(0);
+            return mockMek;
+        }
+
+        /** Sets the Mek's hex burning, with the fire having started on an earlier turn. */
+        private void setHexOnFire() {
+            when(mockHex.containsTerrain(Terrains.FIRE)).thenReturn(true);
+            when(mockHex.getFireTurn()).thenReturn(2);
+        }
+
+        /** Gives the Mek working jump jets that cost the stated heat for a single hex. */
+        private void giveJumpJets(Mek mockMek, int jumpMP, int cheapestJumpHeat) {
+            when(mockMek.getAnyTypeMaxJumpMP()).thenReturn(jumpMP);
+            when(mockMek.getJumpHeat(1)).thenReturn(cheapestJumpHeat);
+        }
+
+        @Test
+        void carronadeCoolsAndKeepsItsPilot() {
+            // Carronade CRN-7M from the log: 10 IS doubles, so 20 points of dissipation, against two
+            // engine criticals. It sheds 10 a turn and walks again next turn.
+            assertTrue(mockPrincess.canRecoverMobility(stalledMek(20, 10)));
+        }
+
+        @Test
+        void huronWarriorCoolsSlowlyAndStillKeepsItsPilot() {
+            // Huron Warrior HUR-WO-R4L from the log: 11 single sinks against two engine criticals. One
+            // point a turn is slow, but the heat is coming down, so the Mek is not abandoned.
+            assertTrue(mockPrincess.canRecoverMobility(stalledMek(11, 10)));
+        }
+
+        @Test
+        void breakingEvenIsNotRecovery() {
+            // Dissipation exactly matching the incoming heat holds that heat forever. The comparison has
+            // to be strictly greater or this Mek stands at zero MP for the rest of the game.
+            assertFalse(mockPrincess.canRecoverMobility(stalledMek(10, 10)));
+        }
+
+        @Test
+        void fireInTheHexIsCountedWhenTheMekCannotLeave() {
+            // The same Huron Warrior, now standing in a fire: 11 against 10 engine plus 5 fire. With no
+            // jump jets it cannot get out of the hex, so the fire heat never stops.
+            Mek mockMek = stalledMek(11, 10);
+            setHexOnFire();
+            assertFalse(mockPrincess.canRecoverMobility(mockMek));
+        }
+
+        @Test
+        void heatDissipatingArmorHalvesTheFireHeat() {
+            // Intact heat-dissipating armor takes 2 from the fire rather than 5, which brings the Mek
+            // back under its 13 points of dissipation.
+            Mek mockMek = stalledMek(13, 10);
+            when(mockMek.hasIntactHeatDissipatingArmor()).thenReturn(true);
+            setHexOnFire();
+            assertTrue(mockPrincess.canRecoverMobility(mockMek));
+        }
+
+        @Test
+        void jumpingOutOfAFireLeavesTheFireBehind() {
+            // Grasshopper GHR-5H with 8 sinks shot away, two engine criticals, standing in a fire.
+            // Staying is 14 against 15 and fails; jumping is 14 against 10 engine plus 3 jump heat and
+            // succeeds, because the fire stops being its problem the moment it leaves the hex.
+            Mek mockMek = stalledMek(14, 10);
+            giveJumpJets(mockMek, 4, 3);
+            setHexOnFire();
+            assertTrue(mockPrincess.canRecoverMobility(mockMek));
+        }
+
+        @Test
+        void jumpHeatCanMakeTheEscapeUnaffordable() {
+            // The same situation with two fewer working sinks: 12 against 15 standing still, and 12
+            // against 13 jumping. The jets are there and it still cannot use them.
+            Mek mockMek = stalledMek(12, 10);
+            giveJumpJets(mockMek, 4, 3);
+            setHexOnFire();
+            assertFalse(mockPrincess.canRecoverMobility(mockMek));
+        }
+
+        @Test
+        void anXxlEngineIsChargedTheHigherMinimumJumpHeat() {
+            // Same numbers as the Grasshopper above, but an XXL engine pays max(6, hexes * 2) rather
+            // than max(3, hexes). Six heat rather than three is the difference between getting out of
+            // the fire and not.
+            Mek mockMek = stalledMek(14, 10);
+            giveJumpJets(mockMek, 4, 6);
+            setHexOnFire();
+            assertFalse(mockPrincess.canRecoverMobility(mockMek));
+        }
+
+        @Test
+        void aMechanicalJumpBoosterCostsNoHeat() {
+            // Jump boosters are not engine-driven, so they cost nothing to use. The Mek that could not
+            // afford a 3-heat jump out of the fire can afford a free one.
+            Mek mockMek = stalledMek(12, 10);
+            giveJumpJets(mockMek, 2, 0);
+            setHexOnFire();
+            assertTrue(mockPrincess.canRecoverMobility(mockMek));
+        }
+
+        @Test
+        void aProneMekCannotUseItsJumpJets() {
+            // The Grasshopper again, knocked down. Standing up needs walking MP, which heat has taken,
+            // so the jets are out of reach and the fire keeps burning it.
+            Mek mockMek = stalledMek(14, 10);
+            giveJumpJets(mockMek, 4, 3);
+            setHexOnFire();
+            when(mockMek.isProne()).thenReturn(true);
+            assertFalse(mockPrincess.canRecoverMobility(mockMek));
+        }
+
+        @Test
+        void jumpingDoesNotRescueAMekThatCannotCool() {
+            // Wolverine WVR-6R with 3 sinks destroyed and two engine criticals: 9 dissipation against 10
+            // engine heat, with no fire to escape. Jumping only adds heat, so it buys nothing.
+            Mek mockMek = stalledMek(9, 10);
+            giveJumpJets(mockMek, 5, 3);
+            assertFalse(mockPrincess.canRecoverMobility(mockMek));
+        }
+
+        @Test
+        void stealthArmorIsNotCountedBecauseTheBotAlreadyShedsIt() {
+            // Huron Warrior HUR-WO-R4N, the stealth variant: 20 dissipation against 10 engine heat.
+            // BotClient.toggleStealth already switches the armor off in the end phase once the Mek is
+            // over roughly 13 to 19 heat, and this Mek is at 25, so its 10 points are not recurring.
+            Mek mockMek = stalledMek(20, 10);
+            when(mockMek.isStealthOn()).thenReturn(true);
+            assertTrue(mockPrincess.canRecoverMobility(mockMek));
+        }
+
+        @Test
+        void nullSignatureHeatIsCounted() {
+            // Nothing in the bot switches a Null Signature System off, so its 10 points a turn keep
+            // arriving and this Mek never cools.
+            Mek mockMek = stalledMek(20, 10);
+            when(mockMek.isNullSigOn()).thenReturn(true);
+            assertFalse(mockPrincess.canRecoverMobility(mockMek));
+        }
+
+        @Test
+        void voidSignatureHeatIsCounted() {
+            // Same 10 points a turn, same lack of any bot code to switch it off.
+            Mek mockMek = stalledMek(20, 10);
+            when(mockMek.isVoidSigOn()).thenReturn(true);
+            assertFalse(mockPrincess.canRecoverMobility(mockMek));
+        }
+
+        @Test
+        void chameleonShieldHeatIsCounted() {
+            // A Chameleon Light Polarization Shield is 6 a turn, which is enough to close a 5-point gap.
+            Mek mockMek = stalledMek(15, 10);
+            when(mockMek.isChameleonShieldOn()).thenReturn(true);
+            assertFalse(mockPrincess.canRecoverMobility(mockMek));
+        }
+
+        @Test
+        void novaCewsHeatIsCounted() {
+            // Two points a turn is enough to turn a Mek that was clearing its bar by exactly one into a
+            // Mek that never cools.
+            Mek mockMek = stalledMek(11, 10);
+            when(mockMek.hasActiveNovaCEWS()).thenReturn(true);
+            assertFalse(mockPrincess.canRecoverMobility(mockMek));
+        }
+
+        @Test
+        void damageThatIsNotHeatIsStillPermanent() {
+            // Both legs gone. The core rules already measure this with heat ignored, so no amount of
+            // cooling brings the movement back and the crew should get out.
+            Mek mockMek = stalledMek(20, 0);
+            when(mockMek.isPermanentlyImmobilized(true)).thenReturn(true);
+            assertFalse(mockPrincess.canRecoverMobility(mockMek));
+        }
+
+        @Test
+        void aUnitThatDoesNotTrackHeatIsUnaffected() {
+            // A vehicle never lost its movement to heat, so the gate leaves it exactly as it was.
+            Tank mockTank = mock(Tank.class);
+            when(mockTank.isPermanentlyImmobilized(true)).thenReturn(false);
+            when(mockTank.getRunMP()).thenReturn(0);
+            when(mockTank.getHeatCapacity()).thenReturn(Entity.DOES_NOT_TRACK_HEAT);
+            assertFalse(mockPrincess.canRecoverMobility(mockTank));
+        }
+
+        @Test
+        void aProneMekThatStillHasMovementIsNotAHeatCase() {
+            // isImmobilized also reports true for a Mek that is prone with poor odds of standing back
+            // up, which has nothing to do with temperature. Found in headless play: a cool, undamaged
+            // Doloire with 28 points of dissipation and no recurring heat was being held on the field
+            // because it had fallen over. If the unit still has run MP, cooling cannot be the answer.
+            Mek mockMek = stalledMek(28, 0);
+            when(mockMek.getRunMP()).thenReturn(6);
+            when(mockMek.isProne()).thenReturn(true);
+            assertFalse(mockPrincess.canRecoverMobility(mockMek));
+        }
+
+        @Test
+        void aStuckMekThatStillHasMovementIsNotAHeatCase() {
+            // Same reasoning for a Mek bogged down in a swamp: its movement is not heat's doing.
+            Mek mockMek = stalledMek(28, 0);
+            when(mockMek.getRunMP()).thenReturn(4);
+            when(mockMek.isStuck()).thenReturn(true);
+            assertFalse(mockPrincess.canRecoverMobility(mockMek));
+        }
+    }
 }


### PR DESCRIPTION
## What this changes

Princess no longer ejects the pilot from a Mek that has simply run too hot. Heat costs a unit one MP for every five heat points, so a Mek walking 5 has nothing left at 25 heat - and that movement comes straight back as it cools. The bot treated that the same as having its legs blown off and abandoned the machine.

Fixes #8775

A withdrawing unit that cannot move is now only abandoned when it will not move again on its own. It still ejects for damage, for a unit that never tracked heat, and for a unit whose heat sinks cannot beat the heat arriving every turn - engine criticals, a burning hex it cannot walk out of, or concealment gear no bot code switches off. A unit with working jets gets a second way out: jumping leaves the fire behind but costs the cheapest jump's heat instead.

In the reporter's own game log, a Carronade CRN-7M with 20 points of dissipation and 10 points of recurring heat had its pilot ejected while it was two turns from walking again.

`isImmobilized()` is untouched, so move ordering behaves exactly as before. Stealth armor is deliberately not counted as unavoidable heat, because `BotClient.toggleStealth()` already sheds it in the end phase above roughly 13 to 19 heat.

This covers **both bots**. The gate lives in `Princess.continueMovementFor`, and CASPAR reaches it because its override falls through to `super.continueMovementFor(entity)` for every unit that is not an aero taking off or landing.

## Testing

`./gradlew test --tests "megamek.client.bot.princess.*"` - 430 tests, 0 failures, including 20 new ones in `PrincessTest.CanRecoverMobilityTests`. Their numbers come from the units in the reporter's log: the Carronade and Huron Warrior that ejected, plus a Grasshopper jumping out of a fire and a Wolverine that cannot afford to.

Revert-verified: stubbing `canRecoverMobility()` to always return `false`, which is exactly the old behaviour, fails 6 of the 20 - the six that assert a pilot is kept.

`./gradlew compileJava compileTestJava checkstyleMain` clean. `./gradlew javadoc` run separately, clean.

Headless, 12 games through `AIMatchRunner` on a scenario built for this: a lance of heat-fragile Meks under Forced Withdrawal against four Doloire DLR-OA, the plasma-and-SRM unit that cooked the reporter's Meks. Six games with the gate and six with it stubbed off. With the gate, a Huron Warrior HUR-WO-R4L with 11 points of dissipation against 5 recurring heat was held rather than abandoned, and a second Huron Warrior that could not cool was still abandoned. The two runs are not seed-paired, so this shows the gate firing correctly in play rather than a controlled before-and-after.

Headless testing also found a real bug in the first version of this fix. `isImmobilized()` also reports true for a Mek that is prone with poor odds of standing, or bogged down, and the gate was overriding those - it held a cool, undamaged Doloire on the field with 28 points of dissipation and no recurring heat at all, purely because it had fallen over. Fixed by refusing the question whenever the unit still has run MP, and covered by two of the new tests.

## What is not proven yet

Not tested in a live GUI game or in a campaign, so this does not carry the **AI ready for Review** label yet.

The fire-hex and jump-clear branches are covered by unit tests only. No headless game happened to produce a Mek stalled inside a fire, so those two paths have not run in a real game.

Whether a held Mek then cooks itself by carrying on shooting is not measured. `FireControl.projectedEndOfTurnHeat()` omits `getEngineCritHeat()`, so the bot's own heat forecast is optimistic by 5 points per engine critical - noted in #8802, not touched here.

The headless scenario is not in this PR. It belongs in mm-data alongside the other `PrincessEval_*` files, and can be added there if it is worth keeping.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
