### PR TITLE
Make the Carried Munitions and Munitions Loaded at Start dropdowns searchable

### DIFF
--- a/megamek/resources/megamek/client/messages.properties
+++ b/megamek/resources/megamek/client/messages.properties
@@ -6960,3 +6960,6 @@ InfantryVsInfantryCombatDisplay.mustBeSameHex=Must be in same hex as target
 InfantryVsInfantryCombatDisplay.noCombatExists=No combat exists - use initiate action instead
 InfantryVsInfantryCombatDisplay.combatAlreadyExists=Combat already exists - use reinforce action instead
 InfantryVsInfantryCombatDisplay.onlyAttackersWithdraw=Only attackers can withdraw from combat
+
+# SearchableComboBox
+SearchableComboBox.tooltip=Type to search the list, Enter picks the highlighted or first match, Escape clears the search

--- a/megamek/src/megamek/client/ui/comboBoxes/FilteredComboBoxModel.java
+++ b/megamek/src/megamek/client/ui/comboBoxes/FilteredComboBoxModel.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.ui.comboBoxes;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.Function;
+import javax.swing.AbstractListModel;
+import javax.swing.ComboBoxModel;
+
+import megamek.common.annotations.Nullable;
+
+/**
+ * A combo box model that keeps the full list of items but only shows the ones whose display text contains the
+ * current filter text. The selected item is kept even while it is filtered out of view, so typing a search never
+ * silently changes what is selected.
+ * <p>
+ * The display text of an item comes from the display function handed to the constructor, so the model never relies
+ * on {@code toString()}.
+ *
+ * @param <E> the type of item held by the model
+ */
+public class FilteredComboBoxModel<E> extends AbstractListModel<E> implements ComboBoxModel<E> {
+
+    private final List<E> allItems;
+    private final Function<E, String> displayFunction;
+    private final List<E> visibleItems = new ArrayList<>();
+    private String filterText = "";
+    private E selectedItem;
+
+    /**
+     * @param items           every item the model can offer, in display order
+     * @param displayFunction converts an item into the text shown to the user and matched against the filter
+     */
+    public FilteredComboBoxModel(List<E> items, Function<E, String> displayFunction) {
+        this.allItems = new ArrayList<>(items);
+        this.displayFunction = displayFunction;
+        visibleItems.addAll(allItems);
+    }
+
+    /**
+     * Restricts the visible items to those whose display text contains the given text, ignoring case. Blank or
+     * {@code null} text shows every item again.
+     *
+     * @param text the text to filter by, or {@code null} to clear the filter
+     */
+    public void setFilter(@Nullable String text) {
+        String newFilterText = (text == null) ? "" : text.trim().toLowerCase(Locale.ROOT);
+        if (newFilterText.equals(filterText)) {
+            return;
+        }
+        filterText = newFilterText;
+        rebuildVisibleItems();
+    }
+
+    /**
+     * Re-reads every item's display text. Call this when the text an item shows has changed (for example a
+     * renamed ammo bin), so the visible list and the current filter reflect the new names.
+     */
+    public void refreshContents() {
+        rebuildVisibleItems();
+    }
+
+    private void rebuildVisibleItems() {
+        int previousSize = visibleItems.size();
+        visibleItems.clear();
+        for (E item : allItems) {
+            if (matchesFilter(item)) {
+                visibleItems.add(item);
+            }
+        }
+        int largestSize = Math.max(previousSize, visibleItems.size());
+        fireContentsChanged(this, 0, Math.max(0, largestSize - 1));
+    }
+
+    /** Shows every item again. */
+    public void clearFilter() {
+        setFilter(null);
+    }
+
+    /**
+     * @return {@code true} when a non-blank filter is currently narrowing the visible items
+     */
+    public boolean isFiltered() {
+        return !filterText.isEmpty();
+    }
+
+    private boolean matchesFilter(E item) {
+        if (filterText.isEmpty()) {
+            return true;
+        }
+        return getDisplayText(item).toLowerCase(Locale.ROOT).contains(filterText);
+    }
+
+    /**
+     * @param item the item to describe
+     *
+     * @return the text shown to the user for the item, never {@code null}
+     */
+    public String getDisplayText(E item) {
+        String displayText = displayFunction.apply(item);
+        return (displayText == null) ? "" : displayText;
+    }
+
+    /**
+     * Looks up the display text of an arbitrary value. Values that are items of this model are described with the
+     * display function; anything else (for example a {@code String} typed by the user) is returned as its string
+     * form.
+     *
+     * @param value the value to describe, or {@code null}
+     *
+     * @return the text to show for the value, never {@code null}
+     */
+    public String displayTextOf(@Nullable Object value) {
+        if (value == null) {
+            return "";
+        }
+        int itemIndex = allItems.indexOf(value);
+        if (itemIndex >= 0) {
+            return getDisplayText(allItems.get(itemIndex));
+        }
+        return value.toString();
+    }
+
+    /**
+     * @param text the display text to look for, compared ignoring case and surrounding whitespace
+     *
+     * @return the item whose display text equals the given text, if any
+     */
+    public Optional<E> findByDisplayText(@Nullable String text) {
+        if (text == null) {
+            return Optional.empty();
+        }
+        String wantedText = text.trim();
+        for (E item : allItems) {
+            if (getDisplayText(item).equalsIgnoreCase(wantedText)) {
+                return Optional.of(item);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * @return the first item that passes the current filter, if any
+     */
+    public Optional<E> getFirstVisibleItem() {
+        return visibleItems.isEmpty() ? Optional.empty() : Optional.of(visibleItems.getFirst());
+    }
+
+    /**
+     * @return an unmodifiable view of every item the model holds, regardless of the filter
+     */
+    public List<E> getAllItems() {
+        return List.copyOf(allItems);
+    }
+
+    @Override
+    public int getSize() {
+        return visibleItems.size();
+    }
+
+    @Override
+    public E getElementAt(int index) {
+        return visibleItems.get(index);
+    }
+
+    /**
+     * Selects the given item. Only {@code null} or an item held by this model is accepted; anything else (such as
+     * raw editor text) is ignored so the selection can never become a value of the wrong type.
+     *
+     * @param anItem the item to select, or {@code null} to clear the selection
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public void setSelectedItem(@Nullable Object anItem) {
+        if ((anItem != null) && !allItems.contains(anItem)) {
+            return;
+        }
+        boolean isUnchanged = (selectedItem == null) ? (anItem == null) : selectedItem.equals(anItem);
+        if (isUnchanged) {
+            return;
+        }
+        selectedItem = (E) anItem;
+        fireContentsChanged(this, -1, -1);
+    }
+
+    @Override
+    public @Nullable E getSelectedItem() {
+        return selectedItem;
+    }
+}

--- a/megamek/src/megamek/client/ui/comboBoxes/SearchableComboBox.java
+++ b/megamek/src/megamek/client/ui/comboBoxes/SearchableComboBox.java
@@ -1,0 +1,422 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.ui.comboBoxes;
+
+import java.awt.Component;
+import java.awt.event.ActionEvent;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import javax.swing.AbstractAction;
+import javax.swing.DefaultListCellRenderer;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
+import javax.swing.JList;
+import javax.swing.JTextField;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
+import javax.swing.event.PopupMenuEvent;
+import javax.swing.event.PopupMenuListener;
+import javax.swing.plaf.basic.BasicComboBoxEditor;
+import javax.swing.plaf.basic.ComboPopup;
+
+import megamek.client.ui.Messages;
+import megamek.common.annotations.Nullable;
+
+/**
+ * A combo box that can be searched by typing. The user can still open the list and pick an entry with the mouse or
+ * the arrow keys, but typing into the box narrows the list to the entries whose text contains what was typed, which
+ * makes long lists (dozens of munition types, for example) quick to navigate.
+ * <p>
+ * Behaviour while typing:
+ * <ul>
+ *     <li>Focusing the box selects its text, so typing replaces the shown entry.</li>
+ *     <li>Typed text is matched ignoring case, anywhere in the entry text.</li>
+ *     <li>{@code Enter} picks the highlighted entry, or the first match when nothing is highlighted.</li>
+ *     <li>{@code Escape}, or leaving the box, drops the search text and shows the current selection again
+ *     without changing it.</li>
+ *     <li>The selection only ever changes to a real entry; stray text can never become the selected value.</li>
+ * </ul>
+ * Entry text comes from the display function handed to the constructor, so the box never relies on
+ * {@code toString()}.
+ *
+ * @param <E> the type of item held by the combo box
+ */
+public class SearchableComboBox<E> extends JComboBox<E> {
+
+    private static final String ACTION_ACCEPT_SEARCH = "acceptSearch";
+    private static final String ACTION_CANCEL_SEARCH = "cancelSearch";
+    /** How long after gaining focus a mouse release still counts as the click that focused the box. */
+    private static final long FOCUSING_CLICK_WINDOW_MILLIS = 300;
+
+    private final FilteredComboBoxModel<E> filteredModel;
+    private final JTextField editorField;
+    private boolean isUpdatingEditorText = false;
+    private boolean isRefreshingPopup = false;
+    private boolean isSearchPending = false;
+    private long focusGainedAtMillis = 0;
+
+    /**
+     * @param name            the component name, used for look-ups in tests and tooling
+     * @param items           the entries to offer, in display order
+     * @param displayFunction converts an entry into the text shown to, and searched by, the user
+     */
+    public SearchableComboBox(String name, List<E> items, Function<E, String> displayFunction) {
+        this(name, new FilteredComboBoxModel<>(items, displayFunction));
+    }
+
+    private SearchableComboBox(String name, FilteredComboBoxModel<E> model) {
+        super(model);
+        filteredModel = model;
+        setName(name);
+
+        DisplayTextEditor editor = new DisplayTextEditor();
+        editorField = editor.getTextField();
+        setEditor(editor);
+        setEditable(true);
+        setRenderer(new DisplayTextRenderer());
+        keepWidthOfWidestEntry();
+
+        editorField.setToolTipText(Messages.getString("SearchableComboBox.tooltip"));
+        editorField.getDocument().addDocumentListener(new EditorTextListener());
+        editorField.addFocusListener(new FocusAdapter() {
+            @Override
+            public void focusGained(FocusEvent event) {
+                focusGainedAtMillis = System.currentTimeMillis();
+                SwingUtilities.invokeLater(editorField::selectAll);
+            }
+
+            @Override
+            public void focusLost(FocusEvent event) {
+                if (!event.isTemporary()) {
+                    restoreEditorFromSelection();
+                }
+            }
+        });
+        editorField.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseReleased(MouseEvent event) {
+                // When the click also activated the window, focus arrives before the press and the press then
+                // moves the caret; re-select after the release so typing still replaces the shown entry.
+                boolean isFocusingClick = (System.currentTimeMillis() - focusGainedAtMillis)
+                      < FOCUSING_CLICK_WINDOW_MILLIS;
+                if (isFocusingClick) {
+                    SwingUtilities.invokeLater(editorField::selectAll);
+                }
+            }
+        });
+        installSearchKeys();
+        addPopupMenuListener(new PopupClosedListener());
+    }
+
+    /**
+     * Sizes the box for its widest entry, so narrowing the list while typing does not make the box shrink and
+     * grow with every keystroke.
+     */
+    private void keepWidthOfWidestEntry() {
+        Optional<E> widestEntry = filteredModel.getAllItems()
+              .stream()
+              .max(Comparator.comparingInt(item -> filteredModel.getDisplayText(item).length()));
+        widestEntry.ifPresent(this::setPrototypeDisplayValue);
+    }
+
+    /**
+     * Binds {@code Enter} to accepting the search and {@code Escape} to cancelling it. Both bindings sit on the
+     * editor itself so they run before the text field's and the combo box's own handling of those keys.
+     */
+    private void installSearchKeys() {
+        editorField.getInputMap(JComponent.WHEN_FOCUSED)
+              .put(KeyStroke.getKeyStroke(KeyEvent.VK_ENTER, 0), ACTION_ACCEPT_SEARCH);
+        editorField.getActionMap().put(ACTION_ACCEPT_SEARCH, new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent event) {
+                acceptSearch();
+            }
+        });
+        editorField.getInputMap(JComponent.WHEN_FOCUSED)
+              .put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), ACTION_CANCEL_SEARCH);
+        editorField.getActionMap().put(ACTION_CANCEL_SEARCH, new AbstractAction() {
+            @Override
+            public void actionPerformed(ActionEvent event) {
+                cancelSearch();
+            }
+        });
+    }
+
+    /**
+     * Selects the entry the user has arrived at: the entry highlighted in the open list if there is one, otherwise
+     * the best match for the typed text. The search text is then dropped.
+     */
+    private void acceptSearch() {
+        E chosenEntry = getHighlightedEntry().orElseGet(() -> resolveEditorText(editorField.getText(), true));
+        setPopupVisible(false);
+        if (chosenEntry != null) {
+            setSelectedItem(chosenEntry);
+        }
+        restoreEditorFromSelection();
+    }
+
+    /** Closes the list and drops the search text, leaving the selection as it was. */
+    private void cancelSearch() {
+        setPopupVisible(false);
+        restoreEditorFromSelection();
+    }
+
+    /**
+     * @return the entry currently highlighted in the open drop-down list, if the list is open and one is
+     *       highlighted
+     */
+    @SuppressWarnings("unchecked")
+    private Optional<E> getHighlightedEntry() {
+        if (!isPopupVisible()) {
+            return Optional.empty();
+        }
+        Object popupChild = getUI().getAccessibleChild(this, 0);
+        if (!(popupChild instanceof ComboPopup popup)) {
+            return Optional.empty();
+        }
+        Object highlighted = popup.getList().getSelectedValue();
+        boolean isEntry = (highlighted != null) && filteredModel.getAllItems().contains(highlighted);
+        return isEntry ? Optional.of((E) highlighted) : Optional.empty();
+    }
+
+    /**
+     * Resolves whatever is in the editor to a real entry.
+     *
+     * @param editorText        the text currently in the editor
+     * @param allowPartialMatch whether the first entry that passes the search may stand in for text that names no
+     *                          entry exactly ({@code true} when the user pressed {@code Enter}; {@code false} when
+     *                          they merely left the box)
+     *
+     * @return the entry the text stands for, or the current selection, or {@code null} when there is neither
+     */
+    private @Nullable E resolveEditorText(String editorText, boolean allowPartialMatch) {
+        Optional<E> exactMatch = filteredModel.findByDisplayText(editorText);
+        if (exactMatch.isPresent()) {
+            return exactMatch.get();
+        }
+        boolean hasSearchText = !editorText.isBlank();
+        Optional<E> firstVisibleMatch = filteredModel.getFirstVisibleItem();
+        if (allowPartialMatch && hasSearchText && firstVisibleMatch.isPresent()) {
+            return firstVisibleMatch.get();
+        }
+        return getSelectedItem();
+    }
+
+    /**
+     * Applies the text now in the editor as the search filter and re-opens the list so it shows only the matches.
+     * Reads the editor at run time rather than taking a snapshot, so quick typing is coalesced into one search.
+     */
+    private void applySearchText() {
+        isSearchPending = false;
+        String typedText = editorField.getText();
+        isUpdatingEditorText = true;
+        try {
+            filteredModel.setFilter(typedText);
+            // Swing resets the editor to the selected entry when the model changes; put the search text back.
+            if (!typedText.equals(editorField.getText())) {
+                editorField.setText(typedText);
+            }
+        } finally {
+            isUpdatingEditorText = false;
+        }
+        refreshPopup();
+    }
+
+    /**
+     * Closes and re-opens the list so its height matches the number of entries that pass the search. The list is
+     * hidden entirely when nothing matches.
+     */
+    private void refreshPopup() {
+        if (!isShowing() || !editorField.isFocusOwner()) {
+            return;
+        }
+        isRefreshingPopup = true;
+        try {
+            if (isPopupVisible()) {
+                setPopupVisible(false);
+            }
+            if (filteredModel.getSize() > 0) {
+                setPopupVisible(true);
+            }
+        } finally {
+            isRefreshingPopup = false;
+        }
+    }
+
+    /**
+     * Re-reads every entry's display text. Call this when what an entry should show has changed (for example an
+     * ammo bin that was just given a different munition), so the list, the box and its width all reflect the new
+     * text.
+     */
+    public void refreshDisplayTexts() {
+        isUpdatingEditorText = true;
+        try {
+            filteredModel.refreshContents();
+            getEditor().setItem(getSelectedItem());
+        } finally {
+            isUpdatingEditorText = false;
+        }
+        keepWidthOfWidestEntry();
+    }
+
+    /**
+     * Drops any search text, shows the full list again and puts the current selection back in the editor.
+     */
+    private void restoreEditorFromSelection() {
+        isUpdatingEditorText = true;
+        try {
+            filteredModel.clearFilter();
+            getEditor().setItem(getSelectedItem());
+        } finally {
+            isUpdatingEditorText = false;
+        }
+    }
+
+    /**
+     * Selects an entry. Raw text (as produced by the editor) is first resolved to the entry it names exactly, so
+     * the selection can never become a value that is not one of the entries.
+     *
+     * @param anObject the entry to select, editor text naming an entry, or {@code null} to clear the selection
+     */
+    @Override
+    public void setSelectedItem(@Nullable Object anObject) {
+        Object itemToSelect = (anObject instanceof String editorText)
+              ? resolveEditorText(editorText, false)
+              : anObject;
+        super.setSelectedItem(itemToSelect);
+    }
+
+    /**
+     * @return the selected entry, or {@code null} when nothing is selected
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public @Nullable E getSelectedItem() {
+        Object selected = super.getSelectedItem();
+        return (selected == null) ? null : (E) selected;
+    }
+
+    /**
+     * Editor that shows an entry's display text rather than its {@code toString()}, and hands back a real entry
+     * (never raw text) when asked for its value.
+     */
+    private class DisplayTextEditor extends BasicComboBoxEditor {
+
+        JTextField getTextField() {
+            return editor;
+        }
+
+        @Override
+        public void setItem(@Nullable Object anObject) {
+            boolean wasUpdating = isUpdatingEditorText;
+            isUpdatingEditorText = true;
+            try {
+                super.setItem(filteredModel.displayTextOf(anObject));
+            } finally {
+                isUpdatingEditorText = wasUpdating;
+            }
+        }
+
+        @Override
+        public @Nullable Object getItem() {
+            return resolveEditorText(editor.getText(), false);
+        }
+    }
+
+    /** Renders each list entry with its display text. */
+    private class DisplayTextRenderer extends DefaultListCellRenderer {
+
+        @Override
+        public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected,
+              boolean cellHasFocus) {
+            return super.getListCellRendererComponent(list, filteredModel.displayTextOf(value), index, isSelected,
+                  cellHasFocus);
+        }
+    }
+
+    /**
+     * Turns edits made by the user into a search. The search runs after the document event has finished, because
+     * Swing forbids changing the editor text while it is still being notified of the previous change.
+     */
+    private class EditorTextListener implements DocumentListener {
+
+        private void onTextChanged() {
+            if (isUpdatingEditorText || isSearchPending) {
+                return;
+            }
+            isSearchPending = true;
+            SwingUtilities.invokeLater(SearchableComboBox.this::applySearchText);
+        }
+
+        @Override
+        public void insertUpdate(DocumentEvent event) {
+            onTextChanged();
+        }
+
+        @Override
+        public void removeUpdate(DocumentEvent event) {
+            onTextChanged();
+        }
+
+        @Override
+        public void changedUpdate(DocumentEvent event) {
+            onTextChanged();
+        }
+    }
+
+    /** Drops the search once the list closes for good, so the next opening shows every entry again. */
+    private class PopupClosedListener implements PopupMenuListener {
+
+        @Override
+        public void popupMenuWillBecomeVisible(PopupMenuEvent event) {}
+
+        @Override
+        public void popupMenuWillBecomeInvisible(PopupMenuEvent event) {
+            if (!isRefreshingPopup) {
+                SwingUtilities.invokeLater(SearchableComboBox.this::restoreEditorFromSelection);
+            }
+        }
+
+        @Override
+        public void popupMenuCanceled(PopupMenuEvent event) {}
+    }
+}

