### PR TITLE
Fix #8754, #7857: Weapon damage and critical hits for Advanced Building turrets

### DIFF
--- a/megamek/mmconf/log4j2.xml
+++ b/megamek/mmconf/log4j2.xml
@@ -145,6 +145,19 @@
           </Logger>
         -->
         <!--
+          Advanced Building (gun emplacement) weapon damage diagnostics. Critical rolls are logged at info by
+          default as [BuildingCrit] lines. Uncomment to also trace every hit's hex, level and damage
+          (TWDamageManager, [BuildingDamage]) and each critical result's effect (BuildingEntityCriticalHandler).
+          Then grep logs/megamek.log for "[Building".
+
+          <Logger name="megamek.server.totalWarfare.TWDamageManager" level="debug" additivity="false">
+              <AppenderRef ref="MegaMekLog" />
+          </Logger>
+          <Logger name="megamek.server.totalWarfare.BuildingEntityCriticalHandler" level="debug" additivity="false">
+              <AppenderRef ref="MegaMekLog" />
+          </Logger>
+        -->
+        <!--
           Bulldozer (rubble clearing / movement override / destruction roll) diagnostics, silent by default
           (parent "megamek" logger at info). All emit [Bulldozer]-tagged lines. Uncomment to trace: the Clear
           Rubble button enablement and rubble-hex target selection (MovementDisplay); the clear-rubble move-step

--- a/megamek/resources/megamek/client/messages.properties
+++ b/megamek/resources/megamek/client/messages.properties
@@ -5948,6 +5948,7 @@ WeaponAttackAction.CantSplitFire=attack already declared against another target.
 WeaponAttackAction.ChargingEDP=ProtoMek is charging EDP.
 WeaponAttackAction.CICDestroyed=CIC destroyed.
 WeaponAttackAction.CrewStunned=Crew stunned.
+WeaponAttackAction.BuildingGunnersKilled=Gunners in this hex are dead.
 WeaponAttackAction.ExactlyAlt1=must be exactly 1 elevation above targeted hex
 WeaponAttackAction.FCSDestroyed=Fire control system destroyed.
 WeaponAttackAction.FrontBlockedByTerrain=Nearby terrain blocks front weapons.

--- a/megamek/resources/megamek/client/messages.properties
+++ b/megamek/resources/megamek/client/messages.properties
@@ -5921,6 +5921,7 @@ WeaponAttackAction.TSEMPRecharging=TSEMP cannon recharging.
 WeaponAttackAction.WaterBlocksShot=Cannot shoot in to or out of water.
 WeaponAttackAction.WeaponCantIgnite=Weapon can not cause fires.
 WeaponAttackAction.WeaponNotReady=Weapon is not in a state where it can be fired
+WeaponAttackAction.WeaponJammed=Weapon jammed
 WeaponAttackAction.WeaponOff=Weapon has been deactivated.
 WeaponAttackAction.WrongSwarmUse=Use the 'Attack Swarmed Mek' attack instead.
 #Phase Rules

--- a/megamek/resources/megamek/common/report-messages.properties
+++ b/megamek/resources/megamek/common/report-messages.properties
@@ -632,6 +632,7 @@
 3800=Damage threshold exceeded. <span class='warning'>Possible critical hit</span>!
 3805=No critical hit.
 3810=<span class='warning'>Crew stunned.</span>
+3811=Crew cannot be stunned, they are already dead - no effect.
 3815=<span class='warning'>Crew killed.</span>
 3820=<span class='warning'>Turret locked.</span>
 3825=<span class='warning'>Turret jammed.</span>

--- a/megamek/resources/megamek/common/report-messages.properties
+++ b/megamek/resources/megamek/common/report-messages.properties
@@ -635,9 +635,11 @@
 3815=<span class='warning'>Crew killed.</span>
 3820=<span class='warning'>Turret locked.</span>
 3825=<span class='warning'>Turret jammed.</span>
+3826=Turret hit, but no turreted weapons in this hex - no effect.
 3830=<span class='warning'>Ammunition explosion! <data> takes <data> damage, reducing its CF to <data>.</span>
 3831=<span class='warning'>Ammunition explosion</span> - no effect.
 3835=<span class='warning'>Equipment hit</span> - no effect.
