### PR TITLE
Close #8456: Rename infantry Inferno weapons to Incendiary

### DIFF
--- a/megamek/src/megamek/common/equipment/WeaponType.java
+++ b/megamek/src/megamek/common/equipment/WeaponType.java
@@ -225,9 +225,7 @@ import megamek.common.weapons.infantry.support.recoillessRifle.InfantrySupportRe
 import megamek.common.weapons.infantry.support.recoillessRifle.InfantrySupportRecoillessRifleLightWeapon;
 import megamek.common.weapons.infantry.support.recoillessRifle.InfantrySupportRecoillessRifleMediumInfernoWeapon;
 import megamek.common.weapons.infantry.support.recoillessRifle.InfantrySupportRecoillessRifleMediumWeapon;
-import megamek.common.weapons.infantry.support.srm.InfantrySupportSRMHeavyInfernoWeapon;
 import megamek.common.weapons.infantry.support.srm.InfantrySupportSRMHeavyWeapon;
-import megamek.common.weapons.infantry.support.srm.InfantrySupportSRMLightInfernoWeapon;
 import megamek.common.weapons.infantry.support.srm.InfantrySupportSRMLightWeapon;
 import megamek.common.weapons.infantry.support.srm.InfantrySupportSRMStandardInfernoWeapon;
 import megamek.common.weapons.infantry.support.srm.InfantrySupportSRMStandardWeapon;

--- a/megamek/src/megamek/common/equipment/WeaponType.java
+++ b/megamek/src/megamek/common/equipment/WeaponType.java
@@ -1850,7 +1850,11 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new InfantryRifleLaserWeapon());
         EquipmentType.addType(new InfantrySupportLRMWeapon());
         EquipmentType.addType(new InfantrySupportLRMInfernoWeapon());
-        EquipmentType.addType(new InfantrySupportSRMLightInfernoWeapon());
+        // Retired by the TechManual pp. 350-352 errata, which deletes the SRM Launcher (Inferno Ammo) rows
+        // outright. No unit file mounts this one, so it is withdrawn rather than left to confuse players. The
+        // class is kept so the decision stays reversible; see InfantrySupportSRMStandardInfernoWeapon for why
+        // the two-shot version is still registered.
+        // EquipmentType.addType(new InfantrySupportSRMLightInfernoWeapon());
         EquipmentType.addType(new InfantrySupportPortableFlamerWeapon());
         EquipmentType.addType(new InfantryTWFlamerWeapon());
 
