### PR TITLE
Close #8786: Let a Gamemaster add units to any player from the lobby

### DIFF
--- a/megamek/src/megamek/client/ui/clientGUI/UnitRecipients.java
+++ b/megamek/src/megamek/client/ui/clientGUI/UnitRecipients.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Set;
 
 import megamek.common.Player;
+import megamek.logging.MMLogger;
 
 /**
  * Which players the person at this screen may add units to.
@@ -56,6 +57,8 @@ import megamek.common.Player;
  * always done it.</p>
  */
 public final class UnitRecipients {
+
+    private static final MMLogger LOGGER = MMLogger.create(UnitRecipients.class);
 
     private UnitRecipients() {
     }
@@ -81,6 +84,11 @@ public final class UnitRecipients {
                 recipients.add(player);
             }
         }
+        // at INFO because the shipped logging runs at INFO, and the question this answers - "why is that player
+        // not in the list" - is one a playtest has to be able to settle from the log. Once per dialog opening.
+        LOGGER.info("[GMAddUnit] {} (gamemaster: {}) may add units to {} of {} player(s): {}",
+              localPlayer.getName(), localPlayer.isGameMaster(), recipients.size(), allPlayers.size(),
+              recipients.stream().map(Player::getName).toList());
         return recipients;
     }
 

--- a/megamek/src/megamek/client/ui/clientGUI/UnitRecipients.java
+++ b/megamek/src/megamek/client/ui/clientGUI/UnitRecipients.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.ui.clientGUI;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import megamek.common.Player;
+
+/**
+ * Which players the person at this screen may add units to.
+ *
+ * <p>Ordinarily that is themselves and any bot they are running, because those are the forces they own. A
+ * gamemaster may add units to anyone: handing out forces is most of what a gamemaster does before a game starts,
+ * and doing it any other way means adding every batch to yourself and then reassigning it a group at a time.</p>
+ *
+ * <p>The rule lives here, on its own, because four separate dialogs ask it - the unit selector, the random army
+ * generator, the force generator and the unit list loader - and a rule answered differently in one of them is how
+ * a dialog comes to say it gave units to one player while giving them to another.</p>
+ *
+ * <p>This asks about players rather than clients on purpose. A remote human has no client on this machine, so
+ * anything that looks for one finds nothing and quietly falls back to the local player; the units are owned by
+ * whoever is named here and sent over the local connection, which is how the in-game reinforcement path has
+ * always done it.</p>
+ */
+public final class UnitRecipients {
+
+    private UnitRecipients() {
+    }
+
+    /**
+     * The players the local player may add units to, in the order they should be offered.
+     *
+     * <p>The local player comes first so that a chooser landing on its first entry lands on the person using it,
+     * which is what happens today and what someone adding units to their own force expects.</p>
+     *
+     * @param localPlayer   The player at this screen
+     * @param allPlayers    Every player in the game
+     * @param localBotNames The names of the bots being run from this machine
+     *
+     * @return the players that may be given units, local player first; never empty
+     */
+    public static List<Player> availableTo(Player localPlayer, Collection<Player> allPlayers,
+          Set<String> localBotNames) {
+        List<Player> recipients = new ArrayList<>();
+        recipients.add(localPlayer);
+        for (Player player : allPlayers) {
+            if (mayBeGivenUnits(player, localPlayer, localBotNames)) {
+                recipients.add(player);
+            }
+        }
+        return recipients;
+    }
+
+    /**
+     * @param player        The player being considered
+     * @param localPlayer   The player at this screen
+     * @param localBotNames The names of the bots being run from this machine
+     *
+     * @return {@code true} when the local player may add units to that player, other than to themselves
+     */
+    private static boolean mayBeGivenUnits(Player player, Player localPlayer, Set<String> localBotNames) {
+        if (player.getId() == localPlayer.getId()) {
+            // already first in the list; a second entry would offer the same person twice
+            return false;
+        }
+        boolean isABotFromThisMachine = localBotNames.contains(player.getName());
+        return isABotFromThisMachine || localPlayer.isGameMaster();
+    }
+}

