### PR TITLE
Core update: autocannon first hit should still destroy slot

### DIFF
--- a/megamek/src/megamek/common/rules/core/CoreRulesWeapons.java
+++ b/megamek/src/megamek/common/rules/core/CoreRulesWeapons.java
@@ -43,6 +43,7 @@ import megamek.common.units.Entity;
 import java.util.Vector;
 
 public class CoreRulesWeapons extends RulesWeapons {
+
     /**
      * {@inheritDoc}
      * RAC unjamming does not limit other actions outside of movement Core p.183
@@ -57,23 +58,32 @@ public class CoreRulesWeapons extends RulesWeapons {
      * ATM cluster size Core p.186
      */
     @Override
-    public int getATMClusterSize() { return 6; }
+    public int getATMClusterSize() {
+        return 6;
+    }
 
     /**
      * {@inheritDoc}
      * UACs cannot jam Core p.183
      */
     @Override
-    public boolean canUACsJam() { return false; }
+    public boolean canUACsJam() {
+        return false;
+    }
 
     /**
      * {@inheritDoc}
      * ACs can get hit one time. Core p.183
      */
     @Override
-    public void setACHit(CriticalSlot cs, Mounted<?> mounted, Vector<Report> reports, int entityId) {
+    public void setACHit(CriticalSlot cs,
+                         Mounted<?> mounted,
+                         Vector<Report> reports,
+                         int entityId) {
         if (!mounted.isAutocannonHit()) {
-            cs.setHit(false);
+            if (mounted.getNumCriticalSlots() == 1) {
+                cs.setHit(false);
+            }
             mounted.setHit(false);
             mounted.setAutocannonHit(true);
 
@@ -90,14 +100,18 @@ public class CoreRulesWeapons extends RulesWeapons {
      * ELRMS under minimum do not reduce missiles that hit. Core p.186
      */
     @Override
-    public int getELRMMinimumRackSize(int rackSize) { return rackSize; }
+    public int getELRMMinimumRackSize(int rackSize) {
+        return rackSize;
+    }
 
     /**
      * {@inheritDoc}
      * MRMs have no additional modifier Core p.186
      */
     @Override
-    public int getMRMModifier(int modifier) { return modifier; }
+    public int getMRMModifier(int modifier) {
+        return modifier;
+    }
 
     /**
      * {@inheritDoc}
@@ -116,14 +130,18 @@ public class CoreRulesWeapons extends RulesWeapons {
      * Apollo does not change the to-hit Core p.197
      */
     @Override
-    public int getApolloToHit() { return 0; }
+    public int getApolloToHit() {
+        return 0;
+    }
 
     /**
      * {@inheritDoc}
      * Flamers do heat and damage Core p.183
      */
     @Override
-    public boolean flamerHeatAndDamage(boolean bmmFlamers) { return true; }
+    public boolean flamerHeatAndDamage(boolean bmmFlamers) {
+        return true;
+    }
 
     /**
      * {@inheritDoc}
@@ -131,8 +149,12 @@ public class CoreRulesWeapons extends RulesWeapons {
      */
     @Nullable
     @Override
-    public Report checkPPCCapacitor(int roll, Entity attackingEntity, WeaponMounted
-          weapon) { return null; }
+    public Report checkPPCCapacitor(int roll,
+                                    Entity attackingEntity,
+                                    WeaponMounted
+                                            weapon) {
+        return null;
+    }
 
     /**
      * {@inheritDoc}
@@ -148,7 +170,8 @@ public class CoreRulesWeapons extends RulesWeapons {
      * HGR does not cause PSRs
      */
     @Override
-    public boolean canHGRTriggerPSR(int mpUsed, int weightClass) {
+    public boolean canHGRTriggerPSR(int mpUsed,
+                                    int weightClass) {
         return false;
     }
 


### PR DESCRIPTION
## What this changes

Core defines that the crit slot is still destroyed for an AC (other than something with only 1 critical slot), but the weapon is not destroyed. This change fixes that it negated the slot hit for all first hits. For ACs that only have a single slot, this mechanism of negating the first crit slot hit is retained.

## Testing

None. Simple logic change

## What is not proven yet

Nothing
---

- [ X ] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [ X ] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)