+3836=<span class='warning'><data> is damaged and rendered inoperative.</span>
 3840=<span class='warning'><data> is hit!</span>
 3841=<span class='warning'>Weapon hit, but no functional weapons remaining.</span>
 3845=<span class='warning'><data> jams!</span>

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/sprite/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/sprite/EntitySprite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2014-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -532,6 +532,10 @@ public class EntitySprite extends Sprite {
             if (entity instanceof Tank tankEntity) {
                 turretLocked = !tankEntity.hasNoTurret() && !tankEntity.canChangeSecondaryFacing();
                 crewStunned = tankEntity.getStunnedTurns();
+            } else if (entity instanceof AbstractBuildingEntity buildingEntity) {
+                // Advanced Building critical hits (TO:AR p. 118) stun the gunners or lock a turret
+                turretLocked = buildingEntity.hasLockedTurret();
+                crewStunned = buildingEntity.getStunnedTurns();
             }
 
             // draw elevation/altitude if non-zero

--- a/megamek/src/megamek/client/ui/clientGUI/boardview/sprite/EntitySprite.java
+++ b/megamek/src/megamek/client/ui/clientGUI/boardview/sprite/EntitySprite.java
@@ -521,7 +521,9 @@ public class EntitySprite extends Sprite {
             graph.draw(bv.getFacingPolys()[entity.getFacing()]);
         }
 
-        if ((secondaryPos == -1) || (secondaryPos == 6)) {
+        // A building entity lists its own hex as secondary position 0, so that sprite carries its status labels
+        boolean isBuildingOriginSprite = (entity instanceof AbstractBuildingEntity) && (secondaryPos == 0);
+        if ((secondaryPos == -1) || (secondaryPos == 6) || isBuildingOriginSprite) {
             // Gather unit conditions
             ArrayList<Status> stStr = new ArrayList<>();
             criticalStatus = false;

--- a/megamek/src/megamek/common/actions/compute/ComputeToHitIsImpossible.java
+++ b/megamek/src/megamek/common/actions/compute/ComputeToHitIsImpossible.java
@@ -1953,6 +1953,11 @@ class ComputeToHitIsImpossible {
                 return Messages.getString("WeaponAttackAction.OutOfArc");
             }
 
+            // A jammed weapon gets its own reason so the player can tell a jam from the other not-ready states
+            if ((!evenIfAlreadyFired) && weapon.isJammed()) {
+                return Messages.getString("WeaponAttackAction.WeaponJammed");
+            }
+
             // Weapon operational?
             // TODO move to top for early-out if possible, as this is the most common
             // reason shot is impossible

--- a/megamek/src/megamek/common/actions/compute/ComputeToHitIsImpossible.java
+++ b/megamek/src/megamek/common/actions/compute/ComputeToHitIsImpossible.java
@@ -93,7 +93,7 @@ class ComputeToHitIsImpossible {
      * @param distance              The distance in hexes from attacker to target
      * @param spotter               The spotting entity for indirect fire, if present
      * @param weaponType            The WeaponType of the weapon being used
-     * @param weapon                The Mounted weapon being used
+     * @param weapon                The Mounted weapon being used, or {@code null} when the attack names no mount
      * @param ammoType              The AmmoType being used for this attack
      * @param ammo                  The Mounted ammo being used
      * @param munition              Long indicating the munition type flag being used, if applicable
@@ -116,7 +116,8 @@ class ComputeToHitIsImpossible {
      */
     static String toHitIsImpossible(Game game, Entity weaponEntity, int attackerId, Targetable target, int targetType,
           LosEffects los, ToHitData losMods, ToHitData toHit, int distance, Entity spotter, WeaponType weaponType,
-          WeaponMounted weapon, int weaponId, AmmoType ammoType, AmmoMounted ammo, EnumSet<AmmoType.Munitions> munition,
+          @Nullable WeaponMounted weapon, int weaponId, AmmoType ammoType, AmmoMounted ammo,
+          EnumSet<AmmoType.Munitions> munition,
           boolean isFlakAttack, boolean isArtilleryDirect, boolean isArtilleryFLAK, boolean isArtilleryIndirect,
           boolean isAttackerInfantry, boolean isBearingsOnlyMissile, boolean isCruiseMissile,
           boolean exchangeSwarmTarget, boolean isHoming, boolean isInferno, boolean isIndirect, boolean isStrafing,
@@ -220,7 +221,8 @@ class ComputeToHitIsImpossible {
             }
             if (target.getTargetType() == Targetable.TYPE_SATURATION
             && !(
-                  weaponType.hasFlag(WeaponType.F_MRM)
+                  (weapon != null)
+                        && weaponType.hasFlag(WeaponType.F_MRM)
                         && weapon.getLinkedBy() != null
                         && weapon.getLinkedBy().getType().hasFlag(MiscType.F_APOLLO)
                         && !(

--- a/megamek/src/megamek/common/actions/compute/ComputeToHitIsImpossible.java
+++ b/megamek/src/megamek/common/actions/compute/ComputeToHitIsImpossible.java
@@ -222,6 +222,7 @@ class ComputeToHitIsImpossible {
             if (target.getTargetType() == Targetable.TYPE_SATURATION
             && !(
                   (weapon != null)
+                        && (weaponType != null)
                         && weaponType.hasFlag(WeaponType.F_MRM)
                         && weapon.getLinkedBy() != null
                         && weapon.getLinkedBy().getType().hasFlag(MiscType.F_APOLLO)

--- a/megamek/src/megamek/common/actions/compute/ComputeToHitIsImpossible.java
+++ b/megamek/src/megamek/common/actions/compute/ComputeToHitIsImpossible.java
@@ -218,7 +218,7 @@ class ComputeToHitIsImpossible {
                   && !AmmoType.canDeliverMinefield(ammoType)) {
                 return Messages.getString("WeaponAttackAction.NoMinefields");
             }
-            if (target.getTargetType() == Targetable.TYPE_SATURATION 
+            if (target.getTargetType() == Targetable.TYPE_SATURATION
             && !(
                   weaponType.hasFlag(WeaponType.F_MRM)
                         && weapon.getLinkedBy() != null
@@ -343,6 +343,16 @@ class ComputeToHitIsImpossible {
         // Stunned vehicle crews can't make attacks
         if (attacker instanceof Tank tank && tank.getStunnedTurns() > 0) {
             return Messages.getString("WeaponAttackAction.CrewStunned");
+        }
+
+        // Advanced building gunners stunned or killed by a critical hit cannot fire (TO:AR p. 118)
+        if (attacker instanceof AbstractBuildingEntity buildingAttacker) {
+            if (buildingAttacker.isStunned()) {
+                return Messages.getString("WeaponAttackAction.CrewStunned");
+            }
+            if ((weapon != null) && buildingAttacker.hasDeadGunners(weapon.getLocation())) {
+                return Messages.getString("WeaponAttackAction.BuildingGunnersKilled");
+            }
         }
 
         // Vehicles with a single crewman can't shoot and unjam a RAC in the same turn (like meks...)
@@ -624,7 +634,7 @@ class ComputeToHitIsImpossible {
                 }
             }
         }
-        
+
         // Bombast lasers while charging cannot fire
         if ((weapon != null) && (weaponType.hasFlag(WeaponType.F_BOMBAST_LASER) && weapon.getChargeState().equals(ChargeLevel.CHARGING))) {
             return Messages.getString("WeaponAttackAction.BombastImpossible");

--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -6329,6 +6329,11 @@ public class Compute {
      *       the roof or in the air above the building, or if any input argument is <code>null</code>
      */
     public static boolean isInBuilding(@Nullable Game game, @Nullable Entity entity, @Nullable Coords coords) {
+        // A building entity occupies its hexes but is never "inside" a building; treating it as an occupant makes
+        // weapon fire absorb against it twice (once as the building, once as a unit in the building)
+        if (entity instanceof AbstractBuildingEntity) {
+            return false;
+        }
         return (game != null) && (entity != null) && (coords != null)
               && isInBuilding(game, entity.getElevation(), coords, entity.getBoardId());
     }

--- a/megamek/src/megamek/common/units/AbstractBuildingEntity.java
+++ b/megamek/src/megamek/common/units/AbstractBuildingEntity.java
@@ -1601,8 +1601,20 @@ public abstract class AbstractBuildingEntity extends Entity implements IBuilding
     }
 
     /**
+     * A building weapon is turret-mounted when its unit file marks it {@code (ST)} or {@code (PT)}; the loader stores
+     * that as the Mek or pintle turret flag, so {@link Mounted#isTurret()} does not see it.
+     *
+     * @param weapon a weapon of this building
+     *
+     * @return {@code true} if the weapon sits in a turret and can normally fire in any direction
+     */
+    public boolean isTurretMounted(WeaponMounted weapon) {
+        return weapon.isMekTurretMounted() || weapon.isPintleTurretMounted() || weapon.isSponsonTurretMounted();
+    }
+
+    /**
      * Applies a Turret Locks critical hit (TO:AR p. 118) to one turreted weapon: it keeps firing, but only into the
-     * arc of its current facing.
+     * building's forward arc.
      *
      * @param weapon the turreted weapon to lock
      */

--- a/megamek/src/megamek/common/units/AbstractBuildingEntity.java
+++ b/megamek/src/megamek/common/units/AbstractBuildingEntity.java
@@ -1461,11 +1461,32 @@ public abstract class AbstractBuildingEntity extends Entity implements IBuilding
     /** Turns the gunners remain stunned; a stunned building takes no actions (TO:AR p. 118, Gunners Stunned). */
     private int stunnedTurns = 0;
 
-    /** Locations whose gunners were killed by a critical hit; no weapon in them fires again (TO:AR p. 118). */
-    private final Set<Integer> deadGunnerLocations = new HashSet<>();
+    /**
+     * Locations whose gunners were killed by a critical hit; no weapon in them fires again (TO:AR p. 118). Not
+     * final: a building deserialized from a save written before this field existed comes back with it {@code null},
+     * so it is created on first use.
+     */
+    private Set<Integer> deadGunnerLocations = new HashSet<>();
 
-    /** Equipment numbers of turreted weapons locked in their current facing by a critical hit (TO:AR p. 118). */
-    private final Set<Integer> lockedTurretWeapons = new HashSet<>();
+    /**
+     * Equipment numbers of turreted weapons locked in their current facing by a critical hit (TO:AR p. 118). Not
+     * final for the same deserialization reason as {@link #deadGunnerLocations}.
+     */
+    private Set<Integer> lockedTurretWeapons = new HashSet<>();
+
+    private Set<Integer> deadGunnerLocations() {
+        if (deadGunnerLocations == null) {
+            deadGunnerLocations = new HashSet<>();
+        }
+        return deadGunnerLocations;
+    }
+
+    private Set<Integer> lockedTurretWeapons() {
+        if (lockedTurretWeapons == null) {
+            lockedTurretWeapons = new HashSet<>();
+        }
+        return lockedTurretWeapons;
+    }
 
     /**
      * A building is never inside a building. Without this override the building entity is treated as a unit standing
@@ -1577,7 +1598,7 @@ public abstract class AbstractBuildingEntity extends Entity implements IBuilding
      * @param coords the board hex whose gunners were killed
      */
     public void killGunnersAt(Coords coords) {
-        deadGunnerLocations.addAll(getLocationsAt(coords));
+        deadGunnerLocations().addAll(getLocationsAt(coords));
         if (allGunnersDead()) {
             getCrew().setDoomed(true);
         }
@@ -1589,7 +1610,7 @@ public abstract class AbstractBuildingEntity extends Entity implements IBuilding
      * @return {@code true} if a Gunners Killed critical hit has silenced that location
      */
     public boolean hasDeadGunners(int location) {
-        return deadGunnerLocations.contains(location);
+        return deadGunnerLocations().contains(location);
     }
 
     /**
@@ -1597,7 +1618,7 @@ public abstract class AbstractBuildingEntity extends Entity implements IBuilding
      */
     public boolean allGunnersDead() {
         return !locationToRelativeCoordsMap.isEmpty()
-              && deadGunnerLocations.containsAll(locationToRelativeCoordsMap.keySet());
+              && deadGunnerLocations().containsAll(locationToRelativeCoordsMap.keySet());
     }
 
     /**
@@ -1619,7 +1640,7 @@ public abstract class AbstractBuildingEntity extends Entity implements IBuilding
      * @param weapon the turreted weapon to lock
      */
     public void lockTurretWeapon(WeaponMounted weapon) {
-        lockedTurretWeapons.add(getEquipmentNum(weapon));
+        lockedTurretWeapons().add(getEquipmentNum(weapon));
     }
 
     /**
@@ -1628,14 +1649,14 @@ public abstract class AbstractBuildingEntity extends Entity implements IBuilding
      * @return {@code true} if a Turret Locks critical hit has fixed that weapon's facing
      */
     public boolean isTurretLocked(WeaponMounted weapon) {
-        return lockedTurretWeapons.contains(getEquipmentNum(weapon));
+        return lockedTurretWeapons().contains(getEquipmentNum(weapon));
     }
 
     /**
      * @return {@code true} if any turret of this building has been locked by a critical hit
      */
     public boolean hasLockedTurret() {
-        return !lockedTurretWeapons.isEmpty();
+        return !lockedTurretWeapons().isEmpty();
     }
 
     @Override

--- a/megamek/src/megamek/common/units/AbstractBuildingEntity.java
+++ b/megamek/src/megamek/common/units/AbstractBuildingEntity.java
@@ -1631,6 +1631,13 @@ public abstract class AbstractBuildingEntity extends Entity implements IBuilding
         return lockedTurretWeapons.contains(getEquipmentNum(weapon));
     }
 
+    /**
+     * @return {@code true} if any turret of this building has been locked by a critical hit
+     */
+    public boolean hasLockedTurret() {
+        return !lockedTurretWeapons.isEmpty();
+    }
+
     @Override
     public void newRound(int roundNumber) {
         super.newRound(roundNumber);

--- a/megamek/src/megamek/common/units/AbstractBuildingEntity.java
+++ b/megamek/src/megamek/common/units/AbstractBuildingEntity.java
@@ -52,7 +52,9 @@ import megamek.common.cost.CostCalculator;
 import megamek.common.enums.AimingMode;
 import megamek.common.enums.BasementType;
 import megamek.common.enums.BuildingType;
+import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.IArmorState;
+import megamek.common.equipment.MiscMounted;
 import megamek.common.equipment.Mounted;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.exceptions.LocationFullException;
@@ -1452,5 +1454,176 @@ public abstract class AbstractBuildingEntity extends Entity implements IBuilding
         // AbstractBuildingEntity can reinforce if it's the target of ongoing combat
         return getGame().getEntitiesVector(getBoardLocation()).stream()
               .anyMatch(e -> e.getInfantryCombatTargetId() == this.getId());
+    }
+
+    // ========== Advanced Building Critical Damage (TO:AR pp. 118-119) ==========
+
+    /** Turns the gunners remain stunned; a stunned building takes no actions (TO:AR p. 118, Gunners Stunned). */
+    private int stunnedTurns = 0;
+
+    /** Locations whose gunners were killed by a critical hit; no weapon in them fires again (TO:AR p. 118). */
+    private final Set<Integer> deadGunnerLocations = new HashSet<>();
+
+    /** Equipment numbers of turreted weapons locked in their current facing by a critical hit (TO:AR p. 118). */
+    private final Set<Integer> lockedTurretWeapons = new HashSet<>();
+
+    /**
+     * A building is never inside a building. Without this override the building entity is treated as a unit standing
+     * inside its own hex, which makes weapon fire absorb against it once as a building and again as an occupant.
+     *
+     * @return {@code false}
+     */
+    @Override
+    public boolean isInBuilding() {
+        return false;
+    }
+
+    /**
+     * @param location an entity location (one hex level of this building)
+     *
+     * @return the board hex that location belongs to, or {@code null} if the location is unknown
+     */
+    public @Nullable Coords getLocationCoords(int location) {
+        CubeCoords relativeCoords = locationToRelativeCoordsMap.get(location);
+        return (relativeCoords == null) ? null : relativeToBoard(relativeCoords);
+    }
+
+    /**
+     * @param location an entity location (one hex level of this building)
+     *
+     * @return the level within the hex that location represents; {@code 0} is the ground level
+     */
+    public int getLocationLevel(int location) {
+        int buildingHeight = getInternalBuilding().getBuildingHeight();
+        return (buildingHeight > 0) ? location % buildingHeight : 0;
+    }
+
+    /**
+     * @param coords a board hex of this building, or {@code null}
+     *
+     * @return every entity location (one per level) that sits in that hex; empty when the hex is not part of this
+     *       building
+     */
+    public List<Integer> getLocationsAt(@Nullable Coords coords) {
+        return coordsToLocations(coords);
+    }
+
+    /**
+     * @param coords a board hex of this building
+     *
+     * @return the weapons mounted in any level of that hex
+     */
+    public List<WeaponMounted> getWeaponsAt(Coords coords) {
+        List<Integer> locations = getLocationsAt(coords);
+        return getWeaponList().stream()
+              .filter(weapon -> locations.contains(weapon.getLocation()))
+              .toList();
+    }
+
+    /**
+     * @param coords a board hex of this building
+     *
+     * @return the ammunition bins mounted in any level of that hex
+     */
+    public List<AmmoMounted> getAmmoAt(Coords coords) {
+        List<Integer> locations = getLocationsAt(coords);
+        return getAmmo().stream()
+              .filter(ammo -> locations.contains(ammo.getLocation()))
+              .toList();
+    }
+
+    /**
+     * @param coords a board hex of this building
+     *
+     * @return the miscellaneous equipment mounted in any level of that hex
+     */
+    public List<MiscMounted> getMiscAt(Coords coords) {
+        List<Integer> locations = getLocationsAt(coords);
+        return getMisc().stream()
+              .filter(misc -> locations.contains(misc.getLocation()))
+              .toList();
+    }
+
+    /**
+     * @return the number of turns the gunners remain stunned; {@code 0} when they can act
+     */
+    public int getStunnedTurns() {
+        return stunnedTurns;
+    }
+
+    /**
+     * @return {@code true} while the gunners are stunned and the building may take no actions
+     */
+    public boolean isStunned() {
+        return stunnedTurns > 0;
+    }
+
+    /**
+     * Applies a Gunners Stunned critical hit (TO:AR p. 118): the building takes no actions during the following turn.
+     * Multiple stuns in the same turn extend the effect by one turn each, matching vehicle crew stuns.
+     */
+    public void stunGunners() {
+        if (stunnedTurns == 0) {
+            stunnedTurns = 2;
+        } else {
+            stunnedTurns++;
+        }
+    }
+
+    /**
+     * Applies a Gunners Killed critical hit (TO:AR p. 118) to one hex: no weapon in that hex fires for the rest of the
+     * scenario. When every hex has lost its gunners the building's crew is marked as doomed.
+     *
+     * @param coords the board hex whose gunners were killed
+     */
+    public void killGunnersAt(Coords coords) {
+        deadGunnerLocations.addAll(getLocationsAt(coords));
+        if (allGunnersDead()) {
+            getCrew().setDoomed(true);
+        }
+    }
+
+    /**
+     * @param location an entity location
+     *
+     * @return {@code true} if a Gunners Killed critical hit has silenced that location
+     */
+    public boolean hasDeadGunners(int location) {
+        return deadGunnerLocations.contains(location);
+    }
+
+    /**
+     * @return {@code true} when every location of this building has lost its gunners
+     */
+    public boolean allGunnersDead() {
+        return !locationToRelativeCoordsMap.isEmpty()
+              && deadGunnerLocations.containsAll(locationToRelativeCoordsMap.keySet());
+    }
+
+    /**
+     * Applies a Turret Locks critical hit (TO:AR p. 118) to one turreted weapon: it keeps firing, but only into the
+     * arc of its current facing.
+     *
+     * @param weapon the turreted weapon to lock
+     */
+    public void lockTurretWeapon(WeaponMounted weapon) {
+        lockedTurretWeapons.add(getEquipmentNum(weapon));
+    }
+
+    /**
+     * @param weapon a weapon of this building
+     *
+     * @return {@code true} if a Turret Locks critical hit has fixed that weapon's facing
+     */
+    public boolean isTurretLocked(WeaponMounted weapon) {
+        return lockedTurretWeapons.contains(getEquipmentNum(weapon));
+    }
+
+    @Override
+    public void newRound(int roundNumber) {
+        super.newRound(roundNumber);
+        if (stunnedTurns > 0) {
+            stunnedTurns--;
+        }
     }
 }

--- a/megamek/src/megamek/common/units/BuildingEntity.java
+++ b/megamek/src/megamek/common/units/BuildingEntity.java
@@ -59,6 +59,9 @@ import megamek.common.equipment.enums.StructureEngine;
  */
 public class BuildingEntity extends AbstractBuildingEntity {
 
+    /** The weapon arc a fixed weapon facing forward fires into; also used for a turret locked by a critical hit. */
+    private static final int FORWARD_ARC = 1;
+
     public BuildingEntity(BuildingType type, int bldgClass) {
         super(type, bldgClass);
     }
@@ -137,9 +140,9 @@ public class BuildingEntity extends AbstractBuildingEntity {
     @Override
     public int getWeaponArc(int weaponNumber) {
         WeaponMounted weapon = getWeapon(weaponNumber);
-        // A turret locked by a critical hit (TO:AR p. 118) fires only into the arc of its current facing
-        if (weapon.isTurret() && !isTurretLocked(weapon)) {
-            return 0;
+        if (isTurretMounted(weapon)) {
+            // A turret locked by a critical hit (TO:AR p. 118) fires only into the building's forward arc
+            return isTurretLocked(weapon) ? FORWARD_ARC : 0;
         }
         return switch (weapon.getFacing()) {
             case 0 -> 1;

--- a/megamek/src/megamek/common/units/BuildingEntity.java
+++ b/megamek/src/megamek/common/units/BuildingEntity.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2003-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2003-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -137,7 +137,8 @@ public class BuildingEntity extends AbstractBuildingEntity {
     @Override
     public int getWeaponArc(int weaponNumber) {
         WeaponMounted weapon = getWeapon(weaponNumber);
-        if (weapon.isTurret()) {
+        // A turret locked by a critical hit (TO:AR p. 118) fires only into the arc of its current facing
+        if (weapon.isTurret() && !isTurretLocked(weapon)) {
             return 0;
         }
         return switch (weapon.getFacing()) {
@@ -367,4 +368,3 @@ public class BuildingEntity extends AbstractBuildingEntity {
           .setAvailability(AvailabilityValue.A, AvailabilityValue.A, AvailabilityValue.A, AvailabilityValue.A)
           .setStaticTechLevel(SimpleTechLevel.ADVANCED);
 }
-

--- a/megamek/src/megamek/common/units/BuildingTarget.java
+++ b/megamek/src/megamek/common/units/BuildingTarget.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000-2002 Ben Mazur (bmazur@sev.org)
- * Copyright (C) 2003-2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2003-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *
@@ -111,7 +111,9 @@ public class BuildingTarget implements Targetable {
             throw new IllegalArgumentException("No building at %s.".formatted(getBoardLocation()));
         }
 
-        name = "Hex %s of %s".formatted(position.getBoardNum(), bldg.toString());
+        // An Advanced Building is an Entity whose toString() is a debug form; use its unit name instead
+        String buildingName = (bldg instanceof Entity buildingEntity) ? buildingEntity.getShortName() : bldg.toString();
+        name = "Hex %s of %s".formatted(position.getBoardNum(), buildingName);
         if (boardId > 0) {
             name += " (Board #%d - %s)".formatted(boardId, board.getBoardName());
         }

--- a/megamek/src/megamek/common/units/Entity.java
+++ b/megamek/src/megamek/common/units/Entity.java
@@ -4902,8 +4902,12 @@ public abstract class Entity extends TurnOrdered
 
     /**
      * Returns the equipment, specified by number
+     *
+     * @param index the equipment number
+     *
+     * @return the mount with that number, or {@code null} when the unit has no equipment with that number
      */
-    public Mounted<?> getEquipment(int index) {
+    public @Nullable Mounted<?> getEquipment(int index) {
         try {
             return equipmentList.get(index);
         } catch (IndexOutOfBoundsException ex) {

--- a/megamek/src/megamek/server/totalWarfare/BuildingEntityCriticalHandler.java
+++ b/megamek/src/megamek/server/totalWarfare/BuildingEntityCriticalHandler.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.server.totalWarfare;
+
+import java.util.List;
+import java.util.Vector;
+
+import megamek.common.Report;
+import megamek.common.board.Coords;
+import megamek.common.compute.Compute;
+import megamek.common.equipment.AmmoMounted;
+import megamek.common.equipment.AmmoType;
+import megamek.common.equipment.MiscMounted;
+import megamek.common.equipment.WeaponMounted;
+import megamek.common.units.AbstractBuildingEntity;
+import megamek.logging.MMLogger;
+
+/**
+ * Resolves a critical hit against an Advanced Building entity using the Advanced Building Critical Hits Table
+ * (TO:AR p. 119). The check itself (a single attack exceeding a tenth of the hex's start-of-turn CF) is made by
+ * {@link TWGameManager#damageBuilding}; this handler only rolls and applies the effect to the equipment in the hex
+ * that was hit.
+ *
+ * <p>Effects are applied per hex, as the table describes. A Gunners Stunned result stuns the whole building, because
+ * stun state is tracked per entity; for the single-hex gun emplacements this is the same thing.</p>
+ */
+class BuildingEntityCriticalHandler extends AbstractTWRuleHandler {
+    private static final MMLogger LOGGER = MMLogger.create(BuildingEntityCriticalHandler.class);
+
+    /** On the Turret Jammed/Turret Locked result a 1D6 of this value or less jams; higher locks (TO:AR p. 119). */
+    private static final int TURRET_JAM_MAX_ROLL = 3;
+
+    BuildingEntityCriticalHandler(TWGameManager gameManager) {
+        super(gameManager);
+    }
+
+    /**
+     * Rolls 2D6 on the Advanced Building Critical Hits Table and applies the result to the given hex.
+     *
+     * @param building the building that exceeded its damage threshold
+     * @param coords   the board hex that was hit
+     *
+     * @return the reports describing the roll and its effect
+     */
+    Vector<Report> resolveCriticalHit(AbstractBuildingEntity building, Coords coords) {
+        return applyCriticalResult(building, coords, Compute.d6(2), Compute.d6());
+    }
+
+    /**
+     * Applies an already-rolled result. Exposed for tests so every row of the table can be exercised without dice.
+     *
+     * @param building     the building that exceeded its damage threshold
+     * @param coords       the board hex that was hit
+     * @param criticalRoll the 2D6 result on the Advanced Building Critical Hits Table
+     * @param turretRoll   the 1D6 used only by the Turret Jammed/Turret Locked result
+     *
+     * @return the reports describing the roll and its effect
+     */
+    Vector<Report> applyCriticalResult(AbstractBuildingEntity building, Coords coords, int criticalRoll,
+          int turretRoll) {
+        Vector<Report> reports = new Vector<>();
+        reports.add(publicReport(3800, 0));
+        LOGGER.debug("[BuildingCrit] {} hex {}: critical roll {} (turret roll {})",
+              building.getShortName(), coords, criticalRoll, turretRoll);
+        switch (criticalRoll) {
+            case 6 -> weaponMalfunction(building, coords, reports);
+            case 7 -> gunnersStunned(building, reports);
+            case 8 -> weaponDestroyed(building, coords, reports);
+            case 9 -> gunnersKilled(building, coords, reports);
+            case 10 -> turretHit(building, coords, turretRoll, reports);
+            case 11 -> ammunitionExplosion(building, coords, reports);
+            case 12 -> otherEquipmentHit(building, coords, reports);
+            default -> reports.add(publicReport(3805, 1));
+        }
+        return reports;
+    }
+
+    /** Result 6: one working weapon in the hex jams until the gunners clear it. */
+    private void weaponMalfunction(AbstractBuildingEntity building, Coords coords, Vector<Report> reports) {
+        List<WeaponMounted> candidates = building.getWeaponsAt(coords).stream()
+              .filter(weapon -> !weapon.isHit() && !weapon.isJammed() && !weapon.jammedThisPhase())
+              .toList();
+        if (candidates.isEmpty()) {
+            reports.add(publicReport(3846, 1));
+            return;
+        }
+        WeaponMounted weapon = candidates.get(Compute.randomInt(candidates.size()));
+        weapon.setJammed(true);
+        Report report = publicReport(3845, 1);
+        report.add(weapon.getDesc());
+        reports.add(report);
+        LOGGER.debug("[BuildingCrit] {}: weapon malfunction, {} jammed", building.getShortName(), weapon.getName());
+    }
+
+    /** Result 7: the gunners are disoriented and the building takes no actions next turn. */
+    private void gunnersStunned(AbstractBuildingEntity building, Vector<Report> reports) {
+        building.stunGunners();
+        reports.add(publicReport(3810, 1));
+        LOGGER.debug("[BuildingCrit] {}: gunners stunned for {} turns", building.getShortName(),
+              building.getStunnedTurns());
+    }
+
+    /** Result 8: one working weapon in the hex stops working for the rest of the scenario. */
+    private void weaponDestroyed(AbstractBuildingEntity building, Coords coords, Vector<Report> reports) {
+        List<WeaponMounted> candidates = building.getWeaponsAt(coords).stream()
+              .filter(weapon -> !weapon.isHit())
+              .toList();
+        if (candidates.isEmpty()) {
+            reports.add(publicReport(3841, 1));
+            return;
+        }
+        WeaponMounted weapon = candidates.get(Compute.randomInt(candidates.size()));
+        weapon.setHit(true);
+        Report report = publicReport(3840, 1);
+        report.add(weapon.getDesc());
+        reports.add(report);
+        LOGGER.debug("[BuildingCrit] {}: weapon destroyed, {}", building.getShortName(), weapon.getName());
+    }
+
+    /** Result 9: nothing in the hex fires again this scenario. */
+    private void gunnersKilled(AbstractBuildingEntity building, Coords coords, Vector<Report> reports) {
+        building.killGunnersAt(coords);
+        reports.add(publicReport(3815, 1));
+        LOGGER.debug("[BuildingCrit] {}: gunners killed in hex {}; all gunners dead = {}", building.getShortName(),
+              coords, building.allGunnersDead());
+    }
+
+    /** Result 10: turreted weapons in the hex jam (1D6 of 1 to 3) or lock in their current facing (4 to 6). */
+    private void turretHit(AbstractBuildingEntity building, Coords coords, int turretRoll, Vector<Report> reports) {
+        List<WeaponMounted> turretWeapons = building.getWeaponsAt(coords).stream()
+              .filter(weapon -> weapon.isTurret() && !weapon.isHit())
+              .toList();
+        if (turretWeapons.isEmpty()) {
+            reports.add(publicReport(3826, 1));
+            return;
+        }
+        if (turretRoll <= TURRET_JAM_MAX_ROLL) {
+            turretWeapons.forEach(weapon -> weapon.setJammed(true));
+            reports.add(publicReport(3825, 1));
+        } else {
+            turretWeapons.forEach(building::lockTurretWeapon);
+            reports.add(publicReport(3820, 1));
+        }
+        LOGGER.debug("[BuildingCrit] {}: turret {} in hex {} ({} weapons)", building.getShortName(),
+              (turretRoll <= TURRET_JAM_MAX_ROLL) ? "jammed" : "locked", coords, turretWeapons.size());
+    }
+
+    /** Result 11: every ammunition bin in the hex explodes and the total is applied to the hex's CF. */
+    private void ammunitionExplosion(AbstractBuildingEntity building, Coords coords, Vector<Report> reports) {
+        int explosionDamage = 0;
+        for (AmmoMounted ammo : building.getAmmoAt(coords)) {
+            ammo.setHit(true);
+            if (ammo.getType().isExplosive(ammo)) {
+                AmmoType ammoType = ammo.getType();
+                explosionDamage += ammo.getHittableShotsLeft() * ammoType.getDamagePerShot() * ammoType.getRackSize();
+            }
+        }
+        explosionDamage = (int) Math.floor(building.getDamageToScale() * explosionDamage);
+        if (explosionDamage == 0) {
+            reports.add(publicReport(3831, 1));
+            return;
+        }
+        int currentCF = building.getCurrentCF(coords);
+        currentCF -= Math.min(currentCF, explosionDamage);
+        building.setCurrentCF(currentCF, coords);
+        Report report = publicReport(3830, 1);
+        report.add(building.getShortName());
+        report.add(explosionDamage);
+        report.add(currentCF);
+        reports.add(report);
+        LOGGER.info("[BuildingCrit] {}: ammunition explosion for {} in hex {}, CF now {}", building.getShortName(),
+              explosionDamage, coords, currentCF);
+    }
+
+    /** Result 12: one other piece of equipment in the hex is rendered inoperative. */
+    private void otherEquipmentHit(AbstractBuildingEntity building, Coords coords, Vector<Report> reports) {
+        List<MiscMounted> candidates = building.getMiscAt(coords).stream()
+              .filter(misc -> !misc.isHit() && !misc.isDestroyed())
+              .toList();
+        if (candidates.isEmpty()) {
+            reports.add(publicReport(3835, 1));
+            return;
+        }
+        MiscMounted equipment = candidates.get(Compute.randomInt(candidates.size()));
+        equipment.setHit(true);
+        Report report = publicReport(3836, 1);
+        report.add(equipment.getDesc());
+        reports.add(report);
+        LOGGER.debug("[BuildingCrit] {}: other equipment hit, {}", building.getShortName(), equipment.getName());
+    }
+
+    private Report publicReport(int messageId, int indent) {
+        Report report = new Report(messageId);
+        report.type = Report.PUBLIC;
+        report.indent(indent);
+        return report;
+    }
+}

--- a/megamek/src/megamek/server/totalWarfare/BuildingEntityCriticalHandler.java
+++ b/megamek/src/megamek/server/totalWarfare/BuildingEntityCriticalHandler.java
@@ -158,7 +158,7 @@ class BuildingEntityCriticalHandler extends AbstractTWRuleHandler {
     /** Result 10: turreted weapons in the hex jam (1D6 of 1 to 3) or lock in their current facing (4 to 6). */
     private void turretHit(AbstractBuildingEntity building, Coords coords, int turretRoll, Vector<Report> reports) {
         List<WeaponMounted> turretWeapons = building.getWeaponsAt(coords).stream()
-              .filter(weapon -> weapon.isTurret() && !weapon.isHit())
+              .filter(weapon -> building.isTurretMounted(weapon) && !weapon.isHit())
               .toList();
         if (turretWeapons.isEmpty()) {
             reports.add(publicReport(3826, 1));

--- a/megamek/src/megamek/server/totalWarfare/BuildingEntityCriticalHandler.java
+++ b/megamek/src/megamek/server/totalWarfare/BuildingEntityCriticalHandler.java
@@ -95,7 +95,7 @@ class BuildingEntityCriticalHandler extends AbstractTWRuleHandler {
               building.getShortName(), coords, criticalRoll, turretRoll);
         switch (criticalRoll) {
             case 6 -> weaponMalfunction(building, coords, reports);
-            case 7 -> gunnersStunned(building, reports);
+            case 7 -> gunnersStunned(building, coords, reports);
             case 8 -> weaponDestroyed(building, coords, reports);
             case 9 -> gunnersKilled(building, coords, reports);
             case 10 -> turretHit(building, coords, turretRoll, reports);
@@ -123,8 +123,18 @@ class BuildingEntityCriticalHandler extends AbstractTWRuleHandler {
         LOGGER.debug("[BuildingCrit] {}: weapon malfunction, {} jammed", building.getShortName(), weapon.getName());
     }
 
-    /** Result 7: the gunners are disoriented and the building takes no actions next turn. */
-    private void gunnersStunned(AbstractBuildingEntity building, Vector<Report> reports) {
+    /**
+     * Result 7: the gunners are disoriented and the building takes no actions next turn. A hex whose gunners are
+     * already dead has nobody to stun, so the result has no effect (TO:AR p. 118, Critical Hit Effects).
+     */
+    private void gunnersStunned(AbstractBuildingEntity building, Coords coords, Vector<Report> reports) {
+        boolean gunnersDead = building.getLocationsAt(coords).stream().allMatch(building::hasDeadGunners);
+        if (gunnersDead) {
+            reports.add(publicReport(3805, 1));
+            LOGGER.debug("[BuildingCrit] {}: gunners stunned in hex {} has no effect, gunners already dead",
+                  building.getShortName(), coords);
+            return;
+        }
         building.stunGunners();
         reports.add(publicReport(3810, 1));
         LOGGER.debug("[BuildingCrit] {}: gunners stunned for {} turns", building.getShortName(),

--- a/megamek/src/megamek/server/totalWarfare/BuildingEntityCriticalHandler.java
+++ b/megamek/src/megamek/server/totalWarfare/BuildingEntityCriticalHandler.java
@@ -41,6 +41,7 @@ import megamek.common.compute.Compute;
 import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.AmmoType;
 import megamek.common.equipment.MiscMounted;
+import megamek.common.equipment.Mounted;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.units.AbstractBuildingEntity;
 import megamek.logging.MMLogger;
@@ -109,7 +110,7 @@ class BuildingEntityCriticalHandler extends AbstractTWRuleHandler {
     /** Result 6: one working weapon in the hex jams until the gunners clear it. */
     private void weaponMalfunction(AbstractBuildingEntity building, Coords coords, Vector<Report> reports) {
         List<WeaponMounted> candidates = building.getWeaponsAt(coords).stream()
-              .filter(weapon -> !weapon.isHit() && !weapon.isJammed() && !weapon.jammedThisPhase())
+              .filter(weapon -> isWorking(weapon) && !weapon.isJammed() && !weapon.jammedThisPhase())
               .toList();
         if (candidates.isEmpty()) {
             reports.add(publicReport(3846, 1));
@@ -144,7 +145,7 @@ class BuildingEntityCriticalHandler extends AbstractTWRuleHandler {
     /** Result 8: one working weapon in the hex stops working for the rest of the scenario. */
     private void weaponDestroyed(AbstractBuildingEntity building, Coords coords, Vector<Report> reports) {
         List<WeaponMounted> candidates = building.getWeaponsAt(coords).stream()
-              .filter(weapon -> !weapon.isHit())
+              .filter(this::isWorking)
               .toList();
         if (candidates.isEmpty()) {
             reports.add(publicReport(3841, 1));
@@ -169,7 +170,7 @@ class BuildingEntityCriticalHandler extends AbstractTWRuleHandler {
     /** Result 10: turreted weapons in the hex jam (1D6 of 1 to 3) or lock in their current facing (4 to 6). */
     private void turretHit(AbstractBuildingEntity building, Coords coords, int turretRoll, Vector<Report> reports) {
         List<WeaponMounted> turretWeapons = building.getWeaponsAt(coords).stream()
-              .filter(weapon -> building.isTurretMounted(weapon) && !weapon.isHit())
+              .filter(weapon -> building.isTurretMounted(weapon) && isWorking(weapon))
               .toList();
         if (turretWeapons.isEmpty()) {
             reports.add(publicReport(3826, 1));
@@ -216,7 +217,7 @@ class BuildingEntityCriticalHandler extends AbstractTWRuleHandler {
     /** Result 12: one other piece of equipment in the hex is rendered inoperative. */
     private void otherEquipmentHit(AbstractBuildingEntity building, Coords coords, Vector<Report> reports) {
         List<MiscMounted> candidates = building.getMiscAt(coords).stream()
-              .filter(misc -> !misc.isHit() && !misc.isDestroyed())
+              .filter(this::isWorking)
               .toList();
         if (candidates.isEmpty()) {
             reports.add(publicReport(3835, 1));
@@ -228,6 +229,15 @@ class BuildingEntityCriticalHandler extends AbstractTWRuleHandler {
         report.add(equipment.getDesc());
         reports.add(report);
         LOGGER.debug("[BuildingCrit] {}: other equipment hit, {}", building.getShortName(), equipment.getName());
+    }
+
+    /**
+     * A critical result only lands on equipment that still works. A mount that took a hit this phase is out even
+     * though it is not yet marked destroyed, and a mount can be destroyed, missing or useless without the hit flag,
+     * for example when its hex collapsed.
+     */
+    private boolean isWorking(Mounted<?> mounted) {
+        return !mounted.isHit() && mounted.isOperable();
     }
 
     private Report publicReport(int messageId, int indent) {

--- a/megamek/src/megamek/server/totalWarfare/BuildingEntityCriticalHandler.java
+++ b/megamek/src/megamek/server/totalWarfare/BuildingEntityCriticalHandler.java
@@ -130,7 +130,7 @@ class BuildingEntityCriticalHandler extends AbstractTWRuleHandler {
     private void gunnersStunned(AbstractBuildingEntity building, Coords coords, Vector<Report> reports) {
         boolean gunnersDead = building.getLocationsAt(coords).stream().allMatch(building::hasDeadGunners);
         if (gunnersDead) {
-            reports.add(publicReport(3805, 1));
+            reports.add(publicReport(3811, 1));
             LOGGER.debug("[BuildingCrit] {}: gunners stunned in hex {} has no effect, gunners already dead",
                   building.getShortName(), coords);
             return;

--- a/megamek/src/megamek/server/totalWarfare/BuildingEntityCriticalHandler.java
+++ b/megamek/src/megamek/server/totalWarfare/BuildingEntityCriticalHandler.java
@@ -90,7 +90,8 @@ class BuildingEntityCriticalHandler extends AbstractTWRuleHandler {
           int turretRoll) {
         Vector<Report> reports = new Vector<>();
         reports.add(publicReport(3800, 0));
-        LOGGER.debug("[BuildingCrit] {} hex {}: critical roll {} (turret roll {})",
+        // A critical roll only happens when a single hit beat the hex's damage threshold, so this stays low-volume
+        LOGGER.info("[BuildingCrit] {} hex {}: critical roll {} (turret roll {})",
               building.getShortName(), coords, criticalRoll, turretRoll);
         switch (criticalRoll) {
             case 6 -> weaponMalfunction(building, coords, reports);

--- a/megamek/src/megamek/server/totalWarfare/TWDamageManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWDamageManager.java
@@ -46,6 +46,7 @@ import megamek.common.HitData;
 import megamek.common.Report;
 import megamek.common.ToHitData;
 import megamek.common.actions.SuicideImplantsAttackAction;
+import megamek.common.annotations.Nullable;
 import megamek.common.battleArmor.BattleArmor;
 import megamek.common.board.Coords;
 import megamek.common.compute.Compute;
@@ -413,6 +414,7 @@ public class TWDamageManager implements IDamageManager {
                   underWater,
                   nukeS2S,
                   mods);
+            case AbstractBuildingEntity buildingEntity -> damageBuildingEntity(reportVec, buildingEntity, hit, damage);
             default -> logger.error(new UnknownEntityTypeException(entity.toString()));
         }
 
@@ -805,7 +807,7 @@ public class TWDamageManager implements IDamageManager {
                     }
                 }
             }
-            
+
             if (ammoExplosion && Game.rulesManager.getRulesExplosions().explosionsAreReduced()) {
                 boolean cased = mek.locationHasCase(hit.getLocation());
                 boolean caseIId = mek.hasCASEII(hit.getLocation());
@@ -817,7 +819,7 @@ public class TWDamageManager implements IDamageManager {
                 } else if (damage > 20) {
                     reducedDamage = 20;
                 }
-                
+
                 // Report this either way
                 report = new Report(6129);
                 report.subject = entityId;
@@ -840,7 +842,7 @@ public class TWDamageManager implements IDamageManager {
                 report.add(mek.getLocationAbbr(hit));
                 reportVec.addElement(report);
             }
-            
+
             if (ammoExplosion) {
                 if (mek instanceof LandAirMek lam) {
                     // LAMs eject if the CT-destroyed switch is on
@@ -1932,6 +1934,62 @@ public class TWDamageManager implements IDamageManager {
      * @param nukeS2S       Whether damage is from a nuclear weapon
      * @param mods          damage modifiers and state tracking
      */
+    /**
+     * Applies weapon damage to an Advanced Building entity (TO:AR p. 118). The building's armour and Construction
+     * Factor live per hex, so the hit is resolved through the same building damage method map buildings use, which
+     * also makes the damage threshold critical hit check for the hex.
+     *
+     * @param reportVec the phase report to add to
+     * @param building  the building entity that was hit
+     * @param hit       the hit data; its location selects the hex and level, and its attacker id is used to pick the
+     *                  nearest standing hex of a multi-hex building
+     * @param damage    the damage to apply
+     */
+    private void damageBuildingEntity(Vector<Report> reportVec, AbstractBuildingEntity building, HitData hit,
+          int damage) {
+        Coords hitCoords = resolveBuildingHitCoords(building, hit);
+        if (hitCoords == null) {
+            logger.warn("[BuildingDamage] {} has no standing hex for hit location {}; {} damage discarded",
+                  building.getShortName(), hit.getLocation(), damage);
+            return;
+        }
+        int level = building.getLocationLevel(hit.getLocation());
+        logger.debug("[BuildingDamage] {} takes {} damage in hex {} level {}", building.getShortName(), damage,
+              hitCoords, level);
+        reportVec.addAll(manager.damageBuilding(building, damage, " takes ", hitCoords, level));
+    }
+
+    /**
+     * Picks the hex of a building entity that a hit lands in. Single-hex buildings and hits with no known attacker use
+     * the hex the hit location belongs to. For a multi-hex building the attacker strikes the standing hex nearest to
+     * it, with ties broken at random.
+     *
+     * @return the hex to damage, or {@code null} if the building has no standing hex left
+     */
+    private @Nullable Coords resolveBuildingHitCoords(AbstractBuildingEntity building, HitData hit) {
+        List<Coords> standingHexes = building.getCoordsList().stream()
+              .filter(building::hasCFIn)
+              .toList();
+        Coords locationCoords = building.getLocationCoords(hit.getLocation());
+        Entity attacker = game.getEntity(hit.getAttackerId());
+        boolean attackerPositionKnown = (attacker != null) && (attacker.getPosition() != null);
+        if (!attackerPositionKnown || (standingHexes.size() <= 1)) {
+            if (locationCoords != null) {
+                return locationCoords;
+            }
+            return standingHexes.isEmpty() ? null : standingHexes.getFirst();
+        }
+        Coords attackerPosition = attacker.getPosition();
+        int nearestDistance = standingHexes.stream()
+              .mapToInt(hex -> hex.distance(attackerPosition))
+              .min()
+              .orElse(0);
+        List<Coords> nearestHexes = standingHexes.stream()
+              .filter(hex -> hex.distance(attackerPosition) == nearestDistance)
+              .toList();
+        return nearestHexes.get(Compute.randomInt(nearestHexes.size()));
+    }
+
     public void damageHandheldWeapon(Vector<Report> reportVec, HandheldWeapon hhw, HitData hit, int damage,
           boolean ammoExplosion,
           DamageType damageType, boolean areaSatArty, boolean throughFront, boolean underWater, boolean nukeS2S,

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -20155,6 +20155,11 @@ public class TWGameManager extends AbstractGameManager {
                 continue;
             }
 
+            // An Advanced Building entity is the building at its hexes and was already damaged as a building
+            if (entity instanceof AbstractBuildingEntity) {
+                continue;
+            }
+
             int range = position.distance(entityPos);
 
             if (range >= damages.length) {
@@ -32596,6 +32601,10 @@ public class TWGameManager extends AbstractGameManager {
             // get units in hex at the specified altitude (elevation + hex level for non-Aerospace) ignoring
             // targetability (if it's there, it's fair)
             for (Entity entity : game.getEntitiesVector(coords, boardId, true)) {
+                // An Advanced Building entity is the building at this hex and was already damaged above
+                if (entity instanceof AbstractBuildingEntity) {
+                    continue;
+                }
                 // Check: is entity excluded?
                 if ((entity == exclude) || alreadyHit.contains(entity.getId())) {
                     continue;

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -59,8 +59,8 @@ import megamek.common.bays.Bay;
 import megamek.common.board.Board;
 import megamek.common.board.BoardDimensions;
 import megamek.common.board.BoardLocation;
-import megamek.common.board.Coords;
 import megamek.common.board.BuildingEditSpec;
+import megamek.common.board.Coords;
 import megamek.common.board.HexEditSpec;
 import megamek.common.board.postprocess.TWBoardTransformer;
 import megamek.common.comparators.WeaponComparatorBV;
@@ -29455,7 +29455,7 @@ public class TWGameManager extends AbstractGameManager {
         // Do nothing if no building or no damage was passed.
         if ((bldg != null) && (damage > 0)) {
             r.messageId = 3434;
-            r.add(bldg.toString());
+            r.add((bldg instanceof Entity buildingEntity) ? buildingEntity.getShortName() : bldg.toString());
             r.add(why);
             r.add(damage);
             r.add(level);
@@ -29548,10 +29548,16 @@ public class TWGameManager extends AbstractGameManager {
                     vPhaseReport.add(r);
                 } else if ((curCF < startingCF) && (damage > damageThresh)) {
                     // need to check for crits
-                    // don't bother unless we have some gun emplacements
-                    Collection<GunEmplacement> guns = game.getGunEmplacements(coords, bldg.getBoardId());
-                    if (!guns.isEmpty()) {
-                        vPhaseReport.addAll(criticalGunEmplacement(guns, bldg, coords));
+                    if (bldg instanceof AbstractBuildingEntity buildingEntity) {
+                        // Advanced Building Critical Hits Table, TO:AR p. 119
+                        vPhaseReport.addAll(new BuildingEntityCriticalHandler(this)
+                              .resolveCriticalHit(buildingEntity, coords));
+                    } else {
+                        // don't bother unless we have some gun emplacements
+                        Collection<GunEmplacement> guns = game.getGunEmplacements(coords, bldg.getBoardId());
+                        if (!guns.isEmpty()) {
+                            vPhaseReport.addAll(criticalGunEmplacement(guns, bldg, coords));
+                        }
                     }
                 }
             }
@@ -33424,4 +33430,3 @@ public class TWGameManager extends AbstractGameManager {
         send(new Packet(PacketCommand.UPDATE_INDUSTRIAL_ELEVATORS, new ArrayList<>(elevators)));
     }
 }
-

--- a/megamek/unittests/megamek/server/totalWarfare/BuildingEntityDamageTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/BuildingEntityDamageTest.java
@@ -205,6 +205,17 @@ class BuildingEntityDamageTest extends GameBoardTestCase {
     }
 
     @Test
+    void criticalRollOfSevenOnDeadGunnersHasNoEffect() {
+        building.killGunnersAt(BUILDING_HEX);
+
+        Vector<Report> reports = new BuildingEntityCriticalHandler(gameManager)
+              .applyCriticalResult(building, BUILDING_HEX, 7, 1);
+
+        assertTrue(containsReport(reports, REPORT_NO_CRITICAL));
+        assertFalse(building.isStunned());
+    }
+
+    @Test
     void criticalRollOfEightDestroysAWeapon() {
         new BuildingEntityCriticalHandler(gameManager).applyCriticalResult(building, BUILDING_HEX, 8, 1);
 

--- a/megamek/unittests/megamek/server/totalWarfare/BuildingEntityDamageTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/BuildingEntityDamageTest.java
@@ -231,6 +231,30 @@ class BuildingEntityDamageTest extends GameBoardTestCase {
     }
 
     @Test
+    void criticalRollOfTenWithLowTurretRollJamsTheTurret() {
+        laser.setMekTurretMounted(true);
+
+        new BuildingEntityCriticalHandler(gameManager).applyCriticalResult(building, BUILDING_HEX, 10, 3);
+
+        assertTrue(laser.jammedThisPhase());
+        assertFalse(building.isTurretLocked(laser));
+    }
+
+    @Test
+    void criticalRollOfTenWithHighTurretRollLocksTheTurretToTheForwardArc() {
+        laser.setMekTurretMounted(true);
+        int allRoundArc = building.getWeaponArc(building.getEquipmentNum(laser));
+
+        new BuildingEntityCriticalHandler(gameManager).applyCriticalResult(building, BUILDING_HEX, 10, 4);
+
+        assertTrue(building.isTurretLocked(laser));
+        assertFalse(laser.jammedThisPhase());
+        assertEquals(0, allRoundArc, "a working turret fires in every direction");
+        assertEquals(1, building.getWeaponArc(building.getEquipmentNum(laser)),
+              "a locked turret fires only into the forward arc");
+    }
+
+    @Test
     void criticalRollOfElevenWithoutAmmunitionHasNoEffect() {
         Vector<Report> reports = new BuildingEntityCriticalHandler(gameManager)
               .applyCriticalResult(building, BUILDING_HEX, 11, 1);

--- a/megamek/unittests/megamek/server/totalWarfare/BuildingEntityDamageTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/BuildingEntityDamageTest.java
@@ -74,6 +74,7 @@ class BuildingEntityDamageTest extends GameBoardTestCase {
     private static final int STARTING_ARMOR = 5;
     private static final int REPORT_CRITICAL_CHECK = 3800;
     private static final int REPORT_NO_CRITICAL = 3805;
+    private static final int REPORT_CREW_ALREADY_DEAD = 3811;
     private static final int REPORT_NO_TURRET = 3826;
     private static final int REPORT_AMMO_NO_EFFECT = 3831;
     private static final int REPORT_EQUIPMENT_NO_EFFECT = 3835;
@@ -211,7 +212,7 @@ class BuildingEntityDamageTest extends GameBoardTestCase {
         Vector<Report> reports = new BuildingEntityCriticalHandler(gameManager)
               .applyCriticalResult(building, BUILDING_HEX, 7, 1);
 
-        assertTrue(containsReport(reports, REPORT_NO_CRITICAL));
+        assertTrue(containsReport(reports, REPORT_CREW_ALREADY_DEAD));
         assertFalse(building.isStunned());
     }
 

--- a/megamek/unittests/megamek/server/totalWarfare/BuildingEntityDamageTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/BuildingEntityDamageTest.java
@@ -75,6 +75,8 @@ class BuildingEntityDamageTest extends GameBoardTestCase {
     private static final int REPORT_CRITICAL_CHECK = 3800;
     private static final int REPORT_NO_CRITICAL = 3805;
     private static final int REPORT_CREW_ALREADY_DEAD = 3811;
+    private static final int REPORT_NO_WEAPON_LEFT = 3841;
+    private static final int REPORT_NO_WEAPON_TO_JAM = 3846;
     private static final int REPORT_NO_TURRET = 3826;
     private static final int REPORT_AMMO_NO_EFFECT = 3831;
     private static final int REPORT_EQUIPMENT_NO_EFFECT = 3835;
@@ -221,6 +223,22 @@ class BuildingEntityDamageTest extends GameBoardTestCase {
         new BuildingEntityCriticalHandler(gameManager).applyCriticalResult(building, BUILDING_HEX, 8, 1);
 
         assertTrue(laser.isHit());
+    }
+
+    @Test
+    void criticalResultsSkipAWeaponDestroyedWithoutTheHitFlag() {
+        // a weapon in a collapsed hex is destroyed directly, never marked hit
+        laser.setDestroyed(true);
+
+        Vector<Report> destroyedReports = new BuildingEntityCriticalHandler(gameManager)
+              .applyCriticalResult(building, BUILDING_HEX, 8, 1);
+        Vector<Report> malfunctionReports = new BuildingEntityCriticalHandler(gameManager)
+              .applyCriticalResult(building, BUILDING_HEX, 6, 1);
+
+        assertTrue(containsReport(destroyedReports, REPORT_NO_WEAPON_LEFT));
+        assertTrue(containsReport(malfunctionReports, REPORT_NO_WEAPON_TO_JAM));
+        assertFalse(laser.isHit());
+        assertFalse(laser.jammedThisPhase());
     }
 
     @Test

--- a/megamek/unittests/megamek/server/totalWarfare/BuildingEntityDamageTest.java
+++ b/megamek/unittests/megamek/server/totalWarfare/BuildingEntityDamageTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.server.totalWarfare;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.Vector;
+
+import megamek.common.GameBoardTestCase;
+import megamek.common.HitData;
+import megamek.common.Player;
+import megamek.common.Report;
+import megamek.common.ToHitData;
+import megamek.common.board.Board;
+import megamek.common.board.Coords;
+import megamek.common.board.CubeCoords;
+import megamek.common.enums.BasementType;
+import megamek.common.enums.BuildingType;
+import megamek.common.equipment.AmmoMounted;
+import megamek.common.equipment.AmmoType;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.WeaponMounted;
+import megamek.common.game.Game;
+import megamek.common.net.packets.Packet;
+import megamek.common.units.BuildingEntity;
+import megamek.common.weapons.lasers.innerSphere.medium.ISLaserMedium;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/**
+ * Weapon damage against an Advanced Building entity (issues #8754 and #7857): hits must reach the building's armour
+ * and Construction Factor, and a single attack over the hex's damage threshold must roll on the Advanced Building
+ * Critical Hits Table (TO:AR pp. 118-119).
+ */
+class BuildingEntityDamageTest extends GameBoardTestCase {
+
+    private static final Coords BUILDING_HEX = new Coords(5, 5);
+    private static final int STARTING_CF = 40;
+    private static final int STARTING_ARMOR = 5;
+    private static final int REPORT_CRITICAL_CHECK = 3800;
+    private static final int REPORT_NO_CRITICAL = 3805;
+    private static final int REPORT_NO_TURRET = 3826;
+    private static final int REPORT_AMMO_NO_EFFECT = 3831;
+    private static final int REPORT_EQUIPMENT_NO_EFFECT = 3835;
+
+    static {
+        initializeBoard("BUILDING_ENTITY_DAMAGE_BOARD", """
+              size 16 17
+              hex 0505 0 "" ""
+              hex 0506 0 "" ""
+              end"""
+        );
+    }
+
+    private TWGameManager gameManager;
+    private Game game;
+    private BuildingEntity building;
+    private WeaponMounted laser;
+
+    @BeforeAll
+    static void beforeAll() {
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        Player player = new Player(0, "Test");
+        gameManager = Mockito.spy(new TWGameManager());
+        Mockito.doNothing().when(gameManager).send(any(Packet.class));
+        Mockito.doNothing().when(gameManager).sendChangedHex(any(Coords.class), any(int.class));
+        Mockito.doNothing().when(gameManager).entityUpdate(any(int.class));
+        Mockito.doNothing().when(gameManager).sendChangedBuildings(any());
+        game = gameManager.getGame();
+        game.addPlayer(0, player);
+
+        Board board = getBoard("BUILDING_ENTITY_DAMAGE_BOARD");
+        game.setBoard(board);
+
+        building = new BuildingEntity(BuildingType.MEDIUM, 1);
+        building.getInternalBuilding().setBuildingHeight(1);
+        building.getInternalBuilding().addHex(CubeCoords.ZERO, STARTING_CF, STARTING_ARMOR, BasementType.UNKNOWN,
+              false);
+        building.setOwner(game.getPlayer(0));
+        building.refreshLocations();
+        building.refreshAdditionalLocations();
+        building.setId(0);
+        laser = new WeaponMounted(building, new ISLaserMedium());
+        building.addEquipment(laser, 0, false);
+        game.addEntity(building);
+        building.setPosition(BUILDING_HEX);
+        building.updateBuildingEntityHexes(board.getBoardId(), gameManager);
+    }
+
+    private Vector<Report> hitBuilding(int damage) {
+        HitData hit = building.rollHitLocation(ToHitData.HIT_NORMAL, ToHitData.SIDE_FRONT);
+        return gameManager.damageEntity(building, hit, damage);
+    }
+
+    private static boolean containsReport(Vector<Report> reports, int messageId) {
+        return reports.stream().anyMatch(report -> report.messageId == messageId);
+    }
+
+    @Test
+    void weaponDamageReachesArmorThenConstructionFactor() {
+        int damage = 8;
+        Vector<Report> reports = hitBuilding(damage);
+
+        int throughArmor = (int) Math.floor(building.getDamageToScale() * (damage - STARTING_ARMOR));
+        assertFalse(reports.isEmpty(), "damage against a building entity must produce a report");
+        assertEquals(0, building.getArmor(BUILDING_HEX));
+        assertEquals(STARTING_CF - throughArmor, building.getCurrentCF(BUILDING_HEX));
+    }
+
+    @Test
+    void damageStoppedByArmorMakesNoCriticalCheck() {
+        Vector<Report> reports = hitBuilding(STARTING_ARMOR);
+
+        assertEquals(STARTING_CF, building.getCurrentCF(BUILDING_HEX));
+        assertFalse(containsReport(reports, REPORT_CRITICAL_CHECK),
+              "TO:AR p. 118: no critical while armour keeps the CF untouched");
+    }
+
+    @Test
+    void damageOverThresholdMakesCriticalCheck() {
+        // threshold is CF 40 / 10 = 4; 12 damage leaves 7 after armour, which exceeds it
+        Vector<Report> reports = hitBuilding(12);
+
+        assertTrue(building.getCurrentCF(BUILDING_HEX) < STARTING_CF);
+        assertTrue(containsReport(reports, REPORT_CRITICAL_CHECK),
+              "TO:AR p. 118: a single attack over the damage threshold rolls for a critical");
+    }
+
+    @Test
+    void damageAtOrUnderThresholdMakesNoCriticalCheck() {
+        // 9 damage leaves 4 after armour, which equals the threshold and does not exceed it
+        Vector<Report> reports = hitBuilding(9);
+
+        assertTrue(building.getCurrentCF(BUILDING_HEX) < STARTING_CF);
+        assertFalse(containsReport(reports, REPORT_CRITICAL_CHECK));
+    }
+
+    @Test
+    void criticalRollOfFiveHasNoEffect() {
+        Vector<Report> reports = new BuildingEntityCriticalHandler(gameManager)
+              .applyCriticalResult(building, BUILDING_HEX, 5, 1);
+
+        assertTrue(containsReport(reports, REPORT_NO_CRITICAL));
+        assertFalse(laser.isHit());
+        assertFalse(laser.jammedThisPhase());
+    }
+
+    @Test
+    void criticalRollOfSixJamsAWeapon() {
+        new BuildingEntityCriticalHandler(gameManager).applyCriticalResult(building, BUILDING_HEX, 6, 1);
+
+        // a jam is recorded for this phase and becomes the weapon's jammed state at the phase change
+        assertTrue(laser.jammedThisPhase());
+        assertFalse(laser.isHit());
+    }
+
+    @Test
+    void criticalRollOfSevenStunsGunnersForTheFollowingTurn() {
+        new BuildingEntityCriticalHandler(gameManager).applyCriticalResult(building, BUILDING_HEX, 7, 1);
+
+        assertTrue(building.isStunned());
+        building.newRound(2);
+        assertTrue(building.isStunned(), "the building takes no actions during the following turn");
+        building.newRound(3);
+        assertFalse(building.isStunned());
+    }
+
+    @Test
+    void criticalRollOfEightDestroysAWeapon() {
+        new BuildingEntityCriticalHandler(gameManager).applyCriticalResult(building, BUILDING_HEX, 8, 1);
+
+        assertTrue(laser.isHit());
+    }
+
+    @Test
+    void criticalRollOfNineKillsTheGunnersOfTheHex() {
+        new BuildingEntityCriticalHandler(gameManager).applyCriticalResult(building, BUILDING_HEX, 9, 1);
+
+        assertTrue(building.hasDeadGunners(laser.getLocation()));
+        assertTrue(building.allGunnersDead(), "a single-hex building has lost all of its gunners");
+        assertTrue(building.getCrew().isDoomed());
+    }
+
+    @Test
+    void criticalRollOfTenWithoutATurretHasNoEffect() {
+        Vector<Report> reports = new BuildingEntityCriticalHandler(gameManager)
+              .applyCriticalResult(building, BUILDING_HEX, 10, 2);
+
+        assertTrue(containsReport(reports, REPORT_NO_TURRET));
+        assertFalse(laser.jammedThisPhase());
+        assertFalse(building.isTurretLocked(laser));
+    }
+
+    @Test
+    void criticalRollOfElevenWithoutAmmunitionHasNoEffect() {
+        Vector<Report> reports = new BuildingEntityCriticalHandler(gameManager)
+              .applyCriticalResult(building, BUILDING_HEX, 11, 1);
+
+        assertTrue(containsReport(reports, REPORT_AMMO_NO_EFFECT));
+        assertEquals(STARTING_CF, building.getCurrentCF(BUILDING_HEX));
+    }
+
+    @Test
+    void criticalRollOfElevenExplodesAmmunitionIntoTheConstructionFactor() throws Exception {
+        AmmoType autocannonAmmo = (AmmoType) EquipmentType.get("ISAC5 Ammo");
+        AmmoMounted ammo = new AmmoMounted(building, autocannonAmmo);
+        building.addEquipment(ammo, 0, false);
+        ammo.setShotsLeft(4);
+        int expectedExplosion = (int) Math.floor(building.getDamageToScale()
+              * 4 * autocannonAmmo.getDamagePerShot() * autocannonAmmo.getRackSize());
+
+        new BuildingEntityCriticalHandler(gameManager).applyCriticalResult(building, BUILDING_HEX, 11, 1);
+
+        assertTrue(ammo.isHit());
+        assertEquals(STARTING_CF - Math.min(STARTING_CF, expectedExplosion), building.getCurrentCF(BUILDING_HEX));
+    }
+
+    @Test
+    void criticalRollOfTwelveWithoutOtherEquipmentHasNoEffect() {
+        Vector<Report> reports = new BuildingEntityCriticalHandler(gameManager)
+              .applyCriticalResult(building, BUILDING_HEX, 12, 1);
+
+        assertTrue(containsReport(reports, REPORT_EQUIPMENT_NO_EFFECT));
+        assertFalse(laser.isHit());
+    }
+
+    @Test
+    void buildingEntityIsNeverInsideABuilding() {
+        assertFalse(building.isInBuilding(),
+              "a building entity treated as an occupant of its own hex absorbs its own damage twice");
+    }
+}


### PR DESCRIPTION
## What this changes

Shots at Advanced Building gun emplacement turrets now land: armour first, then Construction Factor. A single hit over a tenth of the hex's CF rolls on the TO:AR p. 119 critical table against the turret's own equipment.

Fixes #8754, fixes #7857

## Testing

- 17 unit tests: armour then CF, threshold, every table row, turret jam and lock, ammunition explosion.
- Hotseat: Light Laser and Medium Bombard emplacements shot to collapse; every row except 11 seen.
- Stun countdown, gunners dead, turret locked and CrewDead sprite labels confirmed.
- A Locust inside a Medium building still gets building absorption.

## What is not proven yet

- The ammunition explosion row was not rolled in play; unit test only.
- No automated test sends the attack through handlePacket; the hotseat games did.
- Nearest-hex choice for multi-hex buildings; no such turret unit exists to play.
- A jammed building weapon cannot be cleared; the repair action is vehicle-only.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result