--- a/megamek/src/megamek/client/ui/dialogs/randomArmy/ForceGeneratorViewUi.java
+++ b/megamek/src/megamek/client/ui/dialogs/randomArmy/ForceGeneratorViewUi.java
@@ -279,25 +279,21 @@ public class ForceGeneratorViewUi implements ActionListener {
     /**
      * Adds the chosen units to the game
      */
-    public void addChosenUnits(String playerName, ClientGUI clientGui) {
+    public void addChosenUnits(Player owner, ClientGUI clientGui) {
         if ((null != forceTree.getModel().getRoot())
               && (forceTree.getModel().getRoot() instanceof ForceDescriptor)) {
             configureNetworks((ForceDescriptor) forceTree.getModel().getRoot());
         }
 
         List<Entity> entities = new ArrayList<>(modelChosen.allEntities().size());
-        Client c = null;
-        if (null != playerName) {
-            c = (Client) clientGui.getLocalBots().get(playerName);
-        }
-        if (null == c) {
-            c = clientGui.getClient();
-        }
+        // the units belong to the player that was chosen; they are sent over this machine's own connection,
+        // because a remote player has no client here to send through
+        Client localClient = clientGui.getClient();
         for (Entity e : modelChosen.allEntities()) {
-            e.setOwner(c.getLocalPlayer());
-            if (!c.getGame().getPhase().isLounge()) {
-                e.setDeployRound(c.getGame().getRoundCount() + 1);
-                e.setGame(c.getGame());
+            e.setOwner(owner);
+            if (!localClient.getGame().getPhase().isLounge()) {
+                e.setDeployRound(localClient.getGame().getRoundCount() + 1);
+                e.setGame(localClient.getGame());
                 // Set these to true, otherwise units reinforced in
                 // the movement turn are considered selectable
                 e.setDone(true);
@@ -312,9 +308,10 @@ public class ForceGeneratorViewUi implements ActionListener {
             }
             entities.add(e);
         }
-        c.sendAddEntity(entities);
+        localClient.sendAddEntity(entities);
 
-        String msg = clientGui.getClient().getLocalPlayer() + " loaded Units from Random Army for player: " + playerName
+        String msg = clientGui.getClient().getLocalPlayer() + " loaded Units from Random Army for player: "
+              + owner.getName()
               + " [" + entities.size() + " units]";
         clientGui.getClient().sendServerChat(Player.PLAYER_NONE, msg);
 

--- a/megamek/src/megamek/client/ui/dialogs/randomArmy/RandomArmyDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/randomArmy/RandomArmyDialog.java
@@ -165,7 +165,6 @@ public class RandomArmyDialog extends AbstractRandomArmyDialog {
         setVisible(false);
     }
 
-    /** @return the client the generated units belong to: a chosen local bot, or this player */
     /**
      * @return the player the generated units should belong to, which is the local player when the chooser holds
      *       something no longer in the game
@@ -180,6 +179,7 @@ public class RandomArmyDialog extends AbstractRandomArmyDialog {
               .orElse(client.getLocalPlayer());
     }
 
+    /** @return the client the generated units belong to: a chosen local bot, or this player */
     private Client selectedClient() {
         if (playerChooser.getSelectedIndex() > 0) {
             Client botClient = (Client) clientGui.getLocalBots().get((String) playerChooser.getSelectedItem());

--- a/megamek/src/megamek/client/ui/dialogs/randomArmy/RandomArmyDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/randomArmy/RandomArmyDialog.java
@@ -45,15 +45,16 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
 
-import megamek.client.AbstractClient;
 import megamek.client.Client;
 import megamek.client.generator.RandomGenderGenerator;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.client.ratgenerator.GenerationContext;
 import megamek.client.ui.Messages;
 import megamek.client.ui.clientGUI.ClientGUI;
+import megamek.client.ui.clientGUI.UnitRecipients;
 import megamek.client.ui.dialogs.buttonDialogs.SkillGenerationDialog;
 import megamek.common.Player;
+import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
 import megamek.common.event.GameListener;
 import megamek.common.event.GameListenerAdapter;
@@ -122,24 +123,26 @@ public class RandomArmyDialog extends AbstractRandomArmyDialog {
 
     private void okAction() {
         if (tabbedPane.getSelectedIndex() == TAB_FORCE_GENERATOR) {
-            Client selectedClient = selectedClient();
-            forceGeneratorPanel.addChosenUnits((String) playerChooser.getSelectedItem(), clientGui);
+            forceGeneratorPanel.addChosenUnits(selectedPlayer(), clientGui);
             // The Force Generator knows more about what it rolled than any other tab, so it records
             // the same context as the rest rather than being the one source that reports nothing.
-            recordGenerationContext(selectedClient);
+            recordGenerationContext(selectedPlayer());
         } else {
             ArrayList<Entity> entities = new ArrayList<>(chosenUnitsModel.getAllUnits().size());
             Client selectedClient = selectedClient();
-            recordGenerationContext(selectedClient);
+            Player owner = selectedPlayer();
+            recordGenerationContext(owner);
             for (MekSummary ms : chosenUnitsModel.getAllUnits()) {
                 try {
                     Entity entity = new MekFileParser(ms.getSourceFile(), ms.getEntryName()).getEntity();
 
+                    // skills still come from the chosen bot's own generator where there is one; only who owns
+                    // the unit has moved, because a remote player has no client here to generate from
                     autoSetSkillsAndName(entity, selectedClient);
-                    entity.setOwner(selectedClient.getLocalPlayer());
-                    if (!selectedClient.getGame().getPhase().isLounge()) {
-                        entity.setDeployRound(selectedClient.getGame().getRoundCount() + 1);
-                        entity.setGame(selectedClient.getGame());
+                    entity.setOwner(owner);
+                    if (!client.getGame().getPhase().isLounge()) {
+                        entity.setDeployRound(client.getGame().getRoundCount() + 1);
+                        entity.setGame(client.getGame());
                         // Set these to true, otherwise units reinforced in the movement turn are considered selectable
                         entity.setDone(true);
                         entity.setUnloaded(true);
@@ -150,9 +153,10 @@ public class RandomArmyDialog extends AbstractRandomArmyDialog {
                     return;
                 }
             }
-            selectedClient.sendAddEntity(entities);
+            // sent over this machine's own connection whoever the units are for
+            client.sendAddEntity(entities);
             String msg = "%s loaded Units from Random Army for player: %s [%d units]"
-                  .formatted(client.getLocalPlayer(), playerChooser.getSelectedItem(), entities.size());
+                  .formatted(client.getLocalPlayer(), owner.getName(), entities.size());
             client.sendServerChat(Player.PLAYER_NONE, msg);
             clearData();
         }
@@ -161,6 +165,20 @@ public class RandomArmyDialog extends AbstractRandomArmyDialog {
     }
 
     /** @return the client the generated units belong to: a chosen local bot, or this player */
+    /**
+     * @return the player the generated units should belong to, which is the local player when the chooser holds
+     *       something no longer in the game
+     */
+    private Player selectedPlayer() {
+        String chosenName = (String) playerChooser.getSelectedItem();
+        return client.getGame()
+              .getPlayersList()
+              .stream()
+              .filter(player -> player.getName().equals(chosenName))
+              .findFirst()
+              .orElse(client.getLocalPlayer());
+    }
+
     private Client selectedClient() {
         if (playerChooser.getSelectedIndex() > 0) {
             Client botClient = (Client) clientGui.getLocalBots().get((String) playerChooser.getSelectedItem());
@@ -176,9 +194,8 @@ public class RandomArmyDialog extends AbstractRandomArmyDialog {
      * organizes its own. The team faction is set from the same context, which is what the munition
      * autoconfigurator and the name generator read.
      */
-    private void recordGenerationContext(Client selectedClient) {
+    private void recordGenerationContext(Player owner) {
         GenerationContext context = getGenerationContext();
-        Player owner = selectedClient.getLocalPlayer();
 
         // Only a generator that asked the player anything gets recorded. A tab that knows nothing
         // has nothing to say, and recording its default would erase a real choice made on an earlier
@@ -202,16 +219,12 @@ public class RandomArmyDialog extends AbstractRandomArmyDialog {
     }
 
     private void updatePlayerChoice(String selectionName) {
-        String clientName = client.getName();
         playerChooser.setEnabled(false);
         playerChooser.removeAllItems();
-        playerChooser.addItem(clientName);
-        for (AbstractClient botClient : clientGui.getLocalBots().values()) {
-            Player player = client.getGame().getPlayer(botClient.getLocalPlayerNumber());
-
-            if (!player.isObserver()) {
-                playerChooser.addItem(botClient.getName());
-            }
+        for (Player player : UnitRecipients.availableTo(client.getLocalPlayer(),
+              client.getGame().getPlayersList(),
+              clientGui.getLocalBots().keySet())) {
+            playerChooser.addItem(player.getName());
         }
         if (playerChooser.getItemCount() > 1) {
             playerChooser.setEnabled(true);
@@ -227,12 +240,29 @@ public class RandomArmyDialog extends AbstractRandomArmyDialog {
         updatePlayerChoice(lastChoice);
     }
 
-    public void setPlayerFromClient(Client c) {
-        if (c != null) {
-            updatePlayerChoice(c.getName());
-        } else {
+    /**
+     * Points the player chooser at the given player, so a dialog opened from a chosen player opens on them.
+     *
+     * @param player The player to select, or {@code null} to leave the chooser where it was
+     */
+    public void setPlayerFrom(@Nullable Player player) {
+        if (player == null) {
             updatePlayerChoice();
+        } else {
+            updatePlayerChoice(player.getName());
         }
+    }
+
+    /**
+     * @param c The client whose player to select, or {@code null} to leave the chooser where it was
+     *
+     * @deprecated since 0.51.01 - use {@link #setPlayerFrom(Player)}. A client cannot name a remote player,
+     *       because there is none on this machine, so anything asking for one silently fell back to the local
+     *       player.
+     */
+    @Deprecated(since = "0.51.01", forRemoval = true)
+    public void setPlayerFromClient(@Nullable Client c) {
+        setPlayerFrom((c == null) ? null : c.getLocalPlayer());
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/dialogs/randomArmy/RandomArmyDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/randomArmy/RandomArmyDialog.java
@@ -264,15 +264,16 @@ public class RandomArmyDialog extends AbstractRandomArmyDialog {
     }
 
     /**
-     * @param c The client whose player to select, or {@code null} to leave the chooser where it was
+     * @param clientToSelect The client whose player to select, or {@code null} to leave the chooser where it was
      *
      * @deprecated since 0.51.01 - use {@link #setPlayerFrom(Player)}. A client cannot name a remote player,
      *       because there is none on this machine, so anything asking for one silently fell back to the local
      *       player.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
-    public void setPlayerFromClient(@Nullable Client c) {
-        setPlayerFrom((c == null) ? null : c.getLocalPlayer());
+    public void setPlayerFromClient(@Nullable Client clientToSelect) {
+        // named apart from this dialog's own client field, which it would otherwise shadow
+        setPlayerFrom((clientToSelect == null) ? null : clientToSelect.getLocalPlayer());
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/dialogs/randomArmy/RandomArmyDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/randomArmy/RandomArmyDialog.java
@@ -54,6 +54,7 @@ import megamek.client.ui.clientGUI.ClientGUI;
 import megamek.client.ui.clientGUI.UnitRecipients;
 import megamek.client.ui.dialogs.buttonDialogs.SkillGenerationDialog;
 import megamek.common.Player;
+import megamek.common.Team;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.Gender;
 import megamek.common.event.GameListener;
@@ -202,7 +203,16 @@ public class RandomArmyDialog extends AbstractRandomArmyDialog {
         // roll - topping a ComStar force up from the plain RAT tab would file it as Inner Sphere.
         if (context.source() != GenerationContext.Source.UNSPECIFIED) {
             clientGui.setGenerationContext(owner.getId(), context);
-            clientGui.getClient().getGame().getTeamForPlayer(owner).setFaction(context.faction());
+            // a player on no team has no team faction to set, which is the ordinary state of an observer being
+            // handed their first force: the faction is recorded against the player either way, and the team picks
+            // it up when they are put on one
+            Team team = clientGui.getClient().getGame().getTeamForPlayer(owner);
+            if (team != null) {
+                team.setFaction(context.faction());
+            } else {
+                LOGGER.info("[GMAddUnit] {} is on no team, so the rolled faction {} is recorded against the player "
+                            + "only", owner.getName(), context.faction());
+            }
             // The year goes in as text: message formatting would group the digits into "3,067".
             String year = String.valueOf(context.year());
             String message = (context.rating() == null)

--- a/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/MegaMekUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/MegaMekUnitSelectorDialog.java
@@ -44,13 +44,13 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingConstants;
 
-import megamek.client.AbstractClient;
 import megamek.client.Client;
 import megamek.client.generator.RandomGenderGenerator;
 import megamek.client.generator.RandomNameGenerator;
 import megamek.client.ui.Messages;
 import megamek.client.ui.clientGUI.ClientGUI;
 import megamek.client.ui.dialogs.UnitLoadingDialog;
+import megamek.client.ui.clientGUI.UnitRecipients;
 import megamek.common.Player;
 import megamek.common.TechConstants;
 import megamek.common.annotations.Nullable;
@@ -157,27 +157,37 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
         if (entities.isEmpty()) {
             return;
         }
-        Client client = null;
-        String name = (String) comboPlayer.getSelectedItem();
+        Player owner = chosenOwner();
 
-        if (comboPlayer.getSelectedIndex() > 0) {
-            client = (Client) clientGUI.getLocalBots().get(name);
+        for (Entity entity : entities) {
+            autoSetSkillsAndName(entity, owner);
+            entity.setOwner(owner);
         }
+        // sent over this machine's own connection whoever the units are for, the way reinforcements during a game
+        // have always been sent: a remote player has no client here to send through
+        clientGUI.getClient().sendAddEntity(entities);
 
-        if (client == null) {
-            client = clientGUI.getClient();
-        }
+        // named from the owner the units were actually given, not from the chooser: those were two different
+        // things to read, and the chat line could name a player who received nothing
+        String message = clientGUI.getClient().getLocalPlayer() + " selected "
+              + ((entities.size() == 1) ? "a unit" : entities.size() + " units")
+              + " for player: " + owner.getName();
+        clientGUI.getClient().sendServerChat(Player.PLAYER_NONE, message);
+    }
 
-        for (var e : entities) {
-            autoSetSkillsAndName(e, client.getLocalPlayer());
-            e.setOwner(client.getLocalPlayer());
-        }
-        client.sendAddEntity(entities);
-
-        String msg = clientGUI.getClient().getLocalPlayer() + " selected " + (entities.size() == 1 ?
-              "a unit" :
-              entities.size() + " units") + " for player: " + name;
-        clientGUI.getClient().sendServerChat(Player.PLAYER_NONE, msg);
+    /**
+     * @return the player the chosen units should belong to, which is the local player when the chooser holds
+     *       something no longer in the game
+     */
+    private Player chosenOwner() {
+        String chosenName = (String) comboPlayer.getSelectedItem();
+        return clientGUI.getClient()
+              .getGame()
+              .getPlayersList()
+              .stream()
+              .filter(player -> player.getName().equals(chosenName))
+              .findFirst()
+              .orElse(clientGUI.getClient().getLocalPlayer());
     }
 
     private void autoSetSkillsAndName(Entity e, Player player) {
@@ -206,13 +216,12 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
     }
 
     private void updatePlayerChoice(String selectionName) {
-        String clientName = clientGUI.getClient().getName();
         comboPlayer.setEnabled(false);
         comboPlayer.removeAllItems();
-        comboPlayer.addItem(clientName);
-
-        for (AbstractClient client : clientGUI.getLocalBots().values()) {
-            comboPlayer.addItem(client.getName());
+        for (Player player : UnitRecipients.availableTo(clientGUI.getClient().getLocalPlayer(),
+              clientGUI.getClient().getGame().getPlayersList(),
+              clientGUI.getLocalBots().keySet())) {
+            comboPlayer.addItem(player.getName());
         }
         comboPlayer.setSelectedItem(selectionName);
         if (comboPlayer.getSelectedIndex() < 0) {
@@ -228,12 +237,29 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
         updatePlayerChoice(lastChoice);
     }
 
-    public void setPlayerFromClient(Client c) {
-        if (c != null) {
-            updatePlayerChoice(c.getName());
-        } else {
+    /**
+     * Points the player chooser at the given player, so a dialog opened from a chosen player opens on them.
+     *
+     * @param player The player to select, or {@code null} to leave the chooser where it was
+     */
+    public void setPlayerFrom(@Nullable Player player) {
+        if (player == null) {
             updatePlayerChoice();
+        } else {
+            updatePlayerChoice(player.getName());
         }
+    }
+
+    /**
+     * @param c The client whose player to select, or {@code null} to leave the chooser where it was
+     *
+     * @deprecated since 0.51.01 - use {@link #setPlayerFrom(Player)}. A client cannot name a remote player,
+     *       because there is none on this machine, so anything asking for one silently fell back to the local
+     *       player.
+     */
+    @Deprecated(since = "0.51.01", forRemoval = true)
+    public void setPlayerFromClient(@Nullable Client c) {
+        setPlayerFrom((c == null) ? null : c.getLocalPlayer());
     }
     //endregion Button Methods
 

--- a/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/MegaMekUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/MegaMekUnitSelectorDialog.java
@@ -251,15 +251,15 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
     }
 
     /**
-     * @param c The client whose player to select, or {@code null} to leave the chooser where it was
+     * @param client The client whose player to select, or {@code null} to leave the chooser where it was
      *
      * @deprecated since 0.51.01 - use {@link #setPlayerFrom(Player)}. A client cannot name a remote player,
      *       because there is none on this machine, so anything asking for one silently fell back to the local
      *       player.
      */
     @Deprecated(since = "0.51.01", forRemoval = true)
-    public void setPlayerFromClient(@Nullable Client c) {
-        setPlayerFrom((c == null) ? null : c.getLocalPlayer());
+    public void setPlayerFromClient(@Nullable Client client) {
+        setPlayerFrom((client == null) ? null : client.getLocalPlayer());
     }
     //endregion Button Methods
 

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
@@ -107,6 +107,7 @@ import megamek.client.ui.Messages;
 import megamek.client.ui.buttons.DialogButton;
 import megamek.client.ui.buttons.MMToggleButton;
 import megamek.client.ui.clientGUI.ClientGUI;
+import megamek.client.ui.clientGUI.UnitRecipients;
 import megamek.client.ui.clientGUI.CloseAction;
 import megamek.client.ui.clientGUI.GUIPreferences;
 import megamek.client.ui.clientGUI.IMapSettingsObserver;
@@ -2104,7 +2105,7 @@ public class ChatLounge extends AbstractPhaseDisplay
             } else if (ev.getSource().equals(butLoadList)) {
                 // Allow the player to replace their current list of entities with a list from a file.
                 Player selectedPlayer = getSelectedPlayer();
-                if (selectedPlayer == null) {
+                if ((selectedPlayer == null) || !mayActForPlayer(selectedPlayer)) {
                     clientgui.doAlertDialog(Messages.getString("ChatLounge.ImproperCommand"),
                           Messages.getString("ChatLounge.SelectBotOrPlayer"));
                     return;
@@ -2115,7 +2116,7 @@ public class ChatLounge extends AbstractPhaseDisplay
                 // Allow the player to save their current
                 // list of entities to a file.
                 Player selectedPlayer = getSelectedPlayer();
-                if (selectedPlayer == null) {
+                if ((selectedPlayer == null) || !mayActForPlayer(selectedPlayer)) {
                     clientgui.doAlertDialog(Messages.getString("ChatLounge.ImproperCommand"),
                           Messages.getString("ChatLounge.SelectBotOrPlayer"));
                     return;
@@ -2744,6 +2745,23 @@ public class ChatLounge extends AbstractPhaseDisplay
      *
      * @return the selected player, or {@code null} when no row is selected
      */
+    /**
+     * Whether the local player may act on the given player's force.
+     *
+     * <p>The same rule the unit choosers use, asked here as well: their chooser only offers players it is willing
+     * to act for, so the rule is enforced by what is in the list. The unit list buttons act on whoever is selected
+     * in the player table, which is anyone at all, so they have to ask.</p>
+     *
+     * @param player The player whose force is to be acted on
+     *
+     * @return {@code true} when the local player may load or save that player's units
+     */
+    private boolean mayActForPlayer(Player player) {
+        return UnitRecipients.availableTo(localPlayer(),
+              clientgui.getClient().getGame().getPlayersList(),
+              clientgui.getLocalBots().keySet()).contains(player);
+    }
+
     @Nullable Player getSelectedPlayer() {
         if (tablePlayers.getSelectedRowCount() == 0) {
             return null;

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
@@ -1906,15 +1906,13 @@ public class ChatLounge extends AbstractPhaseDisplay
      * Pop up the dialog to load a mek
      */
     private void addUnit() {
-        Client c = getSelectedClient();
         clientgui.getMekSelectorDialog().updateOptionValues();
-        clientgui.getMekSelectorDialog().setPlayerFromClient(c);
+        clientgui.getMekSelectorDialog().setPlayerFrom(getSelectedPlayer());
         clientgui.getMekSelectorDialog().setVisible(true);
     }
 
     private void createArmy() {
-        Client c = getSelectedClient();
-        clientgui.getRandomArmyDialog().setPlayerFromClient(c);
+        clientgui.getRandomArmyDialog().setPlayerFrom(getSelectedPlayer());
         clientgui.getRandomArmyDialog().setVisible(true);
     }
 
@@ -2105,29 +2103,29 @@ public class ChatLounge extends AbstractPhaseDisplay
                 toggleCompact();
             } else if (ev.getSource().equals(butLoadList)) {
                 // Allow the player to replace their current list of entities with a list from a file.
-                Client c = getSelectedClient();
-                if (c == null) {
+                Player selectedPlayer = getSelectedPlayer();
+                if (selectedPlayer == null) {
                     clientgui.doAlertDialog(Messages.getString("ChatLounge.ImproperCommand"),
                           Messages.getString("ChatLounge.SelectBotOrPlayer"));
                     return;
                 }
-                clientgui.loadListFile(c.getLocalPlayer());
+                clientgui.loadListFile(selectedPlayer);
 
             } else if (ev.getSource().equals(butSaveList) || ev.getSource().equals(butPrintList)) {
                 // Allow the player to save their current
                 // list of entities to a file.
-                Client c = getSelectedClient();
-                if (c == null) {
+                Player selectedPlayer = getSelectedPlayer();
+                if (selectedPlayer == null) {
                     clientgui.doAlertDialog(Messages.getString("ChatLounge.ImproperCommand"),
                           Messages.getString("ChatLounge.SelectBotOrPlayer"));
                     return;
                 }
-                ArrayList<Entity> entities = c.getGame().getPlayerEntities(c.getLocalPlayer(), false);
+                ArrayList<Entity> entities = client().getGame().getPlayerEntities(selectedPlayer, false);
                 for (Entity entity : entities) {
                     entity.setForceString(game().getForces().forceStringFor(entity));
                 }
                 if (ev.getSource().equals(butSaveList)) {
-                    clientgui.saveListFile(entities, c.getLocalPlayer().getName());
+                    clientgui.saveListFile(entities, selectedPlayer.getName());
                 } else {
                     clientgui.printList(entities, (JButton) ev.getSource());
                 }
@@ -2734,6 +2732,23 @@ public class ChatLounge extends AbstractPhaseDisplay
         for (AbstractClient botClient : clientgui.getLocalBots().values()) {
             botClient.sendDone(done);
         }
+    }
+
+    /**
+     * The player highlighted in the player table, whoever is running them.
+     *
+     * <p>Separate from {@link #getSelectedClient()} because most of what the lobby does to a player needs only
+     * the player: units are owned by a player and sent over this machine's own connection. A remote human has no
+     * client here, so anything that asks for one gets nothing back and quietly does the work for the local player
+     * instead.</p>
+     *
+     * @return the selected player, or {@code null} when no row is selected
+     */
+    @Nullable Player getSelectedPlayer() {
+        if (tablePlayers.getSelectedRowCount() == 0) {
+            return null;
+        }
+        return playerModel.getPlayerAt(tablePlayers.getSelectedRow());
     }
 
     Client getSelectedClient() {

--- a/megamek/unittests/megamek/client/ui/clientGUI/UnitRecipientsTest.java
+++ b/megamek/unittests/megamek/client/ui/clientGUI/UnitRecipientsTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.ui.clientGUI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+
+import megamek.common.Player;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies which players the person at this screen may add units to.
+ *
+ * <p>The lobby scenario throughout: Dave is at this screen, Blue and Green are remote humans, Princess-1 is a bot
+ * Dave is running and Princess-2 is a bot Blue is running.</p>
+ */
+class UnitRecipientsTest {
+
+    private static final Player DAVE = new Player(0, "Dave");
+    private static final Player BLUE = new Player(1, "Blue");
+    private static final Player GREEN = new Player(2, "Green");
+    private static final Player PRINCESS_ONE = new Player(3, "Princess-1");
+    private static final Player PRINCESS_TWO = new Player(4, "Princess-2");
+
+    private static final List<Player> EVERYONE = List.of(DAVE, BLUE, GREEN, PRINCESS_ONE, PRINCESS_TWO);
+    private static final Set<String> DAVES_BOTS = Set.of("Princess-1");
+
+    /** @return the names offered, which is what a chooser shows */
+    private static List<String> namesOfferedTo(Player localPlayer) {
+        return UnitRecipients.availableTo(localPlayer, EVERYONE, DAVES_BOTS).stream().map(Player::getName).toList();
+    }
+
+    @Test
+    void anOrdinaryPlayerIsOfferedThemselvesAndTheirOwnBots() {
+        DAVE.setGameMaster(false);
+
+        assertEquals(List.of("Dave", "Princess-1"), namesOfferedTo(DAVE),
+              "without the gamemaster role the choice is your own force and the bots you run, as it always was");
+    }
+
+    @Test
+    void aGamemasterIsOfferedEveryone() {
+        DAVE.setGameMaster(true);
+
+        List<String> offered = namesOfferedTo(DAVE);
+
+        assertTrue(offered.containsAll(List.of("Dave", "Blue", "Green", "Princess-1", "Princess-2")),
+              "handing out forces is what a gamemaster does, so every player is a possible recipient");
+        assertEquals(5, offered.size(), "and nobody should be offered twice");
+    }
+
+    @Test
+    void anotherPlayersBotIsOfferedOnlyToAGamemaster() {
+        DAVE.setGameMaster(false);
+        assertFalse(namesOfferedTo(DAVE).contains("Princess-2"),
+              "Blue runs that bot, so stocking it is Blue's business");
+
+        DAVE.setGameMaster(true);
+        assertTrue(namesOfferedTo(DAVE).contains("Princess-2"),
+              "a gamemaster may stock it along with everyone else");
+    }
+
+    @Test
+    void theLocalPlayerIsAlwaysFirst() {
+        DAVE.setGameMaster(true);
+
+        assertEquals("Dave", namesOfferedTo(DAVE).getFirst(),
+              "a chooser landing on its first entry must land on the person using it");
+    }
+
+    @Test
+    void theLocalPlayerIsNeverOfferedTwice() {
+        DAVE.setGameMaster(true);
+
+        assertEquals(1, namesOfferedTo(DAVE).stream().filter("Dave"::equals).count(),
+              "the local player is added at the front, so the sweep must not add them again");
+    }
+
+    @Test
+    void aGamemasterWithNoOneElseInTheGameIsStillOfferedThemselves() {
+        DAVE.setGameMaster(true);
+
+        List<Player> recipients = UnitRecipients.availableTo(DAVE, List.of(DAVE), Set.of());
+
+        assertEquals(List.of("Dave"), recipients.stream().map(Player::getName).toList(),
+              "there is always someone to add units to, so a chooser is never left empty");
+    }
+}

--- a/megamek/unittests/megamek/client/ui/clientGUI/UnitRecipientsTest.java
+++ b/megamek/unittests/megamek/client/ui/clientGUI/UnitRecipientsTest.java
@@ -119,4 +119,21 @@ class UnitRecipientsTest {
         assertEquals(List.of("Dave"), recipients.stream().map(Player::getName).toList(),
               "there is always someone to add units to, so a chooser is never left empty");
     }
+
+    @Test
+    void theListDoublesAsAPermissionCheck() {
+        // the unit list buttons act on whoever is highlighted in the player table rather than on a chooser, so they
+        // ask this the other way round: is that player someone I am allowed to act for?
+        DAVE.setGameMaster(false);
+        List<Player> allowedToAnOrdinaryPlayer = UnitRecipients.availableTo(DAVE, EVERYONE, DAVES_BOTS);
+
+        assertTrue(allowedToAnOrdinaryPlayer.contains(DAVE), "your own force is always yours to load and save");
+        assertTrue(allowedToAnOrdinaryPlayer.contains(PRINCESS_ONE), "and so is a bot you are running");
+        assertFalse(allowedToAnOrdinaryPlayer.contains(BLUE),
+              "but another player's force is not, and asking must say so rather than quietly allowing it");
+
+        DAVE.setGameMaster(true);
+        assertTrue(UnitRecipients.availableTo(DAVE, EVERYONE, DAVES_BOTS).contains(BLUE),
+              "a gamemaster may act for anyone");
+    }
 }


### PR DESCRIPTION
## What this changes

Select a remote human player in the lobby, press **Add Unit**, and the units landed on **you** - with no error and no warning. Same for Create Random Army, the Force Generator tab, and Load MUL file.

The cause is one mistake repeated in four dialogs: they looked up a *client* for the selected player. A remote human has no client on your machine, the lookup returned nothing, and nothing was read as "use the local player". So a Gamemaster handing out forces before a game had to add every batch to themselves and reassign it afterwards.

Ownership and delivery are now two separate things. The units belong to the **player** that was chosen; they go out over **your own connection**, which is how reinforcement during a game has always worked. Who may be chosen is decided in one place, `UnitRecipients`: your own force and any bot you run, or anyone at all when you hold the Gamemaster role. Ordinary players see exactly what they see today.

Fixes #8786

### What a reviewer should look at

- **`UnitRecipients`** is the whole rule, in one small class with its own tests. Everything else is four dialogs being taught to ask it.
- **The client/server split is deliberate and worth knowing about.** This rule lives only on the client, because there is no server-side counterpart to align it with: `receiveEntityAdd` does not check who sent the packet, and never has - it trusts the owner id in the payload, which is how in-game reinforcement for another player already works. This pull request neither widens nor narrows that. Adding a server-side ownership check is a real change with its own consequences (loading a unit list for your own bot travels the same route) and belongs in its own pull request.
- **`setPlayerFromClient` is deprecated rather than deleted**, since it is public API that MegaMekLab or MekHQ could be calling. It delegates to a new `setPlayerFrom(Player)`. The point of the change is that a client cannot name a remote player.
- **No new packets, no new serialized state.** Nothing appended to `PacketCommand`, so no wire-format risk, and this does not conflict with #8785.

## Testing

- Playtested in game by the issue author, host plus a second connected client: **Add Unit**, **Create Random Army** and the **Force Generator** tab all assign to a chosen remote player in Gamemaster mode.
- **Load MUL file** was confirmed to proceed for a remote player - it previously refused outright with "Please select a bot you control or your player from the player list".
- The observer case was exercised specifically: a player connecting mid-game with no team, being handed a force. That found a crash, fixed here - see below.
- Full suite green: 15,389 tests, no failures. Six of them cover `UnitRecipients` directly, using a lobby of two humans and two bots.
- One line is logged per dialog opening recording who is at the screen, whether they hold the Gamemaster role, and how many of the game's players are offered. This is what turned "the dropdown did not show all players" into an answered question during testing.

### A crash found and fixed during testing

Rolling a random army for a player on no team threw a `NullPointerException` and took the client down. Recording what a force was rolled for sets the faction on the owner's **team**, and `getTeamForPlayer` returns null for a player who has none.

That is a regression from this change: the owner used to always be the local player or a local bot, both of whom have a team, so the null could not arise until the choice widened. The faction is still recorded against the player, which is what the munition autoconfigurator and name generator read; only the team half is skipped, and it is logged rather than passing silently.

## What is not proven yet

- **Whether MUL-loaded units land on the chosen player.** The refusal is confirmed gone and the button now proceeds, but nobody watched whose force the units joined. It uses the same `loadListFile(player)` call the in-game reinforcement path has always used, and the three other paths confirm ownership assignment works, so this is low risk rather than unknown.
- **Save and Print MUL file** were changed the same way and were not exercised. They should now act on the selected player's force.
- **No automated coverage of the Swing wiring.** The tests cover the rule about who may be offered; the dialogs themselves were verified by hand only.
- **A player who has not connected yet cannot be chosen**, because the lobby lists only connected players. The issue mentions preparing forces for absent players; that needs a placeholder-player concept and is deliberately out of scope here.
- **Not exercised with more than two connected clients**, nor with a game that has several human players on different teams.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result
