### PR TITLE
Fix #8838: Targeting computers offered aimed shots against ProtoMeks

### DIFF
--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/AimedShotHandler.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/AimedShotHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2016-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -53,7 +53,6 @@ import megamek.common.equipment.WeaponMounted;
 import megamek.common.units.Entity;
 import megamek.common.units.LargeSupportTank;
 import megamek.common.units.Mek;
-import megamek.common.units.ProtoMek;
 import megamek.common.units.SuperHeavyTank;
 import megamek.common.units.Tank;
 
@@ -126,8 +125,6 @@ public class AimedShotHandler implements ActionListener, ItemListener {
                 if (side == ToHitData.SIDE_FRONT) {
                     aimingAt = Tank.LOC_FRONT;
                 }
-            } else if (this.firingDisplay.getTarget() instanceof ProtoMek) {
-                aimingAt = ProtoMek.LOC_TORSO;
             } else if (this.firingDisplay.getTarget() instanceof BattleArmor) {
                 aimingAt = BattleArmor.LOC_TROOPER_1;
             } else {
@@ -148,7 +145,7 @@ public class AimedShotHandler implements ActionListener, ItemListener {
         }
     }
 
-    private boolean[] createEnabledMask(int length) {
+    boolean[] createEnabledMask(int length) {
         boolean[] mask = new boolean[length];
 
         Arrays.fill(mask, true);
@@ -255,13 +252,6 @@ public class AimedShotHandler implements ActionListener, ItemListener {
             }
         }
 
-        // remove main gun on protos that don't have one
-        if (this.firingDisplay.getTarget() instanceof ProtoMek) {
-            if (!((ProtoMek) this.firingDisplay.getTarget()).hasMainGun()) {
-                mask[ProtoMek.LOC_MAIN_GUN] = false;
-            }
-        }
-
         // remove squad location on BAs
         // also remove dead troopers
         if (this.firingDisplay.getTarget() instanceof BattleArmor) {
@@ -305,8 +295,8 @@ public class AimedShotHandler implements ActionListener, ItemListener {
             }
         }
 
-        if (aimingMode.isTargetingComputer()) {
-            // Can't target head with targeting computer.
+        if (aimingMode.isTargetingComputer() && (firingDisplay.getTarget() instanceof Mek)) {
+            // Can't target head with targeting computer (TW p.143).
             mask[Mek.LOC_HEAD] = false;
         }
         return mask;
@@ -376,12 +366,12 @@ public class AimedShotHandler implements ActionListener, ItemListener {
             return;
         }
 
-        // TC against a mek
+        // TC against a mek, tank or battle armor. Not against a ProtoMek: they are too small for a targeting
+        // computer to pick a hit location, though the TC's usual -1 still applies (TW p.185).
         allowAim = ((this.firingDisplay.getTarget() != null) && (attacker != null)
               && attacker.hasAimModeTargComp() && ((this.firingDisplay.getTarget() instanceof Mek)
               || (this.firingDisplay.getTarget() instanceof Tank)
-              || (this.firingDisplay.getTarget() instanceof BattleArmor)
-              || (this.firingDisplay.getTarget() instanceof ProtoMek)));
+              || (this.firingDisplay.getTarget() instanceof BattleArmor)));
         if (allowAim) {
             aimingMode = AimingMode.TARGETING_COMPUTER;
             return;

--- a/megamek/unittests/megamek/client/ui/panels/phaseDisplay/AimedShotHandlerTest.java
+++ b/megamek/unittests/megamek/client/ui/panels/phaseDisplay/AimedShotHandlerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.ui.panels.phaseDisplay;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import megamek.common.Player;
+import megamek.common.board.Coords;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.game.Game;
+import megamek.common.options.OptionsConstants;
+import megamek.common.units.BipedMek;
+import megamek.common.units.Crew;
+import megamek.common.units.CrewType;
+import megamek.common.units.Entity;
+import megamek.common.units.Mek;
+import megamek.common.units.ProtoMek;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests which targets a targeting computer may aim at, and what the aimed-shot location mask allows.
+ * <p>
+ * A targeting computer cannot pick a hit location on a ProtoMek at all - they are too small (TW p.185) - and cannot
+ * aim at a Mek's head (TW p.143).
+ */
+@DisplayName("AimedShotHandler targeting-computer aiming")
+class AimedShotHandlerTest {
+
+    private Game game;
+    private FiringDisplay firingDisplay;
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void setUp() {
+        game = new Game();
+        game.addPlayer(0, new Player(0, "Test Player"));
+        firingDisplay = mock(FiringDisplay.class);
+    }
+
+    /** An attacker with aimed-shot capability from TCP + VDNI (IO p.81), so no targeting computer has to be mounted. */
+    private BipedMek createAimingAttacker() {
+        BipedMek mek = createMek(1, "Test Attacker", new Coords(0, 0), 3);
+        mek.getCrew().getOptions().getOption(OptionsConstants.MD_TRIPLE_CORE_PROCESSOR).setValue(true);
+        mek.getCrew().getOptions().getOption(OptionsConstants.MD_VDNI).setValue(true);
+        return mek;
+    }
+
+    private BipedMek createMek(int id, String chassis, Coords position, int facing) {
+        BipedMek mek = new BipedMek();
+        mek.setGame(game);
+        mek.setId(id);
+        mek.setChassis(chassis);
+        mek.setModel("Standard");
+        mek.setWeight(50);
+        mek.setCrew(new Crew(CrewType.SINGLE));
+        mek.setOwner(game.getPlayer(0));
+        mek.autoSetInternal();
+        mek.setPosition(position);
+        mek.setFacing(facing);
+        return mek;
+    }
+
+    private ProtoMek createProtoMekTarget() {
+        ProtoMek protoMek = new ProtoMek();
+        protoMek.setGame(game);
+        protoMek.setId(2);
+        protoMek.setChassis("Test ProtoMek");
+        protoMek.setModel("Standard");
+        protoMek.setWeight(5);
+        protoMek.setCrew(new Crew(CrewType.SINGLE));
+        protoMek.setOwner(game.getPlayer(0));
+        protoMek.autoSetInternal();
+        protoMek.setPosition(new Coords(0, 2));
+        protoMek.setFacing(0);
+        return protoMek;
+    }
+
+    private AimedShotHandler handlerAimingAt(Entity target) {
+        when(firingDisplay.currentEntity()).thenReturn(createAimingAttacker());
+        when(firingDisplay.getTarget()).thenReturn(target);
+        AimedShotHandler handler = new AimedShotHandler(firingDisplay);
+        handler.setAimingMode();
+        return handler;
+    }
+
+    @Test
+    @DisplayName("A targeting computer cannot aim at a ProtoMek at all")
+    void targetingComputerCannotAimAtProtoMek() {
+        AimedShotHandler handler = handlerAimingAt(createProtoMekTarget());
+
+        assertTrue(handler.getAimingMode().isNone(),
+              "a ProtoMek is too small for a targeting computer to pick a hit location (TW p.185)");
+    }
+
+    @Test
+    @DisplayName("A targeting computer can aim at a Mek, but not at its head")
+    void targetingComputerAimsAtMekButNotHead() {
+        BipedMek target = createMek(2, "Test Target", new Coords(0, 2), 0);
+        AimedShotHandler handler = handlerAimingAt(target);
+
+        assertTrue(handler.getAimingMode().isTargetingComputer(), "the attacker should be aiming with a TC");
+        boolean[] mask = handler.createEnabledMask(target.getLocationNames().length);
+        assertFalse(mask[Mek.LOC_HEAD], "the Mek head should be disabled under a targeting computer (TW p.143)");
+        assertTrue(mask[Mek.LOC_CENTER_TORSO], "the Mek center torso should stay selectable");
+    }
+}


### PR DESCRIPTION
## What this changes

A targeting computer no longer offers an aimed shot against a ProtoMek. ProtoMeks are too small for a TC to pick a hit location, though the TC's usual -1 still applies (TW p.185). Before this, the aimed-shot dialog opened against a ProtoMek with the head still selectable, because the head restriction cleared the Mek head index (0), which on a ProtoMek is the body.

Fixes #8838

## Testing

- New `AimedShotHandlerTest`: a TC attacker against a ProtoMek gets no aiming mode; against a Mek it still aims with the head disabled. The ProtoMek case fails on `main` and passes with the fix.
- In game: a TC attacker in aimed mode against a ProtoMek got only the -1 to-hit and no aimed-shot dialog.
- `checkstyleMain`, `checkstyleTest` and `javadoc` clean.

## What is not proven yet

Nothing. Princess is unaffected - it only aims at Meks. The to-hit calculator does not validate aiming rules, so this stays a client-side gate as it was before.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
