### PR TITLE
CLAN_NARC_CAPABLE_MUNITION_MUTATOR

### DIFF
--- a/megamek/src/megamek/common/equipment/AmmoType.java
+++ b/megamek/src/megamek/common/equipment/AmmoType.java
@@ -665,7 +665,7 @@ public class AmmoType extends EquipmentType {
                 .setProductionFactions(Faction.FS),
           rulesRefs(SourceBookCode.TO_AUE, 182));
 
-    private static final MunitionMutator CLAN_NARC_CAPABLE_MUNITION_MUTATOR_UNOFFICIAL = new MunitionMutator(
+    private static final MunitionMutator CLAN_NARC_CAPABLE_MUNITION_MUTATOR = new MunitionMutator(
           "(Clan) Narc-capable", "Narc",
           1,
           Munitions.M_NARC_CAPABLE,
@@ -1740,7 +1740,7 @@ public class AmmoType extends EquipmentType {
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED),
           rulesRefs(SourceBookCode.TO_AUE, 173));
 
-    private static final MunitionMutator CLAN_NARC_CAPABLE_MUNITION_MUTATOR_FOR_MISSILE = new MunitionMutator(
+    private static final MunitionMutator CLAN_NARC_CAPABLE_MUNITION_MUTATOR_FOR_LRM = new MunitionMutator(
           "(Clan) Narc-capable", "Narc",
           1,
           Munitions.M_NARC_CAPABLE,
@@ -3427,7 +3427,7 @@ public class AmmoType extends EquipmentType {
         munitions.add(CLAN_FRAGMENTATION_MUNITION_MUTATOR);
         munitions.add(CLAN_LISTEN_KILL_MUNITION_MUTATOR_UNOFFICIAL);
         munitions.add(CLAN_MINE_CLEARANCE_MUNITION_MUTATOR_UNOFFICIAL);
-        munitions.add(CLAN_NARC_CAPABLE_MUNITION_MUTATOR_UNOFFICIAL);
+        munitions.add(CLAN_NARC_CAPABLE_MUNITION_MUTATOR);
         AmmoType.createMunitions(clanSrmAmmos, munitions);
         AmmoType.createMunitions(clanImprovedSRMsAmmo, munitions);
 
@@ -3499,7 +3499,7 @@ public class AmmoType extends EquipmentType {
         munitions.add(CLAN_FRAGMENTATION_MUNITION_MUTATOR);
         munitions.add(CLAN_LISTEN_KILL_MUNITION_MUTATOR_UNOFFICIAL);
         munitions.add(CLAN_MINE_CLEARANCE_MUNITION_MUTATOR_UNOFFICIAL);
-        munitions.add(CLAN_NARC_CAPABLE_MUNITION_MUTATOR_FOR_MISSILE);
+        munitions.add(CLAN_NARC_CAPABLE_MUNITION_MUTATOR_FOR_LRM);
         AmmoType.createMunitions(clanLrmAmmos, munitions);
         AmmoType.createMunitions(clanImprovedLRMsAmmo, munitions);
 

--- a/megamek/src/megamek/common/equipment/AmmoType.java
+++ b/megamek/src/megamek/common/equipment/AmmoType.java
@@ -3421,7 +3421,7 @@ public class AmmoType extends EquipmentType {
         /*
          * munitions.add(new MunitionMutator("Incendiary", 2,
          * Munitions.M_INCENDIARY_LRM, new
-         * TechAdvancement(ITechnology.TechBase.IS)  
+         * TechAdvancement(ITechnology.TechBase.IS)
          * .setTechRating(TechRating.C) .setAvailability(TechRating.E, TechRating.E, TechRating.E,
          * TechRating.E) .setClanAdvancement(2341, 2342, 2352, DATE_NONE, DATE_NONE)
          * .setClanApproximate(false, false, false, false, false)
@@ -3458,7 +3458,7 @@ public class AmmoType extends EquipmentType {
         /*
          * munitions.add(new MunitionMutator("(Clan) Incendiary", 2,
          * Munitions.M_INCENDIARY_LRM,
-         * new TechAdvancement(TechBase.CLAN) 
+         * new TechAdvancement(TechBase.CLAN)
          *  .setTechRating(TechRating.C) .setAvailability(TechRating.E,
          * TechRating.E, TechRating.E, TechRating.E) .setClanAdvancement(2341, 2342, 2352,
          * DATE_NONE, DATE_NONE) .setClanApproximate(false, false, false, false, false)

--- a/megamek/src/megamek/common/equipment/AmmoType.java
+++ b/megamek/src/megamek/common/equipment/AmmoType.java
@@ -670,7 +670,7 @@ public class AmmoType extends EquipmentType {
           1,
           Munitions.M_NARC_CAPABLE,
           new TechAdvancement(TechBase.CLAN)
-                .setStaticTechLevel(SimpleTechLevel.UNOFFICIAL)
+                .setStaticTechLevel(SimpleTechLevel.STANDARD)
                 .setTechRating(TechRating.E)
                 .setAvailability(AvailabilityValue.E, AvailabilityValue.F, AvailabilityValue.D, AvailabilityValue.C)
                 .setClanAdvancement(DATE_NONE, DATE_NONE, 2828, DATE_NONE, DATE_NONE)
@@ -1739,20 +1739,6 @@ public class AmmoType extends EquipmentType {
                 .setClanApproximate(false, false, false, false, false)
                 .setStaticTechLevel(SimpleTechLevel.ADVANCED),
           rulesRefs(SourceBookCode.TO_AUE, 173));
-
-    private static final MunitionMutator CLAN_NARC_CAPABLE_MUNITION_MUTATOR_FOR_LRM = new MunitionMutator(
-          "(Clan) Narc-capable", "Narc",
-          1,
-          Munitions.M_NARC_CAPABLE,
-          new TechAdvancement(TechBase.CLAN)
-                .setTechRating(TechRating.E)
-                .setAvailability(AvailabilityValue.E, AvailabilityValue.F, AvailabilityValue.D, AvailabilityValue.C)
-                .setClanAdvancement(2520, 2587, 3049, DATE_NONE, DATE_NONE)
-                .setClanApproximate(true, false, false, false, false)
-                .setPrototypeFactions(Faction.TH)
-                .setProductionFactions(Faction.TH)
-                .setStaticTechLevel(SimpleTechLevel.STANDARD),
-          rulesRefs(SourceBookCode.TW, 142));
 
     private static final MunitionMutator CLAN_SMOKE_MORTAR_MUNITION_MUTATOR = new MunitionMutator("Smoke",
           1,
@@ -3499,7 +3485,7 @@ public class AmmoType extends EquipmentType {
         munitions.add(CLAN_FRAGMENTATION_MUNITION_MUTATOR);
         munitions.add(CLAN_LISTEN_KILL_MUNITION_MUTATOR_UNOFFICIAL);
         munitions.add(CLAN_MINE_CLEARANCE_MUNITION_MUTATOR_UNOFFICIAL);
-        munitions.add(CLAN_NARC_CAPABLE_MUNITION_MUTATOR_FOR_LRM);
+        munitions.add(CLAN_NARC_CAPABLE_MUNITION_MUTATOR);
         AmmoType.createMunitions(clanLrmAmmos, munitions);
         AmmoType.createMunitions(clanImprovedLRMsAmmo, munitions);
 


### PR DESCRIPTION
This PR fixes the wrongly marked CLAN_NARC_CAPABLE_MUNITION_MUTATOR_UNOFFICIAL to be official.

this also removes the duplicated CLAN_NARC_CAPABLE_MUNITION_MUTATOR_FOR_MISSILE and unifies LRM/SRM under a single mutator per IO:AE p.56 with date 2828