@@ -2194,7 +2198,8 @@ public class WeaponType extends EquipmentType {
         EquipmentType.addType(new InfantrySupportSRMStandardWeapon());
         EquipmentType.addType(new InfantrySupportSRMStandardInfernoWeapon());
         EquipmentType.addType(new InfantrySupportSRMHeavyWeapon());
-        EquipmentType.addType(new InfantrySupportSRMHeavyInfernoWeapon());
+        // Retired by the TechManual pp. 350-352 errata, as with the light version above. No unit file mounts it.
+        // EquipmentType.addType(new InfantrySupportSRMHeavyInfernoWeapon());
         EquipmentType.addType(new InfantrySupportSRMLightWeapon());
         EquipmentType.addType(new InfantrySupportLaserWeapon());
         EquipmentType.addType(new InfantrySupportERLaserWeapon());

--- a/megamek/src/megamek/common/weapons/infantry/grenade/InfantryGrenadeInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/grenade/InfantryGrenadeInfernoWeapon.java
@@ -54,11 +54,13 @@ public class InfantryGrenadeInfernoWeapon extends InfantryWeapon {
     public InfantryGrenadeInfernoWeapon() {
         super();
 
-        name = "Grenade (Inferno)";
+        name = "Grenade (Incendiary)";
         // I can find no reference to a Thrown Inferno Grenade. Moving these to Unofficial.
         // Hammer Feb 2017
 
         setInternalName("InfantryGrenadeInferno");
+
+        addLookupName("Grenade (Inferno)");
         addLookupName(name);
         addLookupName("InfantryInfernoGrenade");
         addLookupName("Inferno Grenades");

--- a/megamek/src/megamek/common/weapons/infantry/grenade/InfantryGrenadeMiniInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/grenade/InfantryGrenadeMiniInfernoWeapon.java
@@ -61,8 +61,9 @@ public class InfantryGrenadeMiniInfernoWeapon extends InfantryWeapon {
     public InfantryGrenadeMiniInfernoWeapon() {
         super();
 
-        name = "Grenade (Mini) (Inferno)";
+        name = "Grenade (Mini) (Incendiary)";
         setInternalName("InfantryMiniGrenadeInferno");
+        addLookupName("Grenade (Mini) (Inferno)");
         addLookupName(name);
         addLookupName("InfantryMiniInfernoGrenade");
         addLookupName("Mini Inferno Grenades");

--- a/megamek/src/megamek/common/weapons/infantry/grenade/InfantryGrenadeStandardWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/grenade/InfantryGrenadeStandardWeapon.java
@@ -61,8 +61,9 @@ public class InfantryGrenadeStandardWeapon extends InfantryWeapon {
     public InfantryGrenadeStandardWeapon() {
         super();
 
-        name = "Grenade (Non-Inferno)";
+        name = "Grenade (Non-Incendiary)";
         setInternalName("InfantryGrenade");
+        addLookupName("Grenade (Non-Inferno)");
         addLookupName(name);
         addLookupName("Grenades");
         ammoType = AmmoType.AmmoTypeEnum.NA;

--- a/megamek/src/megamek/common/weapons/infantry/rifle/InfantryRifleClanMauserIICIASInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/rifle/InfantryRifleClanMauserIICIASInfernoWeapon.java
@@ -62,8 +62,11 @@ public class InfantryRifleClanMauserIICIASInfernoWeapon extends InfantryWeapon {
     public InfantryRifleClanMauserIICIASInfernoWeapon() {
         super();
 
-        name = "Laser Rifle (Mauser IIC IAS) (Inferno Grenades)";
-        setInternalName(name);
+        name = "Laser Rifle (Mauser IIC IAS) (Incendiary Grenades)";
+        // The internal name stays on the pre-errata spelling because unit files store it. setInternalName()
+        // registers it as a lookup too, so existing files keep loading.
+        setInternalName("Laser Rifle (Mauser IIC IAS) (Inferno Grenades)");
+        addLookupName(name);
         addLookupName("InfantryClanMauserIICIASInferno");
         addLookupName("Infantry Clan Mauser IIC Inferno");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;

--- a/megamek/src/megamek/common/weapons/infantry/rifle/InfantryRifleFederatedBarrettM42BInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/rifle/InfantryRifleFederatedBarrettM42BInfernoWeapon.java
@@ -55,8 +55,9 @@ public class InfantryRifleFederatedBarrettM42BInfernoWeapon extends InfantryWeap
     public InfantryRifleFederatedBarrettM42BInfernoWeapon() {
         super();
 
-        name = "Rifle (Federated-Barrett M42B) (Inferno Grenades)";
+        name = "Rifle (Federated-Barrett M42B) (Incendiary Grenades)";
         setInternalName("InfantryFederatedBarrettM42BInferno");
+        addLookupName("Rifle (Federated-Barrett M42B) (Inferno Grenades)");
         addLookupName(name);
         addLookupName("Federated Barrett M42B Inferno");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;

--- a/megamek/src/megamek/common/weapons/infantry/rifle/InfantryRifleFederatedBarrettM61ALaserInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/rifle/InfantryRifleFederatedBarrettM61ALaserInfernoWeapon.java
@@ -62,8 +62,9 @@ public class InfantryRifleFederatedBarrettM61ALaserInfernoWeapon extends Infantr
     public InfantryRifleFederatedBarrettM61ALaserInfernoWeapon() {
         super();
 
-        name = "Laser Rifle (Federated-Barrett M61A) (Inferno Grenades)";
+        name = "Laser Rifle (Federated-Barrett M61A) (Incendiary Grenades)";
         setInternalName("InfantryFederatedBarrettM61AInferno");
+        addLookupName("Laser Rifle (Federated-Barrett M61A) (Inferno Grenades)");
         addLookupName(name);
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;
         cost = 2150;

--- a/megamek/src/megamek/common/weapons/infantry/support/InfantrySupportLRMInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/InfantrySupportLRMInfernoWeapon.java
@@ -64,8 +64,9 @@ public class InfantrySupportLRMInfernoWeapon extends InfantryWeapon {
     public InfantrySupportLRMInfernoWeapon() {
         super();
 
-        name = "LRM Launcher (Corean Farshot) w/Inferno";
+        name = "LRM Launcher (Corean Farshot) w/Incendiary";
         setInternalName("InfantryLRMInferno");
+        addLookupName("LRM Launcher (Corean Farshot) w/Inferno");
         addLookupName(name);
         addLookupName("InfantryInfernoLRM");
         addLookupName("LRM Inferno Launcher");

--- a/megamek/src/megamek/common/weapons/infantry/support/InfantrySupportOneShotMRMInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/InfantrySupportOneShotMRMInfernoWeapon.java
@@ -62,8 +62,9 @@ public class InfantrySupportOneShotMRMInfernoWeapon extends InfantryWeapon {
     public InfantrySupportOneShotMRMInfernoWeapon() {
         super();
 
-        name = "MRM Launcher w/Inferno";
+        name = "MRM Launcher w/Incendiary";
         setInternalName("InfantryOneShotMRMInferno");
+        addLookupName("MRM Launcher w/Inferno");
         addLookupName(name);
         addLookupName("InfantryInfernoMRM");
         addLookupName("InfantryOneShotInfernoMRM");

--- a/megamek/src/megamek/common/weapons/infantry/support/grenadeLauncher/InfantrySupportGrenadeLauncherAutoInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/grenadeLauncher/InfantrySupportGrenadeLauncherAutoInfernoWeapon.java
@@ -61,8 +61,9 @@ public class InfantrySupportGrenadeLauncherAutoInfernoWeapon extends InfantryWea
     public InfantrySupportGrenadeLauncherAutoInfernoWeapon() {
         super();
 
-        name = "Grenade Launcher (Auto) - Inferno";
+        name = "Grenade Launcher (Auto) - Incendiary";
         setInternalName("InfantryAutoGLInferno");
+        addLookupName("Grenade Launcher (Auto) - Inferno");
         addLookupName(name);
         addLookupName("Infantry Inferno Auto Grenade Launcher");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;

--- a/megamek/src/megamek/common/weapons/infantry/support/grenadeLauncher/InfantrySupportGrenadeLauncherHeavyAutoInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/grenadeLauncher/InfantrySupportGrenadeLauncherHeavyAutoInfernoWeapon.java
@@ -62,8 +62,9 @@ public class InfantrySupportGrenadeLauncherHeavyAutoInfernoWeapon extends Infant
     public InfantrySupportGrenadeLauncherHeavyAutoInfernoWeapon() {
         super();
 
-        name = "Grenade Launcher (Heavy Auto) w/Inferno";
+        name = "Grenade Launcher (Heavy Auto) w/Incendiary";
         setInternalName("InfantryHeavyAutoGrenadeLauncherInferno");
+        addLookupName("Grenade Launcher (Heavy Auto) w/Inferno");
         addLookupName(name);
         addLookupName("Infantry Inferno Heavy Auto Grenade Launcher");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;

--- a/megamek/src/megamek/common/weapons/infantry/support/grenadeLauncher/InfantrySupportGrenadeLauncherInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/grenadeLauncher/InfantrySupportGrenadeLauncherInfernoWeapon.java
@@ -61,8 +61,9 @@ public class InfantrySupportGrenadeLauncherInfernoWeapon extends InfantryWeapon 
     public InfantrySupportGrenadeLauncherInfernoWeapon() {
         super();
 
-        name = "Grenade Launcher - Inferno";
+        name = "Grenade Launcher - Incendiary";
         setInternalName("InfantryGrenadeLauncherInferno");
+        addLookupName("Grenade Launcher - Inferno");
         addLookupName(name);
         addLookupName("InfantryInfernoGrenadeLauncher");
         addLookupName("Infantry Inferno Grenade Launcher");

--- a/megamek/src/megamek/common/weapons/infantry/support/heavy/InfantrySupportHeavyGrenadeLauncherInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/heavy/InfantrySupportHeavyGrenadeLauncherInfernoWeapon.java
@@ -62,8 +62,9 @@ public class InfantrySupportHeavyGrenadeLauncherInfernoWeapon extends InfantryWe
     public InfantrySupportHeavyGrenadeLauncherInfernoWeapon() {
         super();
 
-        name = "Grenade Launcher (Heavy) w/Inferno";
+        name = "Grenade Launcher (Heavy) w/Incendiary";
         setInternalName("InfantryHeavyGrenadeLauncherInferno");
+        addLookupName("Grenade Launcher (Heavy) w/Inferno");
         addLookupName(name);
         addLookupName("Infantry Heavy Inferno Grenade Launcher");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;

--- a/megamek/src/megamek/common/weapons/infantry/support/mortar/InfantrySupportMortarHeavyInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mortar/InfantrySupportMortarHeavyInfernoWeapon.java
@@ -64,8 +64,9 @@ public class InfantrySupportMortarHeavyInfernoWeapon extends InfantryWeapon {
     public InfantrySupportMortarHeavyInfernoWeapon() {
         super();
 
-        name = "Mortar (Heavy) - Inferno";
+        name = "Mortar (Heavy) - Incendiary";
         setInternalName(EquipmentTypeLookup.INFANTRY_MORTAR_HEAVY_INFERNO);
+        addLookupName("Mortar (Heavy) - Inferno");
         addLookupName(name);
         addLookupName("Infantry Heavy Inferno Mortar");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;

--- a/megamek/src/megamek/common/weapons/infantry/support/mortar/InfantrySupportMortarLightInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/mortar/InfantrySupportMortarLightInfernoWeapon.java
@@ -64,8 +64,9 @@ public class InfantrySupportMortarLightInfernoWeapon extends InfantryWeapon {
     public InfantrySupportMortarLightInfernoWeapon() {
         super();
 
-        name = "Mortar (Light) - Inferno";
+        name = "Mortar (Light) - Incendiary";
         setInternalName(EquipmentTypeLookup.INFANTRY_MORTAR_LIGHT_INFERNO);
+        addLookupName("Mortar (Light) - Inferno");
         addLookupName(name);
         addLookupName("Infantry Light Mortar Inferno");
         ammoType = AmmoType.AmmoTypeEnum.INFANTRY;

--- a/megamek/src/megamek/common/weapons/infantry/support/recoillessRifle/InfantrySupportRecoillessRifleHeavyInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/recoillessRifle/InfantrySupportRecoillessRifleHeavyInfernoWeapon.java
@@ -61,8 +61,9 @@ public class InfantrySupportRecoillessRifleHeavyInfernoWeapon extends InfantryWe
     public InfantrySupportRecoillessRifleHeavyInfernoWeapon() {
         super();
 
-        name = "Recoilless Rifle (Heavy) - Inferno";
+        name = "Recoilless Rifle (Heavy) - Incendiary";
         setInternalName("InfantryHRRInferno");
+        addLookupName("Recoilless Rifle (Heavy) - Inferno");
         addLookupName(name);
         addLookupName("InfantryInfernoHRR");
         addLookupName("InfantryHeavyRecoillessRifleInferno");

--- a/megamek/src/megamek/common/weapons/infantry/support/recoillessRifle/InfantrySupportRecoillessRifleLightInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/recoillessRifle/InfantrySupportRecoillessRifleLightInfernoWeapon.java
@@ -61,8 +61,9 @@ public class InfantrySupportRecoillessRifleLightInfernoWeapon extends InfantryWe
     public InfantrySupportRecoillessRifleLightInfernoWeapon() {
         super();
 
-        name = "Recoilless Rifle (Light) - Inferno";
+        name = "Recoilless Rifle (Light) - Incendiary";
         setInternalName("InfantryLRRInferno");
+        addLookupName("Recoilless Rifle (Light) - Inferno");
         addLookupName(name);
         addLookupName("InfantryInfernoLRR");
         addLookupName("InfantryLightRecoillessRifleInferno");

--- a/megamek/src/megamek/common/weapons/infantry/support/recoillessRifle/InfantrySupportRecoillessRifleMediumInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/recoillessRifle/InfantrySupportRecoillessRifleMediumInfernoWeapon.java
@@ -61,8 +61,9 @@ public class InfantrySupportRecoillessRifleMediumInfernoWeapon extends InfantryW
     public InfantrySupportRecoillessRifleMediumInfernoWeapon() {
         super();
 
-        name = "Recoilless Rifle (Medium) - Inferno";
+        name = "Recoilless Rifle (Medium) - Incendiary";
         setInternalName("InfantryMRRInferno");
+        addLookupName("Recoilless Rifle (Medium) - Inferno");
         addLookupName(name);
         addLookupName("InfantryInfernoMRR");
         addLookupName("InfantryMediumRecoillessRifleInferno");

--- a/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMStandardInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMStandardInfernoWeapon.java
@@ -68,7 +68,9 @@ public class InfantrySupportSRMStandardInfernoWeapon extends InfantryWeapon {
         // units and saved games may mount it too, and withdrawing it would break those downstream. The light and
         // heavy versions had no users at all and are commented out in WeaponType.initializeTypes().
         // Unlike the incendiary weapons, which only convert damage to heat, this one carries true Inferno
-        // munitions and should deliver inferno missiles.
+        // munitions and should deliver inferno missiles. It does not yet: this PR is the rename, and the
+        // Damage/Heat modes below are still the incendiary handling. Giving it a working Inferno mode is
+        // MegaMek/megamek#8817, which builds on this branch.
         name = "SRM Launcher (Std, Two-Shot) - Inferno";
         setInternalName("InfantryStandardSRMInferno");
         addLookupName(name);

--- a/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMStandardInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMStandardInfernoWeapon.java
@@ -62,6 +62,13 @@ public class InfantrySupportSRMStandardInfernoWeapon extends InfantryWeapon {
     public InfantrySupportSRMStandardInfernoWeapon() {
         super();
 
+        // The TechManual pp. 350-352 errata deletes this row along with the light and heavy versions, replacing
+        // the weapon with a pre-battle Inferno munition declaration on a normal SRM platoon. It is kept
+        // registered anyway: a stock unit mounts it (Beast Infantry (Elephant) (Needler/SRM)), player-built
+        // units and saved games may mount it too, and withdrawing it would break those downstream. The light and
+        // heavy versions had no users at all and are commented out in WeaponType.initializeTypes().
+        // Unlike the incendiary weapons, which only convert damage to heat, this one carries true Inferno
+        // munitions and should deliver inferno missiles.
         name = "SRM Launcher (Std, Two-Shot) - Inferno";
         setInternalName("InfantryStandardSRMInferno");
         addLookupName(name);

--- a/megamek/unittests/megamek/common/weapons/infantry/IncendiaryInfantryWeaponNameTest.java
+++ b/megamek/unittests/megamek/common/weapons/infantry/IncendiaryInfantryWeaponNameTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.weapons.infantry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+
+import megamek.common.equipment.EquipmentType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Guards the TechManual pp. 350-352 errata rename of the conventional infantry incendiary weapons.
+ *
+ * <p>The errata replaces every use of "Inferno" with "Incendiary" on the conventional infantry weapon tables, so
+ * that flame-based support weapons are not confused with true Inferno munitions. These weapons are renamed for
+ * display, but their pre-errata names must keep resolving: unit files and saved games written before the rename
+ * still refer to them.</p>
+ *
+ * <p>The three SRM launchers that carried real Inferno ammo are deliberately NOT renamed. The errata deletes those
+ * rows rather than renaming them, and the replacement rule - a conventional infantry SRM platoon declaring Inferno
+ * munitions before the battle - is not implemented yet. Renaming them would hide a capability that has no
+ * replacement.</p>
+ */
+class IncendiaryInfantryWeaponNameTest {
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    private static Stream<Arguments> renamedWeapons() {
+        return Stream.of(
+              Arguments.of("Grenade (Inferno)", "Grenade (Incendiary)"),
+              Arguments.of("Grenade (Mini) (Inferno)", "Grenade (Mini) (Incendiary)"),
+              Arguments.of("Grenade (Non-Inferno)", "Grenade (Non-Incendiary)"),
+              Arguments.of("Laser Rifle (Mauser IIC IAS) (Inferno Grenades)",
+                    "Laser Rifle (Mauser IIC IAS) (Incendiary Grenades)"),
+              Arguments.of("Rifle (Federated-Barrett M42B) (Inferno Grenades)",
+                    "Rifle (Federated-Barrett M42B) (Incendiary Grenades)"),
+              Arguments.of("Laser Rifle (Federated-Barrett M61A) (Inferno Grenades)",
+                    "Laser Rifle (Federated-Barrett M61A) (Incendiary Grenades)"),
+              Arguments.of("LRM Launcher (Corean Farshot) w/Inferno", "LRM Launcher (Corean Farshot) w/Incendiary"),
+              Arguments.of("MRM Launcher w/Inferno", "MRM Launcher w/Incendiary"),
+              Arguments.of("Grenade Launcher (Auto) - Inferno", "Grenade Launcher (Auto) - Incendiary"),
+              Arguments.of("Grenade Launcher (Heavy Auto) w/Inferno", "Grenade Launcher (Heavy Auto) w/Incendiary"),
+              Arguments.of("Grenade Launcher - Inferno", "Grenade Launcher - Incendiary"),
+              Arguments.of("Grenade Launcher (Heavy) w/Inferno", "Grenade Launcher (Heavy) w/Incendiary"),
+              Arguments.of("Mortar (Heavy) - Inferno", "Mortar (Heavy) - Incendiary"),
+              Arguments.of("Mortar (Light) - Inferno", "Mortar (Light) - Incendiary"),
+              Arguments.of("Recoilless Rifle (Heavy) - Inferno", "Recoilless Rifle (Heavy) - Incendiary"),
+              Arguments.of("Recoilless Rifle (Light) - Inferno", "Recoilless Rifle (Light) - Incendiary"),
+              Arguments.of("Recoilless Rifle (Medium) - Inferno", "Recoilless Rifle (Medium) - Incendiary"));
+    }
+
+    @ParameterizedTest(name = "{0} -> {1}")
+    @MethodSource("renamedWeapons")
+    @DisplayName("The pre-errata name still resolves to the renamed weapon")
+    void preErrataNameStillResolves(String preErrataName, String errataName) {
+        EquipmentType byOldName = EquipmentType.get(preErrataName);
+        EquipmentType byNewName = EquipmentType.get(errataName);
+
+        assertNotNull(byOldName, "Unit files written before the rename still use \"" + preErrataName
+              + "\", so it must stay resolvable");
+        assertNotNull(byNewName, "The renamed weapon must resolve under its errata name \"" + errataName + "\"");
+        assertSame(byOldName, byNewName, "Both names must resolve to the same weapon");
+        assertEquals(errataName, byOldName.getName(), "The weapon should display its errata name");
+    }
+
+    @Test
+    @DisplayName("The true Inferno SRM launchers keep their name")
+    void infernoSrmLaunchersAreNotRenamed() {
+        String[] infernoSrmLaunchers = {
+              "InfantryStandardSRMInferno",
+              "InfantryHeavySRMInferno",
+              "InfantrySRMLightInferno" };
+
+        for (String internalName : infernoSrmLaunchers) {
+            EquipmentType launcher = EquipmentType.get(internalName);
+            assertNotNull(launcher, internalName + " should still exist");
+            assertTrue(launcher.getName().contains("Inferno"),
+                  "The SRM launchers carry real Inferno munitions and are not part of the incendiary rename; "
+                        + internalName + " is named \"" + launcher.getName() + "\"");
+        }
+    }
+}

--- a/megamek/unittests/megamek/common/weapons/infantry/IncendiaryInfantryWeaponNameTest.java
+++ b/megamek/unittests/megamek/common/weapons/infantry/IncendiaryInfantryWeaponNameTest.java
@@ -35,6 +35,7 @@ package megamek.common.weapons.infantry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -56,10 +57,10 @@ import org.junit.jupiter.params.provider.MethodSource;
  * display, but their pre-errata names must keep resolving: unit files and saved games written before the rename
  * still refer to them.</p>
  *
- * <p>The three SRM launchers that carried real Inferno ammo are deliberately NOT renamed. The errata deletes those
- * rows rather than renaming them, and the replacement rule - a conventional infantry SRM platoon declaring Inferno
- * munitions before the battle - is not implemented yet. Renaming them would hide a capability that has no
- * replacement.</p>
+ * <p>The SRM launchers that carry real Inferno ammo are handled differently, because the errata deletes those rows
+ * rather than renaming them. The light and heavy versions had no users at all and are withdrawn. The two-shot
+ * version stays registered and keeps its name: a stock unit mounts it, and player-built units and saved games may
+ * too. Unlike the incendiary weapons, which only convert damage to heat, it carries true Inferno munitions.</p>
  */
 class IncendiaryInfantryWeaponNameTest {
 
@@ -107,19 +108,25 @@ class IncendiaryInfantryWeaponNameTest {
     }
 
     @Test
-    @DisplayName("The true Inferno SRM launchers keep their name")
-    void infernoSrmLaunchersAreNotRenamed() {
-        String[] infernoSrmLaunchers = {
-              "InfantryStandardSRMInferno",
-              "InfantryHeavySRMInferno",
-              "InfantrySRMLightInferno" };
+    @DisplayName("The two-shot Inferno SRM launcher stays registered and keeps its name")
+    void infernoSrmLauncherIsNotRenamed() {
+        EquipmentType launcher = EquipmentType.get("InfantryStandardSRMInferno");
 
-        for (String internalName : infernoSrmLaunchers) {
-            EquipmentType launcher = EquipmentType.get(internalName);
-            assertNotNull(launcher, internalName + " should still exist");
-            assertTrue(launcher.getName().contains("Inferno"),
-                  "The SRM launchers carry real Inferno munitions and are not part of the incendiary rename; "
-                        + internalName + " is named \"" + launcher.getName() + "\"");
+        assertNotNull(launcher, "A stock unit mounts this launcher, so withdrawing it would break unit files");
+        assertTrue(launcher.getName().contains("Inferno"),
+              "This launcher carries true Inferno munitions and is not part of the incendiary rename; it is "
+                    + "named \"" + launcher.getName() + "\"");
+    }
+
+    @Test
+    @DisplayName("The unused Inferno SRM launchers are withdrawn per the errata")
+    void unusedInfernoSrmLaunchersAreNotRegistered() {
+        String[] withdrawnLaunchers = { "InfantryHeavySRMInferno", "InfantrySRMLightInferno" };
+
+        for (String internalName : withdrawnLaunchers) {
+            assertNull(EquipmentType.get(internalName),
+                  "The errata deletes this row and no unit file mounts it, so it should no longer be "
+                        + "registered: " + internalName);
         }
     }
 }

--- a/megamek/unittests/megamek/common/weapons/infantry/IncendiaryInfantryWeaponNameTest.java
+++ b/megamek/unittests/megamek/common/weapons/infantry/IncendiaryInfantryWeaponNameTest.java
@@ -113,9 +113,11 @@ class IncendiaryInfantryWeaponNameTest {
         EquipmentType launcher = EquipmentType.get("InfantryStandardSRMInferno");
 
         assertNotNull(launcher, "A stock unit mounts this launcher, so withdrawing it would break unit files");
-        assertTrue(launcher.getName().contains("Inferno"),
-              "This launcher carries true Inferno munitions and is not part of the incendiary rename; it is "
-                    + "named \"" + launcher.getName() + "\"");
+        // Pinned to the exact display name rather than to a substring: the test's whole claim is that this
+        // launcher is NOT renamed, and a substring check would sail through a partial rename that happened to
+        // keep the word Inferno in it.
+        assertEquals("SRM Launcher (Std, Two-Shot) - Inferno", launcher.getName(),
+              "This launcher carries true Inferno munitions and is not part of the incendiary rename");
     }
 
     @Test


### PR DESCRIPTION
## What this changes

Conventional infantry flame weapons are now called **Incendiary** instead of **Inferno**. A platoon that used to carry a "Grenade Launcher (Auto) - Inferno" now carries a "Grenade Launcher (Auto) - Incendiary".

This is the TechManual pp. 350-352 errata, ruled by Hammer on the official forum: "replace all examples of the word 'Inferno' with 'Incendiary'" on the conventional infantry weapon tables. The point of the rename is that these weapons are *not* Inferno munitions, and calling them Inferno led players to expect the Inferno missile effect against vehicles. That is the confusion reported in #8456.

Seventeen weapons are renamed. Their pre-errata names are kept as lookup names, so existing unit files and saved games still load. Internal names are untouched, since that is what unit files store.

Part of #8456. The closing keyword is on the follow-up PR that gives the Inferno SRM launcher its Inferno mode, so the issue closes once both have landed.

**The Inferno SRM launchers are handled differently, because the errata deletes those rows rather than renaming them.** The light and heavy versions are mounted by no unit file anywhere in mm-data, MekHQ or MegaMekLab, so their registrations are commented out rather than deleted, keeping the decision reversible. The two-shot version stays: Beast Infantry (Elephant) (Needler/SRM) mounts it, and player-built units and saved games may too, so withdrawing it would break those downstream. It also carries true Inferno munitions rather than merely converting damage to heat, which the follow-up PR builds on.

## Testing

`./gradlew test javadoc` green: 15,401 tests, 0 failures, plus `checkstyleMain`. No pre-existing failures.

A new parameterized test covers all 17 renames, asserting for each that the pre-errata name still resolves, that the errata name resolves, that both return the same weapon, and that the weapon reports its new name. Two more tests pin the decisions on the SRM launchers: the two-shot version stays registered and keeps its name, and the two unused ones are gone.

Checked for anything that referenced the old display names as strings:

- No Java outside the weapon classes themselves.
- No entries in `resources`.
- No unit files in mm-data. Every `.blk` that mounts one of these weapons refers to it by internal name, which did not change.

One weapon was excluded after this check: `InfantryGrenadeMiniWeapon` ("Grenade (Mini) (Non-Inferno)") is never registered in `WeaponType.initializeTypes()`, so nothing can look it up and renaming it would have been a no-op edit. It is left as it is.

## What is not proven yet

Not tested in game. Nothing here changes behaviour - only the name shown in the unit selector, the record sheet and the game log - so the risk is a name that fails to resolve rather than a rule that resolves wrongly, and that is what the new tests cover. Worth a quick look in the lobby at one renamed platoon to confirm the new name displays and the weapon still fires.

MekHQ and MegaMekLab were not checked for references to the old display names.

---
- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
