### PR TITLE
Fix: Register two missing infantry weapons and complete the Heavy Burst rule

### DIFF
--- a/megamek/resources/megamek/common/report-messages.properties
+++ b/megamek/resources/megamek/common/report-messages.properties
@@ -526,6 +526,8 @@
 3418=\ [<data> base + <data> TSM]
 3419=\ [<data> base + <data> <data>]
 3421=\ [<data> base + <data> TSM + <data> <data>]
+3422=\ [+<data> Heavy Burst]
+3423=\ [+<data> beast burst]
 3420=<data> missiles continue.
 3425=The remaining <data> missile(s) find no new target.
 3426=The remaining <data> missile(s) find no new target due to hostile ECM interference.

--- a/megamek/src/megamek/common/SourceBookCode.java
+++ b/megamek/src/megamek/common/SourceBookCode.java
@@ -55,6 +55,7 @@ public enum SourceBookCode {
     SHRAPNEL_5("Shrap05"),
     SHRAPNEL_7("Shrap07"),
     SHRAPNEL_9("Shrap09"),
+    SHRAPNEL_22("Shrap22"),
     TM("TM"),
     TO_AR("TO:AR"),
     TO_AUE("TO:AUE"),

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -39,6 +39,7 @@ import static java.lang.Math.min;
 
 import java.util.*;
 
+import megamek.MMConstants;
 import megamek.common.*;
 import megamek.common.actions.*;
 import megamek.common.annotations.Nullable;
@@ -1834,7 +1835,14 @@ public class Compute {
                 mods.addModifier(1, "point blank support weapon");
             }
 
-            if (primaryWeapon.hasFlag(WeaponType.F_INF_BURST)) {
+            // A platoon whose primary weapon is over the damage cap has its damage reduced to the cap and
+            // "automatically gain[s] the Heavy Burst Weapon special feature" (TM p. 152). That feature is both a
+            // -1 to-hit at range 0 and +1D6 damage against conventional infantry; the damage half is applied in
+            // InfantryWeaponHandler, so the to-hit half has to honour the same condition or the platoon gets only
+            // half of what the rule grants.
+            boolean heavyBurstFromDamageCap =
+                  primaryWeapon.getInfantryDamage() > MMConstants.INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP;
+            if (primaryWeapon.hasFlag(WeaponType.F_INF_BURST) || heavyBurstFromDamageCap) {
                 mods.addModifier(-1, "point blank burst fire weapon");
             }
         }

--- a/megamek/src/megamek/common/equipment/WeaponType.java
+++ b/megamek/src/megamek/common/equipment/WeaponType.java
@@ -211,6 +211,21 @@ import megamek.common.weapons.infantry.support.laser.InfantrySupportLaserUltraHe
 import megamek.common.weapons.infantry.support.laser.InfantrySupportLaserWeapon;
 import megamek.common.weapons.infantry.support.laser.InfantrySupportPulseLaserWeapon;
 import megamek.common.weapons.infantry.support.laser.InfantrySupportSemiPortableLaserWeapon;
+import megamek.common.weapons.infantry.support.mg.InfantryMachineGunAkaiRyu;
+import megamek.common.weapons.infantry.support.mg.InfantryMachineGunBooneMGL14A;
+import megamek.common.weapons.infantry.support.mg.InfantryMachineGunBooneMGL14D;
+import megamek.common.weapons.infantry.support.mg.InfantryMachineGunFogueDefender;
+import megamek.common.weapons.infantry.support.mg.InfantryMachineGunHCKM2MG;
+import megamek.common.weapons.infantry.support.mg.InfantryMachineGunHuoDushe;
+import megamek.common.weapons.infantry.support.mg.InfantryMachineGunNambuM12;
+import megamek.common.weapons.infantry.support.mg.InfantryMachineGunPeacekeeperLB;
+import megamek.common.weapons.infantry.support.mg.InfantryMachineGunPeacekeeperLLB;
+import megamek.common.weapons.infantry.support.mg.InfantryMachineGunPeacekeeperLSB;
+import megamek.common.weapons.infantry.support.mg.InfantryMachineGunPeacekeeperSB;
+import megamek.common.weapons.infantry.support.mg.InfantryMachineGunSarcotMG19;
+import megamek.common.weapons.infantry.support.mg.InfantryMachineGunTIE124;
+import megamek.common.weapons.infantry.support.mg.InfantryMachineGunTharwepNachtgewitter;
+import megamek.common.weapons.infantry.support.mg.InfantryMachineGunType17;
 import megamek.common.weapons.infantry.support.mg.InfantrySupportMGLightWeapon;
 import megamek.common.weapons.infantry.support.mg.InfantrySupportMGPortableWeapon;
 import megamek.common.weapons.infantry.support.mg.InfantrySupportMGSemiPortableWeapon;
@@ -2150,6 +2165,22 @@ public class WeaponType extends EquipmentType {
 
         // Infantry Support Weapons
         EquipmentType.addType(new InfantrySupportMGPortableWeapon());
+        // Light machine guns from Shrapnel #22.
+        EquipmentType.addType(new InfantryMachineGunType17());
+        EquipmentType.addType(new InfantryMachineGunHuoDushe());
+        EquipmentType.addType(new InfantryMachineGunNambuM12());
+        EquipmentType.addType(new InfantryMachineGunAkaiRyu());
+        EquipmentType.addType(new InfantryMachineGunSarcotMG19());
+        EquipmentType.addType(new InfantryMachineGunFogueDefender());
+        EquipmentType.addType(new InfantryMachineGunHCKM2MG());
+        EquipmentType.addType(new InfantryMachineGunTharwepNachtgewitter());
+        EquipmentType.addType(new InfantryMachineGunPeacekeeperLSB());
+        EquipmentType.addType(new InfantryMachineGunPeacekeeperSB());
+        EquipmentType.addType(new InfantryMachineGunPeacekeeperLLB());
+        EquipmentType.addType(new InfantryMachineGunPeacekeeperLB());
+        EquipmentType.addType(new InfantryMachineGunBooneMGL14A());
+        EquipmentType.addType(new InfantryMachineGunBooneMGL14D());
+        EquipmentType.addType(new InfantryMachineGunTIE124());
         EquipmentType.addType(new InfantrySupportMGSemiPortableWeapon());
         EquipmentType.addType(new InfantrySupportMk1LightAAWeapon());
         EquipmentType.addType(new InfantrySupportMk2PortableAAWeapon());

--- a/megamek/src/megamek/common/equipment/WeaponType.java
+++ b/megamek/src/megamek/common/equipment/WeaponType.java
@@ -153,6 +153,7 @@ import megamek.common.weapons.infantry.archaic.*;
 import megamek.common.weapons.infantry.grenade.InfantryGrenadeInfernoWeapon;
 import megamek.common.weapons.infantry.grenade.InfantryGrenadeMicroWeapon;
 import megamek.common.weapons.infantry.grenade.InfantryGrenadeMiniInfernoWeapon;
+import megamek.common.weapons.infantry.grenade.InfantryGrenadeMiniWeapon;
 import megamek.common.weapons.infantry.grenade.InfantryGrenadeRAGWeapon;
 import megamek.common.weapons.infantry.grenade.InfantryGrenadeStandardWeapon;
 import megamek.common.weapons.infantry.laser.InfantryLaserCarbineBrightStarL15;
@@ -2221,6 +2222,7 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new InfantryGrenadeInfernoWeapon());
         EquipmentType.addType(new InfantryGrenadeMicroWeapon());
         EquipmentType.addType(new InfantryGrenadeMiniInfernoWeapon());
+        EquipmentType.addType(new InfantryGrenadeMiniWeapon());
         EquipmentType.addType(new InfantryGrenadeRAGWeapon());
         EquipmentType.addType(new InfantryGrenadeStandardWeapon());
 
@@ -2237,6 +2239,7 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new InfantryProstheticSMGWeapon());
         EquipmentType.addType(new InfantryProstheticBladeWeapon());
         EquipmentType.addType(new InfantryProstheticNeedleWeapon());
+        EquipmentType.addType(new InfantryProstheticRumalGarroteWeapon());
         EquipmentType.addType(new InfantryProstheticShockerWeapon());
         EquipmentType.addType(new InfantryProstheticVibroBladeWeapon());
         EquipmentType.addType(new InfantryProstheticClimbingClawsWeapon());

