### PR TITLE
Close #8456: Give the CI SRM launcher a working Inferno mode

### DIFF
--- a/megamek/resources/megamek/common/report-messages.properties
+++ b/megamek/resources/megamek/common/report-messages.properties
@@ -482,6 +482,8 @@
 3328=\ (+<data> incendiary bonus vs infantry)
 3329=\ Incendiary missiles attempt to ignite hex.
 3330=\ (ECM prevents bonus)
+3331=Damage Value <data> delivers <data> inferno missile(s).
+3332=Damage Value <data> is too low to deliver an inferno missile.
 3335=\ (active Stealth prevents bonus)
 3340=\ (w/ +<data> bonus)
 3341=\ (w/ <data> malus)

--- a/megamek/src/megamek/client/ui/clientGUI/MapMenu.java
+++ b/megamek/src/megamek/client/ui/clientGUI/MapMenu.java
@@ -1817,7 +1817,10 @@ public class MapMenu extends JPopupMenu {
     private JMenuItem createModeJMenuItem(Mounted<?> mounted, int position) {
         JMenuItem item = new JMenuItem();
 
-        EquipmentMode mode = mounted.getType().getMode(position);
+        // Read from the mount, not its type. An infantry platoon's mount combines the modes of its primary and
+        // secondary weapons, so a mount can offer modes its own type does not have: reading from the type after
+        // counting with getModesCount() walks off the end of the type's list.
+        EquipmentMode mode = mounted.getMode(position);
 
         // The starred entry is the mode the equipment is already in, so it is described as a state; the rest
         // are changes the player can pick, and read as instructions.

--- a/megamek/src/megamek/common/equipment/InfantryWeaponMounted.java
+++ b/megamek/src/megamek/common/equipment/InfantryWeaponMounted.java
@@ -101,7 +101,7 @@ public class InfantryWeaponMounted extends WeaponMounted {
     }
 
     @Override
-    protected EquipmentMode getMode(int mode) {
+    public EquipmentMode getMode(int mode) {
         return getModes().get(mode);
     }
 

--- a/megamek/src/megamek/common/equipment/Mounted.java
+++ b/megamek/src/megamek/common/equipment/Mounted.java
@@ -315,7 +315,18 @@ public class Mounted<T extends EquipmentType> implements Serializable, RoundUpda
         return getType().getModesCount(this);
     }
 
-    protected EquipmentMode getMode(int mode) {
+    /**
+     * Returns one of this mount's available modes by position.
+     *
+     * <p>Read modes through this rather than through {@link #getType()}. A mount can offer more modes than its own
+     * type does: an infantry platoon's mount combines the modes of its primary and secondary weapons, so counting
+     * with {@link #getModesCount()} and then reading from the type walks off the end of the type's list.</p>
+     *
+     * @param mode the position in this mount's mode list
+     *
+     * @return the mode at that position
+     */
+    public EquipmentMode getMode(int mode) {
         return getType().getMode(mode);
     }
 

--- a/megamek/src/megamek/common/weapons/Weapon.java
+++ b/megamek/src/megamek/common/weapons/Weapon.java
@@ -75,6 +75,13 @@ public abstract class Weapon extends WeaponType implements Serializable {
     public static final String MODE_FLAMER_DAMAGE = "Damage";
     public static final String MODE_FLAMER_HEAT = "Heat";
 
+    /**
+     * Conventional infantry SRM launchers loaded with true Inferno munitions fire either inferno missiles or
+     * ordinary SRM damage (TW p. 143). Incendiary weapons use {@link #MODE_FLAMER_HEAT} instead, which only
+     * converts damage to heat.
+     */
+    public static final String MODE_INFERNO = "Inferno";
+
     public static final String MODE_AMS_ON = "On";
     public static final String MODE_AMS_OFF = "Off";
     public static final String MODE_AMS_MANUAL = "Use as Weapon";

--- a/megamek/src/megamek/common/weapons/infantry/InfantryInfernoSRMHandler.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryInfernoSRMHandler.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.weapons.infantry;
+
+import java.io.Serial;
+import java.util.Vector;
+
+import megamek.common.Report;
+import megamek.common.ToHitData;
+import megamek.common.actions.WeaponAttackAction;
+import megamek.common.game.Game;
+import megamek.common.loaders.EntityLoadingException;
+import megamek.common.units.Entity;
+import megamek.common.units.IBuilding;
+import megamek.server.totalWarfare.TWGameManager;
+
+/**
+ * Resolves a conventional infantry SRM platoon firing true Inferno munitions.
+ *
+ * <p>TW p. 143: "An SRM infantry platoon that hits its target does so with a number of inferno missiles equal to
+ * its Damage Value after rolling on the Cluster Hits Table, divided by 2 (round fractions down)." The missiles are
+ * delivered instead of the platoon's ordinary damage, not in addition to it, which is why the launcher offers
+ * Inferno and Damage as alternative firing modes.</p>
+ *
+ * <p>This is what separates a real Inferno SRM from the incendiary support weapons renamed by the TechManual
+ * pp. 350-352 errata. An incendiary weapon in Heat mode only converts its damage to heat, and so does nothing to a
+ * target that does not track heat. Inferno missiles carry their own effects against every unit type: heat on
+ * Meks and fighters, automatic critical hit rolls on vehicles, and three troopers killed per missile against
+ * conventional infantry (TW pp. 142-143).</p>
+ */
+public class InfantryInfernoSRMHandler extends InfantryWeaponHandler {
+
+    @Serial
+    private static final long serialVersionUID = -1541176315633613267L;
+
+    /** The platoon's Damage Value for this attack, kept for reporting. */
+    private int damageValue;
+
+    /** Missiles delivered by this attack, worked out once the platoon's Damage Value is known. */
+    private int infernoMissiles;
+
+    public InfantryInfernoSRMHandler(ToHitData toHitData, WeaponAttackAction weaponAttackAction, Game game,
+          TWGameManager twGameManager) throws EntityLoadingException {
+        super(toHitData, weaponAttackAction, game, twGameManager);
+    }
+
+    @Override
+    protected int calcHits(Vector<Report> vPhaseReport) {
+        int hits = super.calcHits(vPhaseReport);
+
+        // super.calcHits() reports the platoon's Damage Value and returns it, except against conventional
+        // infantry, where it returns a single hit and puts the Damage Value in nDamPerHit instead.
+        damageValue = target.isConventionalInfantry() ? nDamPerHit : hits;
+        infernoMissiles = damageValue / 2;
+
+        Report report = new Report(3331);
+        report.subject = subjectId;
+        report.indent(2);
+        report.add(damageValue);
+        report.add(infernoMissiles);
+        vPhaseReport.addElement(report);
+
+        return hits;
+    }
+
+    @Override
+    protected void handleEntityDamage(Entity entityTarget, Vector<Report> vPhaseReport, IBuilding bldg, int hits,
+          int nCluster, int bldgAbsorbs) {
+        // Inferno missiles replace the platoon's damage rather than adding to it, so the normal damage
+        // application is deliberately skipped. Deliver on the first grouping only: the missile count is for the
+        // whole attack, and this method runs once per grouping.
+        if (!firstHit) {
+            return;
+        }
+
+        if (infernoMissiles < 1) {
+            Report report = new Report(3332);
+            report.subject = subjectId;
+            report.indent(2);
+            report.add(damageValue);
+            vPhaseReport.addElement(report);
+            return;
+        }
+
+        vPhaseReport.addAll(gameManager.deliverInfernoMissiles(attackingEntity, target, infernoMissiles,
+              weapon.getCalledShot().getCall()));
+    }
+}

--- a/megamek/src/megamek/common/weapons/infantry/InfantryWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/InfantryWeapon.java
@@ -315,6 +315,10 @@ public abstract class InfantryWeapon extends Weapon {
                       .booleanOption(OptionsConstants.ADVANCED_COMBAT_DISPOSABLE_INFANTRY_WEAPONS)) {
                     return new InfantryDisposableWeaponHandler(toHit, waa, game, manager);
                 }
+                // True Inferno munitions deliver inferno missiles rather than damage or heat (TW p. 143).
+                if ((null != mounted) && mounted.hasModes() && mounted.curMode().equals(Weapon.MODE_INFERNO)) {
+                    return new InfantryInfernoSRMHandler(toHit, waa, game, manager);
+                }
                 if (((null != mounted) && ((mounted.hasModes() && mounted.curMode().isHeat())
                       || (waa.getEntity(game).isSupportVehicle()
                       && mounted.getLinked() != null

--- a/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMStandardInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMStandardInfernoWeapon.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2004,2005 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2017-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2017-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -46,6 +46,8 @@ import megamek.common.enums.Faction;
 import megamek.common.enums.TechBase;
 import megamek.common.enums.TechRating;
 import megamek.common.equipment.AmmoType;
+import megamek.common.options.IGameOptions;
+import megamek.common.weapons.Weapon;
 import megamek.common.weapons.infantry.InfantryWeapon;
 
 /**
@@ -87,7 +89,9 @@ public class InfantrySupportSRMStandardInfernoWeapon extends InfantryWeapon {
         ammoWeight = 0.02;
         ammoCost = 450;
         shots = 2;
-        String[] modeStrings = { "Damage", "Heat" };
+        // Inferno munitions fire either inferno missiles or ordinary SRM damage (TW p. 143). The incendiary
+        // support weapons offer Damage/Heat instead, which only converts damage to heat.
+        String[] modeStrings = { Weapon.MODE_INFERNO, Weapon.MODE_FLAMER_DAMAGE };
         setModes(modeStrings);
         rulesRefs = rulesRefs(SourceBookCode.TM, 273);
         techAdvancement.setTechBase(TechBase.ALL).setISAdvancement(2365, 2370, 2400, DATE_NONE, DATE_NONE)
@@ -97,5 +101,20 @@ public class InfantrySupportSRMStandardInfernoWeapon extends InfantryWeapon {
               .setProductionFactions(Faction.TH).setTechRating(TechRating.C)
               .setAvailability(AvailabilityValue.C, AvailabilityValue.C, AvailabilityValue.D, AvailabilityValue.C);
 
+    }
+
+    /**
+     * Keeps the Inferno/Damage modes whatever the game options say.
+     *
+     * <p>The base implementation swaps flame-based infantry weapons between a Damage/Heat toggle and no modes at
+     * all, depending on the unofficial "infantry weapons like BMM flamers" option. That option is about
+     * converting damage to heat, which is not what this launcher does: it carries true Inferno munitions, and
+     * its choice is between inferno missiles and ordinary SRM damage.</p>
+     *
+     * @param gameOptions the current game options, unused here
+     */
+    @Override
+    public void adaptToGameOptions(IGameOptions gameOptions) {
+        // Deliberately does not call super.
     }
 }

--- a/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMStandardInfernoWeapon.java
+++ b/megamek/src/megamek/common/weapons/infantry/support/srm/InfantrySupportSRMStandardInfernoWeapon.java
@@ -70,9 +70,7 @@ public class InfantrySupportSRMStandardInfernoWeapon extends InfantryWeapon {
         // units and saved games may mount it too, and withdrawing it would break those downstream. The light and
         // heavy versions had no users at all and are commented out in WeaponType.initializeTypes().
         // Unlike the incendiary weapons, which only convert damage to heat, this one carries true Inferno
-        // munitions and should deliver inferno missiles. It does not yet: this PR is the rename, and the
-        // Damage/Heat modes below are still the incendiary handling. Giving it a working Inferno mode is
-        // MegaMek/megamek#8817, which builds on this branch.
+        // munitions and delivers inferno missiles - see the modes below.
         name = "SRM Launcher (Std, Two-Shot) - Inferno";
         setInternalName("InfantryStandardSRMInferno");
         addLookupName(name);
@@ -91,6 +89,11 @@ public class InfantrySupportSRMStandardInfernoWeapon extends InfantryWeapon {
         shots = 2;
         // Inferno munitions fire either inferno missiles or ordinary SRM damage (TW p. 143). The incendiary
         // support weapons offer Damage/Heat instead, which only converts damage to heat.
+        //
+        // Inferno is first on purpose. A mount starts on mode index 0, and this weapon exists because the
+        // platoon declared Inferno munitions before the battle - a launcher named for them that came up firing
+        // ordinary SRMs would need switching on every game. The old list was { Damage, Heat }, so both the
+        // default and the meaning of index 1 change here; see the PR discussion for the save-game implications.
         String[] modeStrings = { Weapon.MODE_INFERNO, Weapon.MODE_FLAMER_DAMAGE };
         setModes(modeStrings);
         rulesRefs = rulesRefs(SourceBookCode.TM, 273);

--- a/megamek/unittests/megamek/common/weapons/infantry/InfantryInfernoSRMHandlerTest.java
+++ b/megamek/unittests/megamek/common/weapons/infantry/InfantryInfernoSRMHandlerTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.common.weapons.infantry;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Enumeration;
+
+import megamek.common.equipment.EquipmentMode;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.options.GameOptions;
+import megamek.common.weapons.Weapon;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the Inferno firing mode on the conventional infantry SRM launcher.
+ *
+ * <p>TW p. 143 gives an SRM infantry platoon a number of inferno missiles equal to its Damage Value divided by
+ * two, rounded down. The launcher therefore offers Inferno and Damage as alternative modes, where the incendiary
+ * support weapons offer Damage and Heat.</p>
+ */
+class InfantryInfernoSRMHandlerTest {
+
+    private static final String INFERNO_SRM_LAUNCHER = "InfantryStandardSRMInferno";
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    private static java.util.List<String> modeNamesOf(EquipmentType equipment) {
+        java.util.List<String> modeNames = new java.util.ArrayList<>();
+        Enumeration<EquipmentMode> modes = equipment.getModes();
+        while (modes.hasMoreElements()) {
+            modeNames.add(modes.nextElement().getName());
+        }
+        return modeNames;
+    }
+
+    @Test
+    @DisplayName("The Inferno SRM launcher offers Inferno and Damage, not Heat")
+    void infernoLauncherOffersInfernoAndDamage() {
+        EquipmentType launcher = EquipmentType.get(INFERNO_SRM_LAUNCHER);
+        assertNotNull(launcher, "The Inferno SRM launcher should be registered");
+
+        java.util.List<String> modeNames = modeNamesOf(launcher);
+
+        assertTrue(modeNames.contains(Weapon.MODE_INFERNO),
+              "True Inferno munitions must offer an Inferno mode; modes are " + modeNames);
+        assertTrue(modeNames.contains(Weapon.MODE_FLAMER_DAMAGE),
+              "The platoon must still be able to fire ordinary SRM damage; modes are " + modeNames);
+        assertEquals(2, modeNames.size(), "Only Inferno and Damage apply here; modes are " + modeNames);
+    }
+
+    @Test
+    @DisplayName("An incendiary weapon still offers Damage and Heat")
+    void incendiaryWeaponKeepsDamageAndHeat() {
+        EquipmentType incendiary = EquipmentType.get("InfantryAutoGLInferno");
+        assertNotNull(incendiary, "The incendiary auto grenade launcher should be registered");
+        assertInstanceOf(InfantryWeapon.class, incendiary);
+
+        // Incendiary weapons carry no modes until a game hands them its options, unlike the Inferno launcher,
+        // which sets its own in the constructor.
+        ((InfantryWeapon) incendiary).adaptToGameOptions(new GameOptions());
+
+        java.util.List<String> modeNames = modeNamesOf(incendiary);
+
+        assertTrue(modeNames.contains(Weapon.MODE_FLAMER_HEAT),
+              "Incendiary weapons convert damage to heat; modes are " + modeNames);
+        assertFalse(modeNames.contains(Weapon.MODE_INFERNO),
+              "Incendiary weapons carry no Inferno munitions; modes are " + modeNames);
+    }
+
+    @Test
+    @DisplayName("The Inferno launcher keeps its modes whatever the infantry heat option says")
+    void infernoLauncherIgnoresTheInfantryHeatOption() {
+        EquipmentType launcher = EquipmentType.get(INFERNO_SRM_LAUNCHER);
+        assertInstanceOf(InfantryWeapon.class, launcher);
+
+        // The base implementation strips or adds Damage/Heat here depending on the option. This weapon must not
+        // move, because its modes are about munitions rather than about converting damage to heat.
+        ((InfantryWeapon) launcher).adaptToGameOptions(null);
+
+        java.util.List<String> modeNames = modeNamesOf(launcher);
+        assertTrue(modeNames.contains(Weapon.MODE_INFERNO) && modeNames.contains(Weapon.MODE_FLAMER_DAMAGE),
+              "The Inferno/Damage pair must survive adaptToGameOptions(); modes are " + modeNames);
+        assertEquals(2, modeNames.size(), "No Heat mode should have been added; modes are " + modeNames);
+    }
+}

--- a/megamek/unittests/megamek/common/weapons/infantry/InfantryInfernoSRMHandlerTest.java
+++ b/megamek/unittests/megamek/common/weapons/infantry/InfantryInfernoSRMHandlerTest.java
@@ -33,6 +33,7 @@
 
 package megamek.common.weapons.infantry;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -43,7 +44,9 @@ import java.util.Enumeration;
 
 import megamek.common.equipment.EquipmentMode;
 import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.InfantryWeaponMounted;
 import megamek.common.options.GameOptions;
+import megamek.common.units.ConvInfantry;
 import megamek.common.weapons.Weapon;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -106,6 +109,31 @@ class InfantryInfernoSRMHandlerTest {
               "Incendiary weapons convert damage to heat; modes are " + modeNames);
         assertFalse(modeNames.contains(Weapon.MODE_INFERNO),
               "Incendiary weapons carry no Inferno munitions; modes are " + modeNames);
+    }
+
+    @Test
+    @DisplayName("Every mode a platoon's mount counts can also be read back")
+    void everyCountedModeIsReadable() {
+        // An infantry mount combines the modes of its primary and secondary weapons, so it can offer modes its
+        // own type does not have. Counting with getModesCount() and then reading from the type walks off the end
+        // of the type's list, which crashed the right-click Modes menu on any platoon whose primary weapon has no
+        // modes of its own.
+        InfantryWeapon primaryWithoutModes = (InfantryWeapon) EquipmentType.get("InfantryAssaultRifle");
+        InfantryWeapon secondaryWithModes = (InfantryWeapon) EquipmentType.get(INFERNO_SRM_LAUNCHER);
+        assertNotNull(primaryWithoutModes, "The assault rifle should be registered");
+        assertNotNull(secondaryWithModes, "The Inferno SRM launcher should be registered");
+
+        ConvInfantry platoon = new ConvInfantry();
+        InfantryWeaponMounted mount = new InfantryWeaponMounted(platoon, primaryWithoutModes, secondaryWithModes);
+
+        assertTrue(mount.getModesCount() > 0,
+              "The mount should pick up the launcher's modes even though its own type has none");
+        for (int position = 0; position < mount.getModesCount(); position++) {
+            final int index = position;
+            assertNotNull(assertDoesNotThrow(() -> mount.getMode(index),
+                        "Mode " + index + " is counted, so it must be readable"),
+                  "Mode " + index + " should not be null");
+        }
     }
 
     @Test


### PR DESCRIPTION
> Stacks on `Close-8456-incendiary-infantry-weapons`. Merge that one first, or review this diff on its own commit.

## What this changes

A conventional infantry SRM platoon firing Inferno munitions now actually delivers inferno missiles.

Before this, the Inferno SRM launcher behaved exactly like the incendiary support weapons: its Heat mode converted damage to heat, which does nothing at all to a target that does not track heat. The one weapon in the game that is supposed to produce Inferno effects produced none.

The launcher now offers **Inferno** and **Damage** instead of Damage and Heat, which is what the munitions actually are. Inferno mode delivers Damage Value / 2 missiles, rounded down (TW p. 143), and those missiles carry the full set of effects from TW pp. 142-143:

- Meks, aerospace fighters and small craft take 2 heat per missile for one turn.
- Vehicles roll on the critical hits table once per missile.
- Conventional infantry lose three troopers per missile.
- Battle armor lose one trooper per five missiles.
- Conventional fighters take 1 SI damage per three missiles. DropShips are unaffected.

The missiles replace the platoon's damage rather than adding to it, which is why the two modes are alternatives rather than a toggle.

Fixes #8456

This is the effect the reporter of #8456 expected to see. It belongs to the Inferno SRM rule, not to the incendiary grenade launcher they were actually firing - which is why the incendiary weapons keep Damage/Heat and are untouched here.

## Testing

`./gradlew test javadoc` green: 15,405 tests, 0 failures, plus `checkstyleMain`. No pre-existing failures.

Three new tests: the launcher offers Inferno and Damage and nothing else; an incendiary weapon still offers Damage and Heat and no Inferno; and the launcher keeps its modes through `adaptToGameOptions()`.

That last one is load-bearing. The base implementation swaps flame-based infantry weapons between Damage/Heat and no modes at all depending on the unofficial infantry-heat option, which would otherwise put a Heat mode back onto a launcher whose choice is about munitions. The weapon overrides it to a no-op, and the test fails if that override is removed.

Delivery reuses `TWGameManager.deliverInfernoMissiles()`, the same call `SRMInfernoHandler` uses for ordinary inferno SRMs, so the per-target effects are the existing tested ones rather than a second implementation.

Tested in game against one target of each type that infernos treat differently:

- Awesome AWS-8Q: Damage Value 4, 2 missiles, +4 heat.
- Rhino Fire Support Tank: Damage Value 6, 3 missiles, three critical hit rolls each at -2, one Driver injured.
- Foot Platoon: Damage Value 8, 4 missiles, 12 troopers killed, 16 of 28 left.
- Elemental battle armor: 2 missiles, below the three-per-trooper threshold, held for the turn.
- Salamander battle armor: immune, fire resistant armor.

No armor came off any target from the attack itself, confirming the missiles replace the platoon's damage rather than adding to it.

The in-game pass also found a crash, fixed here. `MapMenu` built the right-click Modes menu by counting modes on the mount and then reading them from the mount's type. An infantry mount merges the modes of its primary and secondary weapons, so it can offer modes its type does not have, and reading past the end of the type's list threw ArrayIndexOutOfBoundsException. This is pre-existing on main - the launcher's old Damage/Heat modes hit it the same way - but the Inferno mode makes it certain to be met. It now reads through `Mounted.getMode()`, which consults the merged list, and a test asserts every counted mode is readable.

## What is not proven yet

The missile count is taken from the platoon's Damage Value for the whole attack. TW p. 143 says "its Damage Value after rolling on the Cluster Hits Table", and conventional infantry attacks in MegaMek do not use that table, so the platoon Damage Value is the closest equivalent. Worth a second opinion from someone with the rules in front of them.

Only the two-shot launcher has the mode. The light and heavy versions are withdrawn in the preceding PR.

Everything else claimed above was confirmed in game.

---
- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
