### PR TITLE
Fix: infantry and battle armor loads scanned every equipment type for a structure named UNKNOWN

### DIFF
--- a/megamek/src/megamek/common/equipment/EquipmentType.java
+++ b/megamek/src/megamek/common/equipment/EquipmentType.java
@@ -1158,11 +1158,25 @@ public class EquipmentType implements ITechnology {
         if (at == T_STRUCTURE_STANDARD) {
             return TA_STANDARD_STRUCTURE;
         }
+        if (!isKnownStructureType(at)) {
+            // Battle armor and conventional infantry have no internal structure type. Looking "UNKNOWN" up by name
+            // missed the lookup table and fell through to a scan of every equipment type, on every such unit loaded.
+            return TA_NONE;
+        }
         EquipmentType structure = EquipmentType.getStructureFromName(EquipmentType.getStructureTypeName(at, clan));
         if (structure != null) {
             return structure.getTechAdvancement();
         }
         return TA_NONE;
+    }
+
+    /**
+     * @param structureType a structure type index
+     *
+     * @return {@code true} if the index names a structure type this class has a name for
+     */
+    private static boolean isKnownStructureType(int structureType) {
+        return (structureType >= 0) && (structureType < structureNames.length);
     }
 
     /**

--- a/megamek/unittests/megamek/common/EquipmentTypeTest.java
+++ b/megamek/unittests/megamek/common/EquipmentTypeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2018-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -47,6 +47,7 @@ import megamek.common.equipment.EquipmentType;
 import megamek.common.equipment.EquipmentTypeLookup;
 import megamek.common.equipment.MiscType;
 import megamek.common.equipment.StructureType;
+import megamek.common.interfaces.ITechnology;
 import megamek.common.weapons.bayWeapons.TeleOperatedMissileBayWeapon;
 import org.junit.jupiter.api.Test;
 
@@ -94,6 +95,21 @@ class EquipmentTypeTest {
         assertEquals(EquipmentType.T_STRUCTURE_INDUSTRIAL, industrialStructure.getStructureTypeId());
         assertEquals(EquipmentType.T_ARMOR_HEAVY_INDUSTRIAL, heavyIndustrialArmor.getArmorType());
         assertEquals(EquipmentType.T_STRUCTURE_UNKNOWN, EquipmentType.getStructureType(standardArmor));
+    }
+
+    @Test
+    void structureTechAdvancementForUnitsWithoutStructureIsBlank() {
+        EquipmentType.initializeTypes();
+
+        // Battle armor and conventional infantry carry no internal structure type; the answer must be a blank
+        // advancement rather than a name lookup that scans every equipment type and misses anyway.
+        TechAdvancement unknownStructure = EquipmentType.getStructureTechAdvancement(
+              EquipmentType.T_STRUCTURE_UNKNOWN, false);
+        TechAdvancement endoSteel = EquipmentType.getStructureTechAdvancement(
+              EquipmentType.T_STRUCTURE_ENDO_STEEL, false);
+
+        assertEquals(ITechnology.DATE_NONE, unknownStructure.getIntroductionDate());
+        assertTrue(endoSteel.getIntroductionDate() > 0, "a real structure type still resolves");
     }
 
     @Test


### PR DESCRIPTION
## What this changes

Loading a conventional infantry or battle armor unit no longer scans every equipment type looking for a structure named UNKNOWN. In a profiled MekHQ campaign load that scan was a quarter of the loading thread.

## Testing

- EquipmentTypeTest gains a test for the no-structure case; eight tests plus checkstyle green.
- The same MekHQ save profiled before and after; the scan is gone from the loading thread.

## What is not proven yet

- Nothing beyond the unit test and the profile; no game was played on this branch.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result
