### PR TITLE
Fix #8818: Crippled bot units fire on players who never dishonored them

### DIFF
--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -3985,14 +3985,16 @@ public class Princess extends BotClient {
 
     @Override
     public void endOfTurnProcessing() {
+        // Taken before refreshCrippledUnits folds in this turn's damage. Both checkForDishonoredEnemies and
+        // updateReturnFirePermission judge this turn's attacks against who was visibly crippled when those
+        // attacks were declared, not against who is crippled now.
+        final Set<Integer> unitsWithdrawingAtStartOfTurn = Set.copyOf(crippledUnits);
         checkForDishonoredEnemies();
         checkForBrokenEnemies();
         // refreshCrippledUnits should happen after checkForDishonoredEnemies, since checkForDishonoredEnemies
         // wants to examine the units that were considered crippled at the *beginning* of the turn and were attacked.
         refreshCrippledUnits();
-        // updateReturnFirePermission wants the opposite: the freshly refreshed crippled set, so a unit
-        // crippled and attacked in the same turn may return fire next turn.
-        updateReturnFirePermission();
+        updateReturnFirePermission(unitsWithdrawingAtStartOfTurn);
         setAMSModes();
         updateEnemyHeatMaps();
         updateFriendlyHeatMap();
@@ -4001,27 +4003,31 @@ public class Princess extends BotClient {
 
     /**
      * Grants withdrawing units permission to return fire. A crippled unit under Forced Withdrawal holds its
-     * fire unless it has been attacked while fleeing. That permission used to be granted only by
-     * {@code checkForDishonoredEnemies}, which works with the crippled set as it stood at the start of the
-     * turn - so a unit crippled and attacked in the same turn gained permission only if an enemy attacked it
-     * again on a later turn. Bot opponents never do (their honor rules stop them from attacking crippled
-     * units), which left withdrawing units permanently unable to defend themselves.
+     * fire unless an enemy attacks it while it is withdrawing - the same act that marks that enemy
+     * dishonored. So a unit only earns return fire from attacks made after it was already visibly crippled:
+     * the attacks that crippled it this turn were declared against a legitimate target and grant nothing.
      *
-     * <p>This pass runs on the freshly refreshed crippled set instead: attacked this turn and crippled now
-     * means the unit may return fire from the next turn on. {@code checkForDishonoredEnemies} keeps its
-     * start-of-turn view, because an attacker should only be dishonored for shooting a unit that was already
-     * visibly crippled.</p>
+     * <p>{@code checkForDishonoredEnemies} grants the same permission from the same start-of-turn view, but
+     * only for an attacker still on the board - it looks each one up by id and skips the ones it cannot find.
+     * This pass also covers a withdrawing unit whose attacker was destroyed later in the same turn, because
+     * it only needs to know that the unit was attacked, not by whom.</p>
+     *
+     * @param unitsWithdrawingAtStartOfTurn ids of this bot's units that were already crippled, and so visibly
+     *                                      withdrawing, when this turn's attacks were declared
      */
-    private void updateReturnFirePermission() {
+    void updateReturnFirePermission(final Set<Integer> unitsWithdrawingAtStartOfTurn) {
         if (!getForcedWithdrawal()) {
             return;
         }
         for (final Entity ownedEntity : getEntitiesOwned()) {
-            if (crippledUnits.contains(ownedEntity.getId()) && !ownedEntity.getAttackedByThisTurn().isEmpty()) {
-                if (attackedWhileFleeing.add(ownedEntity.getId())) {
-                    LOGGER.info("[ForcedWithdrawal] {} is crippled and was attacked this turn; may return fire "
-                          + "from now on.", ownedEntity.getDisplayName());
-                }
+            boolean wasAlreadyWithdrawing = unitsWithdrawingAtStartOfTurn.contains(ownedEntity.getId());
+            boolean wasAttackedThisTurn = !ownedEntity.getAttackedByThisTurn().isEmpty();
+            if (!wasAlreadyWithdrawing || !wasAttackedThisTurn) {
+                continue;
+            }
+            if (attackedWhileFleeing.add(ownedEntity.getId())) {
+                LOGGER.info("[ForcedWithdrawal] {} was attacked while already crippled and withdrawing; may "
+                      + "return fire from now on.", ownedEntity.getDisplayName());
             }
         }
     }

--- a/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessTest.java
@@ -440,47 +440,66 @@ class PrincessTest {
         assertFalse(mockPrincess.wantsToFallBack(mockMek));
     }
 
+    /**
+     * Issue #8818: the attacks that cripple a unit are not an honor violation, because the unit was still a
+     * legitimate target when they were declared. Only an enemy shooting it once it is already visibly
+     * crippled and withdrawing unlocks its return fire.
+     */
     @Test
-    void testUpdateReturnFirePermissionGrantsFireAfterSameTurnAttack() {
+    void testReturnFirePermissionNeedsAnAttackAfterTheUnitWasAlreadyCrippled() {
         Princess princess = spy(new Princess("TestPrincess", UUID.randomUUID().toString(), 1));
         princess.getBehaviorSettings().setForcedWithdrawal(true);
 
-        // Crippled this turn AND attacked this turn: gains permission to return fire.
-        BipedMek crippledMek = mock(BipedMek.class);
-        when(crippledMek.getId()).thenReturn(10);
-        when(crippledMek.isCrippled(true)).thenReturn(true);
-        when(crippledMek.getAttackedByThisTurn()).thenReturn(Set.of(99));
-        when(crippledMek.getDisplayName()).thenReturn("Crippled Mek");
+        // Healthy when this turn's attacks were declared, and crippled by those very attacks.
+        BipedMek crippledThisTurnMek = mock(BipedMek.class);
+        when(crippledThisTurnMek.getId()).thenReturn(10);
+        when(crippledThisTurnMek.getAttackedByThisTurn()).thenReturn(Set.of(99));
+        when(crippledThisTurnMek.getDisplayName()).thenReturn("Crippled This Turn Mek");
 
-        // Attacked but not crippled: no withdrawal, so no permission needed or granted.
-        BipedMek healthyMek = mock(BipedMek.class);
-        when(healthyMek.getId()).thenReturn(11);
-        when(healthyMek.isCrippled(true)).thenReturn(false);
-        when(healthyMek.getAttackedByThisTurn()).thenReturn(Set.of(99));
+        // Already crippled and withdrawing when this turn's attacks were declared, and attacked anyway.
+        BipedMek withdrawingMek = mock(BipedMek.class);
+        when(withdrawingMek.getId()).thenReturn(11);
+        when(withdrawingMek.getAttackedByThisTurn()).thenReturn(Set.of(99));
+        when(withdrawingMek.getDisplayName()).thenReturn("Withdrawing Mek");
 
-        // Crippled but left alone: keeps holding fire.
-        BipedMek ignoredCrippledMek = mock(BipedMek.class);
-        when(ignoredCrippledMek.getId()).thenReturn(12);
-        when(ignoredCrippledMek.isCrippled(true)).thenReturn(true);
-        when(ignoredCrippledMek.getAttackedByThisTurn()).thenReturn(Set.of());
+        // Already crippled and withdrawing, but left alone: keeps holding its fire.
+        BipedMek ignoredWithdrawingMek = mock(BipedMek.class);
+        when(ignoredWithdrawingMek.getId()).thenReturn(12);
+        when(ignoredWithdrawingMek.getAttackedByThisTurn()).thenReturn(Set.of());
+        when(ignoredWithdrawingMek.getDisplayName()).thenReturn("Ignored Withdrawing Mek");
 
-        doReturn(List.of(crippledMek, healthyMek, ignoredCrippledMek)).when(princess).getEntitiesOwned();
+        doReturn(List.of(crippledThisTurnMek, withdrawingMek, ignoredWithdrawingMek)).when(princess)
+              .getEntitiesOwned();
 
-        // End-of-turn order: refresh the crippled set, then grant return-fire permission from it.
-        princess.refreshCrippledUnits();
-        try {
-            java.lang.reflect.Method method = Princess.class.getDeclaredMethod("updateReturnFirePermission");
-            method.setAccessible(true);
-            method.invoke(princess);
-        } catch (Exception exception) {
-            throw new RuntimeException("Failed to invoke updateReturnFirePermission", exception);
-        }
+        // Only the last two were visibly withdrawing when the enemy declared this turn's attacks.
+        princess.updateReturnFirePermission(Set.of(withdrawingMek.getId(), ignoredWithdrawingMek.getId()));
 
-        assertTrue(princess.canShootWhileFallingBack(crippledMek),
-              "a unit crippled and attacked in the same turn must be allowed to return fire");
-        assertFalse(princess.canShootWhileFallingBack(healthyMek));
-        assertFalse(princess.canShootWhileFallingBack(ignoredCrippledMek),
-              "a crippled unit no one attacks keeps holding its fire");
+        assertFalse(princess.canShootWhileFallingBack(crippledThisTurnMek),
+              "the attacks that crippled a unit must not also unlock its return fire");
+        assertTrue(princess.canShootWhileFallingBack(withdrawingMek),
+              "a unit attacked while already crippled and withdrawing may return fire");
+        assertFalse(princess.canShootWhileFallingBack(ignoredWithdrawingMek),
+              "a withdrawing unit no one attacks keeps holding its fire");
+    }
+
+    /**
+     * With Forced Withdrawal switched off there is no withdrawal to protect, so the pass grants nothing and
+     * crippled units fight on under the ordinary firing rules.
+     */
+    @Test
+    void testReturnFirePermissionIsNotGrantedWithoutForcedWithdrawal() {
+        Princess princess = spy(new Princess("TestPrincess", UUID.randomUUID().toString(), 1));
+        princess.getBehaviorSettings().setForcedWithdrawal(false);
+
+        BipedMek withdrawingMek = mock(BipedMek.class);
+        when(withdrawingMek.getId()).thenReturn(11);
+        when(withdrawingMek.getAttackedByThisTurn()).thenReturn(Set.of(99));
+
+        doReturn(List.of(withdrawingMek)).when(princess).getEntitiesOwned();
+
+        princess.updateReturnFirePermission(Set.of(withdrawingMek.getId()));
+
+        assertFalse(princess.canShootWhileFallingBack(withdrawingMek));
     }
 
     @Test


### PR DESCRIPTION
## What this changes

A crippled bot unit under Forced Withdrawal is supposed to hold its fire while it retreats, and shoot back only at an enemy who attacks it once it is visibly crippled - the same act that marks that enemy dishonored. Players were getting shot at anyway, by units that were openly withdrawing, while the bot's own dishonored list stayed empty and no honor warning ever appeared.

The reporter's log shows it plainly. A fresh Dragon takes weapons fire and a punch in round 7, the punch rolls two engine crits and cripples it, and in round 8 it withdraws while still shooting at the player - who had done nothing wrong, because the Dragon was a perfectly legitimate target the whole time those attacks were being declared. `Princess.updateReturnFirePermission` was running after `refreshCrippledUnits`, so it only asked "is this unit crippled *now*, and was it attacked at some point this turn?" The attacks that did the crippling satisfied that test and unlocked the unit's return fire, while the dishonor check, reading the start-of-turn crippled set, correctly found no violation. The two ended up describing different events.

Fixes #8818

## Testing

- Played in game from the reporter's save: the crippled Dragon withdrew without firing on the player. That confirms the withdrawal path end to end - a unit that is holding its fire still retreats properly, and the fix does not leave it stranded or silent in some other way.
- `testReturnFirePermissionNeedsAnAttackAfterTheUnitWasAlreadyCrippled` asserts both directions in one test - crippled by this turn's attacks grants nothing, attacked while already withdrawing does grant return fire - so the negative case cannot pass just because the pass never grants anything. Confirmed it fails against the old behaviour before the fix went in.
- `testReturnFirePermissionIsNotGrantedWithoutForcedWithdrawal` covers Forced Withdrawal switched off.
- Full `megamek` suite green: 15,389 tests, no failures or errors. Checkstyle clean.

## What is not proven yet

- The crippling turn itself has not been watched in a live game. The unit tests cover it directly, but nobody has yet sat through a match, crippled a bot unit with their own attacks, and watched it hold its fire the following turn. The reporter's save cannot show this: it begins after the Dragon was already crippled, and the permission flag lives only in the bot's memory rather than in the savegame, so a reload starts from a clean slate either way.
- The snapshot's position in `endOfTurnProcessing` has no test of its own. It is the first statement in the method, so a reordering that broke it would be visibly wrong, and the pass itself is fully covered - but driving the real `endOfTurnProcessing` in a test needs a fully mocked game, heat maps and a client connection, which I judged not worth it.
- Only the crippled-Mek path was exercised in game. The change is unit-type agnostic, so vehicles and other crippled unit types should behave the same, but they were not played through.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result
