### PR TITLE
Fix #8450, #8435: Pain shunts vs battle armor and flame damage reporting

### DIFF
--- a/megamek/resources/megamek/common/report-messages.properties
+++ b/megamek/resources/megamek/common/report-messages.properties
@@ -519,6 +519,7 @@
 3403=<data> missiles hit the cover.
 3405=<span class='success'><B>hits</B></span> <data> <data>
 3406=Target gains <data> <msg:3401,3402> heat during heat phase, changed from <data> by <data> armor.
+3407=<data> does not track heat, so the attack deals damage instead.
 3410=\ (hit aimed location)
 3415=<data> (<data>) suffers no damage.
 3416=<data> (<data>) is unaffected by VGL fragmentation grenades!
@@ -1517,7 +1518,7 @@
 9972=, damage changed to <data> (<data>)
 9973=in building
 9974=Mechanized
-
+9975=Artificial Pain Shunt halves the damage to <data>
 9976=Building provides no protection when units are on the same level!
 9980=Direct fire
 9981=Ballistic cluster

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -6725,8 +6725,10 @@ public class Compute {
         r.messageId = 9970;
         String mod = "1:1";
 
-        // Update for MOS
-        damageType += mos;
+        // Update for MOS. The Non-Conventional Damage against Infantry table ends at 7D6, so a large margin of
+        // success cannot shift the damage past its last row. Without the clamp the shifted class matches no case
+        // below and the weapon falls back to its base damage, which is far less than the burst it should roll.
+        damageType = Math.clamp(damageType + mos, WeaponType.WEAPON_DIRECT_FIRE, WeaponType.WEAPON_BURST_7D6);
         double priorDamage = damage;
 
         switch (damageType) {

--- a/megamek/src/megamek/common/weapons/handlers/FlamerHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/FlamerHandler.java
@@ -41,7 +41,6 @@ import megamek.common.HitData;
 import megamek.common.Report;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
-import megamek.common.battleArmor.BattleArmor;
 import megamek.common.compute.ComputeSideTable;
 import megamek.common.equipment.EquipmentMode;
 import megamek.common.game.Game;
@@ -119,16 +118,11 @@ public class FlamerHandler extends WeaponHandler {
 
     @Override
     protected int calcDamagePerHit() {
-        int toReturn = super.calcDamagePerHit();
-        if (target.isConventionalInfantry()) {
-            // pain shunted infantry get half damage
-            if (((Entity) target).hasAbility(OptionsConstants.MD_PAIN_SHUNT)) {
-                toReturn = (int) Math.floor(toReturn / 2.0);
-            }
-        } else if ((target instanceof BattleArmor) && ((BattleArmor) target).isFireResistant()) {
-            toReturn = 0;
+        if (targetIgnoresHeatWeaponDamage()) {
+            return 0;
         }
-        return toReturn;
+        // Conventional infantry and battle armor with an Artificial Pain Shunt halve flame damage (IO p. 78).
+        return (int) applyPainShuntModifier(super.calcDamagePerHit());
     }
 
     @Override

--- a/megamek/src/megamek/common/weapons/handlers/VehicleFlamerHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/VehicleFlamerHandler.java
@@ -34,8 +34,6 @@
 
 package megamek.common.weapons.handlers;
 
-import static java.lang.Math.floor;
-
 import java.io.Serial;
 import java.util.Vector;
 
@@ -43,8 +41,6 @@ import megamek.common.HitData;
 import megamek.common.Report;
 import megamek.common.ToHitData;
 import megamek.common.actions.WeaponAttackAction;
-import megamek.common.battleArmor.BattleArmor;
-import megamek.common.compute.Compute;
 import megamek.common.compute.ComputeSideTable;
 import megamek.common.equipment.EquipmentMode;
 import megamek.common.game.Game;
@@ -55,8 +51,6 @@ import megamek.common.units.Entity;
 import megamek.common.units.IBuilding;
 import megamek.common.weapons.FlamerHandlerHelper;
 import megamek.common.weapons.Weapon;
-import megamek.common.weapons.flamers.clan.CLHeavyFlamer;
-import megamek.common.weapons.flamers.innerSphere.ISHeavyFlamer;
 import megamek.server.totalWarfare.TWGameManager;
 
 /**
@@ -141,29 +135,14 @@ public class VehicleFlamerHandler extends AmmoWeaponHandler {
      */
     @Override
     protected int calcDamagePerHit() {
-        double toReturn;
-        if (target.isConventionalInfantry()) {
-            if (attackingEntity instanceof BattleArmor) {
-                toReturn = Compute.d6(3);
-            } else if ((weaponType instanceof ISHeavyFlamer)
-                  || (weaponType instanceof CLHeavyFlamer)) {
-                toReturn = Compute.d6(6);
-            } else {
-                toReturn = Compute.d6(4);
-            }
-            if (bDirect) {
-                toReturn += (int) floor(toHit.getMoS() / 3.0);
-            }
-            // pain shunted infantry get half damage
-            if (((Entity) target).hasAbility(OptionsConstants.MD_PAIN_SHUNT)) {
-                toReturn /= 2;
-            }
-
-            toReturn = applyGlancingBlowModifier(toReturn, true);
-        } else {
-            toReturn = super.calcDamagePerHit();
+        if (targetIgnoresHeatWeaponDamage()) {
+            return 0;
         }
-        return (int) toReturn;
+        // Anti-infantry damage is rolled by the shared handler from the weapon's infantry damage class, which is
+        // 6D6 for the heavy flamers and 4D6 for the vehicle flamer. Rolling it here instead skipped the burst
+        // halving against mechanized infantry and through buildings, and skipped the damage breakdown report.
+        // Conventional infantry and battle armor with an Artificial Pain Shunt halve flame damage (IO p. 78).
+        return (int) applyPainShuntModifier(super.calcDamagePerHit());
     }
 
     @Override

--- a/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
@@ -1326,6 +1326,51 @@ public class WeaponHandler implements AttackHandler, Serializable {
     }
 
     /**
+     * @return {@code true} when the target is battle armor wearing Fire-Resistant armor, whose suit "ignores
+     *       damage by heat-causing weapons" (TM p. 170). Flamers of every size are heat-causing, so they do
+     *       nothing to it.
+     */
+    protected boolean targetIgnoresHeatWeaponDamage() {
+        return (target instanceof BattleArmor battleArmorTarget) && battleArmorTarget.isFireResistant();
+    }
+
+    /**
+     * Halves the damage of a flame-based attack when the target is a pain-shunted infantry or battle armor unit.
+     *
+     * <p>Conventional infantry and battle armor units made up of warriors with an Artificial Pain Shunt reduce by
+     * half any damage caused by flame-based weapons (IO p. 78). Battle armor is covered by the same sentence as
+     * conventional infantry, so both unit types are handled here.</p>
+     *
+     * <p>IO does not define "flame-based weapon". TO:AR p. 171 does, listing plasma, flamer and Firedrake, which
+     * is the same set {@code InfantryWeapon.isFlameBased()} already recognises. Core Rules does not use the term
+     * at all; it tags both flamers and plasma as Heat-Causing (p. 183), so that tag does not separate them
+     * either.</p>
+     *
+     * <p>Callers must apply this to the value that scales the total damage of the attack. That is the damage per
+     * hit for some handlers and the number of hits for others, so the call site differs per weapon.</p>
+     *
+     * @param damage the flame damage before the reduction
+     *
+     * @return half the damage, rounded down, or the unchanged damage when the target has no pain shunt
+     */
+    protected double applyPainShuntModifier(double damage) {
+        if (!(target instanceof Infantry infantryTarget)
+              || !infantryTarget.hasAbility(OptionsConstants.MD_PAIN_SHUNT)) {
+            return damage;
+        }
+
+        double reducedDamage = floor(damage / 2.0);
+
+        Report report = new Report(9975);
+        report.subject = subjectId;
+        report.indent(2);
+        report.add((int) reducedDamage);
+        calcDmgPerHitReport.addElement(report);
+
+        return reducedDamage;
+    }
+
+    /**
      * Calculate the attack value based on range
      *
      * @return an <code>int</code> representing the attack value at that range.

--- a/megamek/src/megamek/common/weapons/handlers/plasma/PlasmaCannonHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/plasma/PlasmaCannonHandler.java
@@ -51,7 +51,6 @@ import megamek.common.equipment.ArmorType;
 import megamek.common.equipment.EquipmentType;
 import megamek.common.game.Game;
 import megamek.common.loaders.EntityLoadingException;
-import megamek.common.options.OptionsConstants;
 import megamek.common.rolls.TargetRoll;
 import megamek.common.units.BuildingTarget;
 import megamek.common.units.Entity;
@@ -264,20 +263,23 @@ public class PlasmaCannonHandler extends AmmoWeaponHandler {
         if (target.tracksHeat()) {
             return 0;
         }
+        boolean targetIsConventionalInfantry = target.isConventionalInfantry();
         int toReturn = 1;
-        if (target.isConventionalInfantry()) {
+        if (targetIsConventionalInfantry) {
             toReturn = Compute.d6(3);
-            // pain shunted infantry get half damage
             if (bDirect) {
                 toReturn += toHit.getMoS() / 3;
-            }
-            if (((Entity) target).hasAbility(OptionsConstants.MD_PAIN_SHUNT)) {
-                toReturn = Math.max(toReturn / 2, 1);
             }
         } else if (bDirect) {
             toReturn = Math.min(toReturn + (toHit.getMoS() / 3), toReturn * 2);
         }
-        toReturn = applyGlancingBlowModifier(toReturn, target.isConventionalInfantry());
+        toReturn = applyGlancingBlowModifier(toReturn, targetIsConventionalInfantry);
+
+        if (targetIsConventionalInfantry) {
+            // Pain-shunted conventional infantry halve flame damage (IO p. 78). Battle armor gets the same
+            // reduction in calcHits(), where its damage total lives.
+            toReturn = (int) applyPainShuntModifier(toReturn);
+        }
         return toReturn;
     }
 
@@ -297,10 +299,12 @@ public class PlasmaCannonHandler extends AmmoWeaponHandler {
         // BAs can't mount Plasma Cannons
         if (target.isConventionalInfantry() || target.tracksHeat()) {
             return 1;
-        } else if ((target instanceof BattleArmor) && ((BattleArmor) target).isFireResistant()) {
+        } else if ((target instanceof BattleArmor battleArmorTarget) && battleArmorTarget.isFireResistant()) {
             return 0;
         } else {
-            return Compute.d6(3);
+            // Pain-shunted battle armor halves flame damage (IO p. 78). Plasma damage against battle armor
+            // arrives as 1-point hits, so the hit count is what carries the damage total.
+            return (int) applyPainShuntModifier(Compute.d6(3));
         }
     }
 

--- a/megamek/src/megamek/common/weapons/handlers/plasma/PlasmaRifleHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/plasma/PlasmaRifleHandler.java
@@ -54,7 +54,6 @@ import megamek.common.options.OptionsConstants;
 import megamek.common.rolls.TargetRoll;
 import megamek.common.units.Entity;
 import megamek.common.units.IBuilding;
-import megamek.common.units.Infantry;
 import megamek.common.weapons.handlers.AmmoWeaponHandler;
 import megamek.common.weapons.ppc.innerSphere.ISHeavyPlasmaRifle;
 import megamek.common.weapons.ppc.innerSphere.ISLightPlasmaRifle;
@@ -168,11 +167,6 @@ public class PlasmaRifleHandler extends AmmoWeaponHandler {
         }
 
         bSalvo = true;
-        // pain-shunted infantry gets half-damage
-        if ((target instanceof Infantry) && ((Entity) target).hasAbility(OptionsConstants.MD_PAIN_SHUNT)) {
-            toReturn = Math.max(toReturn / 2, 1);
-        }
-
         return toReturn;
     }
 
@@ -200,6 +194,10 @@ public class PlasmaRifleHandler extends AmmoWeaponHandler {
                 toReturn = damage;
             }
             toReturn = applyGlancingBlowModifier(toReturn, false);
+            // Conventional infantry and battle armor with an Artificial Pain Shunt halve flame damage (IO p. 78).
+            // Plasma delivers that damage as 1-point hits, so the hit count is what carries the damage total.
+            // Halving the cluster size instead, as this handler used to, only regroups the same total.
+            toReturn = (int) applyPainShuntModifier(toReturn);
         }
         return toReturn;
     }

--- a/megamek/src/megamek/common/weapons/infantry/InfantryHeatWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryHeatWeaponHandler.java
@@ -139,6 +139,20 @@ public class InfantryHeatWeaponHandler extends InfantryWeaponHandler {
             }
             vPhaseReport.addElement(report);
         } else {
+            // Only heat-tracking targets can be hurt by the heat itself. Against anything else - vehicles,
+            // infantry, ProtoMeks - the attack falls back to ordinary damage, so say why rather than leaving the
+            // player to wonder where the heat went. True Inferno effects are an SRM-only rule and are declared
+            // before the battle; the F-tag support weapons are incendiary, not Inferno (TM pp. 350-352 errata).
+            // Only on the first cluster: this method runs once per damage grouping, and the reason applies to the
+            // whole attack rather than to each grouping.
+            if (firstHit) {
+                Report noHeatReport = new Report(3407);
+                noHeatReport.subject = subjectId;
+                noHeatReport.indent(2);
+                noHeatReport.addDesc(entityTarget);
+                vPhaseReport.addElement(noHeatReport);
+            }
+
             super.handleEntityDamage(entityTarget, vPhaseReport, bldg, hits, nCluster, bldgAbsorbs);
         }
     }

--- a/megamek/src/megamek/common/weapons/infantry/InfantryHeatWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryHeatWeaponHandler.java
@@ -146,6 +146,13 @@ public class InfantryHeatWeaponHandler extends InfantryWeaponHandler {
             // Only on the first cluster: this method runs once per damage grouping, and the reason applies to the
             // whole attack rather than to each grouping.
             if (firstHit) {
+                // super.handleEntityDamage() opens with Report.addNewline(vPhaseReport) on the salvo path,
+                // and bSalvo is always true for this handler. That call breaks the LAST report in the vector,
+                // so inserting the explanation first would hand it the line break meant for the line above it
+                // and glue the two together. Give the preceding line its break here, and the explanation then
+                // takes the one super adds.
+                Report.addNewline(vPhaseReport);
+
                 Report noHeatReport = new Report(3407);
                 noHeatReport.subject = subjectId;
                 noHeatReport.indent(2);

--- a/megamek/unittests/megamek/common/ComputeTest.java
+++ b/megamek/unittests/megamek/common/ComputeTest.java
@@ -975,6 +975,30 @@ class ComputeTest {
     }
 
     @Test
+    void testDirectBlowInfantryMOSCannotShiftPastEndOfTable() {
+        // A heavy flamer is already 6D6, the second-to-last row of the Non-Conventional Damage against Infantry
+        // table. A direct blow that shifts it two rows would run off the end of the table; the shift must stop at
+        // 7D6 rather than falling through to the weapon's base damage.
+        double originalDamage = 4.0;
+        int weaponType = WeaponType.WEAPON_BURST_6D6;
+        Vector<Report> reports = new Vector<>();
+        int newDamage = directBlowInfantryDamage(
+              originalDamage,
+              3,
+              weaponType,
+              false,
+              false,
+              1,
+              reports,
+              1
+        );
+        assertTrue((newDamage >= 7) && (newDamage <= 42),
+              "A 6D6 burst shifted past the end of the table must roll 7D6 (7-42), not fall back to the weapon's "
+                    + "base damage of 4; got " + newDamage);
+        assertEquals(1, reports.size(), "Report size");
+    }
+
+    @Test
     void testDirectBlowInfantryMOS3BurstInBuilding() {
         // Burst Weapon in the building attacking infantry also in the building.
         // 1D6 -> 4D6 -> 4D6 / 2

--- a/megamek/unittests/megamek/common/weapons/handlers/PainShuntFlameDamageTest.java
+++ b/megamek/unittests/megamek/common/weapons/handlers/PainShuntFlameDamageTest.java
@@ -1,0 +1,325 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.weapons.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Vector;
+
+import megamek.common.Player;
+import megamek.common.Report;
+import megamek.common.TechConstants;
+import megamek.common.ToHitData;
+import megamek.common.actions.WeaponAttackAction;
+import megamek.common.battleArmor.BattleArmor;
+import megamek.common.board.Coords;
+import megamek.common.equipment.AmmoType;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.Mounted;
+import megamek.common.equipment.WeaponMounted;
+import megamek.common.equipment.WeaponType;
+import megamek.common.game.Game;
+import megamek.common.loaders.EntityLoadingException;
+import megamek.common.options.OptionsConstants;
+import megamek.common.units.BipedMek;
+import megamek.common.units.ConvInfantry;
+import megamek.common.units.Crew;
+import megamek.common.units.CrewType;
+import megamek.common.units.Entity;
+import megamek.common.units.EntityMovementMode;
+import megamek.common.units.EntityWeightClass;
+import megamek.common.units.Mek;
+import megamek.server.totalWarfare.TWGameManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for issue #8450 and RFE #8435.
+ *
+ * <p>Conventional infantry and battle armor units made up of pain-shunted warriors halve any damage from
+ * flame-based weapons (IO p. 78; TO:AR p. 171 defines flame-based as plasma, flamer and Firedrake). Before the fix
+ * the flamer handlers applied that reduction only when the target was conventional infantry, so pain-shunted
+ * battle armor took full damage.</p>
+ *
+ * <p>The heavy flamer tests also cover the reporting half of #8435: anti-infantry damage now goes through the
+ * shared handler, which writes the step-by-step damage breakdown added by PR #8198.</p>
+ */
+class PainShuntFlameDamageTest {
+
+    private static final String FLAMER = "ISFlamer";
+    private static final String HEAVY_FLAMER = "ISHeavyFlamer";
+    private static final String HEAVY_FLAMER_AMMO = "IS Heavy Flamer Ammo";
+
+    /** Damage of a standard flamer against a target that is not conventional infantry. */
+    private static final int FLAMER_DAMAGE = 2;
+    /** Damage of a heavy flamer against a target that is not conventional infantry. */
+    private static final int HEAVY_FLAMER_DAMAGE = 4;
+
+    private Game game;
+    private TWGameManager gameManager;
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void setUp() {
+        gameManager = new TWGameManager();
+        game = gameManager.getGame();
+        game.addPlayer(0, new Player(0, "Attacker"));
+        game.addPlayer(1, new Player(1, "Defender"));
+    }
+
+    private BipedMek createAttacker() {
+        BipedMek attacker = new BipedMek();
+        attacker.setGame(game);
+        attacker.setId(1);
+        attacker.setChassis("Flame Carrier");
+        attacker.setModel("Attacker");
+        attacker.setCrew(new Crew(CrewType.SINGLE));
+        attacker.setOwner(game.getPlayer(0));
+        attacker.setWeight(50.0);
+        attacker.setOriginalWalkMP(5);
+        attacker.setPosition(new Coords(1, 1));
+        attacker.setFacing(0);
+        return attacker;
+    }
+
+    private WeaponMounted mountFlamer(Entity attacker, String weaponName) throws EntityLoadingException {
+        try {
+            WeaponType weaponType = (WeaponType) EquipmentType.get(weaponName);
+            WeaponMounted weapon = (WeaponMounted) attacker.addEquipment(weaponType, Mek.LOC_RIGHT_ARM);
+            if (weaponType.getAmmoType() != AmmoType.AmmoTypeEnum.NA) {
+                Mounted<?> ammo = attacker.addEquipment(EquipmentType.get(HEAVY_FLAMER_AMMO), Mek.LOC_RIGHT_TORSO);
+                weapon.setLinked(ammo);
+            }
+            return weapon;
+        } catch (Exception exception) {
+            throw new EntityLoadingException(exception.getMessage(), exception);
+        }
+    }
+
+    private BattleArmor createFireResistantBattleArmorTarget() {
+        BattleArmor battleArmor = createBattleArmorTarget(false);
+        // The all-locations overloads; the per-location ones recalculate tech advancement, which needs a fully
+        // built armor entry this bare test unit does not have. Fire-Resistant armor is Clan-only, so the tech
+        // level has to say Clan or the battle value calculator cannot resolve the armor by name.
+        battleArmor.setArmorType(EquipmentType.T_ARMOR_BA_FIRE_RESIST);
+        battleArmor.setArmorTechLevel(TechConstants.T_CLAN_TW);
+        return battleArmor;
+    }
+
+    private BattleArmor createBattleArmorTarget(boolean painShunted) {
+        BattleArmor battleArmor = new BattleArmor();
+        battleArmor.setGame(game);
+        battleArmor.setId(2);
+        battleArmor.setChassis("Asura");
+        battleArmor.setModel("Test");
+        battleArmor.setSquadSize(4);
+        battleArmor.setWeightClass(EntityWeightClass.WEIGHT_MEDIUM);
+
+        Crew crew = new Crew(CrewType.INFANTRY_CREW);
+        battleArmor.setCrew(crew);
+        if (painShunted) {
+            crew.getOptions().getOption(OptionsConstants.MD_PAIN_SHUNT).setValue(true);
+        }
+
+        battleArmor.setOwner(game.getPlayer(1));
+        for (int trooper = 1; trooper <= 4; trooper++) {
+            battleArmor.initializeArmor(4, trooper);
+        }
+        battleArmor.autoSetInternal();
+        battleArmor.setPosition(new Coords(1, 2));
+        return battleArmor;
+    }
+
+    private ConvInfantry createInfantryTarget() {
+        ConvInfantry infantry = new ConvInfantry();
+        infantry.setGame(game);
+        infantry.setId(3);
+        infantry.setMovementMode(EntityMovementMode.INF_LEG);
+        infantry.setSquadSize(7);
+        infantry.setSquadCount(4);
+        infantry.setCrew(new Crew(CrewType.INFANTRY_CREW));
+        infantry.autoSetInternal();
+        infantry.setOwner(game.getPlayer(1));
+        infantry.setPosition(new Coords(1, 2));
+        return infantry;
+    }
+
+    private WeaponAttackAction attack(Entity attacker, Entity target, WeaponMounted weapon) {
+        return new WeaponAttackAction(attacker.getId(), target.getId(), attacker.getEquipmentNum(weapon));
+    }
+
+    @Test
+    @DisplayName("A standard flamer halves its damage against pain-shunted battle armor")
+    void flamerHalvesDamageAgainstPainShuntedBattleArmor() throws EntityLoadingException {
+        BipedMek attacker = createAttacker();
+        WeaponMounted flamer = mountFlamer(attacker, FLAMER);
+        BattleArmor target = createBattleArmorTarget(true);
+        game.addEntity(attacker);
+        game.addEntity(target);
+
+        FlamerHandler handler = new FlamerHandler(new ToHitData(), attack(attacker, target, flamer), game,
+              gameManager);
+
+        assertEquals(FLAMER_DAMAGE / 2, handler.calcDamagePerHit(),
+              "Pain-shunted battle armor halves flame damage (IO p. 78) - regression for #8450");
+    }
+
+    @Test
+    @DisplayName("A standard flamer deals full damage to battle armor without pain shunts")
+    void flamerDealsFullDamageToUnshuntedBattleArmor() throws EntityLoadingException {
+        BipedMek attacker = createAttacker();
+        WeaponMounted flamer = mountFlamer(attacker, FLAMER);
+        BattleArmor target = createBattleArmorTarget(false);
+        game.addEntity(attacker);
+        game.addEntity(target);
+
+        FlamerHandler handler = new FlamerHandler(new ToHitData(), attack(attacker, target, flamer), game,
+              gameManager);
+
+        assertEquals(FLAMER_DAMAGE, handler.calcDamagePerHit(),
+              "Battle armor without a pain shunt takes the flamer's full damage");
+    }
+
+    @Test
+    @DisplayName("A heavy flamer halves its damage against pain-shunted battle armor")
+    void heavyFlamerHalvesDamageAgainstPainShuntedBattleArmor() throws EntityLoadingException {
+        BipedMek attacker = createAttacker();
+        WeaponMounted heavyFlamer = mountFlamer(attacker, HEAVY_FLAMER);
+        BattleArmor target = createBattleArmorTarget(true);
+        game.addEntity(attacker);
+        game.addEntity(target);
+
+        VehicleFlamerHandler handler = new VehicleFlamerHandler(new ToHitData(),
+              attack(attacker, target, heavyFlamer), game, gameManager);
+
+        assertEquals(HEAVY_FLAMER_DAMAGE / 2, handler.calcDamagePerHit(),
+              "Pain-shunted battle armor halves heavy flamer damage too - regression for #8450");
+    }
+
+    @Test
+    @DisplayName("A heavy flamer deals full damage to battle armor without pain shunts")
+    void heavyFlamerDealsFullDamageToUnshuntedBattleArmor() throws EntityLoadingException {
+        BipedMek attacker = createAttacker();
+        WeaponMounted heavyFlamer = mountFlamer(attacker, HEAVY_FLAMER);
+        BattleArmor target = createBattleArmorTarget(false);
+        game.addEntity(attacker);
+        game.addEntity(target);
+
+        VehicleFlamerHandler handler = new VehicleFlamerHandler(new ToHitData(),
+              attack(attacker, target, heavyFlamer), game, gameManager);
+
+        assertEquals(HEAVY_FLAMER_DAMAGE, handler.calcDamagePerHit(),
+              "Battle armor without a pain shunt takes the heavy flamer's full damage");
+    }
+
+    @Test
+    @DisplayName("A standard flamer does nothing to fire-resistant battle armor")
+    void flamerDoesNoDamageToFireResistantBattleArmor() throws EntityLoadingException {
+        BipedMek attacker = createAttacker();
+        WeaponMounted flamer = mountFlamer(attacker, FLAMER);
+        BattleArmor target = createFireResistantBattleArmorTarget();
+        game.addEntity(attacker);
+        game.addEntity(target);
+
+        FlamerHandler handler = new FlamerHandler(new ToHitData(), attack(attacker, target, flamer), game,
+              gameManager);
+
+        assertEquals(0, handler.calcDamagePerHit(),
+              "A Fire-Resistant suit ignores damage from heat-causing weapons (TM p. 170)");
+    }
+
+    @Test
+    @DisplayName("A heavy flamer does nothing to fire-resistant battle armor")
+    void heavyFlamerDoesNoDamageToFireResistantBattleArmor() throws EntityLoadingException {
+        BipedMek attacker = createAttacker();
+        WeaponMounted heavyFlamer = mountFlamer(attacker, HEAVY_FLAMER);
+        BattleArmor target = createFireResistantBattleArmorTarget();
+        game.addEntity(attacker);
+        game.addEntity(target);
+
+        VehicleFlamerHandler handler = new VehicleFlamerHandler(new ToHitData(),
+              attack(attacker, target, heavyFlamer), game, gameManager);
+
+        assertEquals(0, handler.calcDamagePerHit(),
+              "The heavy flamer is heat-causing too, so a Fire-Resistant suit ignores it (TM p. 170). Before the "
+                    + "fix only the standard flamer honoured this");
+    }
+
+    @Test
+    @DisplayName("A heavy flamer still rolls 6d6 against conventional infantry, and now reports the breakdown")
+    void heavyFlamerRollsBurstDamageAndReportsAgainstConventionalInfantry() throws EntityLoadingException {
+        BipedMek attacker = createAttacker();
+        WeaponMounted heavyFlamer = mountFlamer(attacker, HEAVY_FLAMER);
+        ConvInfantry target = createInfantryTarget();
+        game.addEntity(attacker);
+        game.addEntity(target);
+
+        VehicleFlamerHandler handler = new VehicleFlamerHandler(new ToHitData(),
+              attack(attacker, target, heavyFlamer), game, gameManager);
+
+        int damage = handler.calcDamagePerHit();
+
+        assertTrue((damage >= 6) && (damage <= 36),
+              "The heavy flamer's infantry damage class is 6D6, so damage must stay in 6-36; got " + damage);
+        assertFalse(handler.calcDmgPerHitReport.isEmpty(),
+              "Heavy flamer anti-infantry damage must now write the damage breakdown report - RFE #8435");
+    }
+
+    @Test
+    @DisplayName("A heavy flamer halves its 6d6 roll against pain-shunted conventional infantry")
+    void heavyFlamerHalvesDamageAgainstPainShuntedConventionalInfantry() throws EntityLoadingException {
+        BipedMek attacker = createAttacker();
+        WeaponMounted heavyFlamer = mountFlamer(attacker, HEAVY_FLAMER);
+        ConvInfantry target = createInfantryTarget();
+        target.getCrew().getOptions().getOption(OptionsConstants.MD_PAIN_SHUNT).setValue(true);
+        game.addEntity(attacker);
+        game.addEntity(target);
+
+        VehicleFlamerHandler handler = new VehicleFlamerHandler(new ToHitData(),
+              attack(attacker, target, heavyFlamer), game, gameManager);
+
+        int damage = handler.calcDamagePerHit();
+
+        assertTrue((damage >= 3) && (damage <= 18),
+              "Half of a 6D6 burst is 3-18; got " + damage);
+    }
+}

--- a/megamek/unittests/megamek/common/weapons/handlers/plasma/PlasmaPainShuntTest.java
+++ b/megamek/unittests/megamek/common/weapons/handlers/plasma/PlasmaPainShuntTest.java
@@ -168,10 +168,13 @@ class PlasmaPainShuntTest {
 
         int hits = handler.calcHits(new Vector<Report>());
 
+        // The upper bound of the halved band is MAXIMUM_UNSHUNTED_DAMAGE / 2, which is 11, and the first
+        // assertion has already required hits to be under 12. Asserting it a second time can never fail, so
+        // only the lower bound is checked here and the two together still pin the 6-to-11 band.
         assertTrue(hits < MINIMUM_UNSHUNTED_DAMAGE,
               "A pain shunt must actually reduce the damage, not just regroup it. Unshunted damage is at least "
                     + MINIMUM_UNSHUNTED_DAMAGE + "; got " + hits + " - regression for #8450");
-        assertTrue((hits >= MINIMUM_UNSHUNTED_DAMAGE / 2) && (hits <= MAXIMUM_UNSHUNTED_DAMAGE / 2),
+        assertTrue(hits >= MINIMUM_UNSHUNTED_DAMAGE / 2,
               "Half of 10 + 2d6 is 6 to 11; got " + hits);
     }
 

--- a/megamek/unittests/megamek/common/weapons/handlers/plasma/PlasmaPainShuntTest.java
+++ b/megamek/unittests/megamek/common/weapons/handlers/plasma/PlasmaPainShuntTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.weapons.handlers.plasma;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Vector;
+
+import megamek.common.Player;
+import megamek.common.Report;
+import megamek.common.ToHitData;
+import megamek.common.actions.WeaponAttackAction;
+import megamek.common.battleArmor.BattleArmor;
+import megamek.common.board.Coords;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.Mounted;
+import megamek.common.equipment.WeaponMounted;
+import megamek.common.equipment.WeaponType;
+import megamek.common.game.Game;
+import megamek.common.loaders.EntityLoadingException;
+import megamek.common.options.OptionsConstants;
+import megamek.common.units.BipedMek;
+import megamek.common.units.Crew;
+import megamek.common.units.CrewType;
+import megamek.common.units.Entity;
+import megamek.common.units.EntityWeightClass;
+import megamek.common.units.Mek;
+import megamek.server.totalWarfare.TWGameManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for the plasma half of issue #8450.
+ *
+ * <p>The plasma rifle applied the Artificial Pain Shunt reduction (IO p. 78) to the cluster size rather than the
+ * damage. Cluster size does not change the total: the damage loop applies {@code damagePerHit * min(nCluster,
+ * hits)} per group and subtracts {@code nCluster} from the remaining hits, so the total is always
+ * {@code hits * damagePerHit}. Halving the cluster only split the same damage into more, smaller groups, which
+ * against battle armor spreads it over more troopers and wastes less overkill - the shunt was a net penalty.</p>
+ */
+class PlasmaPainShuntTest {
+
+    private static final String PLASMA_RIFLE = "ISPlasmaRifle";
+    private static final String PLASMA_RIFLE_AMMO = "ISPlasmaRifleAmmo";
+
+    /** A plasma rifle deals 10 + 2d6 damage to a target that does not track heat, so 12 to 22. */
+    private static final int MINIMUM_UNSHUNTED_DAMAGE = 12;
+    private static final int MAXIMUM_UNSHUNTED_DAMAGE = 22;
+    /** The cluster size the plasma rifle uses against battle armor. */
+    private static final int BATTLE_ARMOR_CLUSTER_SIZE = 5;
+
+    private Game game;
+    private TWGameManager gameManager;
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void setUp() {
+        gameManager = new TWGameManager();
+        game = gameManager.getGame();
+        game.addPlayer(0, new Player(0, "Attacker"));
+        game.addPlayer(1, new Player(1, "Defender"));
+    }
+
+    private BipedMek createAttacker() {
+        BipedMek attacker = new BipedMek();
+        attacker.setGame(game);
+        attacker.setId(1);
+        attacker.setChassis("Plasma Carrier");
+        attacker.setModel("Attacker");
+        attacker.setCrew(new Crew(CrewType.SINGLE));
+        attacker.setOwner(game.getPlayer(0));
+        attacker.setWeight(50.0);
+        attacker.setOriginalWalkMP(5);
+        attacker.setPosition(new Coords(1, 1));
+        attacker.setFacing(0);
+        return attacker;
+    }
+
+    private WeaponMounted mountPlasmaRifle(Entity attacker) throws EntityLoadingException {
+        try {
+            WeaponType weaponType = (WeaponType) EquipmentType.get(PLASMA_RIFLE);
+            WeaponMounted weapon = (WeaponMounted) attacker.addEquipment(weaponType, Mek.LOC_RIGHT_ARM);
+            Mounted<?> ammo = attacker.addEquipment(EquipmentType.get(PLASMA_RIFLE_AMMO), Mek.LOC_RIGHT_TORSO);
+            weapon.setLinked(ammo);
+            return weapon;
+        } catch (Exception exception) {
+            throw new EntityLoadingException(exception.getMessage(), exception);
+        }
+    }
+
+    private BattleArmor createBattleArmorTarget(boolean painShunted) {
+        BattleArmor battleArmor = new BattleArmor();
+        battleArmor.setGame(game);
+        battleArmor.setId(2);
+        battleArmor.setChassis("Asura");
+        battleArmor.setModel("Test");
+        battleArmor.setSquadSize(4);
+        battleArmor.setWeightClass(EntityWeightClass.WEIGHT_MEDIUM);
+
+        Crew crew = new Crew(CrewType.INFANTRY_CREW);
+        battleArmor.setCrew(crew);
+        if (painShunted) {
+            crew.getOptions().getOption(OptionsConstants.MD_PAIN_SHUNT).setValue(true);
+        }
+
+        battleArmor.setOwner(game.getPlayer(1));
+        for (int trooper = 1; trooper <= 4; trooper++) {
+            battleArmor.initializeArmor(4, trooper);
+        }
+        battleArmor.autoSetInternal();
+        battleArmor.setPosition(new Coords(1, 2));
+        return battleArmor;
+    }
+
+    private PlasmaRifleHandler handlerAgainst(BattleArmor target) throws EntityLoadingException {
+        BipedMek attacker = createAttacker();
+        WeaponMounted plasmaRifle = mountPlasmaRifle(attacker);
+        game.addEntity(attacker);
+        game.addEntity(target);
+
+        WeaponAttackAction weaponAttack = new WeaponAttackAction(attacker.getId(), target.getId(),
+              attacker.getEquipmentNum(plasmaRifle));
+        return new PlasmaRifleHandler(new ToHitData(), weaponAttack, game, gameManager);
+    }
+
+    @Test
+    @DisplayName("Plasma rifle damage against battle armor is halved by a pain shunt")
+    void plasmaRifleHalvesDamageAgainstPainShuntedBattleArmor() throws EntityLoadingException {
+        PlasmaRifleHandler handler = handlerAgainst(createBattleArmorTarget(true));
+
+        int hits = handler.calcHits(new Vector<Report>());
+
+        assertTrue(hits < MINIMUM_UNSHUNTED_DAMAGE,
+              "A pain shunt must actually reduce the damage, not just regroup it. Unshunted damage is at least "
+                    + MINIMUM_UNSHUNTED_DAMAGE + "; got " + hits + " - regression for #8450");
+        assertTrue((hits >= MINIMUM_UNSHUNTED_DAMAGE / 2) && (hits <= MAXIMUM_UNSHUNTED_DAMAGE / 2),
+              "Half of 10 + 2d6 is 6 to 11; got " + hits);
+    }
+
+    @Test
+    @DisplayName("Plasma rifle damage against battle armor without pain shunts is unchanged")
+    void plasmaRifleDealsFullDamageToUnshuntedBattleArmor() throws EntityLoadingException {
+        PlasmaRifleHandler handler = handlerAgainst(createBattleArmorTarget(false));
+
+        int hits = handler.calcHits(new Vector<Report>());
+
+        assertTrue((hits >= MINIMUM_UNSHUNTED_DAMAGE) && (hits <= MAXIMUM_UNSHUNTED_DAMAGE),
+              "A plasma rifle deals 10 + 2d6 to battle armor; got " + hits);
+    }
+
+    @Test
+    @DisplayName("A pain shunt no longer shrinks the plasma cluster size")
+    void painShuntDoesNotChangeClusterSize() throws EntityLoadingException {
+        PlasmaRifleHandler shuntedHandler = handlerAgainst(createBattleArmorTarget(true));
+
+        assertEquals(BATTLE_ARMOR_CLUSTER_SIZE, shuntedHandler.calculateNumCluster(),
+              "Halving the cluster size never reduced the total damage, and against battle armor it spread the "
+                    + "damage over more troopers. The reduction belongs on the damage - regression for #8450");
+    }
+}


### PR DESCRIPTION
## What this changes

**Pain shunts finally work for battle armor.** Interstellar Operations p. 78 says conventional infantry *and battle armor* made up of pain-shunted warriors halve any damage from flame-based weapons. Only conventional infantry got the reduction. A pain-shunted Asura squad took full damage from every flamer.

**The plasma reduction reduced nothing.** The plasma rifle halved the cluster size instead of the damage. Cluster size does not change the total, so a shunted squad still took the same damage - now spread over more troopers, which wasted less overkill and made the shunt a net penalty.

**Heavy and vehicle flamers now show their damage breakdown.** They rolled their own dice instead of using the shared anti-infantry path, so they printed a bare damage number where standard flamers have shown the full step-by-step line since #8198. Routing them through the shared path also picks up two rules they were skipping: the burst halving against mechanized infantry, and the halving inside a building (TW p. 176).

**Fire-Resistant battle armor now stops heavy flamers too.** The suit "ignores damage by heat-causing weapons" (TM p. 170). The standard flamer honoured that; the heavy flamer dealt full damage.

**Infantry incendiary weapons say why they dealt damage.** Firing one in Heat mode at a vehicle deals damage rather than heat, which is correct - true Inferno effects are an SRM-only rule. The log never said so. Damage numbers are unchanged.

Fixes #8450, fixes #8435

Also addresses the report in #8456, which is working as intended: the errata (TechManual pp. 350-352) renames these weapons from Inferno to Incendiary precisely to avoid this confusion. The rename itself is a follow-up PR.

## Testing

`./gradlew test javadoc` green: 15,395 tests, 0 failures, plus `checkstyleMain`. No pre-existing failures.

12 new tests. Reverting the four handler fixes and re-running makes 5 of the 9 handler tests fail - every pain-shunt and reporting assertion. The 4 that still pass are the no-pain-shunt controls and the conventional infantry case the old code already handled.

Tested in game against the reporter's setups:

- Standard flamer at two Asura squads, one shunted: 7 -> 5 armor unshunted, 7 -> 6 shunted, with the reduction line only on the shunted one.
- Plasma rifle at the same pair: 19 damage unshunted in 5-point clusters, 6 damage shunted, still in 5-point clusters. Before the fix the shunted squad took the same total in 2-point clusters.
- Heavy flamer at a Clan Foot Infantry point: `4 dmg Burst-fire (6d6) weapon against infantry, damage changed to 22 (6d6 X 1)`, then doubled in the open, then the armor divisor.
- Heavy flamer at mechanized infantry, in a building and in the open: both new halving steps appear and are labelled.
- Standard and heavy flamer at a Salamander: both now report no damage.
- Inferno grenade launcher in Heat mode at an Awesome (heat, unchanged) and a Rhino Fire Support Tank (damage, unchanged, plus the new line).

The in-game pass found one defect that is fixed here: the "does not track heat" line printed once per damage cluster instead of once per attack.

## What is not proven yet

The clamp in `directBlowInfantryDamage` is covered by a unit test but was never seen live - it needs a direct blow with a margin of success of 6 or more against infantry, which did not come up in play testing.

Everything else in the list above was confirmed in game.

---
- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
