### PR TITLE
Fix #8859: Lobby unit choosers opened on the host for any connecting player

### DIFF
--- a/megamek/src/megamek/client/ui/clientGUI/UnitRecipients.java
+++ b/megamek/src/megamek/client/ui/clientGUI/UnitRecipients.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Set;
 
 import megamek.common.Player;
+import megamek.common.annotations.Nullable;
 import megamek.logging.MMLogger;
 
 /**
@@ -97,18 +98,65 @@ public final class UnitRecipients {
      */
     public static List<Player> availableTo(Player localPlayer, Collection<Player> allPlayers,
           Set<String> localBotNames, boolean isInGame) {
+        return availableTo(localPlayer, allPlayers, localBotNames, isInGame, null);
+    }
+
+    /**
+     * The players the local player may add units to, with one player asked for by name.
+     *
+     * <p>A gamemaster tool that has just put somebody on a team and pressed a reinforcement button has said plainly
+     * who the units are for, and the team change does not reach the board until the end of the round - so the rule
+     * that hides players who cannot deploy yet would otherwise hide the very person being set up. The player asked
+     * for is therefore offered even when they are on no team.</p>
+     *
+     * <p>Being asked for does not get anyone past the ownership rule, though. The lobby hands over whichever player
+     * happens to be highlighted in its player table, and for somebody who has just connected that is the host: an
+     * ordinary player asking for the host is refused, and the chooser stays on the person using it.</p>
+     *
+     * @param localPlayer         The player at this screen
+     * @param allPlayers          Every player in the game
+     * @param localBotNames       The names of the bots being run from this machine
+     * @param isInGame            Whether the game is under way, rather than still in the lobby
+     * @param explicitlyRequested The player a caller asked for by name, or {@code null} when nobody was asked for
+     *
+     * @return the players that may be given units, local player first
+     */
+    public static List<Player> availableTo(Player localPlayer, Collection<Player> allPlayers,
+          Set<String> localBotNames, boolean isInGame, @Nullable Player explicitlyRequested) {
         List<Player> recipients = new ArrayList<>();
         recipients.add(localPlayer);
         List<String> notYetPlaying = new ArrayList<>();
+        boolean requestedPlayerFound = false;
         for (Player player : allPlayers) {
-            if (!mayBeGivenUnits(player, localPlayer, localBotNames)) {
+            boolean isTheRequestedPlayer = (explicitlyRequested != null)
+                  && (player.getId() == explicitlyRequested.getId());
+            requestedPlayerFound |= isTheRequestedPlayer;
+            if (player.getId() == localPlayer.getId()) {
+                // already first in the list; a second entry would offer the same person twice
                 continue;
             }
-            if (isInGame && (player.getTeam() == Player.TEAM_UNASSIGNED)) {
+            if (!mayAddUnitsTo(localPlayer, player, localBotNames)) {
+                if (isTheRequestedPlayer) {
+                    LOGGER.info("[GMAddUnit] refusing to offer {} although they were asked for by name: {} is not "
+                                + "a gamemaster, and {} is neither them nor a bot they run",
+                          player.getName(), localPlayer.getName(), player.getName());
+                }
+                continue;
+            }
+            boolean cannotDeployYet = isInGame && (player.getTeam() == Player.TEAM_UNASSIGNED);
+            if (cannotDeployYet && !isTheRequestedPlayer) {
                 notYetPlaying.add(player.getName());
                 continue;
             }
+            if (cannotDeployYet) {
+                LOGGER.info("[GMAddUnit] offering {} on no team because a gamemaster tool asked for them by name",
+                      player.getName());
+            }
             recipients.add(player);
+        }
+        if ((explicitlyRequested != null) && !requestedPlayerFound) {
+            LOGGER.info("[GMAddUnit] {} was asked for by name but is no longer in the game, so they are not offered",
+                  explicitlyRequested.getName());
         }
         if (!notYetPlaying.isEmpty()) {
             LOGGER.info("[GMAddUnit] not offering {} - on no team, so units given to them could never deploy; "
@@ -123,18 +171,24 @@ public final class UnitRecipients {
     }
 
     /**
-     * @param player        The player being considered
+     * Whether the local player may add units to one particular player.
+     *
+     * <p>This is the whole ownership rule, asked about a single player and without any logging, for the places
+     * that need a quiet yes or no: the lobby deciding whether the highlighted player may be handed to a unit
+     * chooser, and a dialog checking one last time who it is about to send units for.</p>
+     *
      * @param localPlayer   The player at this screen
+     * @param recipient     The player who would receive the units
      * @param localBotNames The names of the bots being run from this machine
      *
-     * @return {@code true} when the local player may add units to that player, other than to themselves
+     * @return {@code true} when the recipient is the local player, a bot run from this machine, or anyone at all
+     *       when the local player holds the gamemaster role
      */
-    private static boolean mayBeGivenUnits(Player player, Player localPlayer, Set<String> localBotNames) {
-        if (player.getId() == localPlayer.getId()) {
-            // already first in the list; a second entry would offer the same person twice
-            return false;
+    public static boolean mayAddUnitsTo(Player localPlayer, Player recipient, Set<String> localBotNames) {
+        if (recipient.getId() == localPlayer.getId()) {
+            return true;
         }
-        boolean isABotFromThisMachine = localBotNames.contains(player.getName());
+        boolean isABotFromThisMachine = localBotNames.contains(recipient.getName());
         return isABotFromThisMachine || localPlayer.isGameMaster();
     }
 }

--- a/megamek/src/megamek/client/ui/dialogs/randomArmy/RandomArmyDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/randomArmy/RandomArmyDialog.java
@@ -79,12 +79,12 @@ public class RandomArmyDialog extends AbstractRandomArmyDialog {
     private final ClientGUI clientGui;
     private final Client client;
     /**
-     * The player a gamemaster tool asked this dialog to open on, or {@code null} when it was opened by itself.
+     * The player a caller asked this dialog to open on, or {@code null} when it was opened by itself.
      *
-     * <p>Such a player is always offered, even when the ordinary rules would leave them out. A gamemaster who has
-     * just put somebody on a team and pressed a reinforcement button has said plainly who the units are for, and the
-     * team change does not reach the board until the end of the round - so the rule that hides players who cannot
-     * deploy yet would otherwise hide the very person being set up.</p>
+     * <p>{@link UnitRecipients} decides what being asked for is worth: a gamemaster tool naming a player who is on
+     * no team yet gets them offered anyway, while an ordinary player whose lobby happened to have the host
+     * highlighted does not get the host. The decision is made there, once, so that this dialog and the unit
+     * selector can never answer it differently.</p>
      */
     private Player explicitlyRequestedPlayer;
 
@@ -177,17 +177,38 @@ public class RandomArmyDialog extends AbstractRandomArmyDialog {
     }
 
     /**
-     * @return the player the generated units should belong to, which is the local player when the chooser holds
-     *       something no longer in the game
+     * The player the generated units should belong to.
+     *
+     * <p>That is whoever the chooser names, when they are still in the game and the local player may add units to
+     * them. Otherwise it is the local player: the chooser only offers permitted players, so anything else here
+     * means the game changed under the open dialog, and units must not go to somebody else on the strength of a
+     * stale entry.</p>
+     *
+     * @return the player who will own the units
      */
     private Player selectedPlayer() {
+        Player localPlayer = client.getLocalPlayer();
         String chosenName = (String) playerChooser.getSelectedItem();
-        return client.getGame()
+        Player chosen = client.getGame()
               .getPlayersList()
               .stream()
               .filter(player -> player.getName().equals(chosenName))
               .findFirst()
-              .orElse(client.getLocalPlayer());
+              .orElse(null);
+        if (chosen == null) {
+            LOGGER.warn("[GMAddUnit] the chooser names {}, who is no longer in the game; the units go to {} instead",
+                  chosenName, localPlayer.getName());
+            return localPlayer;
+        }
+        boolean isPermitted = UnitRecipients.mayAddUnitsTo(localPlayer, chosen, clientGui.getLocalBots().keySet());
+        if (!isPermitted) {
+            LOGGER.warn("[GMAddUnit] the chooser names {}, whom {} may not add units to; the units go to {} instead",
+                  chosen.getName(), localPlayer.getName(), localPlayer.getName());
+            return localPlayer;
+        }
+        LOGGER.info("[GMAddUnit] {} is generating units owned by {}, sent over their own connection",
+              localPlayer.getName(), chosen.getName());
+        return chosen;
     }
 
     /** @return the client the generated units belong to: a chosen local bot, or this player */
@@ -242,11 +263,11 @@ public class RandomArmyDialog extends AbstractRandomArmyDialog {
     private void updatePlayerChoice(String selectionName) {
         playerChooser.setEnabled(false);
         playerChooser.removeAllItems();
-        List<Player> offered = new ArrayList<>(UnitRecipients.availableTo(client.getLocalPlayer(),
+        List<Player> offered = UnitRecipients.availableTo(client.getLocalPlayer(),
               client.getGame().getPlayersList(),
               clientGui.getLocalBots().keySet(),
-              !client.getGame().getPhase().isLounge()));
-        addExplicitlyRequestedPlayer(offered);
+              !client.getGame().getPhase().isLounge(),
+              explicitlyRequestedPlayer);
         for (Player player : offered) {
             playerChooser.addItem(player.getName());
         }
@@ -263,24 +284,6 @@ public class RandomArmyDialog extends AbstractRandomArmyDialog {
         }
     }
 
-    /**
-     * Puts the player a gamemaster tool asked for into the list when the ordinary rules left them out.
-     *
-     * @param offered The players the rules offer, added to in place
-     */
-    private void addExplicitlyRequestedPlayer(List<Player> offered) {
-        if (explicitlyRequestedPlayer == null) {
-            return;
-        }
-        boolean alreadyThere = offered.stream()
-              .anyMatch(player -> player.getId() == explicitlyRequestedPlayer.getId());
-        if (!alreadyThere) {
-            LOGGER.info("[GMAddUnit] offering {} because a gamemaster tool asked for them by name",
-                  explicitlyRequestedPlayer.getName());
-            offered.add(explicitlyRequestedPlayer);
-        }
-    }
-
     private void updatePlayerChoice() {
         String lastChoice = (String) playerChooser.getSelectedItem();
         updatePlayerChoice(lastChoice);
@@ -289,13 +292,19 @@ public class RandomArmyDialog extends AbstractRandomArmyDialog {
     /**
      * Points the player chooser at the given player, so a dialog opened from a chosen player opens on them.
      *
+     * <p>Asking is not the same as getting: if the local player may not add units to that player, the chooser is
+     * left on the person using it, and the log says why.</p>
+     *
      * @param player The player to select, or {@code null} to leave the chooser where it was
      */
     public void setPlayerFrom(@Nullable Player player) {
         explicitlyRequestedPlayer = player;
         if (player == null) {
+            LOGGER.debug("[GMAddUnit] random army dialog opened with no player asked for; the chooser stays where "
+                  + "it was");
             updatePlayerChoice();
         } else {
+            LOGGER.debug("[GMAddUnit] random army dialog opened asking for {}", player.getName());
             updatePlayerChoice(player.getName());
         }
     }

--- a/megamek/src/megamek/client/ui/dialogs/randomArmy/RandomArmyDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/randomArmy/RandomArmyDialog.java
@@ -274,7 +274,13 @@ public class RandomArmyDialog extends AbstractRandomArmyDialog {
         if (playerChooser.getItemCount() > 1) {
             playerChooser.setEnabled(true);
         }
-        playerChooser.setSelectedItem(selectionName);
+        if (selectionName == null) {
+            // the first opening has no previous choice to keep, and the local player is always first
+            playerChooser.setSelectedIndex(0);
+            LOGGER.debug("[GMAddUnit] no previous choice, so the chooser starts on {}", playerChooser.getItemAt(0));
+        } else {
+            playerChooser.setSelectedItem(selectionName);
+        }
         if (playerChooser.getSelectedIndex() < 0) {
             // never fall back in silence: units quietly going to the wrong player looks exactly like them going to
             // the right one, and is only noticed a turn later

--- a/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/MegaMekUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/MegaMekUnitSelectorDialog.java
@@ -72,12 +72,12 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
     //region Variable Declarations
     private final ClientGUI clientGUI;
     /**
-     * The player a gamemaster tool asked this dialog to open on, or {@code null} when it was opened by itself.
+     * The player a caller asked this dialog to open on, or {@code null} when it was opened by itself.
      *
-     * <p>Such a player is always offered, even when the ordinary rules would leave them out. A gamemaster who has
-     * just put somebody on a team and pressed a reinforcement button has said plainly who the units are for, and the
-     * team change does not reach the board until the end of the round - so the rule that hides players who cannot
-     * deploy yet would otherwise hide the very person being set up.</p>
+     * <p>{@link UnitRecipients} decides what being asked for is worth: a gamemaster tool naming a player who is on
+     * no team yet gets them offered anyway, while an ordinary player whose lobby happened to have the host
+     * highlighted does not get the host. The decision is made there, once, so that this dialog and the random army
+     * dialog can never answer it differently.</p>
      */
     private Player explicitlyRequestedPlayer;
 
@@ -187,18 +187,39 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
     }
 
     /**
-     * @return the player the chosen units should belong to, which is the local player when the chooser holds
-     *       something no longer in the game
+     * The player the chosen units should belong to.
+     *
+     * <p>That is whoever the chooser names, when they are still in the game and the local player may add units to
+     * them. Otherwise it is the local player: the chooser only offers permitted players, so anything else here
+     * means the game changed under the open dialog, and units must not go to somebody else on the strength of a
+     * stale entry.</p>
+     *
+     * @return the player who will own the units
      */
     private Player chosenOwner() {
+        Player localPlayer = clientGUI.getClient().getLocalPlayer();
         String chosenName = (String) comboPlayer.getSelectedItem();
-        return clientGUI.getClient()
+        Player chosen = clientGUI.getClient()
               .getGame()
               .getPlayersList()
               .stream()
               .filter(player -> player.getName().equals(chosenName))
               .findFirst()
-              .orElse(clientGUI.getClient().getLocalPlayer());
+              .orElse(null);
+        if (chosen == null) {
+            LOGGER.warn("[GMAddUnit] the chooser names {}, who is no longer in the game; the units go to {} instead",
+                  chosenName, localPlayer.getName());
+            return localPlayer;
+        }
+        boolean isPermitted = UnitRecipients.mayAddUnitsTo(localPlayer, chosen, clientGUI.getLocalBots().keySet());
+        if (!isPermitted) {
+            LOGGER.warn("[GMAddUnit] the chooser names {}, whom {} may not add units to; the units go to {} instead",
+                  chosen.getName(), localPlayer.getName(), localPlayer.getName());
+            return localPlayer;
+        }
+        LOGGER.info("[GMAddUnit] {} is adding units owned by {}, sent over their own connection",
+              localPlayer.getName(), chosen.getName());
+        return chosen;
     }
 
     private void autoSetSkillsAndName(Entity e, Player player) {
@@ -229,11 +250,11 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
     private void updatePlayerChoice(String selectionName) {
         comboPlayer.setEnabled(false);
         comboPlayer.removeAllItems();
-        List<Player> offered = new ArrayList<>(UnitRecipients.availableTo(clientGUI.getClient().getLocalPlayer(),
+        List<Player> offered = UnitRecipients.availableTo(clientGUI.getClient().getLocalPlayer(),
               clientGUI.getClient().getGame().getPlayersList(),
               clientGUI.getLocalBots().keySet(),
-              !clientGUI.getClient().getGame().getPhase().isLounge()));
-        addExplicitlyRequestedPlayer(offered);
+              !clientGUI.getClient().getGame().getPhase().isLounge(),
+              explicitlyRequestedPlayer);
         for (Player player : offered) {
             comboPlayer.addItem(player.getName());
         }
@@ -250,24 +271,6 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
         }
     }
 
-    /**
-     * Puts the player a gamemaster tool asked for into the list when the ordinary rules left them out.
-     *
-     * @param offered The players the rules offer, added to in place
-     */
-    private void addExplicitlyRequestedPlayer(List<Player> offered) {
-        if (explicitlyRequestedPlayer == null) {
-            return;
-        }
-        boolean alreadyThere = offered.stream()
-              .anyMatch(player -> player.getId() == explicitlyRequestedPlayer.getId());
-        if (!alreadyThere) {
-            LOGGER.info("[GMAddUnit] offering {} because a gamemaster tool asked for them by name",
-                  explicitlyRequestedPlayer.getName());
-            offered.add(explicitlyRequestedPlayer);
-        }
-    }
-
     private void updatePlayerChoice() {
         String lastChoice = (String) comboPlayer.getSelectedItem();
         updatePlayerChoice(lastChoice);
@@ -276,13 +279,18 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
     /**
      * Points the player chooser at the given player, so a dialog opened from a chosen player opens on them.
      *
+     * <p>Asking is not the same as getting: if the local player may not add units to that player, the chooser is
+     * left on the person using it, and the log says why.</p>
+     *
      * @param player The player to select, or {@code null} to leave the chooser where it was
      */
     public void setPlayerFrom(@Nullable Player player) {
         explicitlyRequestedPlayer = player;
         if (player == null) {
+            LOGGER.debug("[GMAddUnit] unit selector opened with no player asked for; the chooser stays where it was");
             updatePlayerChoice();
         } else {
+            LOGGER.debug("[GMAddUnit] unit selector opened asking for {}", player.getName());
             updatePlayerChoice(player.getName());
         }
     }

--- a/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/MegaMekUnitSelectorDialog.java
+++ b/megamek/src/megamek/client/ui/dialogs/unitSelectorDialogs/MegaMekUnitSelectorDialog.java
@@ -258,7 +258,13 @@ public class MegaMekUnitSelectorDialog extends AbstractUnitSelectorDialog {
         for (Player player : offered) {
             comboPlayer.addItem(player.getName());
         }
-        comboPlayer.setSelectedItem(selectionName);
+        if (selectionName == null) {
+            // the first opening has no previous choice to keep, and the local player is always first
+            comboPlayer.setSelectedIndex(0);
+            LOGGER.debug("[GMAddUnit] no previous choice, so the chooser starts on {}", comboPlayer.getItemAt(0));
+        } else {
+            comboPlayer.setSelectedItem(selectionName);
+        }
         if (comboPlayer.getSelectedIndex() < 0) {
             // never fall back in silence: units quietly going to the wrong player looks exactly like them going to
             // the right one, and is only noticed a turn later

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
@@ -1638,14 +1638,9 @@ public class ChatLounge extends AbstractPhaseDisplay
      * all act on the highlighted player, and none of them should open pointed at somebody else.</p>
      */
     private void selectLocalPlayerRow() {
+        // the server names this client's player before it sends the phase that builds the lobby, so the local
+        // player is always known here - the selection listener below relies on the same thing
         Player local = localPlayer();
-        if (local == null) {
-            // the player list can arrive before the server has told this client which player it is
-            tablePlayers.addRowSelectionInterval(0, 0);
-            LOGGER.info("[GMAddUnit] the local player is not known yet, so the lobby highlighted row 0 ({}) for now",
-                  playerModel.getPlayerAt(0).getName());
-            return;
-        }
         for (int row = 0; row < playerModel.getRowCount(); row++) {
             if (playerModel.getPlayerAt(row).getId() == local.getId()) {
                 tablePlayers.addRowSelectionInterval(row, row);

--- a/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
+++ b/megamek/src/megamek/client/ui/panels/phaseDisplay/lobby/ChatLounge.java
@@ -1625,11 +1625,37 @@ public class ChatLounge extends AbstractPhaseDisplay
                 tablePlayers.addRowSelectionInterval(row, row);
             }
         }
-        // If no one is selected now (and the table isn't empty), select the first
-        // player
         if ((tablePlayers.getSelectedRowCount() == 0) && (tablePlayers.getRowCount() > 0)) {
-            tablePlayers.addRowSelectionInterval(0, 0);
+            selectLocalPlayerRow();
         }
+    }
+
+    /**
+     * Highlights the local player in the player table when nobody is highlighted.
+     *
+     * <p>The table lists players in the order they joined, so its first row is the host. Somebody who has just
+     * connected wants their own name highlighted, not the host's: Team, Camo, Set Up Player and the unit choosers
+     * all act on the highlighted player, and none of them should open pointed at somebody else.</p>
+     */
+    private void selectLocalPlayerRow() {
+        Player local = localPlayer();
+        if (local == null) {
+            // the player list can arrive before the server has told this client which player it is
+            tablePlayers.addRowSelectionInterval(0, 0);
+            LOGGER.info("[GMAddUnit] the local player is not known yet, so the lobby highlighted row 0 ({}) for now",
+                  playerModel.getPlayerAt(0).getName());
+            return;
+        }
+        for (int row = 0; row < playerModel.getRowCount(); row++) {
+            if (playerModel.getPlayerAt(row).getId() == local.getId()) {
+                tablePlayers.addRowSelectionInterval(row, row);
+                LOGGER.info("[GMAddUnit] lobby highlighted {} (row {}) as the default player", local.getName(), row);
+                return;
+            }
+        }
+        tablePlayers.addRowSelectionInterval(0, 0);
+        LOGGER.warn("[GMAddUnit] {} is not in the player table yet, so the lobby highlighted row 0 ({}) instead",
+              local.getName(), playerModel.getPlayerAt(0).getName());
     }
 
     /**
@@ -1920,13 +1946,42 @@ public class ChatLounge extends AbstractPhaseDisplay
      */
     private void addUnit() {
         clientgui.getMekSelectorDialog().updateOptionValues();
-        clientgui.getMekSelectorDialog().setPlayerFrom(getSelectedPlayer());
+        clientgui.getMekSelectorDialog().setPlayerFrom(permittedHighlightedPlayer());
         clientgui.getMekSelectorDialog().setVisible(true);
     }
 
     private void createArmy() {
-        clientgui.getRandomArmyDialog().setPlayerFrom(getSelectedPlayer());
+        clientgui.getRandomArmyDialog().setPlayerFrom(permittedHighlightedPlayer());
         clientgui.getRandomArmyDialog().setVisible(true);
+    }
+
+    /**
+     * The highlighted player, when the local player may add units to them.
+     *
+     * <p>Somebody who has just connected may well find the host highlighted, because the table lists players in
+     * the order they joined. Handing the host to a unit chooser would make it open on the host - and units picked
+     * without a second look would land in the host's force. So the highlighted player is passed on only when the
+     * local player may give them units; otherwise nobody is asked for and the chooser stays on the person using
+     * it.</p>
+     *
+     * @return the highlighted player when units may be added to them, otherwise {@code null}
+     */
+    private @Nullable Player permittedHighlightedPlayer() {
+        Player highlighted = getSelectedPlayer();
+        if (highlighted == null) {
+            LOGGER.info("[GMAddUnit] {} pressed a unit button with nobody highlighted; the chooser stays where it was",
+                  localPlayer().getName());
+            return null;
+        }
+        if (!mayActForPlayer(highlighted)) {
+            LOGGER.info("[GMAddUnit] {} pressed a unit button with {} highlighted, whom they may not add units to; "
+                        + "the chooser stays on {}", localPlayer().getName(), highlighted.getName(),
+                  localPlayer().getName());
+            return null;
+        }
+        LOGGER.info("[GMAddUnit] {} pressed a unit button with {} highlighted; asking the chooser for them",
+              localPlayer().getName(), highlighted.getName());
+        return highlighted;
     }
 
     public void loadRandomNames() {
@@ -2752,6 +2807,21 @@ public class ChatLounge extends AbstractPhaseDisplay
     }
 
     /**
+     * Whether the local player may act on the given player's force.
+     *
+     * <p>The same rule the unit choosers use, asked here as well: their chooser only offers players it is willing
+     * to act for, so the rule is enforced by what is in the list. The unit list buttons and the unit choosers act on
+     * whoever is highlighted in the player table, which is anyone at all, so they have to ask.</p>
+     *
+     * @param player The player whose force is to be acted on
+     *
+     * @return {@code true} when the local player may add units to, load or save that player's force
+     */
+    private boolean mayActForPlayer(Player player) {
+        return UnitRecipients.mayAddUnitsTo(localPlayer(), player, clientgui.getLocalBots().keySet());
+    }
+
+    /**
      * The player highlighted in the player table, whoever is running them.
      *
      * <p>Separate from {@link #getSelectedClient()} because most of what the lobby does to a player needs only
@@ -2761,23 +2831,6 @@ public class ChatLounge extends AbstractPhaseDisplay
      *
      * @return the selected player, or {@code null} when no row is selected
      */
-    /**
-     * Whether the local player may act on the given player's force.
-     *
-     * <p>The same rule the unit choosers use, asked here as well: their chooser only offers players it is willing
-     * to act for, so the rule is enforced by what is in the list. The unit list buttons act on whoever is selected
-     * in the player table, which is anyone at all, so they have to ask.</p>
-     *
-     * @param player The player whose force is to be acted on
-     *
-     * @return {@code true} when the local player may load or save that player's units
-     */
-    private boolean mayActForPlayer(Player player) {
-        return UnitRecipients.availableTo(localPlayer(),
-              clientgui.getClient().getGame().getPlayersList(),
-              clientgui.getLocalBots().keySet()).contains(player);
-    }
-
     @Nullable Player getSelectedPlayer() {
         if (tablePlayers.getSelectedRowCount() == 0) {
             return null;

--- a/megamek/unittests/megamek/client/ui/clientGUI/UnitRecipientsTest.java
+++ b/megamek/unittests/megamek/client/ui/clientGUI/UnitRecipientsTest.java
@@ -164,4 +164,71 @@ class UnitRecipientsTest {
 
         assertTrue(offeredInLobby.contains("Blue"), "building forces before a game starts is the normal case");
     }
+
+    @Test
+    void anOrdinaryPlayerAskingForTheHostIsNotGivenTheHost() {
+        // the lobby hands a unit chooser whichever player is highlighted in its table, and for somebody who has just
+        // connected that is the host - the table is in joining order. Being asked for must not get the host past
+        // the ownership rule, or every joining player's Add Unit dialog opens pointed at the host
+        DAVE.setGameMaster(false);
+
+        List<String> offered = UnitRecipients.availableTo(DAVE, EVERYONE, DAVES_BOTS, false, BLUE)
+              .stream().map(Player::getName).toList();
+
+        assertEquals(List.of("Dave", "Princess-1"), offered,
+              "asking for Blue changes nothing for a player who may not add units to Blue");
+    }
+
+    @Test
+    void aGamemasterToolMayAskForAPlayerOnNoTeamDuringAGame() {
+        // a gamemaster who has just put a latecomer on a team wants to roll them a force before the team change
+        // reaches the board, so the player asked for is offered although the no-team rule would hide them
+        DAVE.setGameMaster(true);
+        BLUE.setTeam(Player.TEAM_UNASSIGNED);
+
+        List<String> withoutAsking = UnitRecipients.availableTo(DAVE, EVERYONE, DAVES_BOTS, true)
+              .stream().map(Player::getName).toList();
+        List<String> whenAskedFor = UnitRecipients.availableTo(DAVE, EVERYONE, DAVES_BOTS, true, BLUE)
+              .stream().map(Player::getName).toList();
+
+        assertFalse(withoutAsking.contains("Blue"), "unasked, a teamless player stays hidden during a game");
+        assertTrue(whenAskedFor.contains("Blue"), "asked for by a gamemaster, they are offered");
+    }
+
+    @Test
+    void aRequestedPlayerWhoHasLeftTheGameIsNotOffered() {
+        DAVE.setGameMaster(true);
+
+        List<String> offered = UnitRecipients.availableTo(DAVE, List.of(DAVE, BLUE), DAVES_BOTS, false, GREEN)
+              .stream().map(Player::getName).toList();
+
+        assertFalse(offered.contains("Green"),
+              "a player who is gone cannot take delivery, however plainly they were asked for");
+    }
+
+    @Test
+    void askingForYourselfDoesNotOfferYouTwice() {
+        DAVE.setGameMaster(false);
+
+        List<String> offered = UnitRecipients.availableTo(DAVE, EVERYONE, DAVES_BOTS, false, DAVE)
+              .stream().map(Player::getName).toList();
+
+        assertEquals(1, offered.stream().filter("Dave"::equals).count(),
+              "the highlighted player is usually yourself, and that must not add a second entry");
+    }
+
+    @Test
+    void theSinglePlayerRuleMatchesTheList() {
+        // the lobby asks this about the highlighted player before handing them to a chooser, and each dialog asks it
+        // once more about the chosen owner just before sending - so it must agree with the list in every case
+        DAVE.setGameMaster(false);
+        assertTrue(UnitRecipients.mayAddUnitsTo(DAVE, DAVE, DAVES_BOTS), "yourself, always");
+        assertTrue(UnitRecipients.mayAddUnitsTo(DAVE, PRINCESS_ONE, DAVES_BOTS), "a bot you run");
+        assertFalse(UnitRecipients.mayAddUnitsTo(DAVE, BLUE, DAVES_BOTS), "not another human");
+        assertFalse(UnitRecipients.mayAddUnitsTo(DAVE, PRINCESS_TWO, DAVES_BOTS), "not another human's bot");
+
+        DAVE.setGameMaster(true);
+        assertTrue(UnitRecipients.mayAddUnitsTo(DAVE, BLUE, DAVES_BOTS), "a gamemaster may add units to anyone");
+        assertTrue(UnitRecipients.mayAddUnitsTo(DAVE, PRINCESS_TWO, DAVES_BOTS), "including another human's bot");
+    }
 }


### PR DESCRIPTION
## What this changes

Connect to a hosted game as a second player, press **Add A Combat Unit...**, and the **Player:** dropdown was set to the host - press Select without a second look and the unit joined the host's force. **Create Random Army...** did the same. The lobby highlights the first row of the player table on connect, which is the host; #8808 made the lobby hand that highlighted player to the choosers, and #8813 made the choosers offer a player they were handed by name without asking whether the local player may add units to them. Neither change was wrong alone; together they opened every connecting player's chooser on the host.

Now the "asked for by name" exception lives in `UnitRecipients` with the rest of the rule: being asked for gets a player past the "on no team yet" filter that gamemaster tools need, but never past the ownership rule. The lobby forwards the highlighted player only when the local player may add units to them, and highlights the connecting player rather than the host when nobody is selected, so Team, Camo and Set Up Player are live on connect too. Each dialog re-checks the chosen owner once more before sending. Every decision is logged under `[GMAddUnit]`.

Fixes #8859

## Testing

- `UnitRecipientsTest` grew from 9 to 14 tests, all green: an ordinary player asking for the host is not given the host; a gamemaster tool may still ask for a teamless player mid-game; a player who left the game is never offered; asking for yourself does not list you twice; the single-player check agrees with the list in every case. Checkstyle clean.
- Playtested with a host (`Hammershome`) and a second client on `localhost` (`Two`), reading the `[GMAddUnit]` lines after each step:
  - Two's lobby highlighted Two on connect.
  - Two pressed Add Unit with nothing clicked: offered only `[Two]`, unit added to Two.
  - Two clicked the host's row and pressed Add Unit, then Create Random Army: both refused the host and stayed on Two.
  - Hammershome took the Gamemaster role by vote, highlighted Two, pressed Add Unit: offered `[Hammershome, Two]`, unit added to Two. Adding to themselves still worked.
- No `fell back to` warning and no last-line guard fired during the run.

## What is not proven yet

- The playtest found the first-ever opening of the Random Army dialog logging a spurious `null is not in the player list` warning (harmless - it landed on the right player). The second commit makes that case a quiet default in both dialogs. That eight-line change has been rebuilt with tests and checkstyle green but has not yet been re-run in game.
- The server still trusts the owner id in the packet, exactly as before this change. That is #8860, deliberately separate.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result
