### PR TITLE
Fix settings search result stability and visibility

### DIFF
--- a/megamek/resources/megamek/client/messages.properties
+++ b/megamek/resources/megamek/client/messages.properties
@@ -2602,6 +2602,7 @@ GameOptionsDialog.Search=Search
 GameOptionsDialog.SearchToolTip=Search for options that contain the entered text
 GameOptionsDialog.SearchNoMatches=No matching option groups
 GameOptionsDialog.SearchMatches=%d matching option groups
+SettingsNavigation.searching=Searching...
 GameOptionsDialog.rngType.sunRandom=SunRandom
 GameOptionsDialog.rngType.cryptoRandom=Java CryptoRandom
 GameOptionsDialog.rngType.pool36Random=Pool36Random (Unofficial)
@@ -2987,6 +2988,8 @@ KeyBinds.cmdNames.reportFilterKey=Toggle Report Keyword Filter
 KeyBinds.cmdDesc.reportFilterKey=Show the full Phase Report or just the lines containing the filter keywords
 KeyBinds.cmdNames.toggleBotCommandsDisplay=Show Bot Commands
 KeyBinds.cmdDesc.toggleBotCommandsDisplay=Show the Bot Command window to give in-game strategic commands to Princess.
+KeyBinds.cmdNames.toggleShowObjects=Show Objects
+KeyBinds.cmdDesc.toggleShowObjects=Toggles objective control zone outlines and scoring labels on the board
 #Key Bindings Overlay
 KeyBindingsDisplay.fixedBinds=Toggle Unit Display and Minimap: Mouse Button 4\nZoom: Mouse Wheel\nTurn / Torso twist: Shift + Left-Click\nLine of Sight tool: Ctrl + Left-Click (two hexes)\nRuler tool: Alt + Left-Click (two hexes)
 KeyBindingsDisplay.fixedBindsBoardEd=Zoom: Mouse Wheel\nLeft-Click: Draw Hex (replace previous terrain)\nShift + Left-Click: Draw Hex (add to previous terrain)\nCtrl + Left-Click: Draw Hex with hex elevation\nAlt + Left-Click: Eyedropper tool\nDrag-Right Mouse Button: Pan Map

--- a/megamek/src/megamek/client/ui/panels/CommonSettingsPane.java
+++ b/megamek/src/megamek/client/ui/panels/CommonSettingsPane.java
@@ -122,7 +122,8 @@ public class CommonSettingsPane extends JPanel {
             getString("CommonSettingsDialog.SearchNoMatches"),
             getString("CommonSettingsDialog.SearchMatches"),
             getString("SettingsPagePanel.expandAll.text"),
-            getString("SettingsPagePanel.collapseAll.text"));
+            getString("SettingsPagePanel.collapseAll.text"),
+            getString("SettingsNavigation.searching"));
         settingsPane = new SettingsPane(routes, pageFactories, navigationText);
         add(settingsPane, BorderLayout.CENTER);
     }

--- a/megamek/src/megamek/client/ui/panels/GameOptionsPane.java
+++ b/megamek/src/megamek/client/ui/panels/GameOptionsPane.java
@@ -270,7 +270,8 @@ public class GameOptionsPane extends JPanel {
               getTextAt(CLIENT_BUNDLE, "GameOptionsDialog.SearchNoMatches"),
               getTextAt(CLIENT_BUNDLE, "GameOptionsDialog.SearchMatches"),
               getTextAt(CLIENT_BUNDLE, "SettingsPagePanel.expandAll.text"),
-              getTextAt(CLIENT_BUNDLE, "SettingsPagePanel.collapseAll.text"));
+              getTextAt(CLIENT_BUNDLE, "SettingsPagePanel.collapseAll.text"),
+              getTextAt(CLIENT_BUNDLE, "SettingsNavigation.searching"));
         settingsPane = new SettingsPane(routes, pageFactories, navigationText);
         add(settingsPane, BorderLayout.CENTER);
     }

--- a/megamek/src/megamek/client/ui/settings/SettingsContentHost.java
+++ b/megamek/src/megamek/client/ui/settings/SettingsContentHost.java
@@ -281,8 +281,8 @@ public class SettingsContentHost extends JPanel {
                     }
                 };
                 boolean suppressTooltip = swingComponent.getToolTipText() != null;