--- a/megamek/src/megamek/client/ui/dialogs/customMek/MunitionChoice.java
+++ b/megamek/src/megamek/client/ui/dialogs/customMek/MunitionChoice.java
@@ -32,19 +32,18 @@
  */
 package megamek.client.ui.dialogs.customMek;
 
-import java.awt.Component;
+import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.util.List;
 import java.util.Vector;
-import javax.swing.DefaultListCellRenderer;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
-import javax.swing.JList;
 import javax.swing.JPanel;
 
 import megamek.client.ui.GBC2;
 import megamek.client.ui.Messages;
+import megamek.client.ui.comboBoxes.SearchableComboBox;
 import megamek.codeUtilities.MathUtility;
 import megamek.common.battleArmor.BattleArmor;
 import megamek.common.equipment.AmmoMounted;
@@ -59,7 +58,7 @@ import megamek.common.units.ProtoMek;
 public class MunitionChoice {
 
     private final List<AmmoType> ammoTypes;
-    private final JComboBox<AmmoType> comboAmmoTypes;
+    private final SearchableComboBox<AmmoType> comboAmmoTypes;
     private final JComboBox<String> comboNumberOfShots = new JComboBox<>();
     private final ItemListener numShotsListener;
     private ItemListener halfAmmoListener = evt -> {};
@@ -78,8 +77,7 @@ public class MunitionChoice {
         this.ammoMounted = ammoMounted;
         gameOptions = game.getOptions();
         AmmoType ammoType = ammoMounted.getType();
-        comboAmmoTypes = new JComboBox<>(ammoTypes);
-        comboAmmoTypes.setRenderer(new AmmoComboRenderer());
+        comboAmmoTypes = new SearchableComboBox<>("comboAmmoTypes", ammoTypes, MunitionChoice::displayName);
         comboAmmoTypes.setSelectedItem(ammoType);
 
         numShotsListener = evt -> {
@@ -92,13 +90,13 @@ public class MunitionChoice {
         };
         
         halfAmmoListener = evt -> {
-            int numberOfShotsPerTon = this.ammoTypes.get(comboAmmoTypes.getSelectedIndex()).getShots();
+            AmmoType selectedAmmoType = getSelectedAmmoType();
+            int numberOfShotsPerTon = selectedAmmoType.getShots();
             int currShots = 0;
 
             if (chHalfAmmo.isSelected() && !ammoMounted.isHalfLoadAmmo()) {
                 // Switch to a half load of ammo
                 // Only go down this if there is a munition mutator
-                AmmoType selectedAmmoType = this.ammoTypes.get(comboAmmoTypes.getSelectedIndex());
                 if (selectedAmmoType.getMutatorName() != null) {
                     // Check if the KgPerShot is different than the base (indicating a mutator)
                     double baseKgPerShot = selectedAmmoType.getBaseAmmo().getKgPerShot();
@@ -145,6 +143,9 @@ public class MunitionChoice {
         comboNumberOfShots.addItemListener(numShotsListener);
 
         comboAmmoTypes.addItemListener(evt -> {
+            if (evt.getStateChange() != ItemEvent.SELECTED) {
+                return;
+            }
             comboNumberOfShots.removeItemListener(numShotsListener);
 
             int currShots = 0;
@@ -154,7 +155,8 @@ public class MunitionChoice {
             }
 
             comboNumberOfShots.removeAllItems();
-            int numberOfShotsPerTon = this.ammoTypes.get(comboAmmoTypes.getSelectedIndex()).getShots();
+            AmmoType selectedAmmoType = getSelectedAmmoType();
+            int numberOfShotsPerTon = selectedAmmoType.getShots();
 
             // ProtoMeks are limited to number of shots added during construction
             if ((entity instanceof BattleArmor) || (entity instanceof ProtoMek)) {
@@ -175,8 +177,7 @@ public class MunitionChoice {
             chHalfAmmo.setSelected(false);
 
             for (WeaponAmmoChoice weaponAmmoChoice : weaponAmmoChoices) {
-                weaponAmmoChoice.refreshAmmoBinName(this.ammoMounted,
-                      this.ammoTypes.get(comboAmmoTypes.getSelectedIndex()));
+                weaponAmmoChoice.refreshAmmoBinName(this.ammoMounted, selectedAmmoType);
             }
 
             comboNumberOfShots.addItemListener(numShotsListener);
@@ -228,14 +229,13 @@ public class MunitionChoice {
     }
 
     public void applyChoice() {
-        int selectedIndex = comboAmmoTypes.getSelectedIndex();
+        AmmoType ammoType = comboAmmoTypes.getSelectedItem();
 
         // If there's no selection, there's nothing we can do
-        if (selectedIndex == -1) {
+        if (ammoType == null) {
             return;
         }
 
-        AmmoType ammoType = ammoTypes.get(selectedIndex);
         ammoMounted.changeAmmoType(ammoType);
 
         // set # shots only for non-one shot weapons
@@ -271,17 +271,21 @@ public class MunitionChoice {
         comboAmmoTypes.setEnabled(enabled);
     }
 
-    private static class AmmoComboRenderer extends DefaultListCellRenderer {
+    /**
+     * @return the munition currently chosen in the drop-down, falling back to the munition the bin already holds
+     *       when nothing is chosen
+     */
+    private AmmoType getSelectedAmmoType() {
+        AmmoType selectedAmmoType = comboAmmoTypes.getSelectedItem();
+        return (selectedAmmoType == null) ? ammoMounted.getType() : selectedAmmoType;
+    }
 
-        @Override
-        public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected,
-              boolean cellHasFocus) {
-
-            if (value instanceof AmmoType ammoType) {
-                value = ammoType.getName().replace(" Ammo", "");
-
-            }
-            return super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
-        }
+    /**
+     * @param ammoType the munition to describe
+     *
+     * @return the munition's name without the trailing "Ammo", as shown in the drop-down
+     */
+    private static String displayName(AmmoType ammoType) {
+        return ammoType.getName().replace(" Ammo", "");
     }
 }

--- a/megamek/src/megamek/client/ui/dialogs/customMek/WeaponAmmoChoice.java
+++ b/megamek/src/megamek/client/ui/dialogs/customMek/WeaponAmmoChoice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/src/megamek/client/ui/dialogs/customMek/WeaponAmmoChoice.java
+++ b/megamek/src/megamek/client/ui/dialogs/customMek/WeaponAmmoChoice.java
@@ -33,11 +33,14 @@
 package megamek.client.ui.dialogs.customMek;
 
 import java.util.ArrayList;
-import javax.swing.JComboBox;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 import megamek.client.ui.GBC2;
+import megamek.client.ui.comboBoxes.SearchableComboBox;
 import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.Mounted;
@@ -55,8 +58,11 @@ public class WeaponAmmoChoice {
 
     // the weapon being displayed in this row
     private final WeaponMounted weapon;
-    private final ArrayList<AmmoMounted> matchingAmmoBins = new ArrayList<>();
-    private final JComboBox<String> comboAmmoBins = new JComboBox<>();
+    private final List<AmmoMounted> matchingAmmoBins = new ArrayList<>();
+    /** Munitions chosen in the Carried Munitions panel but not yet applied to their bins, keyed by bin. */
+    private final Map<AmmoMounted, AmmoType> pendingAmmoTypes = new HashMap<>();
+    /** The bin chooser, or {@code null} when the weapon has no bins to choose from and the row is not shown. */
+    private final SearchableComboBox<AmmoMounted> comboAmmoBins;
     private final Entity entity;
 
     /**
@@ -94,9 +100,11 @@ public class WeaponAmmoChoice {
 
         // don't bother displaying the row if there's no ammo to be swapped
         if (matchingAmmoBins.isEmpty()) {
+            comboAmmoBins = null;
             return;
         }
 
+        comboAmmoBins = new SearchableComboBox<>("comboAmmoBins", matchingAmmoBins, this::displayName);
         String weaponName = "(%s) %s:"
               .formatted(weapon.getEntity().getLocationAbbr(weapon.getLocation()), weapon.getShortName());
         parentPanel.add(new JLabel(weaponName), gbc.forLabel());
@@ -110,72 +118,63 @@ public class WeaponAmmoChoice {
     }
 
     /**
-     * Worker function that refreshes the combo box with "up-to-date" ammo names.
+     * Shows the bins with their current names and selects the bin the weapon is loaded from.
      */
     public void refreshAmmoBinNames() {
-        int selectedIndex = comboAmmoBins.getSelectedIndex();
-        comboAmmoBins.removeAllItems();
-
-        int currentIndex = 0;
-        for (Mounted<?> ammoBin : matchingAmmoBins) {
-            boolean isInternal = ammoBin.isOneShotAmmo() || ammoBin.isOneShot() || (ammoBin.getLocation() == -1);
-            String prefix = isInternal ? "(Internal) " :
-                  "(" + ammoBin.getEntity().getLocationAbbr(ammoBin.getLocation()) + ") ";
-            String ammoBinName = prefix + ammoBin.getName();
-            comboAmmoBins.addItem(ammoBinName);
-
-            if (weapon.getLinked() == ammoBin) {
-                selectedIndex = currentIndex;
-            }
-
-            currentIndex++;
+        if (comboAmmoBins == null) {
+            return;
         }
-
-        if (selectedIndex >= 0) {
-            comboAmmoBins.setSelectedIndex(selectedIndex);
+        comboAmmoBins.refreshDisplayTexts();
+        boolean isLinkedBinListed = (weapon.getLinked() instanceof AmmoMounted linkedBin)
+              && matchingAmmoBins.contains(linkedBin);
+        if (isLinkedBinListed) {
+            comboAmmoBins.setSelectedItem(weapon.getLinked());
         }
     }
 
     /**
-     * Refreshes a single item in the ammo type combo box to display the correct ammo type name. Because the underlying
-     * ammo bin hasn't been updated yet, we carry out the name swap "in-place".
+     * Shows a bin under the name of the munition just chosen for it. Because the underlying ammo bin hasn't been
+     * updated yet, the new name is remembered here and used until the choice is applied.
      *
      * @param ammoBin          The ammo bin whose ammo type has probably changed.
      * @param selectedAmmoType The new ammo type.
      */
     public void refreshAmmoBinName(Mounted<?> ammoBin, AmmoType selectedAmmoType) {
-        int index;
-        boolean matchFound = false;
-
-        for (index = 0; index < matchingAmmoBins.size(); index++) {
-            if (matchingAmmoBins.get(index) == ammoBin) {
-                matchFound = true;
-                break;
-            }
+        if ((comboAmmoBins == null) || !(ammoBin instanceof AmmoMounted renamedBin)) {
+            return;
         }
-
-        if (matchFound) {
-            int currentBinIndex = comboAmmoBins.getSelectedIndex();
-
-            comboAmmoBins.removeItemAt(index);
-            comboAmmoBins.insertItemAt("(" +
-                  ammoBin.getEntity().getLocationAbbr(ammoBin.getLocation()) +
-                  ") " +
-                  selectedAmmoType.getName(), index);
-
-            if (currentBinIndex == index) {
-                comboAmmoBins.setSelectedIndex(index);
-            }
+        if (!matchingAmmoBins.contains(renamedBin)) {
+            return;
         }
+        pendingAmmoTypes.put(renamedBin, selectedAmmoType);
+        comboAmmoBins.refreshDisplayTexts();
+    }
+
+    /**
+     * @param ammoBin the bin to describe
+     *
+     * @return the bin's location prefix and munition name, using a munition chosen but not yet applied when there
+     *       is one
+     */
+    private String displayName(AmmoMounted ammoBin) {
+        boolean isInternal = ammoBin.isOneShotAmmo() || ammoBin.isOneShot() || (ammoBin.getLocation() == -1);
+        String prefix = isInternal ? "(Internal) " :
+              "(" + ammoBin.getEntity().getLocationAbbr(ammoBin.getLocation()) + ") ";
+        AmmoType pendingAmmoType = pendingAmmoTypes.get(ammoBin);
+        String munitionName = (pendingAmmoType == null) ? ammoBin.getName() : pendingAmmoType.getName();
+        return prefix + munitionName;
     }
 
     /**
      * Common functionality that applies the panel's current ammo bin choice to the panel's weapon.
      */
     public void applyChoice() {
-        int selectedIndex = comboAmmoBins.getSelectedIndex();
-        if ((selectedIndex >= 0) && (selectedIndex < matchingAmmoBins.size())) {
-            entity.loadWeapon(weapon, matchingAmmoBins.get(selectedIndex));
+        if (comboAmmoBins == null) {
+            return;
+        }
+        AmmoMounted selectedBin = comboAmmoBins.getSelectedItem();
+        if (selectedBin != null) {
+            entity.loadWeapon(weapon, selectedBin);
         }
     }
 }

--- a/megamek/unittests/megamek/client/ui/comboBoxes/SearchableComboBoxTest.java
+++ b/megamek/unittests/megamek/client/ui/comboBoxes/SearchableComboBoxTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.ui.comboBoxes;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.swing.JTextField;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the search behaviour behind {@link SearchableComboBox}: the model narrows to matching entries without
+ * losing the selection, and the box only ever selects real entries no matter what text the editor holds.
+ */
+class SearchableComboBoxTest {
+
+    /** A stand-in for a munition: the display text deliberately differs from {@code toString()}. */
+    private record Munition(String code, String label) {
+        @Override
+        public String toString() {
+            return code;
+        }
+    }
+
+    private static final Munition STANDARD = new Munition("LRM-STD", "LRM 20 Standard");
+    private static final Munition INFERNO = new Munition("LRM-INF", "LRM 20 Inferno");
+    private static final Munition SWARM = new Munition("LRM-SWM", "LRM 20 Swarm");
+    private static final Munition THUNDER_INFERNO = new Munition("LRM-THI", "LRM 20 Thunder-Inferno");
+    private static final List<Munition> MUNITIONS = List.of(STANDARD, INFERNO, SWARM, THUNDER_INFERNO);
+
+    private static FilteredComboBoxModel<Munition> newModel() {
+        return new FilteredComboBoxModel<>(MUNITIONS, Munition::label);
+    }
+
+    private static SearchableComboBox<Munition> newComboBox() {
+        return new SearchableComboBox<>("munitions", MUNITIONS, Munition::label);
+    }
+
+    private static String editorText(SearchableComboBox<Munition> comboBox) {
+        return ((JTextField) comboBox.getEditor().getEditorComponent()).getText();
+    }
+
+    @Test
+    void filterNarrowsToEntriesContainingTextIgnoringCase() {
+        FilteredComboBoxModel<Munition> model = newModel();
+
+        model.setFilter("INFerno");
+
+        assertEquals(2, model.getSize());
+        assertEquals(INFERNO, model.getElementAt(0));
+        assertEquals(THUNDER_INFERNO, model.getElementAt(1));
+        assertTrue(model.isFiltered());
+    }
+
+    @Test
+    void clearingTheFilterShowsEveryEntryAgain() {
+        FilteredComboBoxModel<Munition> model = newModel();
+        model.setFilter("swarm");
+
+        model.clearFilter();
+
+        assertEquals(MUNITIONS.size(), model.getSize());
+        assertFalse(model.isFiltered());
+    }
+
+    @Test
+    void selectionSurvivesBeingFilteredOutOfView() {
+        FilteredComboBoxModel<Munition> model = newModel();
+        model.setSelectedItem(STANDARD);
+
+        model.setFilter("inferno");
+
+        assertEquals(STANDARD, model.getSelectedItem());
+        assertEquals(Optional.of(INFERNO), model.getFirstVisibleItem());
+    }
+
+    @Test
+    void modelIgnoresValuesThatAreNotEntries() {
+        FilteredComboBoxModel<Munition> model = newModel();
+        model.setSelectedItem(SWARM);
+
+        model.setSelectedItem("LRM 20 Inferno");
+        model.setSelectedItem(new Munition("LRM-XXX", "LRM 20 Swarm"));
+
+        assertEquals(SWARM, model.getSelectedItem());
+    }
+
+    @Test
+    void displayTextUsesTheDisplayFunctionNotToString() {
+        FilteredComboBoxModel<Munition> model = newModel();
+
+        assertEquals("LRM 20 Inferno", model.displayTextOf(INFERNO));
+        assertEquals("typed text", model.displayTextOf("typed text"));
+        assertEquals("", model.displayTextOf(null));
+        assertEquals(Optional.of(SWARM), model.findByDisplayText("  lrm 20 swarm "));
+        assertTrue(model.findByDisplayText("no such munition").isEmpty());
+    }
+
+    @Test
+    void refreshingContentsPicksUpRenamedEntriesAndReappliesTheFilter() {
+        Map<Munition, String> names = new HashMap<>();
+        MUNITIONS.forEach(munition -> names.put(munition, munition.label()));
+        FilteredComboBoxModel<Munition> model = new FilteredComboBoxModel<>(MUNITIONS, names::get);
+        model.setFilter("inferno");
+        assertEquals(2, model.getSize());
+
+        names.put(SWARM, "LRM 20 Inferno Swarm");
+        model.refreshContents();
+
+        assertEquals("LRM 20 Inferno Swarm", model.displayTextOf(SWARM));
+        assertEquals(3, model.getSize());
+        assertEquals(Optional.of(SWARM), model.findByDisplayText("lrm 20 inferno swarm"));
+    }
+
+    @Test
+    void comboBoxShowsTheNewTextOfARenamedSelection() {
+        Map<Munition, String> names = new HashMap<>();
+        MUNITIONS.forEach(munition -> names.put(munition, munition.label()));
+        SearchableComboBox<Munition> comboBox = new SearchableComboBox<>("munitions", MUNITIONS, names::get);
+        comboBox.setSelectedItem(STANDARD);
+
+        names.put(STANDARD, "LRM 20 Standard (half load)");
+        comboBox.refreshDisplayTexts();
+
+        assertEquals(STANDARD, comboBox.getSelectedItem());
+        assertEquals("LRM 20 Standard (half load)", editorText(comboBox));
+    }
+
+    @Test
+    void comboBoxResolvesExactEditorTextToTheEntry() {
+        SearchableComboBox<Munition> comboBox = newComboBox();
+        comboBox.setSelectedItem(STANDARD);
+
+        comboBox.setSelectedItem("lrm 20 inferno");
+
+        assertEquals(INFERNO, comboBox.getSelectedItem());
+        assertEquals("LRM 20 Inferno", editorText(comboBox));
+    }
+
+    @Test
+    void comboBoxKeepsSelectionWhenEditorTextNamesNoEntry() {
+        SearchableComboBox<Munition> comboBox = newComboBox();
+        comboBox.setSelectedItem(SWARM);
+
+        comboBox.setSelectedItem("inf");
+
+        assertEquals(SWARM, comboBox.getSelectedItem());
+    }
+
+    @Test
+    void comboBoxOffersEveryEntryAndShowsDisplayTextForTheSelection() {
+        SearchableComboBox<Munition> comboBox = newComboBox();
+
+        assertEquals(MUNITIONS.size(), comboBox.getItemCount());
+        assertNull(comboBox.getSelectedItem());
+
+        comboBox.setSelectedItem(THUNDER_INFERNO);
+
+        assertEquals("LRM 20 Thunder-Inferno", editorText(comboBox));
+        assertEquals(3, comboBox.getSelectedIndex());
+    }
+}


### PR DESCRIPTION
## What this changes

In the lobby's Configure > Equipment tab, both munition dropdowns - **Carried Munitions** (which munition each ammo bin holds) and **Munitions Loaded at Start** (which bin each weapon draws from) - can now be searched by typing. Click into the box on an LRM 20 bin and type `inf`, and the list shrinks to `LRM 20 Inferno` and `LRM 20 Thunder-Inferno`. Enter picks the highlighted or first match; Escape, or clicking away, drops the search without changing what was loaded. Opening the list with the mouse and picking an entry works exactly as before. Until now an LRM, SRM or ATM bin offered a plain list of thirty-odd entries with no way to jump to one.

The search is a new reusable `SearchableComboBox` (backed by `FilteredComboBoxModel`) in `megamek.client.ui.comboBoxes`. `MunitionChoice` and `WeaponAmmoChoice` now use it and look their selection up by item rather than by dropdown index, because an index into a filtered list no longer lines up with the full list. `WeaponAmmoChoice` keeps the not-yet-applied munition name per bin, so a bin renamed in the Carried Munitions panel still shows its new name in the weapon row below. MekHQ shares the Carried Munitions panel and gets the same behaviour.


https://github.com/user-attachments/assets/03dc4a8f-e1be-4161-ad37-80f1d9f44e72


## Testing

- 10 unit tests in `SearchableComboBoxTest`: filtering ignores case and matches anywhere in the name, the selection survives being filtered out of view, editor text only ever resolves to a real entry, and a renamed entry updates its text and re-applies an active filter.
- Playtested in the lobby on a Mek: typing narrows the list; Enter, Escape, the arrow keys and the mouse behave as described above; and changing a bin's munition in Carried Munitions relabels that bin in the Munitions Loaded at Start row.
- `compileJava`, the test class and checkstyle are green.

## What is not proven yet

- Nothing outstanding for the two dropdowns themselves; both were exercised in game.
- BattleArmor bins and one-shot-weapon bins go through the same rows and their special handling is unchanged, but they were checked by code reading only, not in game.
- Units that never used these dropdowns (weapon-bay units, small support vehicles) are untouched.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result
