### PR TITLE
Let a host choose the echelon the Formation combo opens on

### DIFF
--- a/megamek/src/megamek/client/ui/dialogs/randomArmy/ForceGeneratorOptionsView.java
+++ b/megamek/src/megamek/client/ui/dialogs/randomArmy/ForceGeneratorOptionsView.java
@@ -33,8 +33,8 @@
 package megamek.client.ui.dialogs.randomArmy;
 
 import java.awt.BorderLayout;
-import java.awt.Dimension;
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -52,7 +52,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.Objects;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
@@ -60,11 +59,11 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.swing.*;
-import javax.swing.event.DocumentEvent;
-import javax.swing.event.DocumentListener;
 import javax.swing.SwingUtilities;
 import javax.swing.border.Border;
 import javax.swing.border.TitledBorder;
+import javax.swing.event.DocumentEvent;
+import javax.swing.event.DocumentListener;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import javax.swing.table.DefaultTableModel;
 
@@ -795,12 +794,14 @@ public class ForceGeneratorOptionsView extends JPanel implements FocusListener, 
      *
      * <p>Split from the combo so the choice can be exercised without building the view.</p>
      *
-     * @param echelonCodes    the ruleset echelon codes this faction offers, in combo order
+     * @param echelonCodes     the ruleset echelon codes this faction offers, in combo order, or {@code null} when
+     *                         the combo has not been populated
      * @param preferredEchelon the echelon wanted, or {@code null} for no preference
      *
      * @return the matching code, or {@code null} when there is no preference or no match
      */