--- a/megamek/src/megamek/common/weapons/infantry/InfantryWeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryWeaponHandler.java
@@ -232,24 +232,31 @@ public class InfantryWeaponHandler extends WeaponHandler {
         int tailDamageDealt = (int) Math.round(tailBonusDamage * troopersHit);
 
         // beast-mounted infantry get range 0 bonus damage per platoon
+        int mountBurstDamageDealt = 0;
         if ((attackingEntity instanceof ConvInfantry infantry) && (nRange == 0)) {
             InfantryMount mount = infantry.getMount();
             if (mount != null) {
                 if (!target.isConventionalInfantry()) {
                     damageDealt += mount.vehicleDamage();
                 } else if (mount.getBurstDamageDice() > 0) {
-                    damageDealt += Compute.d6(mount.getBurstDamageDice());
+                    mountBurstDamageDealt = Compute.d6(mount.getBurstDamageDice());
+                    damageDealt += mountBurstDamageDealt;
                 }
             }
         }
 
-        // conventional infantry weapons with high damage get treated as if they have
-        // the infantry burst mod
-        if (target instanceof ConvInfantry infantry &&
-              (weaponType.hasFlag(WeaponType.F_INF_BURST) ||
-                    (attackingEntity.isConventionalInfantry()
-                          && infantry.primaryWeaponDamageCapped()))) {
-            damageDealt += Compute.d6();
+        // A Heavy Burst weapon adds 1D6 damage against conventional infantry. A platoon whose primary weapon is
+        // over the damage cap gains that feature outright (TM p. 152), so the cap has to be read off the ATTACKING
+        // platoon; reading it off the target made the bonus depend on what the victim happened to be carrying.
+        int heavyBurstDamageDealt = 0;
+        // Kept as instanceof, not isConventionalInfantry(): CombatVehicleEscapePod is a ConvInfantry subclass that
+        // answers false, so switching would silently drop the bonus against escape pods.
+        if ((target instanceof ConvInfantry)
+              && (weaponType.hasFlag(WeaponType.F_INF_BURST)
+                    || ((attackingEntity instanceof ConvInfantry attackingInfantry)
+                          && attackingInfantry.primaryWeaponDamageCapped()))) {
+            heavyBurstDamageDealt = Compute.d6();
+            damageDealt += heavyBurstDamageDealt;
         }
         if ((target instanceof Infantry) && ((Infantry) target).isMechanized()) {
             damageDealt /= 2;
@@ -281,7 +288,9 @@ public class InfantryWeaponHandler extends WeaponHandler {
               - tsmDamageDealt
               - prostheticDamageDealt
               - extraneousDamageDealt
-              - tailDamageDealt;
+              - tailDamageDealt
+              - heavyBurstDamageDealt
+              - mountBurstDamageDealt;
         boolean hasTsm = tsmDamageDealt > 0;
         boolean hasProsthetic = prostheticDamageDealt > 0;
         boolean hasExtraneous = extraneousDamageDealt > 0;
@@ -336,6 +345,23 @@ public class InfantryWeaponHandler extends WeaponHandler {
                 prostheticReport.add(allEnhancementNames.toString());
                 vPhaseReport.addElement(prostheticReport);
             }
+        }
+
+        // The burst dice are rolled, not derived from the weapon, so without a line of their own the player has
+        // no way to tell a high roll from a hard-hitting platoon.
+        if (heavyBurstDamageDealt > 0) {
+            Report heavyBurstReport = new Report(3422);
+            heavyBurstReport.subject = subjectId;
+            heavyBurstReport.indent(2);
+            heavyBurstReport.add(heavyBurstDamageDealt);
+            vPhaseReport.addElement(heavyBurstReport);
+        }
+        if (mountBurstDamageDealt > 0) {
+            Report mountBurstReport = new Report(3423);
+            mountBurstReport.subject = subjectId;
+            mountBurstReport.indent(2);
+            mountBurstReport.add(mountBurstDamageDealt);
+            vPhaseReport.addElement(mountBurstReport);
         }
 
         if (target.isConventionalInfantry()) {

--- a/megamek/src/megamek/common/weapons/infantry/laser/InfantryLaserCarbineBrightStarL15.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/InfantryLaserCarbineBrightStarL15.java
@@ -54,8 +54,9 @@ public class InfantryLaserCarbineBrightStarL15 extends InfantryWeapon {
     public InfantryLaserCarbineBrightStarL15() {
         super();
 
-        name = "Laser Carbine (BrightStar L-15)";
-        setInternalName(name);
+        name = "Laser Carbine (Brightstar L-15)";
+        setInternalName("Laser Carbine (BrightStar L-15)");
+        addLookupName(name);
         addLookupName("BrightstarCarbine");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 2500;

--- a/megamek/src/megamek/common/weapons/infantry/laser/InfantryLaserCarbineBrightStarL15.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/InfantryLaserCarbineBrightStarL15.java
@@ -61,7 +61,7 @@ public class InfantryLaserCarbineBrightStarL15 extends InfantryWeapon {
         cost = 2500;
         bv = 0.2625;
         tonnage = 0.0018;
-        infantryDamage = 0.44;
+        infantryDamage = 0.1313;
         infantryRange = 4;
         shots = 3;
         bursts = 1;

--- a/megamek/src/megamek/common/weapons/infantry/laser/InfantryLaserSniperRifleDWSL5L.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/InfantryLaserSniperRifleDWSL5L.java
@@ -61,11 +61,11 @@ public class InfantryLaserSniperRifleDWSL5L extends InfantryWeapon {
         cost = 2500;
         bv = 1.225;
         tonnage = 0.0075;
-        infantryDamage = 0.61;
+        infantryDamage = 0.6125;
         infantryRange = 5;
         shots = 15;
         bursts = 1;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY).or(F_INF_BURST);
         rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_9);
 
         techAdvancement

--- a/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolAA75L.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolAA75L.java
@@ -62,7 +62,7 @@ public class InfantryLaserPistolAA75L extends InfantryWeapon {
         bv = 0.021;
         tonnage = 0.0001;
         flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
-        infantryDamage = 0.07;
+        infantryDamage = 0.021;
         infantryRange = 1;
         // ammoWeight is not applicable (NA)
         shots = 1;

--- a/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolAWAWilibyMk4LaserPistol.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolAWAWilibyMk4LaserPistol.java
@@ -53,8 +53,9 @@ public class InfantryLaserPistolAWAWilibyMk4LaserPistol extends InfantryWeapon {
     public InfantryLaserPistolAWAWilibyMk4LaserPistol() {
         super();
 
-        name = "Laser Pistol (AWA Wiliby MK4 LASER PISTOL)";
-        setInternalName(name);
+        name = "Laser Pistol (AWA Wiliby Mk4 Laser Pistol)";
+        setInternalName("Laser Pistol (AWA Wiliby MK4 LASER PISTOL)");
+        addLookupName(name);
         addLookupName("WILIBYMK4");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 1500;

--- a/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolAWAWilibyMk4LaserPistol.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolAWAWilibyMk4LaserPistol.java
@@ -61,7 +61,7 @@ public class InfantryLaserPistolAWAWilibyMk4LaserPistol extends InfantryWeapon {
         bv = 0.028;
         tonnage = 0.0018;
         flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
-        infantryDamage = 0.09;
+        infantryDamage = 0.028;
         infantryRange = 1;
         // ammoWeight is not applicable (NA)
         shots = 1;

--- a/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolBR25.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolBR25.java
@@ -60,7 +60,7 @@ public class InfantryLaserPistolBR25 extends InfantryWeapon {
         cost = 950;
         bv = 0.01575;
         tonnage = 0.0013;
-        infantryDamage = 0.05;
+        infantryDamage = 0.0158;
         infantryRange = 1;
         shots = 1;
         bursts = 1; // Bursts value is now always shown

--- a/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolBrightStarL12.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolBrightStarL12.java
@@ -61,7 +61,7 @@ public class InfantryLaserPistolBrightStarL12 extends InfantryWeapon {
         cost = 1100;
         bv = 0.056;
         tonnage = 0.0012;
-        infantryDamage = 0.19;
+        infantryDamage = 0.056;
         infantryRange = 2;
         shots = 2;
         bursts = 1; // Bursts value is now always shown

--- a/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolBrightStarL12.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolBrightStarL12.java
@@ -54,8 +54,9 @@ public class InfantryLaserPistolBrightStarL12 extends InfantryWeapon {
     public InfantryLaserPistolBrightStarL12() {
         super();
 
-        name = "Laser Pistol (BrightStar L-12)";
-        setInternalName(name);
+        name = "Laser Pistol (Brightstar L-12)";
+        setInternalName("Laser Pistol (BrightStar L-12)");
+        addLookupName(name);
         addLookupName("BRIGHTSTARL12");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 1100;

--- a/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolBrightStarL15.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolBrightStarL15.java
@@ -53,8 +53,9 @@ public class InfantryLaserPistolBrightStarL15 extends InfantryWeapon {
     public InfantryLaserPistolBrightStarL15() {
         super();
 
-        name = "Laser Pistol (BrightStar L-15)";
-        setInternalName(name);
+        name = "Laser Pistol (Brightstar L-15)";
+        setInternalName("Laser Pistol (BrightStar L-15)");
+        addLookupName(name);
         addLookupName("BRIGHTSTARL15");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 1750;

--- a/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolBrightStarL15.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolBrightStarL15.java
@@ -60,7 +60,7 @@ public class InfantryLaserPistolBrightStarL15 extends InfantryWeapon {
         cost = 1750;
         bv = 0.056;
         tonnage = 0.0014;
-        infantryDamage = 0.19;
+        infantryDamage = 0.056;
         infantryRange = 3;
         shots = 2;
         bursts = 1;

--- a/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolBrightStarL7.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolBrightStarL7.java
@@ -53,8 +53,9 @@ public class InfantryLaserPistolBrightStarL7 extends InfantryWeapon {
     public InfantryLaserPistolBrightStarL7() {
         super();
 
-        name = "Laser Pistol (BrightStar L-7)";
-        setInternalName(name);
+        name = "Laser Pistol (Brightstar L-7)";
+        setInternalName("Laser Pistol (BrightStar L-7)");
+        addLookupName(name);
         addLookupName("BRIGHTSTARL7");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 950;

--- a/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolBrightStarL7.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolBrightStarL7.java
@@ -60,7 +60,7 @@ public class InfantryLaserPistolBrightStarL7 extends InfantryWeapon {
         cost = 950;
         bv = 0.021;
         tonnage = 0.0011;
-        infantryDamage = 0.07;
+        infantryDamage = 0.021;
         infantryRange = 2;
         shots = 1;
         bursts = 1; // Bursts value is now always shown

--- a/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolDarklightIVLaserPistol.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolDarklightIVLaserPistol.java
@@ -54,8 +54,9 @@ public class InfantryLaserPistolDarklightIVLaserPistol extends InfantryWeapon {
     public InfantryLaserPistolDarklightIVLaserPistol() {
         super();
 
-        name = "Laser Pistol (Darklight IV)";
-        setInternalName(name);
+        name = "Laser Pistol (Darklight IV Laser Pistol)";
+        setInternalName("Laser Pistol (Darklight IV)");
+        addLookupName(name);
         addLookupName("DARKLIGHTIV");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 1200;

--- a/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolDarklightIVLaserPistol.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolDarklightIVLaserPistol.java
@@ -62,7 +62,7 @@ public class InfantryLaserPistolDarklightIVLaserPistol extends InfantryWeapon {
         cost = 1200;
         bv = 0.021;
         tonnage = 0.0012;
-        infantryDamage = 0.07;
+        infantryDamage = 0.021;
         infantryRange = 1;
         shots = 1;
         bursts = 1;

--- a/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolKelvin000Lancer3MM.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolKelvin000Lancer3MM.java
@@ -61,7 +61,7 @@ public class InfantryLaserPistolKelvin000Lancer3MM extends InfantryWeapon {
         cost = 1250;
         bv = 0.01575;
         tonnage = 0.0016;
-        infantryDamage = 0.05;
+        infantryDamage = 0.0158;
         infantryRange = 1;
         shots = 1;
         bursts = 1;

--- a/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolKelvin000Lancer3MM.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolKelvin000Lancer3MM.java
@@ -54,8 +54,9 @@ public class InfantryLaserPistolKelvin000Lancer3MM extends InfantryWeapon {
     public InfantryLaserPistolKelvin000Lancer3MM() {
         super();
 
-        name = "Laser Pistol (Kelvin 000 Lancer 3-MM)";
-        setInternalName(name);
+        name = "Laser Pistol (Kelvin 000 Lancer 3-mm)";
+        setInternalName("Laser Pistol (Kelvin 000 Lancer 3-MM)");
+        addLookupName(name);
         addLookupName("LANCER3MM");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 1250;

--- a/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolXingShan.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolXingShan.java
@@ -60,7 +60,7 @@ public class InfantryLaserPistolXingShan extends InfantryWeapon {
         cost = 795;
         bv = 0.056;
         tonnage = 0.0014;
-        infantryDamage = 0.19;
+        infantryDamage = 0.056;
         infantryRange = 1;
         shots = 2;
         bursts = 1;

--- a/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolXingShanER.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolXingShanER.java
@@ -61,7 +61,7 @@ public class InfantryLaserPistolXingShanER extends InfantryWeapon {
         cost = 830;
         bv = 0.21; // The bv in the image seems incorrect, adjusted to the value from the text
         tonnage = 0.0016;
-        infantryDamage = 0.35;
+        infantryDamage = 0.105;
         infantryRange = 3;
         shots = 3;
         bursts = 1;

--- a/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolXingShanER.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/pistol/InfantryLaserPistolXingShanER.java
@@ -55,9 +55,11 @@ public class InfantryLaserPistolXingShanER extends InfantryWeapon {
         super();
 
         name = "Laser Pistol (Xing Shan ER)";
-        // The pre-normalisation spelling wrote Xing with a non-ASCII i. No unit file used it, and MegaMek
-        // source is ASCII only, so the ASCII spelling is now both the display and the internal name.
+        // The pre-normalisation spelling wrote Xing with a non-ASCII i. MegaMek source is ASCII only, so the
+        // ASCII spelling is now both the display and the internal name, and the old spelling is kept as a
+        // lookup name written as an escape so a player's saved game or custom unit still resolves.
         setInternalName(name);
+        addLookupName("Laser Pistol (X\u012bng Shan ER)");
         addLookupName("XingShanER");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 830;

--- a/megamek/src/megamek/common/weapons/infantry/laser/rifle/InfantryLaserRifleDWSL5S.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/rifle/InfantryLaserRifleDWSL5S.java
@@ -61,7 +61,7 @@ public class InfantryLaserRifleDWSL5S extends InfantryWeapon {
         cost = 2000;
         bv = 0.4375;
         tonnage = 0.0065;
-        infantryDamage = 0.44;
+        infantryDamage = 0.2188;
         infantryRange = 4;
         shots = 5;
         bursts = 1;

--- a/megamek/src/megamek/common/weapons/infantry/laser/rifle/InfantryLaserRifleDarkLightCLLight.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/rifle/InfantryLaserRifleDarkLightCLLight.java
@@ -54,8 +54,9 @@ public class InfantryLaserRifleDarkLightCLLight extends InfantryWeapon {
     public InfantryLaserRifleDarkLightCLLight() {
         super();
 
-        name = "Laser Rifle (Darklight-CL Light)";
-        setInternalName(name);
+        name = "Laser Rifle (Darklight-CL Light Laser Rifle)";
+        setInternalName("Laser Rifle (Darklight-CL Light)");
+        addLookupName(name);
         addLookupName("DARKLIGHT-CL");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 2400;

--- a/megamek/src/megamek/common/weapons/infantry/laser/rifle/InfantryLaserRifleScorcherVIBlazerRifle.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/rifle/InfantryLaserRifleScorcherVIBlazerRifle.java
@@ -62,7 +62,7 @@ public class InfantryLaserRifleScorcherVIBlazerRifle extends InfantryWeapon {
         cost = 1500;
         bv = 1.05;
         tonnage = 0.0075;
-        infantryDamage = 0.53;
+        infantryDamage = 0.525;
         infantryRange = 4;
         shots = 10;
         bursts = 1;

--- a/megamek/src/megamek/common/weapons/infantry/laser/rifle/InfantryLaserRifleScorcherVIBlazerRifle.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/rifle/InfantryLaserRifleScorcherVIBlazerRifle.java
@@ -54,8 +54,9 @@ public class InfantryLaserRifleScorcherVIBlazerRifle extends InfantryWeapon {
     public InfantryLaserRifleScorcherVIBlazerRifle() {
         super();
 
-        name = "Blazer Rifle (Scorcher VI)";
-        setInternalName(name);
+        name = "Laser Rifle (Scorcher VI Blazer Rifle)";
+        setInternalName("Blazer Rifle (Scorcher VI)");
+        addLookupName(name);
         addLookupName("SCORCHERVI");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 1500;

--- a/megamek/src/megamek/common/weapons/infantry/laser/rifle/InfantryLaserRifleSyrtisFirebolt12Repaired.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/rifle/InfantryLaserRifleSyrtisFirebolt12Repaired.java
@@ -61,7 +61,7 @@ public class InfantryLaserRifleSyrtisFirebolt12Repaired extends InfantryWeapon {
         cost = 2500;
         bv = 0.196;
         tonnage = 0.0067;
-        infantryDamage = 0.28;
+        infantryDamage = 0.196;
         infantryRange = 4;
         shots = 7;
         bursts = 1;

--- a/megamek/src/megamek/common/weapons/infantry/laser/rifle/InfantryLaserRifleSyrtisFirebolt12Unrepaired.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/rifle/InfantryLaserRifleSyrtisFirebolt12Unrepaired.java
@@ -61,7 +61,7 @@ public class InfantryLaserRifleSyrtisFirebolt12Unrepaired extends InfantryWeapon
         cost = 2200;
         bv = 0.525;
         tonnage = 0.0065;
-        infantryDamage = 0.53;
+        infantryDamage = 0.2625;
         infantryRange = 5;
         shots = 5;
         bursts = 1;

--- a/megamek/src/megamek/common/weapons/infantry/laser/rifle/InfantryLaserRifleWolfBaronSunraker.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/rifle/InfantryLaserRifleWolfBaronSunraker.java
@@ -61,11 +61,11 @@ public class InfantryLaserRifleWolfBaronSunraker extends InfantryWeapon {
         cost = 2500;
         bv = 1.225;
         tonnage = 0.0067;
-        infantryDamage = 0.61;
+        infantryDamage = 0.6125;
         infantryRange = 4;
         shots = 10;
         bursts = 1;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY).or(F_INF_BURST);
         rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_9);
 
         techAdvancement

--- a/megamek/src/megamek/common/weapons/infantry/laser/rifle/InfantryLaserRifleYangLie.java
+++ b/megamek/src/megamek/common/weapons/infantry/laser/rifle/InfantryLaserRifleYangLie.java
@@ -61,7 +61,7 @@ public class InfantryLaserRifleYangLie extends InfantryWeapon {
         cost = 1275;
         bv = 0.525;
         tonnage = 0.0055;
-        infantryDamage = 0.53;
+        infantryDamage = 0.2625;
         infantryRange = 4;
         shots = 5;
         bursts = 1;

--- a/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolAAGemini.java
+++ b/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolAAGemini.java
@@ -60,7 +60,7 @@ public class InfantryPistolAAGemini extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = 0.28;
         tonnage = 0.0015;
-        infantryDamage = 0.35;
+        infantryDamage = 0.28;
         infantryRange = 1;
         ammoWeight = 0.00001;
         cost = 400;

--- a/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolCamdenHR7.java
+++ b/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolCamdenHR7.java
@@ -59,9 +59,9 @@ public class InfantryPistolCamdenHR7 extends InfantryWeapon {
         setInternalName(name);
         addLookupName("Camden HR-7");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        bv = 0.44;
+        bv = 0.4375;
         tonnage = 0.0025;
-        infantryDamage = 0.44;
+        infantryDamage = 0.2188;
         infantryRange = 1;
         ammoWeight = 0.000005;
         cost = 650;

--- a/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolDreamelDerringer.java
+++ b/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolDreamelDerringer.java
@@ -61,7 +61,7 @@ public class InfantryPistolDreamelDerringer extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = 0.042;
         tonnage = 0.0002;
-        infantryDamage = 0.14;
+        infantryDamage = 0.042;
         infantryRange = 0;
         ammoWeight = 0.000001;
         cost = 60;

--- a/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolHCKP14.java
+++ b/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolHCKP14.java
@@ -61,7 +61,7 @@ public class InfantryPistolHCKP14 extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = 0.056;
         tonnage = 0.0012;
-        infantryDamage = 0.07;
+        infantryDamage = 0.056;
         infantryRange = 0;
         ammoWeight = 0.00004;
         cost = 130;

--- a/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolLemisonCombatRevolver.java
+++ b/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolLemisonCombatRevolver.java
@@ -61,7 +61,7 @@ public class InfantryPistolLemisonCombatRevolver extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = 0.28;
         tonnage = 0.0016;
-        infantryDamage = 0.35;
+        infantryDamage = 0.28;
         infantryRange = 0;
         ammoWeight = 0.000025;
         cost = 120;

--- a/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolMomoDeBaoyingSpecial.java
+++ b/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolMomoDeBaoyingSpecial.java
@@ -54,6 +54,11 @@ public class InfantryPistolMomoDeBaoyingSpecial extends InfantryWeapon {
 
     public InfantryPistolMomoDeBaoyingSpecial() {
         super();
+        // This weapon and its other ammunition load are separate weapon types rather than one weapon with a
+        // mode. The loads have different Battle Values, and Battle Value is worked out from the weapon type
+        // before a battle starts, so a load that could be switched mid-game would leave the platoon's Battle
+        // Value undefined. Keeping them separate also matches how a platoon is built: the load is chosen when
+        // the unit is created, in the same way Inferno munitions are declared before the fight.
 
         name = "Pistol (Momo De Baoying (Special))";
         setInternalName(name);

--- a/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolMomoDeBaoyingSpecial.java
+++ b/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolMomoDeBaoyingSpecial.java
@@ -61,7 +61,7 @@ public class InfantryPistolMomoDeBaoyingSpecial extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = 1.05;
         tonnage = 0.0011;
-        infantryDamage = 0.53;
+        infantryDamage = 0.525;
         infantryRange = 1;
         ammoWeight = 0.000001;
         cost = 275;

--- a/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolMomoDeBaoyingStandard.java
+++ b/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolMomoDeBaoyingStandard.java
@@ -54,6 +54,11 @@ public class InfantryPistolMomoDeBaoyingStandard extends InfantryWeapon {
 
     public InfantryPistolMomoDeBaoyingStandard() {
         super();
+        // This weapon and its other ammunition load are separate weapon types rather than one weapon with a
+        // mode. The loads have different Battle Values, and Battle Value is worked out from the weapon type
+        // before a battle starts, so a load that could be switched mid-game would leave the platoon's Battle
+        // Value undefined. Keeping them separate also matches how a platoon is built: the load is chosen when
+        // the unit is created, in the same way Inferno munitions are declared before the fight.
 
         name = "Pistol (Momo De Baoying (Standard))";
         setInternalName(name);

--- a/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolRFWGalahad.java
+++ b/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolRFWGalahad.java
@@ -60,7 +60,7 @@ public class InfantryPistolRFWGalahad extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = 0.315;
         tonnage = 0.0021;
-        infantryDamage = 0.32;
+        infantryDamage = 0.315;
         infantryRange = 1;
         ammoWeight = 0.000005;
         cost = 200;

--- a/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolSerrek7994.java
+++ b/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolSerrek7994.java
@@ -58,9 +58,9 @@ public class InfantryPistolSerrek7994 extends InfantryWeapon {
         setInternalName(name);
         addLookupName("Serrek 7994");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        bv = 0.202;
+        bv = 0.2025;
         tonnage = 0.0009;
-        infantryDamage = 0.2;
+        infantryDamage = 0.2025;
         infantryRange = 1;
         ammoWeight = 0.000004;
         cost = 300;

--- a/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolSerrek7994SF.java
+++ b/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolSerrek7994SF.java
@@ -64,9 +64,9 @@ public class InfantryPistolSerrek7994SF extends InfantryWeapon {
         setInternalName(name);
         addLookupName("Serrek 7994 SF");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        bv = .202;
+        bv = 0.2025;
         tonnage = 0.0011;
-        infantryDamage = 0.2;
+        infantryDamage = 0.2025;
         infantryRange = 1;
         ammoWeight = 0.000004;
         cost = 400;

--- a/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolWhisper4Standard.java
+++ b/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolWhisper4Standard.java
@@ -59,6 +59,11 @@ public class InfantryPistolWhisper4Standard extends InfantryWeapon {
 
     public InfantryPistolWhisper4Standard() {
         super();
+        // This weapon and its other ammunition load are separate weapon types rather than one weapon with a
+        // mode. The loads have different Battle Values, and Battle Value is worked out from the weapon type
+        // before a battle starts, so a load that could be switched mid-game would leave the platoon's Battle
+        // Value undefined. Keeping them separate also matches how a platoon is built: the load is chosen when
+        // the unit is created, in the same way Inferno munitions are declared before the fight.
 
         name = "Pistol (Whisper-4 (Standard Rounds))";
         setInternalName(name);

--- a/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolWhisper4Standard.java
+++ b/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolWhisper4Standard.java
@@ -66,7 +66,7 @@ public class InfantryPistolWhisper4Standard extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = .42;
         tonnage = 0.0012;
-        infantryDamage = 0.35;
+        infantryDamage = 0.21;
         infantryRange = 1;
         ammoWeight = 0.00005;
         cost = 650;

--- a/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolWhisper4Subsonic.java
+++ b/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolWhisper4Subsonic.java
@@ -66,7 +66,7 @@ public class InfantryPistolWhisper4Subsonic extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = .0945;
         tonnage = 0.0012;
-        infantryDamage = 0.16;
+        infantryDamage = 0.0945;
         infantryRange = 0;
         ammoWeight = 0.00005;
         cost = 650;

--- a/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolWhisper4Subsonic.java
+++ b/megamek/src/megamek/common/weapons/infantry/pistol/InfantryPistolWhisper4Subsonic.java
@@ -59,6 +59,11 @@ public class InfantryPistolWhisper4Subsonic extends InfantryWeapon {
 
     public InfantryPistolWhisper4Subsonic() {
         super();
+        // This weapon and its other ammunition load are separate weapon types rather than one weapon with a
+        // mode. The loads have different Battle Values, and Battle Value is worked out from the weapon type
+        // before a battle starts, so a load that could be switched mid-game would leave the platoon's Battle
+        // Value undefined. Keeping them separate also matches how a platoon is built: the load is chosen when
+        // the unit is created, in the same way Inferno munitions are declared before the fight.
 
         name = "Pistol (Whisper-4 (Sub-Sonic))";
         setInternalName(name);

--- a/megamek/src/megamek/common/weapons/infantry/pulseLaser/InfantryPulseLaserPistolMedusaIII.java
+++ b/megamek/src/megamek/common/weapons/infantry/pulseLaser/InfantryPulseLaserPistolMedusaIII.java
@@ -60,7 +60,7 @@ public class InfantryPulseLaserPistolMedusaIII extends InfantryWeapon {
         cost = 950;
         bv = 0.0315;
         tonnage = 0.0011;
-        infantryDamage = 0.11;
+        infantryDamage = 0.0315;
         infantryRange = 1;
         shots = 2;
         bursts = 1;

--- a/megamek/src/megamek/common/weapons/infantry/pulseLaser/InfantryPulseLaserPistolMedusaIV.java
+++ b/megamek/src/megamek/common/weapons/infantry/pulseLaser/InfantryPulseLaserPistolMedusaIV.java
@@ -60,7 +60,7 @@ public class InfantryPulseLaserPistolMedusaIV extends InfantryWeapon {
         cost = 1500;
         bv = 0.063;
         tonnage = 0.0001;
-        infantryDamage = 0.21;
+        infantryDamage = 0.063;
         infantryRange = 1;
         shots = 3;
         bursts = 1;

--- a/megamek/src/megamek/common/weapons/infantry/pulseLaser/InfantryPulseLaserPistolNWW12.java
+++ b/megamek/src/megamek/common/weapons/infantry/pulseLaser/InfantryPulseLaserPistolNWW12.java
@@ -60,7 +60,7 @@ public class InfantryPulseLaserPistolNWW12 extends InfantryWeapon {
         cost = 850;
         bv = 0.054;
         tonnage = 0.0009;
-        infantryDamage = 0.18;
+        infantryDamage = 0.054;
         infantryRange = 1;
         shots = 2;
         bursts = 5;

--- a/megamek/src/megamek/common/weapons/infantry/pulseLaser/InfantryPulseLaserPistolRDISunSwarmPulsar.java
+++ b/megamek/src/megamek/common/weapons/infantry/pulseLaser/InfantryPulseLaserPistolRDISunSwarmPulsar.java
@@ -53,8 +53,9 @@ public class InfantryPulseLaserPistolRDISunSwarmPulsar extends InfantryWeapon {
     public InfantryPulseLaserPistolRDISunSwarmPulsar() {
         super();
 
-        name = "Pulse Laser Pistol (RDI SunSwarm Pulsar)";
-        setInternalName(name);
+        name = "Pulse Laser Pistol (RDI Sunswarm Pulsar)";
+        setInternalName("Pulse Laser Pistol (RDI SunSwarm Pulsar)");
+        addLookupName(name);
         addLookupName("SUNSWARM");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 1050;

--- a/megamek/src/megamek/common/weapons/infantry/pulseLaser/InfantryPulseLaserPistolRDISunSwarmPulsar.java
+++ b/megamek/src/megamek/common/weapons/infantry/pulseLaser/InfantryPulseLaserPistolRDISunSwarmPulsar.java
@@ -60,7 +60,7 @@ public class InfantryPulseLaserPistolRDISunSwarmPulsar extends InfantryWeapon {
         cost = 1050;
         bv = 0.054;
         tonnage = 0.0001;
-        infantryDamage = 0.18;
+        infantryDamage = 0.054;
         infantryRange = 1;
         shots = 2;
         bursts = 4;

--- a/megamek/src/megamek/common/weapons/infantry/pulseLaser/InfantryPulseLaserRifleDWSL5C.java
+++ b/megamek/src/megamek/common/weapons/infantry/pulseLaser/InfantryPulseLaserRifleDWSL5C.java
@@ -61,7 +61,7 @@ public class InfantryPulseLaserRifleDWSL5C extends InfantryWeapon {
         cost = 1800;
         bv = 0.252;
         tonnage = 0.0055;
-        infantryDamage = 0.36;
+        infantryDamage = 0.252;
         infantryRange = 3;
         shots = 7;
         bursts = 6;

--- a/megamek/src/megamek/common/weapons/infantry/pulseLaser/InfantryPulseLaserRifleGaul.java
+++ b/megamek/src/megamek/common/weapons/infantry/pulseLaser/InfantryPulseLaserRifleGaul.java
@@ -54,8 +54,9 @@ public class InfantryPulseLaserRifleGaul extends InfantryWeapon {
     public InfantryPulseLaserRifleGaul() {
         super();
 
-        name = "Pulse Laser Rifle (Gaul)";
-        setInternalName(name);
+        name = "Pulse Laser Rifle (GAUL)";
+        setInternalName("Pulse Laser Rifle (Gaul)");
+        addLookupName(name);
         addLookupName("GAUL");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 2200;

--- a/megamek/src/megamek/common/weapons/infantry/pulseLaser/InfantryPulseLaserRifleGaul.java
+++ b/megamek/src/megamek/common/weapons/infantry/pulseLaser/InfantryPulseLaserRifleGaul.java
@@ -61,7 +61,7 @@ public class InfantryPulseLaserRifleGaul extends InfantryWeapon {
         cost = 2200;
         bv = 0.252;
         tonnage = 0.0075;
-        infantryDamage = 0.36;
+        infantryDamage = 0.252;
         infantryRange = 4;
         shots = 7;
         bursts = 6;

--- a/megamek/src/megamek/common/weapons/infantry/pulseLaser/InfantryPulseLaserRifleTirbuni.java
+++ b/megamek/src/megamek/common/weapons/infantry/pulseLaser/InfantryPulseLaserRifleTirbuni.java
@@ -61,7 +61,7 @@ public class InfantryPulseLaserRifleTirbuni extends InfantryWeapon {
         cost = 1900;
         bv = 0.9;
         tonnage = 0.0074;
-        infantryDamage = 0.56;
+        infantryDamage = 0.45;
         infantryRange = 4;
         shots = 8;
         bursts = 5;

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunAMIKeymaster15.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunAMIKeymaster15.java
@@ -64,7 +64,7 @@ public class InfantryShotgunAMIKeymaster15 extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = .084;
         tonnage = 0.0012;
-        infantryDamage = 0.21;
+        infantryDamage = 0.084;
         infantryRange = 0;
         ammoWeight = 0.0012;
         cost = 250;

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunAWASS112.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunAWASS112.java
@@ -63,7 +63,7 @@ public class InfantryShotgunAWASS112 extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = .252;
         tonnage = 0.0028;
-        infantryDamage = 0.36;
+        infantryDamage = 0.252;
         infantryRange = 1;
         ammoWeight = 0.0028;
         cost = 300;

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunByron15S.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunByron15S.java
@@ -63,7 +63,7 @@ public class InfantryShotgunByron15S extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = .675;
         tonnage = 0.0035;
-        infantryDamage = 0.56;
+        infantryDamage = 0.3375;
         infantryRange = 1;
         ammoWeight = 0.0035;
         cost = 600;

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunCWIJianhuren.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunCWIJianhuren.java
@@ -63,7 +63,7 @@ public class InfantryShotgunCWIJianhuren extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = .054;
         tonnage = 0.0027;
-        infantryDamage = 0.14;
+        infantryDamage = 0.054;
         infantryRange = 1;
         ammoWeight = 0.0027;
         cost = 225;

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIC.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIC.java
@@ -61,9 +61,9 @@ public class InfantryShotgunDaystarIC extends InfantryWeapon {
         setInternalName(name);
         addLookupName("Daystar I (C)");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        bv = .202;
+        bv = 0.2025;
         tonnage = 0.0028;
-        infantryDamage = 0.2;
+        infantryDamage = 0.2025;
         infantryRange = 1;
         ammoWeight = 0.0028;
         cost = 250;

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIC.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIC.java
@@ -56,6 +56,11 @@ public class InfantryShotgunDaystarIC extends InfantryWeapon {
 
     public InfantryShotgunDaystarIC() {
         super();
+        // This weapon and its other ammunition load are separate weapon types rather than one weapon with a
+        // mode. The loads have different Battle Values, and Battle Value is worked out from the weapon type
+        // before a battle starts, so a load that could be switched mid-game would leave the platoon's Battle
+        // Value undefined. Keeping them separate also matches how a platoon is built: the load is chosen when
+        // the unit is created, in the same way Inferno munitions are declared before the fight.
 
         name = "Shotgun (Daystar I (C))";
         setInternalName(name);

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIIC.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIIC.java
@@ -61,9 +61,9 @@ public class InfantryShotgunDaystarIIC extends InfantryWeapon {
         setInternalName(name);
         addLookupName("Daystar II (C)");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        bv = .202;
+        bv = 0.2025;
         tonnage = 0.0028;
-        infantryDamage = 0.2;
+        infantryDamage = 0.2025;
         infantryRange = 1;
         ammoWeight = 0.0028;
         cost = 250;

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIIC.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIIC.java
@@ -56,6 +56,11 @@ public class InfantryShotgunDaystarIIC extends InfantryWeapon {
 
     public InfantryShotgunDaystarIIC() {
         super();
+        // This weapon and its other ammunition load are separate weapon types rather than one weapon with a
+        // mode. The loads have different Battle Values, and Battle Value is worked out from the weapon type
+        // before a battle starts, so a load that could be switched mid-game would leave the platoon's Battle
+        // Value undefined. Keeping them separate also matches how a platoon is built: the load is chosen when
+        // the unit is created, in the same way Inferno munitions are declared before the fight.
 
         name = "Shotgun (Daystar II (C))";
         setInternalName(name);

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIIIC.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIIIC.java
@@ -56,6 +56,11 @@ public class InfantryShotgunDaystarIIIC extends InfantryWeapon {
 
     public InfantryShotgunDaystarIIIC() {
         super();
+        // This weapon and its other ammunition load are separate weapon types rather than one weapon with a
+        // mode. The loads have different Battle Values, and Battle Value is worked out from the weapon type
+        // before a battle starts, so a load that could be switched mid-game would leave the platoon's Battle
+        // Value undefined. Keeping them separate also matches how a platoon is built: the load is chosen when
+        // the unit is created, in the same way Inferno munitions are declared before the fight.
 
         name = "Shotgun (Daystar III (C))";
         setInternalName(name);

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIIIM.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIIIM.java
@@ -56,6 +56,11 @@ public class InfantryShotgunDaystarIIIM extends InfantryWeapon {
 
     public InfantryShotgunDaystarIIIM() {
         super();
+        // This weapon and its other ammunition load are separate weapon types rather than one weapon with a
+        // mode. The loads have different Battle Values, and Battle Value is worked out from the weapon type
+        // before a battle starts, so a load that could be switched mid-game would leave the platoon's Battle
+        // Value undefined. Keeping them separate also matches how a platoon is built: the load is chosen when
+        // the unit is created, in the same way Inferno munitions are declared before the fight.
 
         name = "Shotgun (Daystar III (M))";
         setInternalName(name);

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIIM.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIIM.java
@@ -56,6 +56,11 @@ public class InfantryShotgunDaystarIIM extends InfantryWeapon {
 
     public InfantryShotgunDaystarIIM() {
         super();
+        // This weapon and its other ammunition load are separate weapon types rather than one weapon with a
+        // mode. The loads have different Battle Values, and Battle Value is worked out from the weapon type
+        // before a battle starts, so a load that could be switched mid-game would leave the platoon's Battle
+        // Value undefined. Keeping them separate also matches how a platoon is built: the load is chosen when
+        // the unit is created, in the same way Inferno munitions are declared before the fight.
 
         name = "Shotgun (Daystar II (M))";
         setInternalName(name);

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIIM.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIIM.java
@@ -61,9 +61,9 @@ public class InfantryShotgunDaystarIIM extends InfantryWeapon {
         setInternalName(name);
         addLookupName("Daystar II (M)");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        bv = .248;
+        bv = 0.2475;
         tonnage = 0.0029;
-        infantryDamage = 0.25;
+        infantryDamage = 0.2475;
         infantryRange = 1;
         ammoWeight = 0.0029;
         cost = 200;

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIM.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIM.java
@@ -56,6 +56,11 @@ public class InfantryShotgunDaystarIM extends InfantryWeapon {
 
     public InfantryShotgunDaystarIM() {
         super();
+        // This weapon and its other ammunition load are separate weapon types rather than one weapon with a
+        // mode. The loads have different Battle Values, and Battle Value is worked out from the weapon type
+        // before a battle starts, so a load that could be switched mid-game would leave the platoon's Battle
+        // Value undefined. Keeping them separate also matches how a platoon is built: the load is chosen when
+        // the unit is created, in the same way Inferno munitions are declared before the fight.
 
         name = "Shotgun (Daystar I (M))";
         setInternalName(name);

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIM.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIM.java
@@ -61,9 +61,9 @@ public class InfantryShotgunDaystarIM extends InfantryWeapon {
         setInternalName(name);
         addLookupName("Daystar I (M)");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        bv = .248;
+        bv = 0.2475;
         tonnage = 0.0029;
-        infantryDamage = 0.25;
+        infantryDamage = 0.2475;
         infantryRange = 1;
         ammoWeight = 0.0029;
         cost = 200;

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIVC.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIVC.java
@@ -56,6 +56,11 @@ public class InfantryShotgunDaystarIVC extends InfantryWeapon {
 
     public InfantryShotgunDaystarIVC() {
         super();
+        // This weapon and its other ammunition load are separate weapon types rather than one weapon with a
+        // mode. The loads have different Battle Values, and Battle Value is worked out from the weapon type
+        // before a battle starts, so a load that could be switched mid-game would leave the platoon's Battle
+        // Value undefined. Keeping them separate also matches how a platoon is built: the load is chosen when
+        // the unit is created, in the same way Inferno munitions are declared before the fight.
 
         name = "Shotgun (Daystar IV (C))";
         setInternalName(name);

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIVM.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarIVM.java
@@ -56,6 +56,11 @@ public class InfantryShotgunDaystarIVM extends InfantryWeapon {
 
     public InfantryShotgunDaystarIVM() {
         super();
+        // This weapon and its other ammunition load are separate weapon types rather than one weapon with a
+        // mode. The loads have different Battle Values, and Battle Value is worked out from the weapon type
+        // before a battle starts, so a load that could be switched mid-game would leave the platoon's Battle
+        // Value undefined. Keeping them separate also matches how a platoon is built: the load is chosen when
+        // the unit is created, in the same way Inferno munitions are declared before the fight.
 
         name = "Shotgun (Daystar IV (M))";
         setInternalName(name);

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarVC.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarVC.java
@@ -61,7 +61,7 @@ public class InfantryShotgunDaystarVC extends InfantryWeapon {
         setInternalName(name);
         addLookupName("Daystar V (C)");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        bv = .44;
+        bv = 0.45;
         tonnage = 0.0024;
         infantryDamage = 0.45;
         infantryRange = 1;

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarVC.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarVC.java
@@ -56,6 +56,11 @@ public class InfantryShotgunDaystarVC extends InfantryWeapon {
 
     public InfantryShotgunDaystarVC() {
         super();
+        // This weapon and its other ammunition load are separate weapon types rather than one weapon with a
+        // mode. The loads have different Battle Values, and Battle Value is worked out from the weapon type
+        // before a battle starts, so a load that could be switched mid-game would leave the platoon's Battle
+        // Value undefined. Keeping them separate also matches how a platoon is built: the load is chosen when
+        // the unit is created, in the same way Inferno munitions are declared before the fight.
 
         name = "Shotgun (Daystar V (C))";
         setInternalName(name);

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarVM.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDaystarVM.java
@@ -56,6 +56,11 @@ public class InfantryShotgunDaystarVM extends InfantryWeapon {
 
     public InfantryShotgunDaystarVM() {
         super();
+        // This weapon and its other ammunition load are separate weapon types rather than one weapon with a
+        // mode. The loads have different Battle Values, and Battle Value is worked out from the weapon type
+        // before a battle starts, so a load that could be switched mid-game would leave the platoon's Battle
+        // Value undefined. Keeping them separate also matches how a platoon is built: the load is chosen when
+        // the unit is created, in the same way Inferno munitions are declared before the fight.
 
         name = "Shotgun (Daystar V (M))";
         setInternalName(name);

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDokuhebi.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDokuhebi.java
@@ -63,7 +63,7 @@ public class InfantryShotgunDokuhebi extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = .225;
         tonnage = 0.0024;
-        infantryDamage = 0.45;
+        infantryDamage = 0.225;
         infantryRange = 0;
         ammoWeight = 0.0024;
         cost = 420;

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDuckettA5.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunDuckettA5.java
@@ -63,7 +63,7 @@ public class InfantryShotgunDuckettA5 extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = .288;
         tonnage = 0.0029;
-        infantryDamage = 0.36;
+        infantryDamage = 0.288;
         infantryRange = 1;
         ammoWeight = 0.0029;
         cost = 400;

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunMorriganStormsweeper.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunMorriganStormsweeper.java
@@ -63,7 +63,7 @@ public class InfantryShotgunMorriganStormsweeper extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = 1.125;
         tonnage = 0.004;
-        infantryDamage = 0.56;
+        infantryDamage = 0.5625;
         infantryRange = 1;
         ammoWeight = 0.004;
         cost = 800;

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunRisen15.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunRisen15.java
@@ -63,7 +63,7 @@ public class InfantryShotgunRisen15 extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = .216;
         tonnage = 0.0039;
-        infantryDamage = 0.27;
+        infantryDamage = 0.216;
         infantryRange = 0;
         ammoWeight = 0.0039;
         cost = 250;

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunSGM3.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunSGM3.java
@@ -61,9 +61,9 @@ public class InfantryShotgunSGM3 extends InfantryWeapon {
         setInternalName(name);
         addLookupName("SGM-3");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        bv = .248;
+        bv = 0.2475;
         tonnage = 0.0029;
-        infantryDamage = 0.25;
+        infantryDamage = 0.2475;
         infantryRange = 1;
         ammoWeight = 0.0029;
         cost = 1000;

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunSGS9E.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunSGS9E.java
@@ -63,14 +63,14 @@ public class InfantryShotgunSGS9E extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = 1.375;
         tonnage = 0.0045;
-        infantryDamage = 0.69;
+        infantryDamage = 0.6875;
         infantryRange = 1;
         ammoWeight = 0.0045;
         cost = 1500;
         ammoCost = 50;
         shots = 21;
         bursts = 3;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_ENCUMBER);
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_ENCUMBER).or(F_INF_BURST);
         rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_7);
         techAdvancement
               .setTechBase(TechBase.CLAN)

--- a/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunWranglemanTriBarrel.java
+++ b/megamek/src/megamek/common/weapons/infantry/shotgun/InfantryShotgunWranglemanTriBarrel.java
@@ -63,7 +63,7 @@ public class InfantryShotgunWranglemanTriBarrel extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = .243;
         tonnage = 0.003;
-        infantryDamage = 0.27;
+        infantryDamage = 0.243;
         infantryRange = 1;
         ammoWeight = 0.003;
         cost = 750;

--- a/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGBlackfieldScorpionMk65.java
+++ b/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGBlackfieldScorpionMk65.java
@@ -63,9 +63,9 @@ public class InfantrySMGBlackfieldScorpionMk65 extends InfantryWeapon {
         setInternalName(name);
         addLookupName("Blackfield Scorpion Mk 65");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        bv = .202;
+        bv = 0.2025;
         tonnage = 0.0014;
-        infantryDamage = 0.2;
+        infantryDamage = 0.2025;
         infantryRange = 0;
         ammoWeight = 0.0014;
         cost = 420;

--- a/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGBoudicca7.java
+++ b/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGBoudicca7.java
@@ -65,14 +65,14 @@ public class InfantrySMGBoudicca7 extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = 1.375;
         tonnage = 0.0021;
-        infantryDamage = 0.69;
+        infantryDamage = 0.6875;
         infantryRange = 1;
         ammoWeight = 0.0021;
         cost = 700;
         ammoCost = 20;
         shots = 40;
         bursts = 8;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC);
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_BURST);
         rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_5);
         techAdvancement
               .setTechBase(TechBase.IS)

--- a/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGJinseYanjingsheAPRounds.java
+++ b/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGJinseYanjingsheAPRounds.java
@@ -69,7 +69,7 @@ public class InfantrySMGJinseYanjingsheAPRounds extends InfantryWeapon {
         ammoCost = 180;
         shots = 30;
         bursts = 5;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC);
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_BURST);
         rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_5);
         techAdvancement
               .setTechBase(TechBase.IS)

--- a/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGJinseYanjingsheAPRounds.java
+++ b/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGJinseYanjingsheAPRounds.java
@@ -55,6 +55,11 @@ public class InfantrySMGJinseYanjingsheAPRounds extends InfantryWeapon {
 
     public InfantrySMGJinseYanjingsheAPRounds() {
         super();
+        // This weapon and its other ammunition load are separate weapon types rather than one weapon with a
+        // mode. The loads have different Battle Values, and Battle Value is worked out from the weapon type
+        // before a battle starts, so a load that could be switched mid-game would leave the platoon's Battle
+        // Value undefined. Keeping them separate also matches how a platoon is built: the load is chosen when
+        // the unit is created, in the same way Inferno munitions are declared before the fight.
 
         name = "SMG (Jinse Yanjingshe (AP Rounds))";
         setInternalName(name);

--- a/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGJinseYanjingsheStandard.java
+++ b/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGJinseYanjingsheStandard.java
@@ -55,6 +55,11 @@ public class InfantrySMGJinseYanjingsheStandard extends InfantryWeapon {
 
     public InfantrySMGJinseYanjingsheStandard() {
         super();
+        // This weapon and its other ammunition load are separate weapon types rather than one weapon with a
+        // mode. The loads have different Battle Values, and Battle Value is worked out from the weapon type
+        // before a battle starts, so a load that could be switched mid-game would leave the platoon's Battle
+        // Value undefined. Keeping them separate also matches how a platoon is built: the load is chosen when
+        // the unit is created, in the same way Inferno munitions are declared before the fight.
 
         name = "SMG (Jinse Yanjingshe (Standard))";
         setInternalName(name);

--- a/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGJinseYanjingsheStandard.java
+++ b/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGJinseYanjingsheStandard.java
@@ -62,7 +62,7 @@ public class InfantrySMGJinseYanjingsheStandard extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = 1.125;
         tonnage = 0.0031;
-        infantryDamage = 0.56;
+        infantryDamage = 0.5625;
         infantryRange = 1;
         ammoWeight = 0.0031;
         cost = 675;

--- a/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGNambuTypeS124.java
+++ b/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGNambuTypeS124.java
@@ -60,9 +60,9 @@ public class InfantrySMGNambuTypeS124 extends InfantryWeapon {
         setInternalName(name);
         addLookupName("Nambu Type S-124");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        bv = .202;
+        bv = 0.2025;
         tonnage = 0.0039;
-        infantryDamage = 0.2;
+        infantryDamage = 0.2025;
         infantryRange = 1;
         ammoWeight = 0.0039;
         cost = 450;

--- a/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGRFWBedivere.java
+++ b/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGRFWBedivere.java
@@ -60,9 +60,9 @@ public class InfantrySMGRFWBedivere extends InfantryWeapon {
         setInternalName(name);
         addLookupName("RFW Bedivere");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        bv = .202;
+        bv = 0.2025;
         tonnage = 0.0012;
-        infantryDamage = 0.2;
+        infantryDamage = 0.2025;
         infantryRange = 1;
         ammoWeight = 0.0012;
         cost = 560;

--- a/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGWC2.java
+++ b/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGWC2.java
@@ -60,9 +60,9 @@ public class InfantrySMGWC2 extends InfantryWeapon {
         setInternalName(name);
         addLookupName("WC-2");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        bv = .202;
+        bv = 0.2025;
         tonnage = 0.0023;
-        infantryDamage = 0.2;
+        infantryDamage = 0.2025;
         infantryRange = 1;
         ammoWeight = 0.0023;
         cost = 700;

--- a/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGWolfBarronA7.java
+++ b/megamek/src/megamek/common/weapons/infantry/smg/InfantrySMGWolfBarronA7.java
@@ -62,7 +62,7 @@ public class InfantrySMGWolfBarronA7 extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = .2475;
         tonnage = 0.0029;
-        infantryDamage = 0.25;
+        infantryDamage = 0.2475;
         infantryRange = 0;
         ammoWeight = 0.0029;
         cost = 450;

--- a/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleBartonAMRAntiArmor.java
+++ b/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleBartonAMRAntiArmor.java
@@ -59,6 +59,11 @@ public class InfantrySniperRifleBartonAMRAntiArmor extends InfantryWeapon {
 
     public InfantrySniperRifleBartonAMRAntiArmor() {
         super();
+        // This weapon and its other ammunition load are separate weapon types rather than one weapon with a
+        // mode. The loads have different Battle Values, and Battle Value is worked out from the weapon type
+        // before a battle starts, so a load that could be switched mid-game would leave the platoon's Battle
+        // Value undefined. Keeping them separate also matches how a platoon is built: the load is chosen when
+        // the unit is created, in the same way Inferno munitions are declared before the fight.
 
         name = "Sniper Rifle (Barton AMR (Anti-Armor))";
         setInternalName(name);

--- a/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleBartonAMRAntiArmor.java
+++ b/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleBartonAMRAntiArmor.java
@@ -72,7 +72,7 @@ public class InfantrySniperRifleBartonAMRAntiArmor extends InfantryWeapon {
         shots = 8;
         bursts = 1;
         flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_ENCUMBER);
-        infantryDamage = 0.74;
+        infantryDamage = 0.588;
         infantryRange = 7;
         rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_1);
         techAdvancement

--- a/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleBartonAMRStandard.java
+++ b/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleBartonAMRStandard.java
@@ -59,6 +59,11 @@ public class InfantrySniperRifleBartonAMRStandard extends InfantryWeapon {
 
     public InfantrySniperRifleBartonAMRStandard() {
         super();
+        // This weapon and its other ammunition load are separate weapon types rather than one weapon with a
+        // mode. The loads have different Battle Values, and Battle Value is worked out from the weapon type
+        // before a battle starts, so a load that could be switched mid-game would leave the platoon's Battle
+        // Value undefined. Keeping them separate also matches how a platoon is built: the load is chosen when
+        // the unit is created, in the same way Inferno munitions are declared before the fight.
 
         name = "Sniper Rifle (Barton AMR (Standard))";
         setInternalName(name);

--- a/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleBartonAMRStandard.java
+++ b/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleBartonAMRStandard.java
@@ -66,7 +66,7 @@ public class InfantrySniperRifleBartonAMRStandard extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = .98;
         tonnage = 0.014;
-        infantryDamage = 0.61;
+        infantryDamage = 0.49;
         infantryRange = 7;
         ammoWeight = 0.014;
         cost = 700;

--- a/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleFNFJ12DarkCaste.java
+++ b/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleFNFJ12DarkCaste.java
@@ -66,7 +66,7 @@ public class InfantrySniperRifleFNFJ12DarkCaste extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = .336;
         tonnage = 0.006;
-        infantryDamage = 0.42;
+        infantryDamage = 0.336;
         infantryRange = 5;
         ammoWeight = 0.006;
         cost = 3500;

--- a/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleFNFJ12SLDF.java
+++ b/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleFNFJ12SLDF.java
@@ -66,7 +66,7 @@ public class InfantrySniperRifleFNFJ12SLDF extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = .336;
         tonnage = 0.006;
-        infantryDamage = 0.42;
+        infantryDamage = 0.336;
         infantryRange = 6;
         ammoWeight = 0.006;
         cost = 3500;

--- a/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleLRS53SniperRifle.java
+++ b/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleLRS53SniperRifle.java
@@ -66,7 +66,7 @@ public class InfantrySniperRifleLRS53SniperRifle extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = .252;
         tonnage = 0.006;
-        infantryDamage = 0.28;
+        infantryDamage = 0.252;
         infantryRange = 5;
         ammoWeight = 0.006;
         cost = 1000;

--- a/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRiflePraetorianS3.java
+++ b/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRiflePraetorianS3.java
@@ -66,7 +66,7 @@ public class InfantrySniperRiflePraetorianS3 extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = .875;
         tonnage = 0.008;
-        infantryDamage = 0.44;
+        infantryDamage = 0.4375;
         infantryRange = 5;
         ammoWeight = 0.008;
         cost = 400;

--- a/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRiflePraetorianS5.java
+++ b/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRiflePraetorianS5.java
@@ -66,7 +66,7 @@ public class InfantrySniperRiflePraetorianS5 extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = 1.05;
         tonnage = 0.007;
-        infantryDamage = 0.53;
+        infantryDamage = 0.525;
         infantryRange = 5;
         ammoWeight = 0.007;
         cost = 600;

--- a/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleSairentosutomu.java
+++ b/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleSairentosutomu.java
@@ -66,7 +66,7 @@ public class InfantrySniperRifleSairentosutomu extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = .224;
         tonnage = 0.007;
-        infantryDamage = 0.28;
+        infantryDamage = 0.224;
         infantryRange = 5;
         ammoWeight = 0.007;
         cost = 900;

--- a/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleThorsHammer.java
+++ b/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleThorsHammer.java
@@ -51,8 +51,9 @@ public class InfantrySniperRifleThorsHammer extends InfantryWeapon {
     public InfantrySniperRifleThorsHammer() {
         super();
 
-        name = "Sniper Rifle (Thors Hammer)";
-        setInternalName(name);
+        name = "Sniper Rifle (Thorshammer)";
+        setInternalName("Sniper Rifle (Thors Hammer)");
+        addLookupName(name);
         addLookupName("Thorshammer");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = 0.28;

--- a/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleWilimtonRS17Stripped.java
+++ b/megamek/src/megamek/common/weapons/infantry/sniperRifle/InfantrySniperRifleWilimtonRS17Stripped.java
@@ -60,7 +60,7 @@ public class InfantrySniperRifleWilimtonRS17Stripped extends InfantryWeapon {
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         bv = 1.05;
         tonnage = 0.009;
-        infantryDamage = 0.53;
+        infantryDamage = 0.525;
         infantryRange = 6;
         ammoWeight = 0.009;
         cost = 2000;

--- a/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunAkaiRyu.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunAkaiRyu.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,8 +31,7 @@
  * affiliated with Microsoft.
  */
 
-
-package megamek.common.weapons.infantry.laser.pistol;
+package megamek.common.weapons.infantry.support.mg;
 
 import java.io.Serial;
 
@@ -45,37 +43,42 @@ import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
-
-public class InfantryLaserPistolXingShanER extends InfantryWeapon {
+/**
+ * Light machine gun from Shrapnel #22.
+ *
+ * <p>Damage and Battle Value come from the Infantry Weapons Calculator sheet, using the updated conversion
+ * formulas and feedback supplied by a CGL freelancer. Cost, mass, shots, bursts and the reload figures are
+ * from Shrapnel #22 itself.</p>
+ */
+public class InfantryMachineGunAkaiRyu extends InfantryWeapon {
 
     @Serial
-    private static final long serialVersionUID = 1L; // Update for each unique class
+    private static final long serialVersionUID = -4899999999999976243L;
 
-    public InfantryLaserPistolXingShanER() {
+    public InfantryMachineGunAkaiRyu() {
         super();
 
-        name = "Laser Pistol (Xing Shan ER)";
-        // The pre-normalisation spelling wrote Xing with a non-ASCII i. No unit file used it, and MegaMek
-        // source is ASCII only, so the ASCII spelling is now both the display and the internal name.
+        name = "Machine Gun (Akai Ryu)";
         setInternalName(name);
-        addLookupName("XingShanER");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        cost = 830;
-        bv = 0.21; // The bv in the image seems incorrect, adjusted to the value from the text
-        tonnage = 0.0016;
-        infantryDamage = 0.105;
+        bv = 1.98;
+        tonnage = 0.0101;
+        ammoWeight = 0.001;
+        ammoCost = 75;
+        infantryDamage = 0.99;
         infantryRange = 3;
-        shots = 3;
-        bursts = 1;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
-        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_9);
-
+        cost = 3500;
+        shots = 50;
+        bursts = 10;
+        crew = 1;
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_SUPPORT);
+        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_22);
         techAdvancement
               .setTechBase(TechBase.IS)
-              .setTechRating(TechRating.E) // Assuming X-X-E-E simplifies to E
-              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.E, AvailabilityValue.E)
-              .setISAdvancement(DATE_NONE, DATE_NONE, 3050, DATE_NONE, DATE_NONE)
-              .setISApproximate(false, false, true, false, false)
-              .setProductionFactions(Faction.CC);
+              .setTechRating(TechRating.D)
+              .setAvailability(AvailabilityValue.E, AvailabilityValue.E, AvailabilityValue.E, AvailabilityValue.E)
+              .setISAdvancement(DATE_NONE, DATE_NONE, DATE_ES, DATE_NONE, DATE_NONE)
+              .setISApproximate(false, false, false, false, false)
+              .setProductionFactions(Faction.DC);
     }
 }

--- a/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunBooneMGL14A.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunBooneMGL14A.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,8 +31,7 @@
  * affiliated with Microsoft.
  */
 
-
-package megamek.common.weapons.infantry.laser.pistol;
+package megamek.common.weapons.infantry.support.mg;
 
 import java.io.Serial;
 
@@ -45,37 +43,42 @@ import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
-
-public class InfantryLaserPistolXingShanER extends InfantryWeapon {
+/**
+ * Light machine gun from Shrapnel #22.
+ *
+ * <p>Damage and Battle Value come from the Infantry Weapons Calculator sheet, using the updated conversion
+ * formulas and feedback supplied by a CGL freelancer. Cost, mass, shots, bursts and the reload figures are
+ * from Shrapnel #22 itself.</p>
+ */
+public class InfantryMachineGunBooneMGL14A extends InfantryWeapon {
 
     @Serial
-    private static final long serialVersionUID = 1L; // Update for each unique class
+    private static final long serialVersionUID = -4899999999999904972L;
 
-    public InfantryLaserPistolXingShanER() {
+    public InfantryMachineGunBooneMGL14A() {
         super();
 
-        name = "Laser Pistol (Xing Shan ER)";
-        // The pre-normalisation spelling wrote Xing with a non-ASCII i. No unit file used it, and MegaMek
-        // source is ASCII only, so the ASCII spelling is now both the display and the internal name.
+        name = "Machine Gun (Boone MGL 14A)";
         setInternalName(name);
-        addLookupName("XingShanER");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        cost = 830;
-        bv = 0.21; // The bv in the image seems incorrect, adjusted to the value from the text
-        tonnage = 0.0016;
-        infantryDamage = 0.105;
-        infantryRange = 3;
-        shots = 3;
-        bursts = 1;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
-        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_9);
-
+        bv = 1.1;
+        tonnage = 0.0091;
+        ammoWeight = 0.0014;
+        ammoCost = 30;
+        infantryDamage = 0.55;
+        infantryRange = 2;
+        cost = 2500;
+        shots = 40;
+        bursts = 8;
+        crew = 1;
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_SUPPORT);
+        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_22);
         techAdvancement
               .setTechBase(TechBase.IS)
-              .setTechRating(TechRating.E) // Assuming X-X-E-E simplifies to E
-              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.E, AvailabilityValue.E)
-              .setISAdvancement(DATE_NONE, DATE_NONE, 3050, DATE_NONE, DATE_NONE)
-              .setISApproximate(false, false, true, false, false)
-              .setProductionFactions(Faction.CC);
+              .setTechRating(TechRating.C)
+              .setAvailability(AvailabilityValue.B, AvailabilityValue.B, AvailabilityValue.B, AvailabilityValue.B)
+              .setISAdvancement(DATE_NONE, DATE_NONE, DATE_ES, DATE_NONE, DATE_NONE)
+              .setISApproximate(false, false, false, false, false)
+              .setProductionFactions(Faction.TC);
     }
 }

--- a/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunBooneMGL14D.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunBooneMGL14D.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,8 +31,7 @@
  * affiliated with Microsoft.
  */
 
-
-package megamek.common.weapons.infantry.laser.pistol;
+package megamek.common.weapons.infantry.support.mg;
 
 import java.io.Serial;
 
@@ -45,37 +43,42 @@ import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
-
-public class InfantryLaserPistolXingShanER extends InfantryWeapon {
+/**
+ * Light machine gun from Shrapnel #22.
+ *
+ * <p>Damage and Battle Value come from the Infantry Weapons Calculator sheet, using the updated conversion
+ * formulas and feedback supplied by a CGL freelancer. Cost, mass, shots, bursts and the reload figures are
+ * from Shrapnel #22 itself.</p>
+ */
+public class InfantryMachineGunBooneMGL14D extends InfantryWeapon {
 
     @Serial
-    private static final long serialVersionUID = 1L; // Update for each unique class
+    private static final long serialVersionUID = -4899999999999897053L;
 
-    public InfantryLaserPistolXingShanER() {
+    public InfantryMachineGunBooneMGL14D() {
         super();
 
-        name = "Laser Pistol (Xing Shan ER)";
-        // The pre-normalisation spelling wrote Xing with a non-ASCII i. No unit file used it, and MegaMek
-        // source is ASCII only, so the ASCII spelling is now both the display and the internal name.
+        name = "Machine Gun (Boone MGL 14D)";
         setInternalName(name);
-        addLookupName("XingShanER");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        cost = 830;
-        bv = 0.21; // The bv in the image seems incorrect, adjusted to the value from the text
-        tonnage = 0.0016;
-        infantryDamage = 0.105;
-        infantryRange = 3;
-        shots = 3;
-        bursts = 1;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
-        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_9);
-
+        bv = 1.5;
+        tonnage = 0.0121;
+        ammoWeight = 0.0055;
+        ammoCost = 130;
+        infantryDamage = 0.75;
+        infantryRange = 2;
+        cost = 2700;
+        shots = 200;
+        bursts = 20;
+        crew = 1;
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_BURST).or(F_INF_SUPPORT);
+        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_22);
         techAdvancement
               .setTechBase(TechBase.IS)
-              .setTechRating(TechRating.E) // Assuming X-X-E-E simplifies to E
-              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.E, AvailabilityValue.E)
-              .setISAdvancement(DATE_NONE, DATE_NONE, 3050, DATE_NONE, DATE_NONE)
-              .setISApproximate(false, false, true, false, false)
-              .setProductionFactions(Faction.CC);
+              .setTechRating(TechRating.C)
+              .setAvailability(AvailabilityValue.B, AvailabilityValue.B, AvailabilityValue.B, AvailabilityValue.B)
+              .setISAdvancement(DATE_NONE, DATE_NONE, DATE_ES, DATE_NONE, DATE_NONE)
+              .setISApproximate(false, false, false, false, false)
+              .setProductionFactions(Faction.TC);
     }
 }

--- a/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunFogueDefender.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunFogueDefender.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,8 +31,7 @@
  * affiliated with Microsoft.
  */
 
-
-package megamek.common.weapons.infantry.laser.pistol;
+package megamek.common.weapons.infantry.support.mg;
 
 import java.io.Serial;
 
@@ -45,37 +43,42 @@ import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
-
-public class InfantryLaserPistolXingShanER extends InfantryWeapon {
+/**
+ * Light machine gun from Shrapnel #22.
+ *
+ * <p>Damage and Battle Value come from the Infantry Weapons Calculator sheet, using the updated conversion
+ * formulas and feedback supplied by a CGL freelancer. Cost, mass, shots, bursts and the reload figures are
+ * from Shrapnel #22 itself.</p>
+ */
+public class InfantryMachineGunFogueDefender extends InfantryWeapon {
 
     @Serial
-    private static final long serialVersionUID = 1L; // Update for each unique class
+    private static final long serialVersionUID = -4899999999999960405L;
 
-    public InfantryLaserPistolXingShanER() {
+    public InfantryMachineGunFogueDefender() {
         super();
 
-        name = "Laser Pistol (Xing Shan ER)";
-        // The pre-normalisation spelling wrote Xing with a non-ASCII i. No unit file used it, and MegaMek
-        // source is ASCII only, so the ASCII spelling is now both the display and the internal name.
+        name = "Machine Gun (Fogue Defender)";
         setInternalName(name);
-        addLookupName("XingShanER");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        cost = 830;
-        bv = 0.21; // The bv in the image seems incorrect, adjusted to the value from the text
-        tonnage = 0.0016;
-        infantryDamage = 0.105;
-        infantryRange = 3;
-        shots = 3;
-        bursts = 1;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
-        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_9);
-
+        bv = 0.44;
+        tonnage = 0.0155;
+        ammoWeight = 0.0015;
+        ammoCost = 50;
+        infantryDamage = 0.44;
+        infantryRange = 2;
+        cost = 1250;
+        shots = 60;
+        bursts = 10;
+        crew = 1;
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_SUPPORT).or(F_INF_ENCUMBER);
+        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_22);
         techAdvancement
               .setTechBase(TechBase.IS)
-              .setTechRating(TechRating.E) // Assuming X-X-E-E simplifies to E
-              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.E, AvailabilityValue.E)
-              .setISAdvancement(DATE_NONE, DATE_NONE, 3050, DATE_NONE, DATE_NONE)
-              .setISApproximate(false, false, true, false, false)
-              .setProductionFactions(Faction.CC);
+              .setTechRating(TechRating.C)
+              .setAvailability(AvailabilityValue.B, AvailabilityValue.B, AvailabilityValue.B, AvailabilityValue.B)
+              .setISAdvancement(DATE_NONE, DATE_NONE, DATE_ES, DATE_NONE, DATE_NONE)
+              .setISApproximate(false, false, false, false, false)
+              .setProductionFactions(Faction.FW);
     }
 }

--- a/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunHCKM2MG.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunHCKM2MG.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,8 +31,7 @@
  * affiliated with Microsoft.
  */
 
-
-package megamek.common.weapons.infantry.laser.pistol;
+package megamek.common.weapons.infantry.support.mg;
 
 import java.io.Serial;
 
@@ -45,37 +43,42 @@ import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
-
-public class InfantryLaserPistolXingShanER extends InfantryWeapon {
+/**
+ * Light machine gun from Shrapnel #22.
+ *
+ * <p>Damage and Battle Value come from the Infantry Weapons Calculator sheet, using the updated conversion
+ * formulas and feedback supplied by a CGL freelancer. Cost, mass, shots, bursts and the reload figures are
+ * from Shrapnel #22 itself.</p>
+ */
+public class InfantryMachineGunHCKM2MG extends InfantryWeapon {
 
     @Serial
-    private static final long serialVersionUID = 1L; // Update for each unique class
+    private static final long serialVersionUID = -4899999999999952486L;
 
-    public InfantryLaserPistolXingShanER() {
+    public InfantryMachineGunHCKM2MG() {
         super();
 
-        name = "Laser Pistol (Xing Shan ER)";
-        // The pre-normalisation spelling wrote Xing with a non-ASCII i. No unit file used it, and MegaMek
-        // source is ASCII only, so the ASCII spelling is now both the display and the internal name.
+        name = "Machine Gun (HCK M-2MG)";
         setInternalName(name);
-        addLookupName("XingShanER");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        cost = 830;
-        bv = 0.21; // The bv in the image seems incorrect, adjusted to the value from the text
-        tonnage = 0.0016;
-        infantryDamage = 0.105;
+        bv = 2.34;
+        tonnage = 0.0102;
+        ammoWeight = 0.0014;
+        ammoCost = 55;
+        infantryDamage = 1.17;
         infantryRange = 3;
-        shots = 3;
-        bursts = 1;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
-        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_9);
-
+        cost = 3300;
+        shots = 60;
+        bursts = 15;
+        crew = 1;
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_BURST).or(F_INF_SUPPORT);
+        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_22);
         techAdvancement
               .setTechBase(TechBase.IS)
-              .setTechRating(TechRating.E) // Assuming X-X-E-E simplifies to E
-              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.E, AvailabilityValue.E)
-              .setISAdvancement(DATE_NONE, DATE_NONE, 3050, DATE_NONE, DATE_NONE)
-              .setISApproximate(false, false, true, false, false)
-              .setProductionFactions(Faction.CC);
+              .setTechRating(TechRating.C)
+              .setAvailability(AvailabilityValue.X, AvailabilityValue.D, AvailabilityValue.D, AvailabilityValue.D)
+              .setISAdvancement(DATE_NONE, DATE_NONE, 2800, DATE_NONE, DATE_NONE)
+              .setISApproximate(false, false, false, false, false)
+              .setProductionFactions(Faction.LC);
     }
 }

--- a/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunHuoDushe.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunHuoDushe.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,8 +31,7 @@
  * affiliated with Microsoft.
  */
 
-
-package megamek.common.weapons.infantry.laser.pistol;
+package megamek.common.weapons.infantry.support.mg;
 
 import java.io.Serial;
 
@@ -45,37 +43,42 @@ import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
-
-public class InfantryLaserPistolXingShanER extends InfantryWeapon {
+/**
+ * Light machine gun from Shrapnel #22.
+ *
+ * <p>Damage and Battle Value come from the Infantry Weapons Calculator sheet, using the updated conversion
+ * formulas and feedback supplied by a CGL freelancer. Cost, mass, shots, bursts and the reload figures are
+ * from Shrapnel #22 itself.</p>
+ */
+public class InfantryMachineGunHuoDushe extends InfantryWeapon {
 
     @Serial
-    private static final long serialVersionUID = 1L; // Update for each unique class
+    private static final long serialVersionUID = -4899999999999992081L;
 
-    public InfantryLaserPistolXingShanER() {
+    public InfantryMachineGunHuoDushe() {
         super();
 
-        name = "Laser Pistol (Xing Shan ER)";
-        // The pre-normalisation spelling wrote Xing with a non-ASCII i. No unit file used it, and MegaMek
-        // source is ASCII only, so the ASCII spelling is now both the display and the internal name.
+        name = "Machine Gun (Huo Dushe)";
         setInternalName(name);
-        addLookupName("XingShanER");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        cost = 830;
-        bv = 0.21; // The bv in the image seems incorrect, adjusted to the value from the text
-        tonnage = 0.0016;
-        infantryDamage = 0.105;
-        infantryRange = 3;
-        shots = 3;
-        bursts = 1;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
-        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_9);
-
+        bv = 2.25;
+        tonnage = 0.0128;
+        ammoWeight = 0.0015;
+        ammoCost = 120;
+        infantryDamage = 1.125;
+        infantryRange = 2;
+        cost = 1500;
+        shots = 200;
+        bursts = 20;
+        crew = 1;
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_BURST).or(F_INF_SUPPORT).or(F_INF_ENCUMBER);
+        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_22);
         techAdvancement
               .setTechBase(TechBase.IS)
-              .setTechRating(TechRating.E) // Assuming X-X-E-E simplifies to E
-              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.E, AvailabilityValue.E)
-              .setISAdvancement(DATE_NONE, DATE_NONE, 3050, DATE_NONE, DATE_NONE)
-              .setISApproximate(false, false, true, false, false)
+              .setTechRating(TechRating.C)
+              .setAvailability(AvailabilityValue.X, AvailabilityValue.D, AvailabilityValue.C, AvailabilityValue.C)
+              .setISAdvancement(DATE_NONE, DATE_NONE, 2800, DATE_NONE, DATE_NONE)
+              .setISApproximate(false, false, false, false, false)
               .setProductionFactions(Faction.CC);
     }
 }

--- a/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunNambuM12.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunNambuM12.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,8 +31,7 @@
  * affiliated with Microsoft.
  */
 
-
-package megamek.common.weapons.infantry.laser.pistol;
+package megamek.common.weapons.infantry.support.mg;
 
 import java.io.Serial;
 
@@ -45,37 +43,42 @@ import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
-
-public class InfantryLaserPistolXingShanER extends InfantryWeapon {
+/**
+ * Light machine gun from Shrapnel #22.
+ *
+ * <p>Damage and Battle Value come from the Infantry Weapons Calculator sheet, using the updated conversion
+ * formulas and feedback supplied by a CGL freelancer. Cost, mass, shots, bursts and the reload figures are
+ * from Shrapnel #22 itself.</p>
+ */
+public class InfantryMachineGunNambuM12 extends InfantryWeapon {
 
     @Serial
-    private static final long serialVersionUID = 1L; // Update for each unique class
+    private static final long serialVersionUID = -4899999999999984162L;
 
-    public InfantryLaserPistolXingShanER() {
+    public InfantryMachineGunNambuM12() {
         super();
 
-        name = "Laser Pistol (Xing Shan ER)";
-        // The pre-normalisation spelling wrote Xing with a non-ASCII i. No unit file used it, and MegaMek
-        // source is ASCII only, so the ASCII spelling is now both the display and the internal name.
+        name = "Machine Gun (Nambu M-12)";
         setInternalName(name);
-        addLookupName("XingShanER");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        cost = 830;
-        bv = 0.21; // The bv in the image seems incorrect, adjusted to the value from the text
-        tonnage = 0.0016;
-        infantryDamage = 0.105;
-        infantryRange = 3;
-        shots = 3;
-        bursts = 1;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
-        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_9);
-
+        bv = 2.31;
+        tonnage = 0.0111;
+        ammoWeight = 0.0012;
+        ammoCost = 50;
+        infantryDamage = 1.155;
+        infantryRange = 2;
+        cost = 2300;
+        shots = 40;
+        bursts = 10;
+        crew = 1;
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_SUPPORT);
+        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_22);
         techAdvancement
               .setTechBase(TechBase.IS)
-              .setTechRating(TechRating.E) // Assuming X-X-E-E simplifies to E
-              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.E, AvailabilityValue.E)
-              .setISAdvancement(DATE_NONE, DATE_NONE, 3050, DATE_NONE, DATE_NONE)
-              .setISApproximate(false, false, true, false, false)
-              .setProductionFactions(Faction.CC);
+              .setTechRating(TechRating.C)
+              .setAvailability(AvailabilityValue.E, AvailabilityValue.E, AvailabilityValue.D, AvailabilityValue.D)
+              .setISAdvancement(DATE_NONE, DATE_NONE, DATE_ES, DATE_NONE, DATE_NONE)
+              .setISApproximate(false, false, false, false, false)
+              .setProductionFactions(Faction.DC);
     }
 }

--- a/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunPeacekeeperLB.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunPeacekeeperLB.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,8 +31,7 @@
  * affiliated with Microsoft.
  */
 
-
-package megamek.common.weapons.infantry.laser.pistol;
+package megamek.common.weapons.infantry.support.mg;
 
 import java.io.Serial;
 
@@ -45,37 +43,42 @@ import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
-
-public class InfantryLaserPistolXingShanER extends InfantryWeapon {
+/**
+ * Light machine gun from Shrapnel #22.
+ *
+ * <p>Damage and Battle Value come from the Infantry Weapons Calculator sheet, using the updated conversion
+ * formulas and feedback supplied by a CGL freelancer. Cost, mass, shots, bursts and the reload figures are
+ * from Shrapnel #22 itself.</p>
+ */
+public class InfantryMachineGunPeacekeeperLB extends InfantryWeapon {
 
     @Serial
-    private static final long serialVersionUID = 1L; // Update for each unique class
+    private static final long serialVersionUID = -4899999999999912891L;
 
-    public InfantryLaserPistolXingShanER() {
+    public InfantryMachineGunPeacekeeperLB() {
         super();
 
-        name = "Laser Pistol (Xing Shan ER)";
-        // The pre-normalisation spelling wrote Xing with a non-ASCII i. No unit file used it, and MegaMek
-        // source is ASCII only, so the ASCII spelling is now both the display and the internal name.
+        name = "Machine Gun (Peacekeeper-LB)";
         setInternalName(name);
-        addLookupName("XingShanER");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        cost = 830;
-        bv = 0.21; // The bv in the image seems incorrect, adjusted to the value from the text
-        tonnage = 0.0016;
-        infantryDamage = 0.105;
+        bv = 1.875;
+        tonnage = 0.0131;
+        ammoWeight = 0.002;
+        ammoCost = 100;
+        infantryDamage = 0.9375;
         infantryRange = 3;
-        shots = 3;
-        bursts = 1;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
-        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_9);
-
+        cost = 2900;
+        shots = 200;
+        bursts = 20;
+        crew = 1;
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_BURST).or(F_INF_SUPPORT).or(F_INF_ENCUMBER);
+        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_22);
         techAdvancement
               .setTechBase(TechBase.IS)
-              .setTechRating(TechRating.E) // Assuming X-X-E-E simplifies to E
-              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.E, AvailabilityValue.E)
-              .setISAdvancement(DATE_NONE, DATE_NONE, 3050, DATE_NONE, DATE_NONE)
-              .setISApproximate(false, false, true, false, false)
-              .setProductionFactions(Faction.CC);
+              .setTechRating(TechRating.D)
+              .setAvailability(AvailabilityValue.D, AvailabilityValue.C, AvailabilityValue.B, AvailabilityValue.B)
+              .setISAdvancement(DATE_NONE, DATE_NONE, DATE_ES, DATE_NONE, DATE_NONE)
+              .setISApproximate(false, false, false, false, false)
+              .setProductionFactions(Faction.FS);
     }
 }

--- a/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunPeacekeeperLLB.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunPeacekeeperLLB.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,8 +31,7 @@
  * affiliated with Microsoft.
  */
 
-
-package megamek.common.weapons.infantry.laser.pistol;
+package megamek.common.weapons.infantry.support.mg;
 
 import java.io.Serial;
 
@@ -45,37 +43,42 @@ import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
-
-public class InfantryLaserPistolXingShanER extends InfantryWeapon {
+/**
+ * Light machine gun from Shrapnel #22.
+ *
+ * <p>Damage and Battle Value come from the Infantry Weapons Calculator sheet, using the updated conversion
+ * formulas and feedback supplied by a CGL freelancer. Cost, mass, shots, bursts and the reload figures are
+ * from Shrapnel #22 itself.</p>
+ */
+public class InfantryMachineGunPeacekeeperLLB extends InfantryWeapon {
 
     @Serial
-    private static final long serialVersionUID = 1L; // Update for each unique class
+    private static final long serialVersionUID = -4899999999999920810L;
 
-    public InfantryLaserPistolXingShanER() {
+    public InfantryMachineGunPeacekeeperLLB() {
         super();
 
-        name = "Laser Pistol (Xing Shan ER)";
-        // The pre-normalisation spelling wrote Xing with a non-ASCII i. No unit file used it, and MegaMek
-        // source is ASCII only, so the ASCII spelling is now both the display and the internal name.
+        name = "Machine Gun (Peacekeeper-LLB)";
         setInternalName(name);
-        addLookupName("XingShanER");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        cost = 830;
-        bv = 0.21; // The bv in the image seems incorrect, adjusted to the value from the text
-        tonnage = 0.0016;
-        infantryDamage = 0.105;
+        bv = 1.875;
+        tonnage = 0.0112;
+        ammoWeight = 0.002;
+        ammoCost = 100;
+        infantryDamage = 0.9375;
         infantryRange = 3;
-        shots = 3;
-        bursts = 1;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
-        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_9);
-
+        cost = 2500;
+        shots = 200;
+        bursts = 20;
+        crew = 1;
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_BURST).or(F_INF_SUPPORT);
+        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_22);
         techAdvancement
               .setTechBase(TechBase.IS)
-              .setTechRating(TechRating.E) // Assuming X-X-E-E simplifies to E
-              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.E, AvailabilityValue.E)
-              .setISAdvancement(DATE_NONE, DATE_NONE, 3050, DATE_NONE, DATE_NONE)
-              .setISApproximate(false, false, true, false, false)
-              .setProductionFactions(Faction.CC);
+              .setTechRating(TechRating.C)
+              .setAvailability(AvailabilityValue.D, AvailabilityValue.C, AvailabilityValue.B, AvailabilityValue.B)
+              .setISAdvancement(DATE_NONE, DATE_NONE, DATE_ES, DATE_NONE, DATE_NONE)
+              .setISApproximate(false, false, false, false, false)
+              .setProductionFactions(Faction.FS);
     }
 }

--- a/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunPeacekeeperLSB.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunPeacekeeperLSB.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,8 +31,7 @@
  * affiliated with Microsoft.
  */
 
-
-package megamek.common.weapons.infantry.laser.pistol;
+package megamek.common.weapons.infantry.support.mg;
 
 import java.io.Serial;
 
@@ -45,37 +43,42 @@ import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
-
-public class InfantryLaserPistolXingShanER extends InfantryWeapon {
+/**
+ * Light machine gun from Shrapnel #22.
+ *
+ * <p>Damage and Battle Value come from the Infantry Weapons Calculator sheet, using the updated conversion
+ * formulas and feedback supplied by a CGL freelancer. Cost, mass, shots, bursts and the reload figures are
+ * from Shrapnel #22 itself.</p>
+ */
+public class InfantryMachineGunPeacekeeperLSB extends InfantryWeapon {
 
     @Serial
-    private static final long serialVersionUID = 1L; // Update for each unique class
+    private static final long serialVersionUID = -4899999999999936648L;
 
-    public InfantryLaserPistolXingShanER() {
+    public InfantryMachineGunPeacekeeperLSB() {
         super();
 
-        name = "Laser Pistol (Xing Shan ER)";
-        // The pre-normalisation spelling wrote Xing with a non-ASCII i. No unit file used it, and MegaMek
-        // source is ASCII only, so the ASCII spelling is now both the display and the internal name.
+        name = "Machine Gun (Peacekeeper-LSB)";
         setInternalName(name);
-        addLookupName("XingShanER");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        cost = 830;
-        bv = 0.21; // The bv in the image seems incorrect, adjusted to the value from the text
-        tonnage = 0.0016;
-        infantryDamage = 0.105;
-        infantryRange = 3;
-        shots = 3;
-        bursts = 1;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
-        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_9);
-
+        bv = 1.375;
+        tonnage = 0.0093;
+        ammoWeight = 0.0017;
+        ammoCost = 50;
+        infantryDamage = 0.6875;
+        infantryRange = 2;
+        cost = 1200;
+        shots = 50;
+        bursts = 10;
+        crew = 1;
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_SUPPORT);
+        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_22);
         techAdvancement
               .setTechBase(TechBase.IS)
-              .setTechRating(TechRating.E) // Assuming X-X-E-E simplifies to E
-              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.E, AvailabilityValue.E)
-              .setISAdvancement(DATE_NONE, DATE_NONE, 3050, DATE_NONE, DATE_NONE)
-              .setISApproximate(false, false, true, false, false)
-              .setProductionFactions(Faction.CC);
+              .setTechRating(TechRating.C)
+              .setAvailability(AvailabilityValue.D, AvailabilityValue.C, AvailabilityValue.B, AvailabilityValue.B)
+              .setISAdvancement(DATE_NONE, DATE_NONE, DATE_ES, DATE_NONE, DATE_NONE)
+              .setISApproximate(false, false, false, false, false)
+              .setProductionFactions(Faction.FS);
     }
 }

--- a/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunPeacekeeperSB.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunPeacekeeperSB.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,8 +31,7 @@
  * affiliated with Microsoft.
  */
 
-
-package megamek.common.weapons.infantry.laser.pistol;
+package megamek.common.weapons.infantry.support.mg;
 
 import java.io.Serial;
 
@@ -45,37 +43,44 @@ import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
-
-public class InfantryLaserPistolXingShanER extends InfantryWeapon {
+/**
+ * Light machine gun from Shrapnel #22.
+ *
+ * <p>Values come from the Infantry Weapons Calculator sheet, using the updated conversion formulas and
+ * feedback supplied by a CGL freelancer. The sheet has no reload cost or reload mass for these weapons, so
+ * {@code ammoCost} and {@code ammoWeight} come from the magazine instead.</p>
+ *
+ * <p>Mass follows Shrapnel #22 at 10.5 kg; the calculator sheet records 10.05 kg.</p>
+ */
+public class InfantryMachineGunPeacekeeperSB extends InfantryWeapon {
 
     @Serial
-    private static final long serialVersionUID = 1L; // Update for each unique class
+    private static final long serialVersionUID = -4899999999999928729L;
 
-    public InfantryLaserPistolXingShanER() {
+    public InfantryMachineGunPeacekeeperSB() {
         super();
 
-        name = "Laser Pistol (Xing Shan ER)";
-        // The pre-normalisation spelling wrote Xing with a non-ASCII i. No unit file used it, and MegaMek
-        // source is ASCII only, so the ASCII spelling is now both the display and the internal name.
+        name = "Machine Gun (Peacekeeper-SB)";
         setInternalName(name);
-        addLookupName("XingShanER");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        cost = 830;
-        bv = 0.21; // The bv in the image seems incorrect, adjusted to the value from the text
-        tonnage = 0.0016;
-        infantryDamage = 0.105;
-        infantryRange = 3;
-        shots = 3;
-        bursts = 1;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
-        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_9);
-
+        bv = 1.375;
+        tonnage = 0.0105;
+        ammoWeight = 0.002;
+        ammoCost = 50;
+        infantryDamage = 0.6875;
+        infantryRange = 2;
+        cost = 1500;
+        shots = 50;
+        bursts = 10;
+        crew = 1;
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_SUPPORT);
+        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_22);
         techAdvancement
               .setTechBase(TechBase.IS)
-              .setTechRating(TechRating.E) // Assuming X-X-E-E simplifies to E
-              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.E, AvailabilityValue.E)
-              .setISAdvancement(DATE_NONE, DATE_NONE, 3050, DATE_NONE, DATE_NONE)
-              .setISApproximate(false, false, true, false, false)
-              .setProductionFactions(Faction.CC);
+              .setTechRating(TechRating.C)
+              .setAvailability(AvailabilityValue.D, AvailabilityValue.C, AvailabilityValue.B, AvailabilityValue.B)
+              .setISAdvancement(DATE_NONE, DATE_NONE, DATE_ES, DATE_NONE, DATE_NONE)
+              .setISApproximate(false, false, false, false, false)
+              .setProductionFactions(Faction.FS);
     }
 }

--- a/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunSarcotMG19.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunSarcotMG19.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,8 +31,7 @@
  * affiliated with Microsoft.
  */
 
-
-package megamek.common.weapons.infantry.laser.pistol;
+package megamek.common.weapons.infantry.support.mg;
 
 import java.io.Serial;
 
@@ -45,37 +43,42 @@ import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
-
-public class InfantryLaserPistolXingShanER extends InfantryWeapon {
+/**
+ * Light machine gun from Shrapnel #22.
+ *
+ * <p>Damage and Battle Value come from the Infantry Weapons Calculator sheet, using the updated conversion
+ * formulas and feedback supplied by a CGL freelancer. Cost, mass, shots, bursts and the reload figures are
+ * from Shrapnel #22 itself.</p>
+ */
+public class InfantryMachineGunSarcotMG19 extends InfantryWeapon {
 
     @Serial
-    private static final long serialVersionUID = 1L; // Update for each unique class
+    private static final long serialVersionUID = -4899999999999968324L;
 
-    public InfantryLaserPistolXingShanER() {
+    public InfantryMachineGunSarcotMG19() {
         super();
 
-        name = "Laser Pistol (Xing Shan ER)";
-        // The pre-normalisation spelling wrote Xing with a non-ASCII i. No unit file used it, and MegaMek
-        // source is ASCII only, so the ASCII spelling is now both the display and the internal name.
+        name = "Machine Gun (Sarcot MG-19)";
         setInternalName(name);
-        addLookupName("XingShanER");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        cost = 830;
-        bv = 0.21; // The bv in the image seems incorrect, adjusted to the value from the text
-        tonnage = 0.0016;
-        infantryDamage = 0.105;
+        bv = 1.625;
+        tonnage = 0.0115;
+        ammoWeight = 0.00125;
+        ammoCost = 60;
+        infantryDamage = 0.8125;
         infantryRange = 3;
-        shots = 3;
-        bursts = 1;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
-        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_9);
-
+        cost = 2500;
+        shots = 150;
+        bursts = 15;
+        crew = 1;
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_BURST).or(F_INF_SUPPORT);
+        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_22);
         techAdvancement
               .setTechBase(TechBase.IS)
-              .setTechRating(TechRating.E) // Assuming X-X-E-E simplifies to E
-              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.E, AvailabilityValue.E)
-              .setISAdvancement(DATE_NONE, DATE_NONE, 3050, DATE_NONE, DATE_NONE)
-              .setISApproximate(false, false, true, false, false)
-              .setProductionFactions(Faction.CC);
+              .setTechRating(TechRating.C)
+              .setAvailability(AvailabilityValue.X, AvailabilityValue.D, AvailabilityValue.C, AvailabilityValue.C)
+              .setISAdvancement(DATE_NONE, DATE_NONE, 2800, DATE_NONE, DATE_NONE)
+              .setISApproximate(false, false, false, false, false)
+              .setProductionFactions(Faction.FW);
     }
 }

--- a/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunTIE124.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunTIE124.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,8 +31,7 @@
  * affiliated with Microsoft.
  */
 
-
-package megamek.common.weapons.infantry.laser.pistol;
+package megamek.common.weapons.infantry.support.mg;
 
 import java.io.Serial;
 
@@ -45,37 +43,42 @@ import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
-
-public class InfantryLaserPistolXingShanER extends InfantryWeapon {
+/**
+ * Light machine gun from Shrapnel #22.
+ *
+ * <p>Damage and Battle Value come from the Infantry Weapons Calculator sheet, using the updated conversion
+ * formulas and feedback supplied by a CGL freelancer. Cost, mass, shots, bursts and the reload figures are
+ * from Shrapnel #22 itself.</p>
+ */
+public class InfantryMachineGunTIE124 extends InfantryWeapon {
 
     @Serial
-    private static final long serialVersionUID = 1L; // Update for each unique class
+    private static final long serialVersionUID = -4899999999999889134L;
 
-    public InfantryLaserPistolXingShanER() {
+    public InfantryMachineGunTIE124() {
         super();
 
-        name = "Laser Pistol (Xing Shan ER)";
-        // The pre-normalisation spelling wrote Xing with a non-ASCII i. No unit file used it, and MegaMek
-        // source is ASCII only, so the ASCII spelling is now both the display and the internal name.
+        name = "Machine Gun (TIE-124)";
         setInternalName(name);
-        addLookupName("XingShanER");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        cost = 830;
-        bv = 0.21; // The bv in the image seems incorrect, adjusted to the value from the text
-        tonnage = 0.0016;
-        infantryDamage = 0.105;
-        infantryRange = 3;
-        shots = 3;
-        bursts = 1;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
-        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_9);
-
+        bv = 3.15;
+        tonnage = 0.0151;
+        ammoWeight = 0.0055;
+        ammoCost = 150;
+        infantryDamage = 1.575;
+        infantryRange = 2;
+        cost = 4500;
+        shots = 200;
+        bursts = 20;
+        crew = 1;
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_BURST).or(F_INF_SUPPORT).or(F_INF_ENCUMBER);
+        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_22);
         techAdvancement
-              .setTechBase(TechBase.IS)
-              .setTechRating(TechRating.E) // Assuming X-X-E-E simplifies to E
-              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.E, AvailabilityValue.E)
-              .setISAdvancement(DATE_NONE, DATE_NONE, 3050, DATE_NONE, DATE_NONE)
-              .setISApproximate(false, false, true, false, false)
-              .setProductionFactions(Faction.CC);
+              .setTechBase(TechBase.CLAN)
+              .setTechRating(TechRating.C)
+              .setAvailability(AvailabilityValue.C, AvailabilityValue.C, AvailabilityValue.C, AvailabilityValue.C)
+              .setClanAdvancement(DATE_NONE, DATE_NONE, DATE_ES, DATE_NONE, DATE_NONE)
+              .setClanApproximate(false, false, false, false, false)
+              .setProductionFactions(Faction.CLAN);
     }
 }

--- a/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunTharwepNachtgewitter.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunTharwepNachtgewitter.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,8 +31,7 @@
  * affiliated with Microsoft.
  */
 
-
-package megamek.common.weapons.infantry.laser.pistol;
+package megamek.common.weapons.infantry.support.mg;
 
 import java.io.Serial;
 
@@ -45,37 +43,42 @@ import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
-
-public class InfantryLaserPistolXingShanER extends InfantryWeapon {
+/**
+ * Light machine gun from Shrapnel #22.
+ *
+ * <p>Damage and Battle Value come from the Infantry Weapons Calculator sheet, using the updated conversion
+ * formulas and feedback supplied by a CGL freelancer. Cost, mass, shots, bursts and the reload figures are
+ * from Shrapnel #22 itself.</p>
+ */
+public class InfantryMachineGunTharwepNachtgewitter extends InfantryWeapon {
 
     @Serial
-    private static final long serialVersionUID = 1L; // Update for each unique class
+    private static final long serialVersionUID = -4899999999999944567L;
 
-    public InfantryLaserPistolXingShanER() {
+    public InfantryMachineGunTharwepNachtgewitter() {
         super();
 
-        name = "Laser Pistol (Xing Shan ER)";
-        // The pre-normalisation spelling wrote Xing with a non-ASCII i. No unit file used it, and MegaMek
-        // source is ASCII only, so the ASCII spelling is now both the display and the internal name.
+        name = "Machine Gun (Tharwep Nachtgewitter)";
         setInternalName(name);
-        addLookupName("XingShanER");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        cost = 830;
-        bv = 0.21; // The bv in the image seems incorrect, adjusted to the value from the text
-        tonnage = 0.0016;
-        infantryDamage = 0.105;
-        infantryRange = 3;
-        shots = 3;
-        bursts = 1;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
-        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_9);
-
+        bv = 1.125;
+        tonnage = 0.0092;
+        ammoWeight = 0.002;
+        ammoCost = 7;
+        infantryDamage = 0.5625;
+        infantryRange = 2;
+        cost = 120;
+        shots = 30;
+        bursts = 7;
+        crew = 1;
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_SUPPORT);
+        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_22);
         techAdvancement
               .setTechBase(TechBase.IS)
-              .setTechRating(TechRating.E) // Assuming X-X-E-E simplifies to E
-              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.E, AvailabilityValue.E)
-              .setISAdvancement(DATE_NONE, DATE_NONE, 3050, DATE_NONE, DATE_NONE)
-              .setISApproximate(false, false, true, false, false)
-              .setProductionFactions(Faction.CC);
+              .setTechRating(TechRating.C)
+              .setAvailability(AvailabilityValue.X, AvailabilityValue.C, AvailabilityValue.B, AvailabilityValue.B)
+              .setISAdvancement(DATE_NONE, DATE_NONE, 2800, DATE_NONE, DATE_NONE)
+              .setISApproximate(false, false, false, false, false)
+              .setProductionFactions(Faction.LC);
     }
 }

--- a/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunType17.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mg/InfantryMachineGunType17.java
@@ -1,6 +1,5 @@
 /*
- * Copyright (C) 2000-2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -32,8 +31,7 @@
  * affiliated with Microsoft.
  */
 
-
-package megamek.common.weapons.infantry.laser.pistol;
+package megamek.common.weapons.infantry.support.mg;
 
 import java.io.Serial;
 
@@ -45,37 +43,42 @@ import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
-
-public class InfantryLaserPistolXingShanER extends InfantryWeapon {
+/**
+ * Light machine gun from Shrapnel #22.
+ *
+ * <p>Damage and Battle Value come from the Infantry Weapons Calculator sheet, using the updated conversion
+ * formulas and feedback supplied by a CGL freelancer. Cost, mass, shots, bursts and the reload figures are
+ * from Shrapnel #22 itself.</p>
+ */
+public class InfantryMachineGunType17 extends InfantryWeapon {
 
     @Serial
-    private static final long serialVersionUID = 1L; // Update for each unique class
+    private static final long serialVersionUID = -4900000000000000000L;
 
-    public InfantryLaserPistolXingShanER() {
+    public InfantryMachineGunType17() {
         super();
 
-        name = "Laser Pistol (Xing Shan ER)";
-        // The pre-normalisation spelling wrote Xing with a non-ASCII i. No unit file used it, and MegaMek
-        // source is ASCII only, so the ASCII spelling is now both the display and the internal name.
+        name = "Machine Gun (Type 17)";
         setInternalName(name);
-        addLookupName("XingShanER");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
-        cost = 830;
-        bv = 0.21; // The bv in the image seems incorrect, adjusted to the value from the text
-        tonnage = 0.0016;
-        infantryDamage = 0.105;
-        infantryRange = 3;
-        shots = 3;
-        bursts = 1;
-        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_LASER).or(F_ENERGY);
-        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_9);
-
+        bv = 0.44;
+        tonnage = 0.0072;
+        ammoWeight = 0.0015;
+        ammoCost = 15;
+        infantryDamage = 0.44;
+        infantryRange = 1;
+        cost = 1000;
+        shots = 50;
+        bursts = 10;
+        crew = 1;
+        flags = flags.or(F_NO_FIRES).or(F_DIRECT_FIRE).or(F_BALLISTIC).or(F_INF_SUPPORT);
+        rulesRefs = rulesRefs(SourceBookCode.SHRAPNEL_22);
         techAdvancement
               .setTechBase(TechBase.IS)
-              .setTechRating(TechRating.E) // Assuming X-X-E-E simplifies to E
-              .setAvailability(AvailabilityValue.X, AvailabilityValue.X, AvailabilityValue.E, AvailabilityValue.E)
-              .setISAdvancement(DATE_NONE, DATE_NONE, 3050, DATE_NONE, DATE_NONE)
-              .setISApproximate(false, false, true, false, false)
+              .setTechRating(TechRating.C)
+              .setAvailability(AvailabilityValue.C, AvailabilityValue.C, AvailabilityValue.C, AvailabilityValue.C)
+              .setISAdvancement(DATE_NONE, DATE_NONE, DATE_ES, DATE_NONE, DATE_NONE)
+              .setISApproximate(false, false, false, false, false)
               .setProductionFactions(Faction.CC);
     }
 }

--- a/megamek/unittests/megamek/common/weapons/infantry/InfantryHeavyBurstDamageTest.java
+++ b/megamek/unittests/megamek/common/weapons/infantry/InfantryHeavyBurstDamageTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.weapons.infantry;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import java.lang.reflect.Field;
+import java.util.Vector;
+
+import megamek.common.Report;
+import megamek.common.ToHitData;
+import megamek.common.Hex;
+import megamek.common.actions.WeaponAttackAction;
+import megamek.common.board.Board;
+import megamek.common.board.Coords;
+import megamek.common.equipment.EquipmentFlag;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.WeaponMounted;
+import megamek.common.equipment.WeaponType;
+import megamek.common.game.Game;
+import megamek.common.options.GameOptions;
+import megamek.common.units.ConvInfantry;
+import megamek.common.units.Targetable;
+import megamek.server.totalWarfare.TWGameManager;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers which platoon the Heavy Burst damage bonus is read off.
+ *
+ * <p>TM p. 152 gives the Heavy Burst Weapon feature to a platoon whose own primary weapon is over the damage cap,
+ * and that feature adds 1D6 damage against conventional infantry. The condition used to test the cap on the
+ * TARGET, so a platoon's bonus depended on what the platoon it was shooting at happened to be carrying.</p>
+ *
+ * <p>Both cases below are invisible with the weapons MegaMek currently ships, because every weapon above the cap
+ * also carries {@code F_INF_BURST} and satisfies the first clause before the cap is ever consulted. They are
+ * written against the condition itself so the swap cannot come back.</p>
+ */
+class InfantryHeavyBurstDamageTest {
+
+    private static final int HEAVY_BURST_REPORT_ID = 3422;
+
+    private ConvInfantry mockAttacker;
+    private ConvInfantry mockTarget;
+    private InfantryWeaponHandler handler;
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockAttacker = mock(ConvInfantry.class);
+        mockTarget = mock(ConvInfantry.class);
+        WeaponType mockWeaponType = mock(WeaponType.class);
+
+        Game mockGame = mock(Game.class);
+        TWGameManager mockGameManager = mock(TWGameManager.class);
+        ToHitData mockToHit = mock(ToHitData.class);
+        WeaponAttackAction mockAction = mock(WeaponAttackAction.class);
+        WeaponMounted mockWeapon = mock(WeaponMounted.class);
+
+        GameOptions mockOptions = mock(GameOptions.class);
+        doReturn(false).when(mockOptions).booleanOption(any(String.class));
+        doReturn(mockOptions).when(mockGame).getOptions();
+
+        Board mockBoard = mock(Board.class);
+        Hex mockHex = mock(Hex.class);
+        doReturn(mockBoard).when(mockGame).getBoard();
+        doReturn(mockHex).when(mockGame).getHexOf(any());
+        doReturn(false).when(mockHex).containsTerrain(anyInt());
+
+        doReturn(1).when(mockAttacker).getId();
+        doReturn(mockAttacker).when(mockGame).getEntity(1);
+        // The handler constructor resolves the firing platoon through the weapon carrier, not the action.
+        doReturn(mockAttacker).when(mockAttacker).getAttackingEntity();
+        // Must be stubbed explicitly: an unstubbed mock answers false, which would let a wrong condition
+        // short-circuit before it reaches the cap check and pass this test for the wrong reason.
+        doReturn(true).when(mockAttacker).isConventionalInfantry();
+        doReturn(new Coords(0, 0)).when(mockAttacker).getPosition();
+        doReturn(-1).when(mockAttacker).getSwarmTargetId();
+        doReturn(10).when(mockAttacker).getShootingStrength();
+        // One point of damage per trooper keeps the base damage well clear of zero, so the only thing that can
+        // put a Heavy Burst line in the report is the bonus itself.
+        doReturn(1.0).when(mockAttacker).getDamagePerTrooper();
+        doReturn(null).when(mockAttacker).getMount();
+
+        doReturn(2).when(mockTarget).getId();
+        doReturn(new Coords(1, 0)).when(mockTarget).getPosition();
+        doReturn(Targetable.TYPE_ENTITY).when(mockTarget).getTargetType();
+        doReturn(mockTarget).when(mockGame).getTarget(Targetable.TYPE_ENTITY, 2);
+        doReturn(true).when(mockTarget).isConventionalInfantry();
+        doReturn(false).when(mockTarget).isMechanized();
+
+        // No F_INF_BURST anywhere: the flag would satisfy the condition before the cap is consulted, which is
+        // exactly what hides this bug with the weapons that ship today.
+        doReturn(false).when(mockWeaponType).hasFlag(any(EquipmentFlag.class));
+        doReturn(mockWeaponType).when(mockWeapon).getType();
+
+        doReturn(1).when(mockAction).getEntityId();
+        doReturn(mockAttacker).when(mockAction).getEntity(mockGame);
+        doReturn(0).when(mockAction).getWeaponId();
+        doReturn(mockWeapon).when(mockAttacker).getWeapon(0);
+        doReturn(mockWeapon).when(mockAttacker).getEquipment(0);
+        doReturn(Targetable.TYPE_ENTITY).when(mockAction).getTargetType();
+        doReturn(2).when(mockAction).getTargetId();
+
+        handler = new InfantryWeaponHandler(mockToHit, mockAction, mockGame, mockGameManager);
+        setField(handler, "attackingEntity", mockAttacker);
+        setField(handler, "target", mockTarget);
+        setField(handler, "weapon", mockWeapon);
+        setField(handler, "weaponType", mockWeaponType);
+        setField(handler, "nRange", 1);
+    }
+
+    @Test
+    @DisplayName("The attacking platoon's over-cap primary weapon earns the bonus")
+    void attackerOverTheCapEarnsTheBonus() {
+        doReturn(true).when(mockAttacker).primaryWeaponDamageCapped();
+        doReturn(false).when(mockTarget).primaryWeaponDamageCapped();
+
+        assertTrue(reportsHeavyBurst(runAttack()),
+              "The attacker's primary weapon is over the cap, so TM p. 152 grants it Heavy Burst and its 1D6");
+    }
+
+    @Test
+    @DisplayName("The target's over-cap primary weapon earns the attacker nothing")
+    void targetOverTheCapEarnsNothing() {
+        doReturn(false).when(mockAttacker).primaryWeaponDamageCapped();
+        doReturn(true).when(mockTarget).primaryWeaponDamageCapped();
+
+        assertFalse(reportsHeavyBurst(runAttack()),
+              "Heavy Burst belongs to the platoon that owns the weapon; what the target carries is irrelevant");
+    }
+
+    private Vector<Report> runAttack() {
+        Vector<Report> reports = new Vector<>();
+        handler.calcHits(reports);
+        return reports;
+    }
+
+    private boolean reportsHeavyBurst(Vector<Report> reports) {
+        for (Report report : reports) {
+            if (report.messageId == HEAVY_BURST_REPORT_ID) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void setField(Object owner, String name, Object value) throws Exception {
+        Class<?> type = owner.getClass();
+        while (type != null) {
+            try {
+                Field field = type.getDeclaredField(name);
+                field.setAccessible(true);
+                field.set(owner, value);
+                return;
+            } catch (NoSuchFieldException notHere) {
+                type = type.getSuperclass();
+            }
+        }
+        throw new NoSuchFieldException(name);
+    }
+}

--- a/megamek/unittests/megamek/common/weapons/infantry/InfantryWeaponRenameCompatibilityTest.java
+++ b/megamek/unittests/megamek/common/weapons/infantry/InfantryWeaponRenameCompatibilityTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.weapons.infantry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.util.stream.Stream;
+
+import megamek.common.equipment.EquipmentType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Guards backwards compatibility for the infantry weapon renames.
+ *
+ * <p>These weapons were renamed to the spelling used by the Infantry Weapons Calculator sheet, mostly to undo the
+ * shouted capitalisation their Shrapnel entries were transcribed with. A saved game or a player's custom unit
+ * written before the rename still names the weapon the old way, so every pre-rename name has to keep resolving,
+ * and has to resolve to the same weapon as the new name.</p>
+ *
+ * <p>The Xing Shan ER is the awkward one. Its old name spelt Xing with a non-ASCII i, and MegaMek source is ASCII
+ * only, so its lookup name is written as an escape rather than as the character itself.</p>
+ */
+class InfantryWeaponRenameCompatibilityTest {
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    private static Stream<Arguments> renamedWeapons() {
+        return Stream.of(
+              Arguments.of("Sniper Rifle (Thors Hammer)", "Sniper Rifle (Thorshammer)"),
+              Arguments.of("Laser Pistol (X\u012bng Shan ER)", "Laser Pistol (Xing Shan ER)"),
+              Arguments.of("Laser Pistol (AWA Wiliby MK4 LASER PISTOL)",
+                    "Laser Pistol (AWA Wiliby Mk4 Laser Pistol)"),
+              Arguments.of("Laser Pistol (Kelvin 000 Lancer 3-MM)", "Laser Pistol (Kelvin 000 Lancer 3-mm)"),
+              Arguments.of("Pulse Laser Pistol (RDI SunSwarm Pulsar)", "Pulse Laser Pistol (RDI Sunswarm Pulsar)"),
+              Arguments.of("Pulse Laser Rifle (Gaul)", "Pulse Laser Rifle (GAUL)"),
+              Arguments.of("Laser Pistol (BrightStar L-7)", "Laser Pistol (Brightstar L-7)"),
+              Arguments.of("Laser Pistol (BrightStar L-12)", "Laser Pistol (Brightstar L-12)"),
+              Arguments.of("Laser Pistol (BrightStar L-15)", "Laser Pistol (Brightstar L-15)"),
+              Arguments.of("Laser Carbine (BrightStar L-15)", "Laser Carbine (Brightstar L-15)"),
+              Arguments.of("Laser Pistol (Darklight IV)", "Laser Pistol (Darklight IV Laser Pistol)"),
+              Arguments.of("Laser Rifle (Darklight-CL Light)", "Laser Rifle (Darklight-CL Light Laser Rifle)"),
+              Arguments.of("Blazer Rifle (Scorcher VI)", "Laser Rifle (Scorcher VI Blazer Rifle)"));
+    }
+
+    @ParameterizedTest(name = "{0} -> {1}")
+    @MethodSource("renamedWeapons")
+    @DisplayName("The pre-rename name still resolves to the renamed weapon")
+    void preRenameNameStillResolves(String preRenameName, String currentName) {
+        EquipmentType byOldName = EquipmentType.get(preRenameName);
+        EquipmentType byNewName = EquipmentType.get(currentName);
+
+        assertNotNull(byOldName, "A saved game or custom unit written before the rename still names this weapon \""
+              + preRenameName + "\", so it must stay resolvable");
+        assertNotNull(byNewName, "The weapon must resolve under its current name \"" + currentName + "\"");
+        assertSame(byOldName, byNewName, "Both names must resolve to the same weapon");
+        assertEquals(currentName, byOldName.getName(), "The weapon should display its current name");
+    }
+}

--- a/megamek/unittests/megamek/common/weapons/infantry/InfantryWeaponTableGapsTest.java
+++ b/megamek/unittests/megamek/common/weapons/infantry/InfantryWeaponTableGapsTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.weapons.infantry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import megamek.MMConstants;
+import megamek.common.ToHitData;
+import megamek.common.compute.Compute;
+import megamek.common.equipment.EquipmentType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers gaps found by auditing the TechManual infantry weapon tables (pp. 349-352) and the infantry weapon Battle
+ * Value table (p. 319) against MegaMek.
+ *
+ * <p>The stat and BV data itself matched the tables, but two weapon classes existed without ever being registered
+ * in {@code WeaponType.initializeTypes()}, so nothing could look them up and no unit could mount them. A third
+ * problem was in the rules rather than the data: a platoon that gains Heavy Burst from the primary weapon damage
+ * cap only received half of what that feature grants.</p>
+ */
+class InfantryWeaponTableGapsTest {
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    @Test
+    @DisplayName("The non-incendiary mini grenade is available")
+    void miniGrenadeIsRegistered() {
+        EquipmentType grenade = EquipmentType.get("InfantryMiniGrenade");
+
+        assertNotNull(grenade, "Grenade (Mini) (Non-Inferno) is a TechManual weapon and must be registered");
+        assertInfantryStats(grenade, 0.27, 0);
+    }
+
+    @Test
+    @DisplayName("The prosthetic rumal/garrote is available")
+    void prostheticRumalGarroteIsRegistered() {
+        EquipmentType garrote = EquipmentType.get("Prosthetic Rumal/Garrote");
+
+        assertNotNull(garrote, "Twelve of the thirteen prosthetic weapons are registered; this one was omitted");
+        assertInfantryStats(garrote, 0.14, 0);
+    }
+
+    private void assertInfantryStats(EquipmentType equipment, double expectedDamage, int expectedRange) {
+        assertTrue(equipment instanceof InfantryWeapon, equipment.getName() + " should be an infantry weapon");
+        InfantryWeapon weapon = (InfantryWeapon) equipment;
+        assertEquals(expectedDamage, weapon.getInfantryDamage(), 0.001, "Damage per trooper");
+        assertEquals(expectedRange, weapon.getInfantryRange(), "Base range");
+    }
+
+    @Test
+    @DisplayName("A primary weapon over the damage cap grants the Heavy Burst to-hit bonus at range 0")
+    void damageCapGrantsHeavyBurstToHitBonus() {
+        // TM p. 152: a primary weapon above the cap has its damage reduced and the platoon "automatically gain[s]
+        // the Heavy Burst Weapon special feature", which is a -1 to-hit at range 0 as well as +1D6 damage.
+        InfantryWeapon overCap = (InfantryWeapon) EquipmentType.get("Sniper Rifle (Barton AMR (Anti-Armor))");
+        assertNotNull(overCap, "The Barton AMR should be registered");
+        assertTrue(overCap.getInfantryDamage() > MMConstants.INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP,
+              "This test needs a primary weapon above the damage cap; " + overCap.getName() + " deals "
+                    + overCap.getInfantryDamage());
+
+        ToHitData atRangeZero = Compute.getInfantryRangeMods(0, overCap, null, null, false);
+
+        assertTrue(hasBurstBonus(atRangeZero),
+              "A capped primary weapon must give the Heavy Burst -1 at range 0; modifiers were "
+                    + atRangeZero.getDesc());
+    }
+
+    @Test
+    @DisplayName("A primary weapon under the damage cap gets no Heavy Burst bonus")
+    void weaponUnderTheCapGetsNoBonus() {
+        InfantryWeapon underCap = (InfantryWeapon) EquipmentType.get("InfantryAssaultRifle");
+        assertNotNull(underCap, "The auto-rifle should be registered");
+        assertTrue(underCap.getInfantryDamage() <= MMConstants.INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP,
+              "This test needs a primary weapon at or below the cap");
+
+        ToHitData atRangeZero = Compute.getInfantryRangeMods(0, underCap, null, null, false);
+
+        assertTrue(!hasBurstBonus(atRangeZero),
+              "A weapon under the cap gains no Heavy Burst feature; modifiers were " + atRangeZero.getDesc());
+    }
+
+    private boolean hasBurstBonus(ToHitData toHit) {
+        return toHit.getDesc() != null && toHit.getDesc().contains("burst fire");
+    }
+}

--- a/megamek/unittests/megamek/common/weapons/infantry/InfantryWeaponTableGapsTest.java
+++ b/megamek/unittests/megamek/common/weapons/infantry/InfantryWeaponTableGapsTest.java
@@ -34,13 +34,19 @@
 package megamek.common.weapons.infantry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
 
 import megamek.MMConstants;
 import megamek.common.ToHitData;
 import megamek.common.compute.Compute;
 import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.WeaponType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -87,21 +93,33 @@ class InfantryWeaponTableGapsTest {
     }
 
     @Test
-    @DisplayName("A primary weapon over the damage cap grants the Heavy Burst to-hit bonus at range 0")
-    void damageCapGrantsHeavyBurstToHitBonus() {
+    @DisplayName("Every weapon over the damage cap grants the Heavy Burst to-hit bonus at range 0")
+    void everyWeaponOverTheDamageCapGrantsTheBonus() {
         // TM p. 152: a primary weapon above the cap has its damage reduced and the platoon "automatically gain[s]
         // the Heavy Burst Weapon special feature", which is a -1 to-hit at range 0 as well as +1D6 damage.
-        InfantryWeapon overCap = (InfantryWeapon) EquipmentType.get("Sniper Rifle (Barton AMR (Anti-Armor))");
-        assertNotNull(overCap, "The Barton AMR should be registered");
-        assertTrue(overCap.getInfantryDamage() > MMConstants.INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP,
-              "This test needs a primary weapon above the damage cap; " + overCap.getName() + " deals "
-                    + overCap.getInfantryDamage());
+        //
+        // Written against the data rather than one named weapon on purpose. Every weapon currently above the cap
+        // also carries F_INF_BURST outright, so naming one would test the flag and not the rule, and would go
+        // stale the moment that weapon's damage changed. This asserts the property the rule actually guarantees,
+        // and fails for any weapon added above the cap without the flag.
+        List<InfantryWeapon> overCap = new ArrayList<>();
+        for (Enumeration<EquipmentType> types = EquipmentType.getAllTypes(); types.hasMoreElements(); ) {
+            EquipmentType equipment = types.nextElement();
+            if ((equipment instanceof InfantryWeapon weapon)
+                  && !weapon.hasFlag(WeaponType.F_INF_SUPPORT)
+                  && (weapon.getInfantryDamage() > MMConstants.INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP)) {
+                overCap.add(weapon);
+            }
+        }
+        assertFalse(overCap.isEmpty(), "There should be some infantry weapons above the primary damage cap");
 
-        ToHitData atRangeZero = Compute.getInfantryRangeMods(0, overCap, null, null, false);
-
-        assertTrue(hasBurstBonus(atRangeZero),
-              "A capped primary weapon must give the Heavy Burst -1 at range 0; modifiers were "
-                    + atRangeZero.getDesc());
+        for (InfantryWeapon weapon : overCap) {
+            ToHitData atRangeZero = Compute.getInfantryRangeMods(0, weapon, null, null, false);
+            assertTrue(hasBurstBonus(atRangeZero),
+                  weapon.getName() + " deals " + weapon.getInfantryDamage()
+                        + ", above the primary weapon damage cap, so it must grant the Heavy Burst -1 at range 0; "
+                        + "modifiers were " + atRangeZero.getDesc());
+        }
     }
 
     @Test

--- a/megamek/unittests/megamek/common/weapons/infantry/InfantryWeaponTableGapsTest.java
+++ b/megamek/unittests/megamek/common/weapons/infantry/InfantryWeaponTableGapsTest.java
@@ -38,6 +38,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -120,6 +123,26 @@ class InfantryWeaponTableGapsTest {
                         + ", above the primary weapon damage cap, so it must grant the Heavy Burst -1 at range 0; "
                         + "modifiers were " + atRangeZero.getDesc());
         }
+    }
+
+    @Test
+    @DisplayName("The damage cap alone grants the bonus, with no Heavy Burst flag set")
+    void theDamageCapAloneGrantsTheBonus() {
+        // Every weapon currently above the cap also carries F_INF_BURST, so no real weapon can tell the cap rule
+        // apart from the flag: delete the rule and the data-driven test above still passes. This is the case that
+        // fails without it - a weapon above the cap that does not carry the flag, which is exactly what the rule
+        // exists to catch when such a weapon is added later.
+        InfantryWeapon overCapWithoutFlag = mock(InfantryWeapon.class);
+        when(overCapWithoutFlag.getInfantryRange()).thenReturn(1);
+        when(overCapWithoutFlag.getInfantryDamage())
+              .thenReturn(MMConstants.INFANTRY_PRIMARY_WEAPON_DAMAGE_CAP + 0.01);
+        when(overCapWithoutFlag.hasFlag(WeaponType.F_INF_BURST)).thenReturn(false);
+
+        ToHitData atRangeZero = Compute.getInfantryRangeMods(0, overCapWithoutFlag, null, null, false);
+
+        assertTrue(hasBurstBonus(atRangeZero),
+              "A weapon above the damage cap grants Heavy Burst whether or not it carries the flag; "
+                    + "modifiers were " + atRangeZero.getDesc());
     }
 
     @Test

--- a/megamek/unittests/megamek/common/weapons/infantry/InfantryWeaponTableGapsTest.java
+++ b/megamek/unittests/megamek/common/weapons/infantry/InfantryWeaponTableGapsTest.java
@@ -46,6 +46,7 @@ import java.util.Enumeration;
 import java.util.List;
 
 import megamek.MMConstants;
+import megamek.common.TargetRollModifier;
 import megamek.common.ToHitData;
 import megamek.common.compute.Compute;
 import megamek.common.equipment.EquipmentType;
@@ -64,6 +65,9 @@ import org.junit.jupiter.api.Test;
  * cap only received half of what that feature grants.</p>
  */
 class InfantryWeaponTableGapsTest {
+
+    /** The Heavy Burst feature is worth exactly -1 to hit at range 0 (TM p. 152). */
+    private static final int HEAVY_BURST_MODIFIER = -1;
 
     @BeforeAll
     static void initializeEquipment() {
@@ -159,7 +163,22 @@ class InfantryWeaponTableGapsTest {
               "A weapon under the cap gains no Heavy Burst feature; modifiers were " + atRangeZero.getDesc());
     }
 
+    /**
+     * Looks for the Heavy Burst modifier in the modifier list rather than in {@code getDesc()}. Matching a
+     * substring of the description would pass on any modifier that happened to mention burst fire whatever
+     * its value, and would break if {@link megamek.common.rolls.TargetRoll} ever changed how it joins
+     * descriptions together. The rule grants exactly -1, so that is what gets asserted.
+     *
+     * @param toHit the to-hit data to inspect
+     *
+     * @return {@code true} if a -1 burst fire modifier is present
+     */
     private boolean hasBurstBonus(ToHitData toHit) {
-        return toHit.getDesc() != null && toHit.getDesc().contains("burst fire");
+        for (TargetRollModifier modifier : toHit.getModifiers()) {
+            if ((modifier.value() == HEAVY_BURST_MODIFIER) && modifier.getDesc().contains("burst fire")) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## What this changes

Two conventional infantry weapons that existed in the code but not in the game are now available, and a platoon that gains Heavy Burst from the damage cap gets the whole feature instead of half of it.

**Grenade (Mini) (Non-Inferno)** and **Prosthetic Rumal/Garrote** were never added in `WeaponType.initializeTypes()`. Nothing could look them up and no unit could mount them. The mini grenade is a TechManual weapon at 0.27 damage and base range 0, and its incendiary twin was registered. Twelve of the thirteen prosthetic weapons were registered; the garrote was the only one left out.

**Heavy Burst from the primary weapon damage cap.** TM p. 152: a platoon whose primary weapon is over the 0.60 cap has that damage reduced and "automatically gain[s] the Heavy Burst Weapon special feature". That feature is +1D6 damage against conventional infantry *and* a -1 to-hit at range 0. Both halves were wrong, in different ways.

The to-hit half tested only `F_INF_BURST` and never looked at the cap, so a platoon over the cap without that flag was short a point at range 0. Seven weapons were in that position: the Boudicca-7 and Jinse Yanjingshe SMGs, the SGS-9E shotgun, both Barton AMR loads, the DWS L5L laser sniper rifle and the Wolf-Barron Sunraker.

The damage half did check the cap, but on the wrong platoon. The condition read `target instanceof ConvInfantry infantry` and then asked `infantry.primaryWeaponDamageCapped()`, so it tested the weapon carried by the platoon being shot at. A platoon's own bonus die depended on what its victim happened to be holding: shoot a Boudicca-7 platoon and you got the die, shoot an auto-rifle platoon with the same weapon and you did not. It now reads the attacking platoon.

**The +1D6 is reported.** The dice are rolled, not derived from the weapon, so without a line of their own a player cannot tell a lucky roll from a hard-hitting platoon. A 12-trooper platoon firing a Mauser 960 now reports `7 base` and `[+4 Heavy Burst]` rather than a bare 11.

The same roll was also corrupting the bonus breakdown that already existed. `baseDamageDealt` subtracted the TSM, prosthetic, extraneous limb and tail bonuses but not the burst dice, so the `[N base + M TSM]` line overstated the base whenever a burst die landed. Both the Heavy Burst die and the beast-mount burst dice are now subtracted, and both get a line.

**Corrected values for 67 weapons**, from the checked Infantry Weapons Calculator sheet: 65 damage values, 13 Battle Values and 5 Heavy Burst flags. Every affected weapon comes from a Shrapnel source, where values had been taken from the published tables rather than recalculated. Most changes are small - the Serrek 7994 goes from 0.2 to 0.2025 - but some are large: the Camden HR-7 drops from 0.44 to 0.2188 and the AMI Keymaster-15 from 0.21 to 0.084.

The five Heavy Burst flags land on exactly the weapons whose damage sits above the 0.60 cap, which is the same answer the runtime rule above produces, reached independently. Both Barton AMR variants lose their claim to it, because their corrected damage now falls below the cap.

Between the two changes no weapon is left relying on the runtime cap rule: five of the seven now carry the flag outright and the two Barton AMRs fall below the cap. The rule stays as the guard for data added later, and it is what the test asserts.

**Fifteen new light machine guns from Shrapnel #22.** These were the only weapons in the calculator sheet that MegaMek did not already carry. Damage and Battle Value come from the sheet; cost, mass, shots, bursts and the reload figures come from the magazine, which the sheet does not record. A `SHRAPNEL_22` source book code is added for them.

**Thirteen weapons renamed** to the sheet's normalised spelling. Most were carrying the shouted spelling of their Shrapnel entry - `Laser Pistol (AWA Wiliby MK4 LASER PISTOL)` - and four differed only in the capitalisation of BrightStar. Every pre-rename name stays resolvable: the internal name is pinned to the old spelling and the new name added as a lookup, so unit files and saved games are unaffected. One rename also removes the last non-ASCII characters from the infantry weapon sources; the Xing Shan ER wrote Xing with an accented i in both its display and internal name, and no unit file referenced it.

**Dual-load weapons gain a comment** recording why they stay as two weapon types rather than becoming one weapon with a mode. The Barton AMR, the Daystar shotguns and seven other families come in two ammunition loads with different Battle Values, and Battle Value is derived from the weapon type before a battle, so a load that could be switched mid-game would leave a platoon's Battle Value undefined.

The updated conversion formulas behind the sheet's values, and the feedback on the conversions themselves, were supplied by a CGL freelancer.

## Testing

`./gradlew test javadoc` green, plus `checkstyleMain`. No pre-existing failures.

Four tests. Reverting the two source changes and re-running makes three of them fail - the two registrations and the to-hit bonus. The fourth is the control: a primary weapon under the cap must gain nothing, and it passes either way.

The Heavy Burst test is written against the data rather than one named weapon. Naming one would now test the flag rather than the rule, since every weapon above the cap carries the flag, and would go stale as soon as that weapon's damage changed. It asserts instead that every non-support weapon above the cap grants the bonus, which fails for any weapon added above the cap without the flag.

This came out of an audit of the TechManual infantry weapon tables (pp. 349-352) and the infantry weapon Battle Value table (p. 319) against MegaMek. Both tables were extracted from the PDF and compared field by field. **The data itself needed no changes**: across every weapon that could be name-matched, damage, base range, crew, Battle Value, and the flame, anti-air and non-penetrating special features all agreed. 164 of 212 BV rows matched with zero mismatches; 152 weapons matched on stats with zero mismatches.

Two points on the audit's limits, so the "zero mismatches" is not read as more than it is:

- Roughly a quarter of each table could not be name-matched, because MegaMek names some weapons differently (`Grenade Launcher` where the table says `Grenade Launcher (Non-Inferno Ammo)`) and deliberately merges several archaic weapons into combined entries (`Blade (Axe/Hatchet/Tomahawk)`). Those rows were not compared.
- The two missing weapons were not found by name matching at all. They were found by checking which `InfantryWeapon` subclasses never appear in `WeaponType.initializeTypes()`, which is the reliable test for "absent from the game". Of 361 subclasses, 359 were registered and these were the two that were not.

Every weapon flagged `F_INF_BURST` was also checked against the table: each is either listed with the B special or sits above the damage cap, so none are mis-flagged.

## What is not proven yet

Two of the three Heavy Burst changes are confirmed in game.

The to-hit bonus: two platoons differing only in the primary weapon - SMG (Boudicca-7) against Auto-Rifle (Modern, Generic), same base range, same flags but Heavy Burst, neither encumbering - standing in the target's hex. The over-cap platoon needed `4 (gunnery) - 1 (point blank burst fire weapon) - 2 (infantry range) = 1`; the control showed no burst line.

The report line: a 12-trooper platoon firing a Mauser 960 reported `causing 12 damage` with `[+5 Heavy Burst]` beside it, which is 12 troopers at the 0.60 cap rounding to 7, plus a die roll of 5. Doubling for infantry caught in the open then took it to 24.

Neither shot exercises the attacker-versus-target fix, and no shot can: every weapon above the cap also carries `F_INF_BURST`, so the first clause of the condition is always satisfied before the cap is read. That fix rests on the two tests, both confirmed by restoring the old condition and watching them fail in opposite directions.

Nothing else is tested in game, and none of it changes a unit MegaMek ships: no unit file mounts any of the 67 corrected weapons, and none mounts any of the 13 renamed weapons under either spelling. The new weapons and the two registrations should show up in MegaMekLab, which composite-builds against this branch, and be absent there on `main`. That has not been run.

The magazine and the sheet agree on the cost of all fifteen new weapons, which is what the two were matched on. They disagree on one mass: the sheet records the Peacekeeper-SB at 10.05 kg where the magazine prints 10.5 kg. The magazine value is used. Worth a second pair of eyes on which is right.

The value corrections change Battle Value for any unit mounting an affected weapon. That is intended - the sheet's values are the checked ones - but it does mean existing forces built with these weapons will re-price.

The unmatched table rows described above were not audited. They are naming and merging differences as far as spot checks go, but they were not individually verified.

---
- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