-                    HelpBinding binding = new HelpBinding(swingComponent, descendantHelpOwner,
-                        swingComponent.getToolTipText(), helpText, suppressTooltip, mouseListener, focusListener);
+                HelpBinding binding = new HelpBinding(swingComponent, descendantHelpOwner,
+                      swingComponent.getToolTipText(), helpText, suppressTooltip, mouseListener, focusListener);
                 swingComponent.addMouseListener(binding.mouseListener());
                 swingComponent.addFocusListener(binding.focusListener());
                 if (suppressTooltip) {

--- a/megamek/src/megamek/client/ui/settings/SettingsContentHost.java
+++ b/megamek/src/megamek/client/ui/settings/SettingsContentHost.java
@@ -42,8 +42,11 @@ import java.awt.event.FocusEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.regex.Pattern;
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -75,6 +78,7 @@ public class SettingsContentHost extends JPanel {
     private final SettingsHelpPanel helpPanel;
     private final List<HelpBinding> activeHelpBindings = new ArrayList<>();
     private Component currentContent;
+    private String activeSearchFilter = "";
 
     public SettingsContentHost(Component content, boolean showHelpPanel) {
         super(new BorderLayout());
@@ -116,7 +120,7 @@ public class SettingsContentHost extends JPanel {
         currentContent = content;
         contentPanel.add(content, BorderLayout.CENTER);
         if (showHelp) {
-            bindHelp(content, null);
+            bindHelp(content, null, null);
         }
         contentPanel.revalidate();
         contentPanel.repaint();
@@ -130,7 +134,8 @@ public class SettingsContentHost extends JPanel {
         unbindHelp();
         helpPanel.clearHelpText();
         if (helpPanel.isVisible() && currentContent != null) {
-            bindHelp(currentContent, null);
+            bindHelp(currentContent, null, null);
+            revealMatchingHelp(activeSearchFilter);
         }
     }
 
@@ -140,12 +145,52 @@ public class SettingsContentHost extends JPanel {
 
     /** Updates the non-mutating text highlights painted over the current settings content. */
     public void setSearchFilter(String normalizedFilter) {
-        searchHighlightLayerUI.setFilter(normalizedFilter, searchHighlightLayer);
+        activeSearchFilter = normalizedFilter == null ? "" : normalizedFilter;
+        searchHighlightLayerUI.setFilter(activeSearchFilter, searchHighlightLayer);
+        helpPanel.clearHelpText();
+        helpPanel.setSearchFilter(activeSearchFilter);
+        revealMatchingHelp(activeSearchFilter);
+    }
+
+    private void revealMatchingHelp(String normalizedFilter) {
+        if (!helpPanel.isVisible() || normalizedFilter == null || normalizedFilter.isBlank()) {
+            searchHighlightLayerUI.setHelpMatchComponents(List.of(), searchHighlightLayer);
+            return;
+        }
+        List<String> tokens = SettingsSearchText.tokens(normalizedFilter);
+        Set<JComponent> matchingOwners = Collections.newSetFromMap(new IdentityHashMap<>());
+        HelpBinding firstMatch = null;
+        for (HelpBinding binding : activeHelpBindings) {
+            String normalizedHelp = SettingsRoute.normalizeSearchText(binding.helpText());
+            if (tokens.stream().allMatch(normalizedHelp::contains)) {
+                matchingOwners.add(binding.helpOwner());
+                if (firstMatch == null) {
+                    firstMatch = binding;
+                }
+            }
+        }
+        searchHighlightLayerUI.setHelpMatchComponents(List.copyOf(matchingOwners), searchHighlightLayer);
+        if (firstMatch == null) {
+            return;
+        }
+        setHelpText(firstMatch.helpText());
+        JComponent firstMatchOwner = firstMatch.helpOwner();
+        SwingUtilities.invokeLater(() -> {
+            if (normalizedFilter.equals(activeSearchFilter)
+                  && SwingUtilities.isDescendingFrom(firstMatchOwner, contentPanel)) {
+                firstMatchOwner.scrollRectToVisible(new Rectangle(
+                      0, 0, firstMatchOwner.getWidth(), firstMatchOwner.getHeight()));
+            }
+        });
     }
 
     /** Exposes painted bounds for headless overlay tests. */
     List<Rectangle> getSearchHighlightBounds() {
         return searchHighlightLayerUI.highlightBounds(searchHighlightLayer);
+    }
+
+    List<Rectangle> getHelpMatchBounds() {
+        return searchHighlightLayerUI.helpMatchBounds(searchHighlightLayer);
     }
 
     /**
@@ -208,8 +253,10 @@ public class SettingsContentHost extends JPanel {
         return pagePanel == null ? defaultShowHelpPanel : pagePanel.shouldShowDetailsPanel();
     }
 
-    private void bindHelp(Component component, @Nullable String inheritedHelpText) {
+    private void bindHelp(Component component, @Nullable String inheritedHelpText,
+          @Nullable JComponent inheritedHelpOwner) {
         String descendantHelpText = inheritedHelpText;
+        JComponent descendantHelpOwner = inheritedHelpOwner;
         boolean supportsHelp = !(component instanceof JButton) || component instanceof SettingsHelpProvider;
         if (component instanceof JComponent swingComponent && supportsHelp) {
             String ownHelpText = component instanceof SettingsHelpProvider provider
@@ -217,8 +264,9 @@ public class SettingsContentHost extends JPanel {
                   : swingComponent.getToolTipText();
             if (ownHelpText != null && !ownHelpText.isBlank()) {
                 descendantHelpText = ownHelpText;
+                descendantHelpOwner = swingComponent;
             }
-            if (descendantHelpText != null && !descendantHelpText.isBlank()) {
+            if (descendantHelpText != null && !descendantHelpText.isBlank() && descendantHelpOwner != null) {
                 String helpText = descendantHelpText;
                 MouseAdapter mouseListener = new MouseAdapter() {
                     @Override
@@ -233,8 +281,8 @@ public class SettingsContentHost extends JPanel {
                     }
                 };
                 boolean suppressTooltip = swingComponent.getToolTipText() != null;
-                HelpBinding binding = new HelpBinding(swingComponent, swingComponent.getToolTipText(),
-                      suppressTooltip, mouseListener, focusListener);
+                    HelpBinding binding = new HelpBinding(swingComponent, descendantHelpOwner,
+                        swingComponent.getToolTipText(), helpText, suppressTooltip, mouseListener, focusListener);
                 swingComponent.addMouseListener(binding.mouseListener());
                 swingComponent.addFocusListener(binding.focusListener());
                 if (suppressTooltip) {
@@ -245,7 +293,7 @@ public class SettingsContentHost extends JPanel {
         }
         if (component instanceof Container container) {
             for (Component child : container.getComponents()) {
-                bindHelp(child, descendantHelpText);
+                bindHelp(child, descendantHelpText, descendantHelpOwner);
             }
         }
     }
@@ -271,12 +319,12 @@ public class SettingsContentHost extends JPanel {
     public void addNotify() {
         super.addNotify();
         if (helpPanel.isVisible() && activeHelpBindings.isEmpty() && currentContent != null) {
-            bindHelp(currentContent, null);
+            bindHelp(currentContent, null, null);
         }
     }
 
-    private record HelpBinding(JComponent component, String originalTooltip, boolean suppressTooltip,
-                               MouseAdapter mouseListener, FocusAdapter focusListener) {
+    private record HelpBinding(JComponent component, JComponent helpOwner, String originalTooltip, String helpText,
+                               boolean suppressTooltip, MouseAdapter mouseListener, FocusAdapter focusListener) {
     }
 
     private static class SettingsContentPanel extends JPanel implements Scrollable {

--- a/megamek/src/megamek/client/ui/settings/SettingsHelpPanel.java
+++ b/megamek/src/megamek/client/ui/settings/SettingsHelpPanel.java
@@ -33,9 +33,11 @@
 package megamek.client.ui.settings;
 
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Graphics;
+import java.util.List;
 import javax.swing.BorderFactory;
 import javax.swing.JEditorPane;
 import javax.swing.JPanel;
@@ -45,6 +47,8 @@ import javax.swing.UIManager;
 import javax.swing.border.Border;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.TitledBorder;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.DefaultHighlighter;
 
 import megamek.client.ui.util.UIUtil;
 import megamek.common.ui.FastJScrollPane;
@@ -57,6 +61,7 @@ public class SettingsHelpPanel extends JPanel {
     private static final int HELP_TEXT_HORIZONTAL_PADDING = 8;
 
     private final JEditorPane helpTextPane = new JEditorPane();
+    private String searchFilter = "";
 
     public SettingsHelpPanel() {
         super(new BorderLayout());
@@ -102,10 +107,38 @@ public class SettingsHelpPanel extends JPanel {
         }
         helpTextPane.setText(helpText);
         helpTextPane.setCaretPosition(0);
+        updateSearchHighlights();
     }
 
     public void clearHelpText() {
         helpTextPane.setText("");
+    }
+
+    void setSearchFilter(String normalizedFilter) {
+        searchFilter = normalizedFilter == null ? "" : normalizedFilter;
+        updateSearchHighlights();
+    }
+
+    int getSearchHighlightCount() {
+        return helpTextPane.getHighlighter().getHighlights().length;
+    }
+
+    private void updateSearchHighlights() {
+        helpTextPane.getHighlighter().removeAllHighlights();
+        List<String> tokens = SettingsSearchText.tokens(searchFilter);
+        if (tokens.isEmpty()) {
+            return;
+        }
+        SettingsSearchText.TextSource source = SettingsSearchText.from(helpTextPane);
+        Color color = SettingsSearchHighlightLayerUI.highlightColor();
+        var painter = new DefaultHighlighter.DefaultHighlightPainter(color);
+        for (SettingsSearchText.TextRange range : SettingsSearchText.ranges(source.text(), tokens)) {
+            try {
+                helpTextPane.getHighlighter().addHighlight(range.start(), range.end(), painter);
+            } catch (BadLocationException exception) {
+                // Ignore stale positions if the help document changes while highlights are being applied.
+            }
+        }
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/settings/SettingsHelpPanel.java
+++ b/megamek/src/megamek/client/ui/settings/SettingsHelpPanel.java
@@ -112,6 +112,7 @@ public class SettingsHelpPanel extends JPanel {
 
     public void clearHelpText() {
         helpTextPane.setText("");
+        updateSearchHighlights();
     }
 
     void setSearchFilter(String normalizedFilter) {

--- a/megamek/src/megamek/client/ui/settings/SettingsNavigationPanel.java
+++ b/megamek/src/megamek/client/ui/settings/SettingsNavigationPanel.java
@@ -35,6 +35,7 @@ package megamek.client.ui.settings;
 import static megamek.client.ui.util.FontHandler.symbolIcon;
 
 import java.awt.BorderLayout;
+import java.awt.CardLayout;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
@@ -72,6 +73,8 @@ public class SettingsNavigationPanel extends JPanel {
 
     private static final int CONTENT_GAP = 6;
     private static final int CONTROL_GAP = 4;
+    private static final String NAVIGATION_TREE_CARD = "navigationTree";
+    private static final String SEARCHING_CARD = "searching";
 
     private final List<SettingsRoute> routes;
     private final Consumer<SettingsRoute> routeSelectionListener;
@@ -79,8 +82,12 @@ public class SettingsNavigationPanel extends JPanel {
     private final JTextField filterField = new JTextField();
     private final JLabel filterStatusLabel = new JLabel();
     private final JTree navigationTree = new JTree();
+    private final CardLayout navigationContentLayout = new CardLayout();
+    private final JPanel navigationContent = new JPanel(navigationContentLayout);
+    private final JLabel searchingLabel = new JLabel();
     private SettingsRoute currentRoute;
     private boolean syncingSelection;
+    private boolean searchInProgress;
     private Runnable searchIndexInitializer;
     private Consumer<String> filterChangeListener = filter -> { };
 
@@ -109,6 +116,12 @@ public class SettingsNavigationPanel extends JPanel {
               ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
               ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
         navigationScrollPane.setName("settingsNavigationScrollPane");
+          searchingLabel.setName("lblSettingsSearching");
+          searchingLabel.setText(text.searching());
+          searchingLabel.setHorizontalAlignment(SwingConstants.CENTER);
+          navigationContent.setName("settingsNavigationContent");
+          navigationContent.add(navigationScrollPane, NAVIGATION_TREE_CARD);
+          navigationContent.add(searchingLabel, SEARCHING_CARD);
 
         int controlGap = UIUtil.scaleForGUI(CONTROL_GAP);
         JPanel searchRow = new JPanel(new BorderLayout(controlGap, 0));
@@ -123,7 +136,7 @@ public class SettingsNavigationPanel extends JPanel {
         filterPanel.add(searchRow, BorderLayout.NORTH);
         filterPanel.add(filterStatusLabel, BorderLayout.SOUTH);
         add(filterPanel, BorderLayout.NORTH);
-        add(navigationScrollPane, BorderLayout.CENTER);
+        add(navigationContent, BorderLayout.CENTER);
         buildNavigationTree("");
     }
 
@@ -239,7 +252,20 @@ public class SettingsNavigationPanel extends JPanel {
     }
 
     public void refreshFilter() {
-        buildNavigationTree(filterField.getText());
+        if (!searchInProgress) {
+            buildNavigationTree(filterField.getText());
+        }
+    }
+
+    void setSearchInProgress(boolean searchInProgress) {
+        this.searchInProgress = searchInProgress;
+        navigationTree.setEnabled(!searchInProgress);
+        if (searchInProgress) {
+            filterStatusLabel.setText("");
+            filterStatusLabel.setVisible(false);
+        }
+        navigationContentLayout.show(navigationContent,
+              searchInProgress ? SEARCHING_CARD : NAVIGATION_TREE_CARD);
     }
 
     /** @return the normalized active search filter */
@@ -266,7 +292,9 @@ public class SettingsNavigationPanel extends JPanel {
         if (searchIndexInitializer != null) {
             searchIndexInitializer.run();
         }
-        buildNavigationTree(filterField.getText());
+        if (!searchInProgress) {
+            buildNavigationTree(filterField.getText());
+        }
         filterChangeListener.accept(getActiveFilter());
     }
 

--- a/megamek/src/megamek/client/ui/settings/SettingsNavigationPanel.java
+++ b/megamek/src/megamek/client/ui/settings/SettingsNavigationPanel.java
@@ -116,12 +116,12 @@ public class SettingsNavigationPanel extends JPanel {
               ScrollPaneConstants.VERTICAL_SCROLLBAR_AS_NEEDED,
               ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
         navigationScrollPane.setName("settingsNavigationScrollPane");
-          searchingLabel.setName("lblSettingsSearching");
-          searchingLabel.setText(text.searching());
-          searchingLabel.setHorizontalAlignment(SwingConstants.CENTER);
-          navigationContent.setName("settingsNavigationContent");
-          navigationContent.add(navigationScrollPane, NAVIGATION_TREE_CARD);
-          navigationContent.add(searchingLabel, SEARCHING_CARD);
+                searchingLabel.setName("lblSettingsSearching");
+                searchingLabel.setText(text.searching());
+                searchingLabel.setHorizontalAlignment(SwingConstants.CENTER);
+                navigationContent.setName("settingsNavigationContent");
+                navigationContent.add(navigationScrollPane, NAVIGATION_TREE_CARD);
+                navigationContent.add(searchingLabel, SEARCHING_CARD);
 
         int controlGap = UIUtil.scaleForGUI(CONTROL_GAP);
         JPanel searchRow = new JPanel(new BorderLayout(controlGap, 0));

--- a/megamek/src/megamek/client/ui/settings/SettingsNavigationText.java
+++ b/megamek/src/megamek/client/ui/settings/SettingsNavigationText.java
@@ -41,7 +41,14 @@ public record SettingsNavigationText(
       String noMatches,
       String matchesFormat,
       String expandAllTooltip,
-      String collapseAllTooltip) {
+    String collapseAllTooltip,
+    String searching) {
+
+    public SettingsNavigationText(String filterPlaceholder, String filterTooltip, String noMatches,
+        String matchesFormat, String expandAllTooltip, String collapseAllTooltip) {
+      this(filterPlaceholder, filterTooltip, noMatches, matchesFormat, expandAllTooltip, collapseAllTooltip,
+          "Searching...");
+    }
 
     public SettingsNavigationText {
         Objects.requireNonNull(filterPlaceholder);
@@ -50,5 +57,6 @@ public record SettingsNavigationText(
         Objects.requireNonNull(matchesFormat);
         Objects.requireNonNull(expandAllTooltip);
         Objects.requireNonNull(collapseAllTooltip);
+        Objects.requireNonNull(searching);
     }
 }

--- a/megamek/src/megamek/client/ui/settings/SettingsPane.java
+++ b/megamek/src/megamek/client/ui/settings/SettingsPane.java
@@ -252,6 +252,7 @@ public class SettingsPane extends JPanel {
             return;
         }
         searchIndexInProgress = true;
+        navigationPanel.setSearchInProgress(true);
         int generation = ++searchIndexGeneration;
         List<SettingsRoute> pageRoutes = routes.stream()
               .filter(route -> pageFactories.containsKey(route.getId()))
@@ -263,6 +264,7 @@ public class SettingsPane extends JPanel {
         if (searchIndexInProgress) {
             searchIndexInProgress = false;
             searchIndexGeneration++;
+            navigationPanel.setSearchInProgress(false);
         }
     }
 
@@ -277,17 +279,19 @@ public class SettingsPane extends JPanel {
         if (index >= pageRoutes.size()) {
             searchIndexInProgress = false;
             searchIndexComplete = true;
+            navigationPanel.setSearchInProgress(false);
             navigationPanel.refreshFilter();
             return;
         }
         SettingsRoute route = pageRoutes.get(index);
         try {
             getPage(route);
-            navigationPanel.refreshFilter();
         } catch (RuntimeException exception) {
             searchIndexInProgress = false;
             searchIndexComplete = false;
             searchIndexGeneration++;
+            navigationPanel.setSearchInProgress(false);
+            navigationPanel.refreshFilter();
             LOGGER.error(exception, "Unable to index settings route " + route.getId());
             return;
         }

--- a/megamek/src/megamek/client/ui/settings/SettingsSearchHighlightLayerUI.java
+++ b/megamek/src/megamek/client/ui/settings/SettingsSearchHighlightLayerUI.java
@@ -38,6 +38,8 @@ import java.awt.Container;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.Point;
 import java.awt.Rectangle;
@@ -76,11 +78,18 @@ final class SettingsSearchHighlightLayerUI extends LayerUI<JScrollPane> {
     private static final int HIGHLIGHT_ALPHA = 160;
     private static final int OUTLINE_ALPHA = 255;
     private static final int ARC_SIZE = 4;
+    private static final int ROW_HIGHLIGHT_ALPHA = 45;
 
     private List<String> tokens = List.of();
+    private List<JComponent> helpMatchComponents = List.of();
 
     void setFilter(String normalizedFilter, JLayer<JScrollPane> layer) {
         tokens = SettingsSearchText.tokens(normalizedFilter);
+        layer.repaint();
+    }
+
+    void setHelpMatchComponents(List<JComponent> components, JLayer<JScrollPane> layer) {
+        helpMatchComponents = List.copyOf(components);
         layer.repaint();
     }
 
@@ -96,8 +105,50 @@ final class SettingsSearchHighlightLayerUI extends LayerUI<JScrollPane> {
         if (root == null) {
             return;
         }
-        paintHighlights((Graphics2D) graphics,
-              collectHighlightBounds(layer, scrollPane, graphics.getClipBounds()));
+        Graphics2D graphics2D = (Graphics2D) graphics;
+        paintHelpMatches(graphics2D, collectHelpMatchBounds(layer, scrollPane));
+        paintHighlights(graphics2D, collectHighlightBounds(layer, scrollPane, graphics.getClipBounds()));
+    }
+
+    List<Rectangle> helpMatchBounds(JLayer<JScrollPane> layer) {
+        return List.copyOf(collectHelpMatchBounds(layer, layer.getView()));
+    }
+
+    private List<Rectangle> collectHelpMatchBounds(JLayer<?> layer, JScrollPane scrollPane) {
+        JViewport viewport = scrollPane.getViewport();
+        Rectangle viewportBounds = SwingUtilities.convertRectangle(viewport,
+              new Rectangle(0, 0, viewport.getWidth(), viewport.getHeight()), layer);
+        List<Rectangle> matches = new ArrayList<>();
+        for (JComponent component : helpMatchComponents) {
+            if (!component.isVisible() || !SwingUtilities.isDescendingFrom(component, layer)) {
+                continue;
+            }
+            Rectangle bounds = matchingRowBounds(component, layer).intersection(viewportBounds);
+            if (!bounds.isEmpty() && !matches.contains(bounds)) {
+                matches.add(bounds);
+            }
+        }
+        return matches;
+    }
+
+    private static Rectangle matchingRowBounds(JComponent component, JLayer<?> layer) {
+        if (component instanceof AbstractButton) {
+            return SwingUtilities.convertRectangle(component,
+                  new Rectangle(0, 0, component.getWidth(), component.getHeight()), layer);
+        }
+        Container parent = component.getParent();
+        if (parent == null || !(parent.getLayout() instanceof GridBagLayout layout)) {
+            return SwingUtilities.convertRectangle(component,
+                  new Rectangle(0, 0, component.getWidth(), component.getHeight()), layer);
+        }
+        GridBagConstraints target = layout.getConstraints(component);
+        Rectangle rowBounds = new Rectangle(component.getBounds());
+        for (Component sibling : parent.getComponents()) {
+            if (layout.getConstraints(sibling).gridy == target.gridy) {
+                rowBounds = rowBounds.union(sibling.getBounds());
+            }
+        }
+        return SwingUtilities.convertRectangle(parent, rowBounds, layer);
     }
 
     List<Rectangle> highlightBounds(JLayer<JScrollPane> layer) {
@@ -445,10 +496,7 @@ final class SettingsSearchHighlightLayerUI extends LayerUI<JScrollPane> {
         if (highlights.isEmpty()) {
             return;
         }
-        Color baseColor = UIManager.getColor(HIGHLIGHT_COLOR_KEY);
-        if (baseColor == null) {
-            baseColor = DEFAULT_HIGHLIGHT_COLOR;
-        }
+        Color baseColor = highlightColor();
         Color fillColor = new Color(baseColor.getRed(), baseColor.getGreen(), baseColor.getBlue(), HIGHLIGHT_ALPHA);
         Color outlineColor = new Color(baseColor.getRed(), baseColor.getGreen(), baseColor.getBlue(), OUTLINE_ALPHA);
         Graphics2D copy = (Graphics2D) graphics.create();
@@ -458,6 +506,25 @@ final class SettingsSearchHighlightLayerUI extends LayerUI<JScrollPane> {
                 copy.fillRoundRect(bounds.x, bounds.y, bounds.width, bounds.height, ARC_SIZE, ARC_SIZE);
                 copy.setColor(outlineColor);
                 copy.drawRoundRect(bounds.x, bounds.y, bounds.width, bounds.height, ARC_SIZE, ARC_SIZE);
+            }
+        } finally {
+            copy.dispose();
+        }
+    }
+
+    static Color highlightColor() {
+        Color color = UIManager.getColor(HIGHLIGHT_COLOR_KEY);
+        return color == null ? DEFAULT_HIGHLIGHT_COLOR : color;
+    }
+
+    private static void paintHelpMatches(Graphics2D graphics, List<Rectangle> matches) {
+        Color color = highlightColor();
+        Color fill = new Color(color.getRed(), color.getGreen(), color.getBlue(), ROW_HIGHLIGHT_ALPHA);
+        Graphics2D copy = (Graphics2D) graphics.create();
+        try {
+            for (Rectangle bounds : matches) {
+                copy.setColor(fill);
+                copy.fillRect(bounds.x, bounds.y, bounds.width, bounds.height);
             }
         } finally {
             copy.dispose();

--- a/megamek/unittests/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialogTest.java
+++ b/megamek/unittests/megamek/client/ui/dialogs/buttonDialogs/CommonSettingsDialogTest.java
@@ -80,6 +80,7 @@ import megamek.client.ui.settings.SettingsButton;
 import megamek.client.ui.settings.SettingsCheckBox;
 import megamek.client.ui.settings.SettingsFormPanel;
 import megamek.client.ui.settings.SettingsPagePanel;
+import megamek.client.ui.util.KeyCommandBind;
 import megamek.client.ui.util.PlayerColour;
 import megamek.client.ui.util.UIUtil;
 import org.junit.jupiter.api.Test;
@@ -1340,6 +1341,14 @@ class CommonSettingsDialogTest {
         assertEquals(key.getPreferredSize().width, key.getWidth());
         assertTrue(command.getX() > 0);
         assertTrue(key.getX() + key.getWidth() < bindingsGrid.getWidth());
+    }
+
+    @Test
+    void everyKeyBindingHasLocalizedNameAndDescription() {
+        for (KeyCommandBind keyBind : KeyCommandBind.values()) {
+            assertTrue(Messages.keyExists("KeyBinds.cmdNames." + keyBind.cmd), keyBind.cmd);
+            assertTrue(Messages.keyExists("KeyBinds.cmdDesc." + keyBind.cmd), keyBind.cmd);
+        }
     }
 
     @Test

--- a/megamek/unittests/megamek/client/ui/panels/CommonSettingsPaneTest.java
+++ b/megamek/unittests/megamek/client/ui/panels/CommonSettingsPaneTest.java
@@ -42,6 +42,7 @@ import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.JCheckBox;
 import javax.swing.JLabel;
 import javax.swing.JList;
@@ -64,6 +65,7 @@ class CommonSettingsPaneTest {
 
     @Test
     void searchIndexesNestedLabelsAndTooltips() throws Exception {
+        AtomicReference<CommonSettingsPane> pane = new AtomicReference<>();
         runOnEdt(() -> {
             JPanel main = new JPanel();
             main.add(new JLabel("Display scale"));
@@ -71,25 +73,26 @@ class CommonSettingsPaneTest {
             JCheckBox mute = new JCheckBox("Mute notifications");
             mute.setToolTipText("Silence chat alerts");
             audio.add(mute);
-            CommonSettingsPane pane = pane(main, audio);
+            pane.set(pane(main, audio));
 
-            pane.setFilterText("chat alerts");
-
-            assertEquals("Audio", selectedTreeLabel(pane));
+            pane.get().setFilterText("chat alerts");
         });
+        finishSearchIndexing();
+        runOnEdt(() -> assertEquals("Audio", selectedTreeLabel(pane.get())));
     }
 
     @Test
     void searchIndexesListEntries() throws Exception {
+        AtomicReference<CommonSettingsPane> pane = new AtomicReference<>();
         runOnEdt(() -> {
             JPanel main = new JPanel();
             main.add(new JList<>(new String[] { "General option", "Experimental pathfinder" }));
-            CommonSettingsPane pane = pane(main, new JPanel());
+            pane.set(pane(main, new JPanel()));
 
-            pane.setFilterText("pathfinder");
-
-            assertEquals("Main", selectedTreeLabel(pane));
+            pane.get().setFilterText("pathfinder");
         });
+        finishSearchIndexing();
+        runOnEdt(() -> assertEquals("Main", selectedTreeLabel(pane.get())));
     }
 
     @Test
@@ -306,5 +309,10 @@ class CommonSettingsPaneTest {
             }
             throw exception;
         }
+    }
+
+    private static void finishSearchIndexing() throws Exception {
+        runOnEdt(() -> { });
+        runOnEdt(() -> { });
     }
 }

--- a/megamek/unittests/megamek/client/ui/panels/GameOptionsPaneTest.java
+++ b/megamek/unittests/megamek/client/ui/panels/GameOptionsPaneTest.java
@@ -61,6 +61,7 @@ import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.swing.JCheckBox;
@@ -179,27 +180,30 @@ class GameOptionsPaneTest {
 
     @Test
     void visibilityRefreshKeepsSectionSearchAndReplacesVisibleOptionIndex() throws Exception {
+        AtomicBoolean showBridgeRepair = new AtomicBoolean(false);
+        AtomicReference<GameOptionsPane> pane = new AtomicReference<>();
         runOnEdt(() -> {
             GameOptions options = new GameOptions();
             DialogOptionComponentYPanel bridgeBuilding = component(
                   options.getOption(OptionsConstants.ADVANCED_BRIDGE_BUILDING_ENGINEERS));
             DialogOptionComponentYPanel bridgeRepair = component(
                   options.getOption(OptionsConstants.UNOFFICIAL_BRIDGE_REPAIR_ENGINEERS));
-            AtomicBoolean showBridgeRepair = new AtomicBoolean(false);
-            GameOptionsPane pane = pane("advancedRules", List.of(bridgeBuilding, bridgeRepair),
+            pane.set(pane("advancedRules", List.of(bridgeBuilding, bridgeRepair),
                   option -> !option.getName().equals(OptionsConstants.UNOFFICIAL_BRIDGE_REPAIR_ENGINEERS)
-                        || showBridgeRepair.get());
-            JTree tree = findComponent(pane, JTree.class);
+                        || showBridgeRepair.get()));
 
-            pane.setFilterText(OptionsConstants.UNOFFICIAL_BRIDGE_REPAIR_ENGINEERS);
+            pane.get().setFilterText(OptionsConstants.UNOFFICIAL_BRIDGE_REPAIR_ENGINEERS);
+        });
+        runOnEdt(() -> {
+            JTree tree = findComponent(pane.get(), JTree.class);
             assertTreePathDoesNotExist(tree, "Rules", "Terrain and Environment");
 
-            pane.setFilterText("Battlefield Engineering");
+            pane.get().setFilterText("Battlefield Engineering");
             assertTreePathExists(tree, "Rules", "Terrain and Environment");
 
             showBridgeRepair.set(true);
-            pane.refreshVisibility();
-            pane.setFilterText(OptionsConstants.UNOFFICIAL_BRIDGE_REPAIR_ENGINEERS);
+            pane.get().refreshVisibility();
+            pane.get().setFilterText(OptionsConstants.UNOFFICIAL_BRIDGE_REPAIR_ENGINEERS);
             assertTreePathExists(tree, "Rules", "Terrain and Environment");
         });
     }

--- a/megamek/unittests/megamek/client/ui/settings/SettingsContentHostTest.java
+++ b/megamek/unittests/megamek/client/ui/settings/SettingsContentHostTest.java
@@ -43,6 +43,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.FocusEvent;
 import java.awt.event.FocusListener;
@@ -50,6 +52,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.util.ListResourceBundle;
 import javax.swing.JButton;
+import javax.swing.JCheckBox;
 import javax.swing.JEditorPane;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -219,6 +222,71 @@ class SettingsContentHostTest {
 
         assertFalse(host.getSearchHighlightBounds().isEmpty());
         assertEquals(originalText, label.getText());
+    }
+
+    @Test
+    void searchFilterRevealsTooltipOnlyMatchInOptionDetails() {
+        JPanel row = new JPanel(new GridBagLayout());
+        JLabel label = new JLabel("Get Up");
+        label.setToolTipText("Attempt to stand up from Prone position");
+        JTextField control = new JTextField("U");
+        GridBagConstraints labelLayout = new GridBagConstraints();
+        labelLayout.gridx = 0;
+        labelLayout.gridy = 0;
+        row.add(label, labelLayout);
+        GridBagConstraints controlLayout = new GridBagConstraints();
+        controlLayout.gridx = 1;
+        controlLayout.gridy = 0;
+        row.add(control, controlLayout);
+        JLabel secondLabel = new JLabel("Stand");
+        secondLabel.setToolTipText("Temporarily stand the unit upright");
+        GridBagConstraints secondLabelLayout = new GridBagConstraints();
+        secondLabelLayout.gridx = 0;
+        secondLabelLayout.gridy = 1;
+        row.add(secondLabel, secondLabelLayout);
+        SettingsContentHost host = new SettingsContentHost(row, true);
+        host.setSize(320, 240);
+        layoutTree(host);
+
+        host.setSearchFilter(SettingsRoute.normalizeSearchText("temp"));
+
+        JEditorPane helpPane = findComponent(host, "settingsHelpText", JEditorPane.class);
+        assertTrue(helpPane.getText().contains("Attempt to stand up from Prone position"), helpPane.getText());
+        SettingsHelpPanel helpPanel = findComponent(host, "settingsHelpPanel", SettingsHelpPanel.class);
+        assertEquals(1, helpPanel.getSearchHighlightCount());
+        assertEquals(2, host.getHelpMatchBounds().size());
+          assertTrue(host.getHelpMatchBounds().stream()
+              .anyMatch(bounds -> bounds.width >= label.getWidth() + control.getWidth()));
+
+        host.setSearchFilter("");
+
+        assertEquals(0, helpPanel.getSearchHighlightCount());
+        assertTrue(host.getHelpMatchBounds().isEmpty());
+    }
+
+    @Test
+    void helpMatchMarksOnlyMatchingCheckboxInSharedGridRow() {
+        JPanel row = new JPanel(new GridBagLayout());
+        JCheckBox first = new JCheckBox("First option");
+        first.setToolTipText("Unrelated details");
+        JCheckBox second = new JCheckBox("Second option");
+        second.setToolTipText("Matching needle details");
+        GridBagConstraints firstLayout = new GridBagConstraints();
+        firstLayout.gridx = 0;
+        firstLayout.gridy = 0;
+        row.add(first, firstLayout);
+        GridBagConstraints secondLayout = new GridBagConstraints();
+        secondLayout.gridx = 1;
+        secondLayout.gridy = 0;
+        row.add(second, secondLayout);
+        SettingsContentHost host = new SettingsContentHost(row, true);
+        host.setSize(480, 240);
+        layoutTree(host);
+
+        host.setSearchFilter(SettingsRoute.normalizeSearchText("needle"));
+
+        assertEquals(1, host.getHelpMatchBounds().size());
+        assertEquals(second.getWidth(), host.getHelpMatchBounds().getFirst().width);
     }
 
     @Test

--- a/megamek/unittests/megamek/client/ui/settings/SettingsContentHostTest.java
+++ b/megamek/unittests/megamek/client/ui/settings/SettingsContentHostTest.java
@@ -255,13 +255,26 @@ class SettingsContentHostTest {
         SettingsHelpPanel helpPanel = findComponent(host, "settingsHelpPanel", SettingsHelpPanel.class);
         assertEquals(1, helpPanel.getSearchHighlightCount());
         assertEquals(2, host.getHelpMatchBounds().size());
-          assertTrue(host.getHelpMatchBounds().stream()
+                assertTrue(host.getHelpMatchBounds().stream()
               .anyMatch(bounds -> bounds.width >= label.getWidth() + control.getWidth()));
 
         host.setSearchFilter("");
 
         assertEquals(0, helpPanel.getSearchHighlightCount());
         assertTrue(host.getHelpMatchBounds().isEmpty());
+    }
+
+    @Test
+    void blankHelpTextClearsSearchHighlights() {
+        SettingsHelpPanel helpPanel = new SettingsHelpPanel();
+        helpPanel.setSearchFilter("stand");
+        helpPanel.setHelpText("Attempt to stand up");
+
+        assertEquals(1, helpPanel.getSearchHighlightCount());
+
+        helpPanel.setHelpText("");
+
+        assertEquals(0, helpPanel.getSearchHighlightCount());
     }
 
     @Test

--- a/megamek/unittests/megamek/client/ui/settings/SettingsPaneTest.java
+++ b/megamek/unittests/megamek/client/ui/settings/SettingsPaneTest.java
@@ -49,6 +49,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JTree;
 import javax.swing.SwingUtilities;
 
 import org.junit.jupiter.api.Test;
@@ -246,7 +247,7 @@ class SettingsPaneTest {
     }
 
     @Test
-    void searchIndexRefreshesResultsAfterEachPage() throws Exception {
+    void searchIndexPublishesResultsAtomically() throws Exception {
         AtomicInteger secondBuilds = new AtomicInteger();
         AtomicReference<SettingsPane> pane = new AtomicReference<>();
         runOnEdt(() -> {
@@ -259,13 +260,27 @@ class SettingsPaneTest {
                       return page("Needle section", null);
                   }), NAVIGATION_TEXT));
             pane.get().setFilterText("needle");
+
+            JLabel status = findComponent(pane.get(), "lblSettingsFilterStatus", JLabel.class);
+            JLabel searching = findComponent(pane.get(), "lblSettingsSearching", JLabel.class);
+            JTree tree = findComponent(pane.get(), "settingsNavigationTree", JTree.class);
+            assertFalse(status.isVisible());
+            assertEquals("Searching...", searching.getText());
+            assertTrue(searching.isVisible());
+            assertFalse(tree.isEnabled());
+            assertEquals(2, tree.getRowCount());
         });
         finishSearchIndexing();
 
         runOnEdt(() -> {
             JLabel status = findComponent(pane.get(), "lblSettingsFilterStatus", JLabel.class);
+            JLabel searching = findComponent(pane.get(), "lblSettingsSearching", JLabel.class);
+            JTree tree = findComponent(pane.get(), "settingsNavigationTree", JTree.class);
             assertEquals(1, secondBuilds.get());
             assertEquals("1 matches", status.getText());
+            assertFalse(searching.isVisible());
+            assertTrue(tree.isEnabled());
+            assertEquals(1, tree.getRowCount());
         });
     }
 


### PR DESCRIPTION
## What this changes

Settings searches now build their lazy index atomically, showing a centered Searching state instead of allowing result rows to move under the pointer. Matches found only in Option Details identify the relevant option, reveal and highlight the matching details text, and mark only the matching option in shared checkbox rows.

This also adds the missing Show Objects key-bind localization.

## Testing

- `./gradlew.bat :megamek:test --tests megamek.client.ui.settings.SettingsContentHostTest --tests megamek.client.ui.settings.SettingsSearchHighlightLayerUITest`
- `./gradlew.bat :megamek:test --tests megamek.client.ui.settings.SettingsPaneTest --tests megamek.client.ui.panels.CommonSettingsPaneTest`
- `./gradlew.bat :megamek:test --tests megamek.client.ui.panels.GameOptionsPaneTest.visibilityRefreshKeepsSectionSearchAndReplacesVisibleOptionIndex`
- Manually exercised Client Settings and MekHQ Campaign Options search behavior.

## What is not proven yet

The complete local suite ran 16,058 tests with 16,053 passing and 8 skipped. Its only failures were five `FormationNamingConventionTest` checks caused by the sibling `mm-data` checkout using formation XML newer than this MegaMek revision's schema; the formation test class reproduces those failures independently of this settings patch.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result