### PR TITLE
Fix #8798: Burning buildings were never reported and stayed standing at CF 0

### DIFF
--- a/megamek/resources/megamek/common/report-messages.properties
+++ b/megamek/resources/megamek/common/report-messages.properties
@@ -839,6 +839,7 @@
 5115=<data> (<data>) has finished dumping <data>.
 5116=<data> (<data>) has dropped <data>.
 5120=<data> has burned to the ground!
+5121=<data> (<data>) burns: <data> damage, <data> Construction Factor remaining.
 5125=Fire at <data> is burning brightly.
 5130=Inferno fire at <data> is burning brightly.
 5135=Fire at <data> was started this round.

--- a/megamek/src/megamek/server/FireProcessor.java
+++ b/megamek/src/megamek/server/FireProcessor.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2005-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2005-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -35,7 +35,6 @@
 package megamek.server;
 
 import java.util.ArrayList;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,6 +62,12 @@ import megamek.server.totalWarfare.TWGameManager;
 
 public class FireProcessor extends DynamicTerrainProcessor {
     private static final MMLogger logger = MMLogger.create(FireProcessor.class);
+
+    /**
+     * Construction Factor a burning building hex loses each turn. TO:AR p.41: "For each turn that a building is on
+     * fire, it loses 2 CF (regardless of the size or type of building)."
+     */
+    private static final int BURNING_BUILDING_CF_LOSS = 2;
 
     private Game game;
     Vector<Report> vPhaseReport;
@@ -106,25 +111,46 @@ public class FireProcessor extends DynamicTerrainProcessor {
         // Cycle through all buildings, checking for fire.
         // ASSUMPTION: buildings don't lose 2 CF on the turn a fire starts.
         // ASSUMPTION: multi-hex buildings lose 2 CF in each burning hex
-        Enumeration<IBuilding> buildings = board.getBuildings();
-        while (buildings.hasMoreElements()) {
-            IBuilding bldg = buildings.nextElement();
-            Enumeration<Coords> bldgCoords = bldg.getCoords();
-            while (bldgCoords.hasMoreElements()) {
-                Coords coords = bldgCoords.nextElement();
-                if (bldg.isBurning(coords)) {
-                    int cf = Math.max(bldg.getCurrentCF(coords) - 2, 0);
-                    bldg.setCurrentCF(cf, coords);
+        Vector<IBuilding> burningBuildings = new Vector<>();
+        // Copy the list; collapsing a building can remove it from the board's building vector.
+        for (IBuilding building : new ArrayList<>(board.getBuildingsVector())) {
+            boolean burnedThisTurn = false;
+            // Copy the coords; collapsing a hex removes it from the building while we are walking its hexes.
+            for (Coords coords : new ArrayList<>(building.getCoordsList())) {
+                if (!building.isBurning(coords)) {
+                    continue;
+                }
+                burnedThisTurn = true;
+                int constructionFactor = Math.max(building.getCurrentCF(coords) - BURNING_BUILDING_CF_LOSS, 0);
+                building.setCurrentCF(constructionFactor, coords);
+                vPhaseReport.addElement(Report.publicReport(5121)
+                      .add(building.getName())
+                      .add(coords.getBoardNum())
+                      .add(BURNING_BUILDING_CF_LOSS)
+                      .add(constructionFactor));
 
-                    // Does the building burn down?
-                    if (cf == 0) {
-                        vPhaseReport.addElement(Report.publicReport(5120).add(bldg.getName()));
-                    } else if (!gameManager.checkForCollapse(bldg, positionMap, coords, false, vPhaseReport)) {
-                        // If it doesn't collapse under its load, mark it for update.
-                        bldg.setPhaseCF(cf, coords);
-                    }
+                // Does the building burn down?
+                if (constructionFactor == 0) {
+                    vPhaseReport.addElement(Report.publicReport(5120).add(building.getName()));
+                    // A building at CF 0 cannot stand. Bring it down here so whatever is inside it, on top of it or
+                    // in its basement is resolved now rather than a phase later. The phase CF is deliberately left
+                    // alone: the falling debris is scored on the CF the hex had before this turn's burn, the same
+                    // way it is for a building knocked down by weapon damage.
+                    gameManager.collapseBuilding(building, positionMap, coords, vPhaseReport);
+                } else if (!gameManager.checkForCollapse(building, positionMap, coords, false, vPhaseReport)) {
+                    // If it doesn't collapse under its load, mark it for update.
+                    building.setPhaseCF(constructionFactor, coords);
                 }
             }
+            if (burnedThisTurn) {
+                burningBuildings.add(building);
+            }
+        }
+
+        // Tell the clients about the CF the fire took off, so tooltips and bot pathing see the damaged building
+        // rather than the CF it started the game with.
+        if (!burningBuildings.isEmpty()) {
+            gameManager.sendChangedBuildings(burningBuildings);
         }
 
         // Cycle through all hexes, checking for fire and the spread of fire

--- a/megamek/src/megamek/server/totalWarfare/BuildingCollapseHandler.java
+++ b/megamek/src/megamek/server/totalWarfare/BuildingCollapseHandler.java
@@ -97,8 +97,9 @@ public class BuildingCollapseHandler extends AbstractTWRuleHandler {
     boolean checkForCollapse(IBuilding bldg, Map<BoardLocation, List<Entity>> positionMap, Coords coords,
           boolean checkBecauseOfDamage, Vector<Report> vPhaseReport) {
 
-        // If the input is meaningless, do nothing and throw no exception.
-        if ((bldg == null) || (positionMap == null) || positionMap.isEmpty() || (coords == null)
+        // If the input is meaningless, do nothing and throw no exception. An empty position map is legal: nothing
+        // is standing on the board, but the building can still come down (a building burning down on an empty map).
+        if ((bldg == null) || (positionMap == null) || (coords == null)
               || !bldg.isIn(coords) || !bldg.hasCFIn(coords)) {
             LOGGER.error("Illegal/null arguments");
             return false;

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -28833,6 +28833,22 @@ public class TWGameManager extends AbstractGameManager {
     }
 
     /**
+     * Collapse one hex of a building that can no longer stand, such as a building hex burned down to a Construction
+     * Factor of 0. Damages and drops whatever is inside, on top of or in the basement of that hex, replaces the hex
+     * with rubble and updates the clients.
+     *
+     * @param building     the Building that is coming down. This value should not be {@code null}.
+     * @param positionMap  a map of the Coords positions of each unit in the game to the {@link Entity}s at that
+     *                     position. May be empty when no unit is on the board.
+     * @param coords       the Coords of the building hex that is coming down
+     * @param vPhaseReport the current phase reports to attach new reports to
+     */
+    public void collapseBuilding(IBuilding building, Map<BoardLocation, List<Entity>> positionMap, Coords coords,
+          Vector<Report> vPhaseReport) {
+        buildingCollapseHandler.collapseBuilding(building, positionMap, coords, vPhaseReport);
+    }
+
+    /**
      * Determine if the given building should collapse. If so, inflict the appropriate amount of damage on each entity
      * in the building and update the clients. If the building does not collapse, determine if any entities crash
      * through its floor into its basement. Again, apply appropriate damage.

--- a/megamek/unittests/megamek/server/BurningBuildingTest.java
+++ b/megamek/unittests/megamek/server/BurningBuildingTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+
+import java.util.Vector;
+
+import megamek.common.Report;
+import megamek.common.board.Board;
+import megamek.common.board.Coords;
+import megamek.common.game.Game;
+import megamek.common.net.packets.Packet;
+import megamek.common.units.IBuilding;
+import megamek.common.units.Terrains;
+import megamek.server.totalWarfare.TWGameManager;
+import megamek.utils.BoardLoader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * Tests for what a burning building does during the End Phase (TO:AR p.41): it loses 2 Construction Factor per burning
+ * hex, that loss is reported and sent to the clients, and the hex comes down when the Construction Factor reaches 0.
+ */
+class BurningBuildingTest {
+
+    /** Report ID for the per-turn burn line. */
+    private static final int BURN_REPORT = 5121;
+
+    /** Report ID for "has burned to the ground!". */
+    private static final int BURNED_DOWN_REPORT = 5120;
+
+    private static final Coords BUILDING_HEX = new Coords(0, 0);
+
+    /**
+     * A Medium building of CF 40, alone on an otherwise empty board. The board loader ignores the coordinates in the
+     * hex lines and fills the board in file order, so this hex is the first one: 0101.
+     */
+    private static final String BOARD_DATA = """
+          size 5 5
+          hex 0101 0 "bldg_elev:2;building:2;bldg_class:1;bldg_cf:40" ""
+          end""";
+
+    private TWGameManager gameManager;
+    private Board board;
+    private Vector<Report> reports;
+    private MockedStatic<Server> mockedServer;
+
+    @BeforeEach
+    void beforeEach() {
+        // The collapse handler held inside the game manager sends packets of its own, so stand in a mock Server
+        // rather than stubbing single methods on the spy below.
+        mockedServer = mockStatic(Server.class);
+        mockedServer.when(Server::getServerInstance).thenReturn(mock(Server.class));
+
+        gameManager = Mockito.spy(new TWGameManager());
+
+        // Mock the methods that need a running Server.
+        Mockito.doNothing().when(gameManager).send(any(Packet.class));
+        Mockito.doNothing().when(gameManager).sendChangedHex(any(Coords.class), any(int.class));
+        Mockito.doNothing().when(gameManager).entityUpdate(any(int.class));
+        Mockito.doNothing().when(gameManager).sendChangedBuildings(any());
+
+        Game game = gameManager.getGame();
+        // A fresh board per test: these tests burn the building down, which would leave a shared board collapsed.
+        board = BoardLoader.initializeBoard(BOARD_DATA);
+        game.setBoard(board);
+
+        reports = new Vector<>();
+    }
+
+    @AfterEach
+    void afterEach() {
+        mockedServer.close();
+    }
+
+    /** Sets the building hex alight and runs one End Phase of fire processing. */
+    private IBuilding burnForOnePhase(int startingConstructionFactor) {
+        IBuilding building = board.getBuildingAt(BUILDING_HEX);
+        assertNotNull(building, "The test board should have a building at 0101");
+        building.setCurrentCF(startingConstructionFactor, BUILDING_HEX);
+        building.setPhaseCF(startingConstructionFactor, BUILDING_HEX);
+        building.setBurning(true, BUILDING_HEX);
+
+        new FireProcessor(gameManager).doEndPhaseChanges(reports);
+        return building;
+    }
+
+    private Report findReport(int messageId) {
+        for (Report report : reports) {
+            if (report.messageId == messageId) {
+                return report;
+            }
+        }
+        return null;
+    }
+
+    private boolean hasReport(int messageId) {
+        return findReport(messageId) != null;
+    }
+
+    @Test
+    @DisplayName("A burning building hex loses 2 CF and says so, naming the hex and what is left")
+    void burningHexReportsItsDamageAndRemainingConstructionFactor() {
+        IBuilding building = burnForOnePhase(40);
+
+        assertEquals(38, building.getCurrentCF(BUILDING_HEX), "A burning hex loses 2 CF per turn (TO:AR p.41)");
+
+        Report burnReport = findReport(BURN_REPORT);
+        assertNotNull(burnReport, "The burn should be reported every turn, not only when the building falls");
+        String text = burnReport.text();
+        assertTrue(text.contains(building.getName()), "The report should name the building: " + text);
+        assertTrue(text.contains(BUILDING_HEX.getBoardNum()), "The report should name the hex: " + text);
+        assertTrue(text.contains("2 damage"), "The report should state the damage: " + text);
+        assertTrue(text.contains("38 Construction Factor remaining"),
+              "The report should state what is left: " + text);
+    }
+
+    @Test
+    @DisplayName("A building that is not burning is not damaged and not reported")
+    void buildingThatIsNotBurningIsLeftAlone() {
+        IBuilding building = board.getBuildingAt(BUILDING_HEX);
+        assertNotNull(building);
+        building.setCurrentCF(40, BUILDING_HEX);
+        building.setPhaseCF(40, BUILDING_HEX);
+
+        new FireProcessor(gameManager).doEndPhaseChanges(reports);
+
+        assertEquals(40, building.getCurrentCF(BUILDING_HEX));
+        assertFalse(hasReport(BURN_REPORT), "A building that is not on fire should produce no burn report");
+    }
+
+    @Test
+    @DisplayName("The clients are told about the CF the fire took off")
+    void burningHexSendsTheNewConstructionFactorToClients() {
+        burnForOnePhase(40);
+
+        verify(gameManager, atLeastOnce()).sendChangedBuildings(any());
+    }
+
+    @Test
+    @DisplayName("A building hex burned down to CF 0 comes down in the same phase")
+    void hexBurnedToZeroCollapsesImmediately() {
+        IBuilding building = burnForOnePhase(2);
+
+        assertEquals(0, building.getCurrentCF(BUILDING_HEX));
+        assertTrue(hasReport(BURN_REPORT), "The final burn should be reported too");
+        assertTrue(hasReport(BURNED_DOWN_REPORT), "The building should announce that it burned down");
+
+        // The hex must actually come down: no building there any more, and the building terrain is replaced by rubble.
+        assertNull(board.getBuildingAt(BUILDING_HEX), "A building at CF 0 cannot keep standing");
+        assertFalse(board.getHex(BUILDING_HEX).containsTerrain(Terrains.BUILDING),
+              "The collapsed hex should no longer hold building terrain");
+        assertTrue(board.getHex(BUILDING_HEX).containsTerrain(Terrains.RUBBLE),
+              "A collapsed building leaves rubble");
+    }
+
+    @Test
+    @DisplayName("A building burns down on a board with no units on it")
+    void hexBurnedToZeroCollapsesWithNoUnitsOnTheBoard() {
+        // The game has no entities, so the position map handed to the collapse check is empty. That is a legal
+        // state - a quiet map - and must not stop the building from coming down.
+        assertTrue(gameManager.getGame().getEntitiesVector().isEmpty(), "This test needs an empty board");
+
+        burnForOnePhase(2);
+
+        assertNull(board.getBuildingAt(BUILDING_HEX), "A building at CF 0 falls even with nothing standing near it");
+    }
+}


### PR DESCRIPTION
## What this changes

A burning building now tells you what is happening to it. Every turn a building hex burns, the report names the building and the hex, the 2 Construction Factor the fire took off, and what is left, so you can see how long it has. When the Construction Factor reaches 0 the hex actually comes down in that same phase instead of announcing that it burned to the ground and then standing there. The building's Construction Factor is also sent to the clients as it drops, so the hex tooltip counts down with the fire rather than showing the value the building started the game with.

Fixes #8798

## Testing

`BurningBuildingTest` is new and covers the five behaviours: the per-turn report and its numbers, no report when the building is not burning, the client update, the collapse at 0, and the collapse on a board with no units on it. Four of the five fail with the fix reverted; the "not burning" one is the control and passes either way.

Full megamek test suite, `checkstyleMain` and `javadoc` all pass. The 100 javadoc warnings are pre-existing and none are in the files this touches. `BuildingCollapseHandlerTest`, `BridgeBuildingTest` and the `megamek.common.*Building*` tests were run separately and pass.

Tested in game: a building was set alight, the burn line appeared each turn counting down, and the building collapsed to rubble when it reached 0.

## What is not proven yet

Only the single-hex case has been played. A multi-hex building losing 2 per burning hex reports per hex by design, but the multi-hex burn-down has not been run in a game. Nothing was tested with a unit standing inside or on top of a building at the moment the fire finished it, so the falling-debris and basement paths are covered by the existing collapse code and its tests rather than by a fresh playtest.

---
- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
