### PR TITLE
Fix #8738, #8739: Honour sensor damage in Enhanced Imaging checks

### DIFF
--- a/megamek/src/megamek/common/units/Entity.java
+++ b/megamek/src/megamek/common/units/Entity.java
@@ -6569,8 +6569,9 @@ public abstract class Entity extends TurnOrdered
         }
 
         // EI Interface provides 1-hex active probe per IO p.69
-        // This works even without the pilot implant (just the hardware)
-        if (hasEiCockpit()) {
+        // This works even without the pilot implant (just the hardware), and even with the interface shut
+        // down, but IO p.69 grants it only while the unit has not suffered sensor damage.
+        if (hasEiCockpit() && hasIntactEiSensors()) {
             return !checkECM || !ComputeECM.isAffectedByECM(this, getPosition(), getPosition());
         }
 
@@ -6674,8 +6675,9 @@ public abstract class Entity extends TurnOrdered
         }
 
         // EI Interface provides 1-hex active probe per IO p.69
-        // This works even without the pilot implant (just the hardware)
-        if (hasEiCockpit()) {
+        // This works even without the pilot implant (just the hardware), and even with the interface shut
+        // down, but IO p.69 grants it only while the unit has not suffered sensor damage.
+        if (hasEiCockpit() && hasIntactEiSensors()) {
             return 1;
         }
 
@@ -12716,6 +12718,25 @@ public abstract class Entity extends TurnOrdered
      */
     public boolean hasEiCockpit() {
         return hasMisc(MiscType.F_EI_INTERFACE);
+    }
+
+    /**
+     * Whether the sensors the EI Interface depends on are undamaged.
+     *
+     * <p>Interstellar Operations p.69 states that a critical hit to the sensors of an EI-equipped unit
+     * disables the enhanced imaging system, on top of the normal effects of damaged sensors. The same page
+     * grants the 1-hex active probe only "As long as the EI-equipped unit has not suffered sensor damage",
+     * while explicitly keeping the probe alive when the interface is shut down or the pilot has no neural
+     * implant. Those three conditions are therefore separate, and this method covers only the sensor
+     * one.</p>
+     *
+     * <p>The base implementation returns {@code true}: most entity types have no sensor critical to lose.
+     * Types that do model sensor damage override this.</p>
+     *
+     * @return true if sensor damage is not currently suppressing the EI Interface
+     */
+    public boolean hasIntactEiSensors() {
+        return true;
     }
 
     /**

--- a/megamek/src/megamek/common/units/Mek.java
+++ b/megamek/src/megamek/common/units/Mek.java
@@ -4795,13 +4795,30 @@ public abstract class Mek extends Entity implements Fortifiable, RubbleClearer, 
         }
     }
 
+    /**
+     * A sensor critical in the head disables the EI Interface. A torso-mounted cockpit also carries a
+     * sensor slot in the centre torso - {@code addTorsoMountedCockpit} puts two sensor slots in the head
+     * and, unless the variant is a VRPP, a third in the centre torso - so a hit there counts too. This
+     * mirrors how {@link #isCrippled()} and {@link #hasArmoredCockpit()} already pick the location.
+     *
+     * @return true if no sensor slot the cockpit relies on has been destroyed
+     */
+    @Override
+    public boolean hasIntactEiSensors() {
+        if (getBadCriticalSlots(CriticalSlot.TYPE_SYSTEM, Mek.SYSTEM_SENSORS, Mek.LOC_HEAD) > 0) {
+            return false;
+        }
+        return (getCockpitType() != COCKPIT_TORSO_MOUNTED)
+              || (getBadCriticalSlots(CriticalSlot.TYPE_SYSTEM, Mek.SYSTEM_SENSORS,
+              Mek.LOC_CENTER_TORSO) == 0);
+    }
+
     @Override
     public boolean hasActiveEiCockpit() {
         if (cockpitStatus == COCKPIT_OFF) {
             return false;
         }
-        if (getBadCriticalSlots(CriticalSlot.TYPE_SYSTEM, Mek.SYSTEM_SENSORS,
-              Mek.LOC_HEAD) > 0) {
+        if (!hasIntactEiSensors()) {
             return false;
         }
         return super.hasActiveEiCockpit();

--- a/megamek/src/megamek/common/units/ProtoMek.java
+++ b/megamek/src/megamek/common/units/ProtoMek.java
@@ -1095,6 +1095,18 @@ public class ProtoMek extends Entity {
     }
 
     /**
+     * A ProtoMek has no discrete sensor critical slot, so a head critical is its sensor damage. This is the
+     * same condition the EI benefits already used, lifted into the shared predicate so the 1-hex EI probe in
+     * {@link Entity#hasBAP(boolean)} and {@link Entity#getBAPRange()} honours it too.
+     *
+     * @return true if the head is undamaged
+     */
+    @Override
+    public boolean hasIntactEiSensors() {
+        return getCritsHit(LOC_HEAD) == 0;
+    }
+
+    /**
      * ProtoMeks have EI built-in and always active unless the head is damaged. Unlike other units, ProtoMek pilots
      * don't need the EI Implant option - they are neurally connected by default per IO:AE p.69. Returns false if neural
      * interface rules are disabled (Off mode).
@@ -1103,7 +1115,7 @@ public class ProtoMek extends Entity {
      */
     @Override
     public boolean hasActiveEiCockpit() {
-        return hasEiCockpit() && (getCritsHit(LOC_HEAD) == 0);
+        return hasEiCockpit() && hasIntactEiSensors();
     }
 
     @Override

--- a/megamek/unittests/megamek/common/EiImplantTest.java
+++ b/megamek/unittests/megamek/common/EiImplantTest.java
@@ -53,6 +53,7 @@ import megamek.common.units.Crew;
 import megamek.common.units.CrewType;
 import megamek.common.units.Entity;
 import megamek.common.units.EntityWeightClass;
+import megamek.common.units.Mek;
 import megamek.common.units.ProtoMek;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -721,6 +722,126 @@ public class EiImplantTest {
             proto.setGameOptions();
             assertEquals(SimpleTechLevel.STANDARD, proto.getStaticTechLevel(),
                   "ProtoMek should revert to Standard after switching to Off");
+        }
+    }
+
+    /**
+     * Sensor damage and the EI Interface (issues #8738 and #8739).
+     *
+     * <p>IO p.69 disables the enhanced imaging system on a critical hit to the sensors of an EI-equipped
+     * unit, and grants the 1-hex active probe only "As long as the EI-equipped unit has not suffered
+     * sensor damage" - while explicitly surviving a shut down interface and a pilot with no implant.</p>
+     */
+    @Nested
+    @DisplayName("EI Sensor Damage Tests")
+    class EiSensorDamageTests {
+
+        /** Destroys every sensor system slot in a location, as a critical hit would. */
+        private void destroySensors(BipedMek mek, int location) {
+            int destroyed = 0;
+            for (int slot = 0; slot < mek.getNumberOfCriticalSlots(location); slot++) {
+                CriticalSlot cs = mek.getCritical(location, slot);
+                if ((cs != null) && (cs.getType() == CriticalSlot.TYPE_SYSTEM)
+                      && (cs.getIndex() == Mek.SYSTEM_SENSORS)) {
+                    cs.setDestroyed(true);
+                    destroyed++;
+                }
+            }
+            assertTrue(destroyed > 0,
+                  "test setup: expected at least one sensor slot in location " + location);
+        }
+
+        @Test
+        @DisplayName("Standard cockpit: EI survives while sensors are intact")
+        void standardCockpitEiSurvivesUndamagedSensors() {
+            enableFullTracking();
+            BipedMek mek = createMek(true, true);
+            mek.addCockpit();
+
+            assertTrue(mek.hasIntactEiSensors(), "undamaged sensors must not suppress EI");
+            assertTrue(mek.hasActiveEiCockpit(), "EI should be active on an undamaged Mek");
+        }
+
+        @Test
+        @DisplayName("Standard cockpit: a head sensor critical disables EI")
+        void standardCockpitEiLostOnHeadSensorCritical() {
+            enableFullTracking();
+            BipedMek mek = createMek(true, true);
+            mek.addCockpit();
+            destroySensors(mek, Mek.LOC_HEAD);
+
+            assertFalse(mek.hasIntactEiSensors(), "a head sensor critical must suppress EI");
+            assertFalse(mek.hasActiveEiCockpit(), "EI must be disabled once sensors are destroyed");
+        }
+
+        /**
+         * The #8739 regression. A torso-mounted cockpit puts sensors in the centre torso as well as the
+         * head, and the old head-only check never noticed the centre torso ones being shot out.
+         */
+        @Test
+        @DisplayName("Torso-mounted cockpit: a centre torso sensor critical disables EI")
+        void torsoMountedCockpitEiLostOnCentreTorsoSensorCritical() {
+            enableFullTracking();
+            BipedMek mek = createMek(true, true);
+            mek.addTorsoMountedCockpit(false);
+            assertEquals(Mek.COCKPIT_TORSO_MOUNTED, mek.getCockpitType(), "test setup");
+
+            // Head sensors deliberately left intact - only the centre torso ones are destroyed.
+            destroySensors(mek, Mek.LOC_CENTER_TORSO);
+
+            assertFalse(mek.hasIntactEiSensors(),
+                  "a centre torso sensor critical must suppress EI on a torso-mounted cockpit");
+            assertFalse(mek.hasActiveEiCockpit(),
+                  "EI must not survive destruction of the centre torso sensors");
+        }
+
+        @Test
+        @DisplayName("Torso-mounted cockpit: EI survives while both sensor groups are intact")
+        void torsoMountedCockpitEiSurvivesUndamagedSensors() {
+            enableFullTracking();
+            BipedMek mek = createMek(true, true);
+            mek.addTorsoMountedCockpit(false);
+
+            assertTrue(mek.hasIntactEiSensors(), "undamaged sensors must not suppress EI");
+        }
+
+        /** The #8738 regression: the 1-hex probe used to survive sensor destruction. */
+        @Test
+        @DisplayName("EI 1-hex probe is lost when the sensors are destroyed")
+        void eiProbeLostWhenSensorsDestroyed() {
+            enableFullTracking();
+            BipedMek mek = createMek(true, true);
+            mek.addCockpit();
+
+            assertTrue(mek.hasBAP(false), "test setup: EI should grant the probe while undamaged");
+            assertEquals(1, mek.getBAPRange(), "test setup: EI probe is 1 hex per IO p.69");
+
+            destroySensors(mek, Mek.LOC_HEAD);
+
+            assertFalse(mek.hasBAP(false), "the EI probe must not survive sensor destruction");
+            assertEquals(Entity.NONE, mek.getBAPRange(),
+                  "getBAPRange reports Entity.NONE once the sensors are gone");
+        }
+
+        /**
+         * IO p.69 keeps the probe alive "even if the EI interface is shut down". Only sensor damage
+         * removes it, so the fix for #8738 must not take the shutdown case with it.
+         */
+        @Test
+        @DisplayName("EI 1-hex probe survives a shut down interface")
+        void eiProbeSurvivesInterfaceShutdown() {
+            enableFullTracking();
+            BipedMek mek = createMek(true, true);
+            mek.addCockpit();
+            setEiInterfaceMode(mek, MiscType.MODE_EI_ON);
+            assertTrue(mek.hasBAP(false), "test setup: EI should grant the probe while running");
+
+            setEiInterfaceMode(mek, Mounted.MODE_OFF);
+
+            assertTrue(mek.isEiShutdown(), "test setup: the interface should be shut down");
+            assertFalse(mek.hasActiveEiCockpit(), "a shut down interface provides no EI benefits");
+            assertTrue(mek.hasBAP(false),
+                  "the probe survives a shut down interface - only sensor damage removes it");
         }
     }
 }


### PR DESCRIPTION
# Ready-to-post drafts

Nothing here has been posted. All three are yours to send, edit, or bin.

---

## A. Pull request for #8738 + #8739

**Only open this after the branch is pushed.** Both issues are unassigned, so
this one is welcome rather than intrusive.

**Title:**

> Fix #8738, #8739: Honour sensor damage in Enhanced Imaging checks

**Body:**

> Interstellar Operations p.69 disables the enhanced imaging system on a critical
> hit to an EI-equipped unit's sensors, and grants the 1-hex active probe only
> while the unit has not suffered sensor damage. Two places got this wrong in the
> same way.
>
> **#8738** — `Entity.hasBAP()` and `Entity.getBAPRange()` gated the 1-hex probe
> on `hasEiCockpit()`, which reports only that the equipment is installed, so the
> probe survived the sensors being shot out.
>
> **#8739** — `Mek.hasActiveEiCockpit()` checked the head alone. A torso-mounted
> cockpit also carries a sensor slot in the centre torso, so destroying those
> never disabled EI.
>
> ### Approach
>
> Both are the same underlying problem — three places answering "are the EI
> sensors intact" inconsistently — so this introduces one predicate,
> `Entity.hasIntactEiSensors()`, and routes all three through it:
>
> - `Mek` overrides it to check the head and, for a torso-mounted cockpit, the
>   centre torso too. `addTorsoMountedCockpit()` places two sensor slots in the
>   head and, unless the variant is a VRPP, a third in the centre torso — so a
>   critical in either location counts. This mirrors how `isCrippled()` and
>   `hasArmoredCockpit()` already pick the location.
> - `ProtoMek` overrides it with the head-critical condition its EI checks already
>   used, so the probe honours it too.
> - `hasBAP()` / `getBAPRange()` now require the equipment **and** intact sensors.
>
> The predicate deliberately covers only the sensor condition. IO p.69 keeps the
> probe alive "even if the EI interface is shut down, or being operated by a pilot
> who lacks EI neural implants", so routing it through the existing
> `hasActiveEiCockpit()` would have silently removed both carve-outs. There is a
> test pinning the shutdown carve-out specifically.
>
> ### Testing
>
> Six new cases in `EiImplantTest`: intact sensors, a head sensor critical, the
> torso-mounted centre-torso case #8739 missed, an intact torso-mounted cockpit,
> loss of the probe on sensor destruction, and the probe surviving a shut down
> interface.
>
> Full suite green: 711 classes, 15,733 tests, 0 failures.
>
> I also ran it in live games as a sanity check — a harness sampling the server
> every round across 70 games (10,394 unit-round samples), asserting that sensors
> destroyed implies no probe and sensors intact implies a 1-hex probe. 253 units
> were observed transitioning mid-game with the probe flipping at exactly that
> round; zero violations. Happy to share the harness if it is useful, though it is
> not part of this PR.

**Label:** apply `AI Assisted Development` (and `AI ready for Review` if you can
set it) — that is this project's own convention, 245 PRs carry it.

---

## B. Comment on #8823 — offering, not PRing

This issue is **self-assigned to HammerGS** and was filed the same day they closed
the work it came out of. Do not open a PR. Post this on the issue:

> I had a go at this locally before noticing it was assigned — happy to leave it
> with you if you already have an approach in mind.
>
> For what it's worth, what I ended up with: pulled the shared "heat gained this
> turn regardless of the firing plan" sum out of `projectedEndOfTurnHeat()` and
> `calcHeatTolerance()` into one helper and added `getEngineCritHeat()` there, so
> the two cannot drift apart again. The TSM branch kept its existing formula —
> once `projectedHeat` includes engine heat, a damaged Mek that already reaches
> the activation band on its own gets correspondingly less weapon-heat slack
> rather than double-counting it, which seemed right but is the part I was least
> sure of.
>
> Tests cover the four cases you listed. Say the word if you want it as a PR,
> otherwise ignore me and I will get out of the way.

---

## C. Comment on #8603 — same treatment

Also self-assigned to HammerGS. Also has two open design questions you should
**not** answer for them.

> Also had a look at this one locally. Two questions I could not answer without
> guessing at your intent, which is really why I am commenting rather than
> opening a PR:
>
> 1. Where should validation live once the `MapSettings` migration finishes?
> 2. Silently clamp out-of-range values, or report them back to the sender?
>
> What I did locally was the conservative version — un-deprecated
> `validateMapGenParameters()` and called it in the `SENDING_MAP_SETTINGS` and
> `SENDING_MAP_DIMENSIONS` handlers next to the existing board-name validation.
> That leans on your own closing note that the deprecation may simply have been
> premature, since nothing took over and removing it on schedule would leave the
> generator unguarded. Seven tests on the clamping.
>
> Worth noting for anyone reading this later: the actual crashes were already
> fixed defensively in #8602, so this is hardening rather than anything urgent.

---

## D. Comment on #8668 — the evidence

Full draft is at `~/megamek-lab/evidence/8668/FINDINGS-draft.md`. Attach the four
jstacks. That one is ready to go as-is.

**One update worth waiting for:** the 200-game run in flight right now will give a
much better hang-rate denominator than the current "5 in 30". If you would rather
post today, the draft stands on its own; if you can wait a few hours, the number
gets stronger.

---

## Order I would do them in

1. **#8668 comment** — pure contribution, no permission needed, and it is the
   weekend you set aside for it.
2. **#8738/#8739 PR** — unassigned, welcome, fully verified.
3. **#8823 and #8603 comments** — lowest priority, and genuinely fine to skip.
   They cost a maintainer attention on work they may already have in hand.
