### PR TITLE
Fix #8915: a Mek on the top level of a building is still inside it for line of sight

### DIFF
--- a/megamek/src/megamek/common/LosEffects.java
+++ b/megamek/src/megamek/common/LosEffects.java
@@ -301,7 +301,7 @@ public class LosEffects {
     public int getHeavySmoke() {
         return heavySmoke;
     }
-    
+
     public int getBAPReduceSmoke() { return bapReduceSmoke; }
 
     public int getScreen() {
@@ -1096,6 +1096,20 @@ public class LosEffects {
     }
 
     /**
+     * The attacker's elevation above its hex, without the height of the unit itself. Whether a unit is inside a
+     * building depends on the level it stands on: a Mek's extra level is not added inside a building hex for line of
+     * sight purposes (TW p. 175), so a Mek whose head reaches the roof line is still inside.
+     */
+    private static int attackerElevationInHex(Game game, AttackInfo ai) {
+        return ai.attackAbsHeight - ai.attackHeight - game.getHex(ai.attackPos, ai.boardId).getLevel();
+    }
+
+    /** The target's elevation above its hex, without the height of the unit itself; see {@link #attackerElevationInHex}. */
+    private static int targetElevationInHex(Game game, AttackInfo ai) {
+        return ai.targetAbsHeight - ai.targetHeight - game.getHex(ai.targetPos, ai.boardId).getLevel();
+    }
+
+    /**
      * Returns LosEffects for a line that never passes exactly between two hexes. Since intervening() returns all the
      * coordinates, we just add the effects of all those hexes.
      */
@@ -1104,17 +1118,13 @@ public class LosEffects {
         LosEffects los = new LosEffects();
         boolean targetInBuilding = false;
         if (ai.targetEntity) {
-            targetInBuilding = Compute.isInBuilding(game,
-                  ai.targetAbsHeight - game.getHex(ai.targetPos, ai.boardId).getLevel(),
-                  ai.targetPos, ai.boardId);
+            targetInBuilding = Compute.isInBuilding(game, targetElevationInHex(game, ai), ai.targetPos, ai.boardId);
         }
 
         // If the target and attacker are both in a
         // building, set that as the first LOS effect.
         if (targetInBuilding &&
-              Compute.isInBuilding(game,
-                    ai.attackAbsHeight - game.getHex(ai.attackPos, ai.boardId).getLevel(),
-                    ai.attackPos, ai.boardId)) {
+              Compute.isInBuilding(game, attackerElevationInHex(game, ai), ai.attackPos, ai.boardId)) {
             los.setThruBldg(game.getBoard(ai.boardId).getBuildingAt(in.getFirst()));
             // elevation differences count as building hexes passed through
             los.buildingLevelsOrHexes += (Math.abs((ai.attackAbsHeight - ai.attackHeight) -
@@ -1162,17 +1172,13 @@ public class LosEffects {
         LosEffects los = new LosEffects();
         boolean targetInBuilding = false;
         if (ai.targetEntity) {
-            targetInBuilding = Compute.isInBuilding(game,
-                  ai.targetAbsHeight - game.getHex(ai.targetPos, ai.boardId).getLevel(),
-                  ai.targetPos, ai.boardId);
+            targetInBuilding = Compute.isInBuilding(game, targetElevationInHex(game, ai), ai.targetPos, ai.boardId);
         }
 
         // If the target and attacker are both in a
         // building, set that as the first LOS effect.
         if (targetInBuilding &&
-              Compute.isInBuilding(game,
-                    ai.attackAbsHeight - game.getHex(ai.attackPos, ai.boardId).getLevel(),
-                    ai.attackPos, ai.boardId)) {
+              Compute.isInBuilding(game, attackerElevationInHex(game, ai), ai.attackPos, ai.boardId)) {
             los.setThruBldg(game.getBoard(ai.boardId).getBuildingAt(in.getFirst()));
             // elevation differences count as building hexes passed through
             los.buildingLevelsOrHexes += (Math.abs((ai.attackAbsHeight - ai.attackHeight) -
@@ -1609,7 +1615,7 @@ public class LosEffects {
                           ((terrainEl > ai.attackAbsHeight) && attackerAdjacent) ||
                           ((terrainEl > ai.targetAbsHeight) && targetAdjacent);
                 }
-                
+
                 int smokeModifier = 0;
                 if (affectsLos) {
                     // smoke and woods stack for LOS so check them both
@@ -1631,7 +1637,7 @@ public class LosEffects {
                     }
                     Entity attacker = game.getEntity(ai.attackerId);
                     if (attacker != null && attacker.hasBAP(true) && ai.attackPos.distance(coords) <= attacker.getBAPRange()) {
-                        los.bapReduceSmoke += smokeModifier; 
+                        los.bapReduceSmoke += smokeModifier;
                     }
                     // Check woods/jungle
                     if ((woodsLevel == 1) || (jungleLevel == 1)) {

--- a/megamek/unittests/megamek/common/MekInsideBuildingLineOfSightTest.java
+++ b/megamek/unittests/megamek/common/MekInsideBuildingLineOfSightTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import megamek.common.board.Board;
+import megamek.common.board.Coords;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.game.Game;
+import megamek.common.units.BipedMek;
+import megamek.common.units.ConvInfantry;
+import megamek.common.units.Entity;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A Mek inside a building is inside on the level it stands on: its extra level of height is not added for line of
+ * sight purposes (TW p. 175). A Mek whose head reaches the roof line, such as any Mek in a one-level building, must
+ * still share the building with the infantry it fires on. A Mek standing on the roof is outside.
+ */
+class MekInsideBuildingLineOfSightTest extends GameBoardTestCase {
+
+    private static final Coords ONE_LEVEL_HEX = new Coords(0, 0);
+    private static final Coords TWO_LEVEL_HEX = new Coords(1, 0);
+
+    static {
+        initializeBoard("MEK_INSIDE_BUILDING_LOS", """
+              size 3 3
+              hex 0101 0 "building:3;bldg_cf:90;bldg_elev:1" ""
+              hex 0201 0 "building:3;bldg_cf:90;bldg_elev:2" ""
+              end"""
+        );
+    }
+
+    private Game game;
+
+    @BeforeAll
+    static void beforeAll() {
+        EquipmentType.initializeTypes();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        Board board = getBoard("MEK_INSIDE_BUILDING_LOS");
+        game = new Game();
+        game.setBoard(board);
+        game.addPlayer(0, new Player(0, "Test"));
+    }
+
+    private <T extends Entity> T place(T entity, Coords position, int elevation) {
+        entity.setGame(game);
+        entity.setId(game.getNextEntityId());
+        entity.setOwner(game.getPlayer(0));
+        game.addEntity(entity);
+        entity.setDeployed(true);
+        entity.setPosition(position);
+        entity.setElevation(elevation);
+        return entity;
+    }
+
+    private LosEffects mekFiresAtPlatoon(Coords hex, int mekLevel, int platoonLevel) {
+        BipedMek mek = place(new BipedMek(), hex, mekLevel);
+        ConvInfantry platoon = place(new ConvInfantry(), hex, platoonLevel);
+        return LosEffects.calculateLOS(game, mek, platoon);
+    }
+
+    @Test
+    void mekInAOneLevelBuildingSharesItWithThePlatoon() {
+        LosEffects los = mekFiresAtPlatoon(ONE_LEVEL_HEX, 0, 0);
+
+        assertNotNull(los.getThruBldg(), "a Mek on the only level of a building is inside it");
+    }
+
+    @Test
+    void mekOnTheTopLevelOfATwoLevelBuildingIsStillInside() {
+        LosEffects los = mekFiresAtPlatoon(TWO_LEVEL_HEX, 1, 0);
+
+        assertNotNull(los.getThruBldg(), "a Mek whose head reaches the roof line is still inside");
+    }
+
+    @Test
+    void mekBelowTheTopLevelWasAlreadyInside() {
+        LosEffects los = mekFiresAtPlatoon(TWO_LEVEL_HEX, 0, 0);
+
+        assertNotNull(los.getThruBldg());
+    }
+
+    @Test
+    void mekOnTheRoofIsOutside() {
+        LosEffects los = mekFiresAtPlatoon(TWO_LEVEL_HEX, 2, 0);
+
+        assertNull(los.getThruBldg(), "the roof is not inside the building (TW p. 175, Rooftops)");
+    }
+}


### PR DESCRIPTION
## What this changes

A Mek whose head reaches the roof line of the building it stands in now counts as inside that building for line of sight, as TW p. 175 requires (no extra level is added to a Mek's height inside a building). Until now every Mek in a one-level building, and any Mek on the top level of a taller one, was treated as outside and could not fire on infantry in its own building.

Fixes #8915

## Testing

- Unit tests: a Mek on the only level of a one-level building, on the top level and below it in a two-level building, all inside; a Mek on the roof outside. Existing line-of-sight tests unchanged.
- Spotless and the building test set green; full suite green on the combined test branch.
- Played hotseat 7 September: a Locust and a platoon on level 0 of a one-level building, the shot allowed with the same-level modifiers; before the fix it read "Attack on infantry crosses building exterior wall/roof".

## What is not proven yet

- The roof case was not played; the unit test covers it.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result