-    static @Nullable String preferredEchelonItem(List<String> echelonCodes, @Nullable Integer preferredEchelon) {
+    static @Nullable String preferredEchelonItem(@Nullable List<String> echelonCodes,
+          @Nullable Integer preferredEchelon) {
         if ((preferredEchelon == null) || (echelonCodes == null)) {
             return null;
         }

--- a/megamek/src/megamek/client/ui/dialogs/randomArmy/ForceGeneratorOptionsView.java
+++ b/megamek/src/megamek/client/ui/dialogs/randomArmy/ForceGeneratorOptionsView.java
@@ -154,6 +154,12 @@ public class ForceGeneratorOptionsView extends JPanel implements FocusListener, 
 
     /** The formation the player has picked in the palette, applied to a node from the tree's right-click menu. */
     private String selectedFormation;
+
+    /**
+     * Echelon a host would rather the formation combo opened on, or {@code null} to let the faction's ruleset
+     * decide. See {@link #setPreferredEchelon(Integer)}.
+     */
+    private Integer preferredEchelon;
     /** Holds the mix editor when a host shows it inline rather than opening it from the button. */
     private JPanel panFormationMixInline;
     /** The inline panel's title, which names the selected formation so the pick is visible without scrolling. */
@@ -743,6 +749,77 @@ public class ForceGeneratorOptionsView extends JPanel implements FocusListener, 
     }
 
     /**
+     * Sets the echelon the formation combo should open on, for a host that generates at a known size.
+     *
+     * <p>Not to be confused with {@link #setSelectedFormation}, which picks the formation applied to nodes in the
+     * organisation tree. This one chooses which entry of the Formation combo - Lance, Company, Battalion and so on -
+     * is selected when the combo is populated.</p>
+     *
+     * <p>Random Army leaves this unset and keeps the faction ruleset's own default echelon. MekHQ's Command Designer
+     * sets it, because a command is built at a size the player chose rather than at whatever size the ruleset
+     * happens to favour.</p>
+     *
+     * <p>The preference only decides the opening selection. A player who picks a different echelon keeps it, and it
+     * survives a change of faction wherever the new faction offers that echelon too. The faction ruleset's default
+     * is used whenever the preferred echelon is unset or is not one this faction fields.</p>
+     *
+     * @param preferredEchelon the echelon to open on, numbered as {@code ForceDescriptor} echelons are
+     *                         (constants.txt: LANCE 3, COMPANY 4, BATTALION 5, REGIMENT 6), or {@code null} to
+     *                         restore the ruleset default
+     */
+    public void setPreferredEchelon(@Nullable Integer preferredEchelon) {
+        this.preferredEchelon = preferredEchelon;
+    }
+
+    /**
+     * The combo entry matching {@link #preferredEchelon}, if this faction fields that echelon.
+     *
+     * <p>Combo entries are the ruleset's own echelon codes, which carry the echelon number plus an optional
+     * modifier - "4" for a company, "4+" reinforced, "4-" understrength, "4^" an augmented formation. The plain
+     * code is preferred so the combo opens on an ordinary formation of that size; a modified code is accepted only
+     * when the faction fields no plain one.</p>
+     *
+     * @return the matching combo entry, or {@code null} when no preference is set or this faction has no such
+     *       echelon
+     */
+    private @Nullable String preferredEchelonItem() {
+        List<String> items = new ArrayList<>(cbFormation.getItemCount());
+        for (int index = 0; index < cbFormation.getItemCount(); index++) {
+            items.add(cbFormation.getItemAt(index));
+        }
+        return preferredEchelonItem(items, preferredEchelon);
+    }
+
+    /**
+     * Picks the echelon code matching {@code preferredEchelon} out of {@code echelonCodes}.
+     *
+     * <p>Split from the combo so the choice can be exercised without building the view.</p>
+     *
+     * @param echelonCodes    the ruleset echelon codes this faction offers, in combo order
+     * @param preferredEchelon the echelon wanted, or {@code null} for no preference
+     *
+     * @return the matching code, or {@code null} when there is no preference or no match
+     */
+    static @Nullable String preferredEchelonItem(List<String> echelonCodes, @Nullable Integer preferredEchelon) {
+        if ((preferredEchelon == null) || (echelonCodes == null)) {
+            return null;
+        }
+        String modifiedMatch = null;
+        for (String code : echelonCodes) {
+            if ((code == null) || (MathUtility.parseInt(code.replaceAll("[^0-9]", ""), -1) != preferredEchelon)) {
+                continue;
+            }
+            if (code.matches("[0-9]+")) {
+                return code;
+            }
+            if (modifiedMatch == null) {
+                modifiedMatch = code;
+            }
+        }
+        return modifiedMatch;
+    }
+
+    /**
      * Clears the picked formation, so nothing is selected and the tree offers nothing to apply.
      *
      * <p>Called when a host resets its options: the selection lives here rather than in the host's own options, so
@@ -1308,10 +1385,14 @@ public class ForceGeneratorOptionsView extends JPanel implements FocusListener, 
         if (hasCurrent) {
             cbFormation.setSelectedItem(currentFormation);
         } else {
-            Ruleset rs = Ruleset.findRuleset(forceDesc.getFaction());
-            String echelon = rs.getDefaultEschelon(forceDesc);
-            if ((echelon == null || !formationDisplayNames.containsKey(echelon) && cbFormation.getItemCount() > 0)) {
-                echelon = cbFormation.getItemAt(0);
+            String echelon = preferredEchelonItem();
+            if (echelon == null) {
+                Ruleset rs = Ruleset.findRuleset(forceDesc.getFaction());
+                echelon = rs.getDefaultEschelon(forceDesc);
+                if ((echelon == null ||
+                           !formationDisplayNames.containsKey(echelon) && cbFormation.getItemCount() > 0)) {
+                    echelon = cbFormation.getItemAt(0);
+                }
             }
             if (echelon != null) {
                 cbFormation.setSelectedItem(echelon);

--- a/megamek/unittests/megamek/client/ui/dialogs/randomArmy/ForceGeneratorOptionsViewEchelonTest.java
+++ b/megamek/unittests/megamek/client/ui/dialogs/randomArmy/ForceGeneratorOptionsViewEchelonTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.ui.dialogs.randomArmy;
+
+import static megamek.client.ui.dialogs.randomArmy.ForceGeneratorOptionsView.preferredEchelonItem;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the echelon a host can ask the Formation combo to open on. Codes are the ruleset's own: the echelon number
+ * (constants.txt: LANCE 3, COMPANY 4, BATTALION 5, REGIMENT 6) plus an optional modifier - "+" reinforced, "-"
+ * understrength, "^" augmented.
+ */
+class ForceGeneratorOptionsViewEchelonTest {
+
+    @Test
+    void noPreference_leavesTheRulesetDefaultInCharge() {
+        assertNull(preferredEchelonItem(List.of("3", "4", "5"), null));
+    }
+
+    @Test
+    void preferredEchelonPresent_isPicked() {
+        assertEquals("4", preferredEchelonItem(List.of("3", "4", "5"), 4));
+    }
+
+    @Test
+    void preferredEchelonAbsent_fallsThroughToTheRulesetDefault() {
+        assertNull(preferredEchelonItem(List.of("3", "5", "6"), 4),
+              "a faction that fields no company must fall back rather than pick a different size");
+    }
+
+    @Test
+    void plainCodeWins_overAModifiedOneOfTheSameSize() {
+        assertEquals("4", preferredEchelonItem(List.of("4+", "4", "4-"), 4),
+              "an ordinary company opens ahead of a reinforced or understrength one");
+    }
+
+    @Test
+    void modifiedCodeIsAcceptedWhenNoPlainOneExists() {
+        assertEquals("4+", preferredEchelonItem(List.of("3", "4+", "5"), 4));
+        assertEquals("4^", preferredEchelonItem(List.of("4^", "5"), 4));
+    }
+
+    @Test
+    void modifiedCodeTakesTheFirstOffered() {
+        assertEquals("4-", preferredEchelonItem(List.of("4-", "4+"), 4));
+    }
+
+    @Test
+    void multiDigitEchelonsAreNotConfusedWithSingleDigitOnes() {
+        assertNull(preferredEchelonItem(List.of("14", "41"), 4),
+              "a code of 14 or 41 is not a company");
+        assertEquals("14", preferredEchelonItem(List.of("14", "41"), 14));
+    }
+
+    @Test
+    void emptyOrNullInputs_returnNull() {
+        assertNull(preferredEchelonItem(List.of(), 4));
+        assertNull(preferredEchelonItem(null, 4));
+    }
+
+    @Test
+    void nullEntriesAreSkippedRatherThanThrowing() {
+        List<String> codes = new ArrayList<>();
+        codes.add(null);
+        codes.add("4");
+        assertEquals("4", preferredEchelonItem(codes, 4));
+    }
+
+    @Test
+    void codeWithNoDigitsIsNeverMatched() {
+        assertNull(preferredEchelonItem(List.of("^", "+"), 4),
+              "an unparseable code must not match, and must not read as echelon 0 either");
+        assertNull(preferredEchelonItem(List.of("^"), 0));
+    }
+}


### PR DESCRIPTION
## What this changes

The Force Generator's Formation combo opens on whatever echelon the faction's ruleset prefers. A host that already knows what size force it wants can now say so.

- New `ForceGeneratorOptionsView.setPreferredEchelon(Integer)`.
- Random Army does not set it, so nothing changes there. The ruleset default still decides.
- Set it, and the combo opens on that echelon whenever the faction fields one. Where it does not, the ruleset default is used as before.
- The preference only decides the opening selection. A player who picks a different echelon keeps it, and it survives a change of faction wherever the new faction offers that echelon too.

Asked for by MekHQ, whose Command Designer builds a command at a size the player chose and wants the combo to open on Company. See MegaMek/mekhq#9955. The MekHQ side is a separate PR that calls this.

Combo entries are ruleset echelon codes: the echelon number plus an optional modifier, so "4" is a company, "4+" reinforced, "4-" understrength, "4^" augmented. The plain code is preferred so the combo opens on an ordinary formation of that size; a modified code is taken only when the faction fields no plain one.

Not to be confused with `setSelectedFormation`, which picks the formation applied to nodes in the organisation tree. This one chooses which entry of the Formation combo is selected.

## Testing

- `./gradlew :megamek:test :megamek:checkstyleMain :megamek:javadoc` run.
- 10 new tests in `ForceGeneratorOptionsViewEchelonTest`, covering the plain-code preference, modifier fallback, a faction that fields no such echelon, multi-digit echelons, and null or unparseable codes.
- 16,427 tests run, 4 failures. All four are pre-existing: `CommonSettingsDialogTest` (3) and `SettingsFormPanelTest` (1) fail the same way on unmodified `main` with these changes stashed. They are Swing layout tests and nothing here touches them.

## What is not proven yet

- The combo itself. The matching is unit tested, but the branch in `refreshFormations()` that applies it needs the view on screen, so it has not been exercised by a test. It will be once the MekHQ side lands and the Command Designer opens on Company.
- Nothing in MegaMek calls the new method yet. Random Army is unchanged by design.

---
- [x] Focused on one issue or RFE
- [x] Every file in the diff has a deliberate change
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use {@code true} / {@code null}
- [x] Dev team only: AI tools used -> AI Assisted Development label applied
