### PR TITLE
Fix #7284, #8888, #8889, #8890, #8891: Fixed a Multitude of PACAR bugs

### DIFF
--- a/megamek/src/megamek/client/HeadlessClient.java
+++ b/megamek/src/megamek/client/HeadlessClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/src/megamek/client/HeadlessClient.java
+++ b/megamek/src/megamek/client/HeadlessClient.java
@@ -63,8 +63,11 @@ public class HeadlessClient extends Client {
      * The game result captured the instant the VICTORY phase begins, before any server-side reset can wipe the board.
      * This is how the result reaches MekHQ even when the VICTORY phase never formally ends (e.g. a bot disconnect
      * stalls the readiness check). See issue #8889.
+     *
+     * <p>Written on the game/receive thread in {@link #changePhase(GamePhase)} and read from the Swing EDT in the
+     * Commander window's hand-off, so it is {@code volatile} to publish the snapshot across those threads.</p>
      */
-    private GameVictoryEvent victorySnapshot;
+    private volatile GameVictoryEvent victorySnapshot;
 
     /**
      * A client with no GUI has nothing to show an entity's picture in, so it does not cache one.

--- a/megamek/src/megamek/client/HeadlessClient.java
+++ b/megamek/src/megamek/client/HeadlessClient.java
@@ -33,19 +33,13 @@
 
 package megamek.client;
 
-import static megamek.client.ui.clientGUI.ClientGUI.CG_FILENAME_SALVAGE;
 import static megamek.client.ui.clientGUI.ClientGUI.CG_FILE_EXTENSION_MUL;
 
 import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Enumeration;
 
 import megamek.common.Player;
 import megamek.common.annotations.Nullable;
 import megamek.common.enums.GamePhase;
-import megamek.common.event.GameEndEvent;
-import megamek.common.event.GameListenerAdapter;
 import megamek.common.event.GameVictoryEvent;
 import megamek.common.preference.ClientPreferences;
 import megamek.common.preference.PreferenceManager;
@@ -89,64 +83,9 @@ public class HeadlessClient extends Client {
 
     public HeadlessClient(String name, String host, int port) {
         super(name, host, port);
-
-        // Make a list of the player's living units.
-        // Be sure to include all units that have retreated.
-        // save all destroyed units in a separate "salvage MUL"
-        // Save the destroyed entities to the file.
-        var gameListener = new GameListenerAdapter() {
-            @Override
-            public void gameEnd(GameEndEvent e) {
-                // Make a list of the player's living units.
-                ArrayList<Entity> living = getGame().getPlayerEntities(getLocalPlayer(), false);
-
-                // Be sure to include all units that have retreated.
-                for (Enumeration<Entity> iter = getGame().getRetreatedEntities(); iter.hasMoreElements(); ) {
-                    Entity ent = iter.nextElement();
-                    if (ent.getOwnerId() == getLocalPlayer().getId()) {
-                        living.add(ent);
-                    }
-                }
-
-                // save all destroyed units in a separate "salvage MUL"
-                ArrayList<Entity> destroyed = new ArrayList<>();
-                Enumeration<Entity> graveyard = getGame().getGraveyardEntities();
-                while (graveyard.hasMoreElements()) {
-                    Entity entity = graveyard.nextElement();
-                    if (entity.isSalvage()) {
-                        destroyed.add(entity);
-                    }
-                }
-
-                if (!destroyed.isEmpty()) {
-                    String sLogDir = PREFERENCES.getLogDirectory();
-                    File logDir = new File(sLogDir);
-                    if (!logDir.exists()) {
-                        try {
-                            // noinspection ResultOfMethodCallIgnored
-                            logDir.mkdir();
-                        } catch (SecurityException ex) {
-                            LOGGER.error(ex, "Failed to create log directory");
-                            return;
-                        }
-                    }
-                    String fileName = CG_FILENAME_SALVAGE + CG_FILE_EXTENSION_MUL;
-                    if (PREFERENCES.stampFilenames()) {
-                        fileName = StringUtil.addDateTimeStamp(fileName);
-                    }
-                    File unitFile = new File(sLogDir + File.separator + fileName);
-                    try {
-                        // Save the destroyed entities to the file.
-                        EntityListFile.saveTo(unitFile, destroyed);
-                    } catch (IOException ex) {
-                        LOGGER.error(ex, "Failed to save entity list file");
-                    }
-                }
-                saveVictoryList();
-            }
-        };
-
-        getGame().addGameListener(gameListener);
+        // Note: the end-of-game MUL is written from changePhase(VICTORY) via saveVictoryList(), not from a gameEnd
+        // listener. GameEndEvent is only fired when the client receives an END_OF_GAME packet, which the server no
+        // longer sends, so a gameEnd listener here would never run. See issue #8890.
     }
 
     public void setSendDoneOnVictoryAutomatically(boolean value) {
@@ -160,6 +99,9 @@ public class HeadlessClient extends Client {
             // Commander interface) can be handed the result on demand without depending on the VICTORY phase ending
             // or on the GAME_VICTORY_EVENT packet arriving. See issue #8889.
             victorySnapshot = new GameVictoryEvent(this, getGame());
+            // Write the player's end-of-game MUL now, while the board is still populated. Waiting for gameEnd never
+            // worked (its END_OF_GAME packet is no longer sent) and the game is reset right after VICTORY. See #8890.
+            saveVictoryList();
             if (sendDoneOnVictoryAutomatically) {
                 sendDone(true);
             }
@@ -175,33 +117,38 @@ public class HeadlessClient extends Client {
         return victorySnapshot;
     }
 
+    /**
+     * Writes a MUL of the player's surviving force to the log directory, named after the player. PACAR hands the
+     * player's units to an "@AI" bot on the player's own team, so the force is gathered by team rather than by the old
+     * (and now removed) lookup of a bot named "{@literal <player>@AI}", which {@code resetGame()} deleted before the
+     * write could ever run. The file is a fallback the player can use to resolve the scenario manually if the
+     * post-scenario dialogs are lost. See issue #8890.
+     */
     private void saveVictoryList() {
-        String filename = getLocalPlayer().getName();
-
-        // Did we select a file?
-        File unitFile = new File(filename + CG_FILE_EXTENSION_MUL);
-        if (!(unitFile.getName().toLowerCase().endsWith(CG_FILE_EXTENSION_MUL))) {
-            try {
-                unitFile = new File(unitFile.getCanonicalPath() + CG_FILE_EXTENSION_MUL);
-            } catch (Exception ignored) {
-                LOGGER.error("Could not set proper extension for file path.");
-                return;
-            }
+        Player localPlayer = getLocalPlayer();
+        if (localPlayer == null) {
+            return;
         }
 
-
-            // What bot was this player? We need it to get the propper salvage MUL, just in case
-            Player botPlayer =
-                  getGame().getPlayersList().stream().filter(p -> p.isBot() && p.getName().equals(getLocalPlayer().getName() +
-                        "@AI")).findFirst().orElse(null);
-
-            if (botPlayer != null) {
-                try {
-                    // Save the player's entities to the file.
-                    EntityListFile.saveTo(unitFile, this, botPlayer);
-                } catch (Exception ex) {
-                    LOGGER.error(ex, "saveVictoryList");
-                }
-            }
+        String logDirectoryPath = PREFERENCES.getLogDirectory();
+        File logDir = new File(logDirectoryPath);
+        if (!logDir.exists() && !logDir.mkdirs()) {
+            LOGGER.error("Failed to create log directory {}", logDirectoryPath);
+            return;
         }
+
+        String fileName = localPlayer.getName() + CG_FILE_EXTENSION_MUL;
+        if (PREFERENCES.stampFilenames()) {
+            fileName = StringUtil.addDateTimeStamp(fileName);
+        }
+        File unitFile = new File(logDir, fileName);
+
+        try {
+            // teamAsLiving = true: gather the whole player team (the player plus the "@AI" bot the units were handed
+            // to) into the survivors/retreated sections; the enemy team goes to salvage. See issue #8890.
+            EntityListFile.saveTo(unitFile, this, localPlayer, true);
+        } catch (Exception ex) {
+            LOGGER.error(ex, "saveVictoryList");
+        }
+    }
 }

--- a/megamek/src/megamek/client/HeadlessClient.java
+++ b/megamek/src/megamek/client/HeadlessClient.java
@@ -42,13 +42,15 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 
 import megamek.common.Player;
-import megamek.common.units.Entity;
-import megamek.common.units.EntityListFile;
+import megamek.common.annotations.Nullable;
 import megamek.common.enums.GamePhase;
 import megamek.common.event.GameEndEvent;
 import megamek.common.event.GameListenerAdapter;
+import megamek.common.event.GameVictoryEvent;
 import megamek.common.preference.ClientPreferences;
 import megamek.common.preference.PreferenceManager;
+import megamek.common.units.Entity;
+import megamek.common.units.EntityListFile;
 import megamek.common.util.StringUtil;
 import megamek.logging.MMLogger;
 
@@ -62,6 +64,13 @@ public class HeadlessClient extends Client {
     protected static final ClientPreferences PREFERENCES = PreferenceManager.getClientPreferences();
 
     private boolean sendDoneOnVictoryAutomatically = true;
+
+    /**
+     * The game result captured the instant the VICTORY phase begins, before any server-side reset can wipe the board.
+     * This is how the result reaches MekHQ even when the VICTORY phase never formally ends (e.g. a bot disconnect
+     * stalls the readiness check). See issue #8889.
+     */
+    private GameVictoryEvent victorySnapshot;
 
     /**
      * A client with no GUI has nothing to show an entity's picture in, so it does not cache one.
@@ -147,6 +156,10 @@ public class HeadlessClient extends Client {
     @Override
     public void changePhase(GamePhase phase) {
         if (phase == GamePhase.VICTORY) {
+            // Capture the final game state now, while the board is still populated, so a consumer (e.g. MekHQ via the
+            // Commander interface) can be handed the result on demand without depending on the VICTORY phase ending
+            // or on the GAME_VICTORY_EVENT packet arriving. See issue #8889.
+            victorySnapshot = new GameVictoryEvent(this, getGame());
             if (sendDoneOnVictoryAutomatically) {
                 sendDone(true);
             }
@@ -154,6 +167,13 @@ public class HeadlessClient extends Client {
         super.changePhase(phase);
     }
 
+    /**
+     * @return the game result captured when the VICTORY phase began, or {@code null} if the game has not reached
+     *       victory yet
+     */
+    public @Nullable GameVictoryEvent getVictorySnapshot() {
+        return victorySnapshot;
+    }
 
     private void saveVictoryList() {
         String filename = getLocalPlayer().getName();

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -38,8 +38,15 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStreamReader;
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Vector;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
@@ -72,17 +79,16 @@ import megamek.common.equipment.AmmoType.AmmoTypeEnum;
 import megamek.common.equipment.AmmoType.Munitions;
 import megamek.common.equipment.Minefield;
 import megamek.common.equipment.MiscMounted;
-import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
 import megamek.common.equipment.WeaponMounted;
 import megamek.common.equipment.WeaponType;
 import megamek.common.event.GameCFREvent;
 import megamek.common.event.GameListenerAdapter;
-import megamek.common.event.entity.GameEntityChangeEvent;
-import megamek.common.event.entity.GameEntityNewEvent;
 import megamek.common.event.GamePhaseChangeEvent;
 import megamek.common.event.GameReportEvent;
 import megamek.common.event.GameTurnChangeEvent;
+import megamek.common.event.entity.GameEntityChangeEvent;
+import megamek.common.event.entity.GameEntityNewEvent;
 import megamek.common.event.player.GamePlayerChatEvent;
 import megamek.common.game.Game;
 import megamek.common.game.InitiativeRoll;
@@ -751,7 +757,11 @@ public abstract class BotClient extends Client {
                     break;
                 case VICTORY:
                     runEndGame();
-                    sendChat(Messages.getString("BotClient.Bye"));
+                    // Signal done before disconnecting so the server's readiness check never has to wait on this
+                    // bot's socket closing, and skip the farewell chat so the disconnect does not race a chat
+                    // rebroadcast on other connection threads - the lock-contention/deadlock class from issue #8889
+                    // (see also mekhq#8240). Both Princess and CASPAR inherit this.
+                    sendDone(true);
                     die();
                     break;
                 default:

--- a/megamek/src/megamek/client/bot/BotClient.java
+++ b/megamek/src/megamek/client/bot/BotClient.java
@@ -1495,22 +1495,22 @@ public abstract class BotClient extends Client {
     protected void deployMinefields() {
     	MinefieldDeploymentPlanner mdp = new MinefieldDeploymentPlanner(getLocalPlayer(), getGame());
     	Vector<Minefield> deployedMinefields = new Vector<>();
-    	
+
     	// cycle through all possible mine field types
     	for (int minefieldType = 0; minefieldType < Minefield.TYPE_SIZE; minefieldType++) {
     		int minesToPlace = getLocalPlayer().getMinefieldCount(minefieldType);
-    		
+
     		// avoid unnecessary loops and evaluations
     		if (minesToPlace <= 0) {
     			continue;
     		}
-    		
-    		Map<Double, List<Coords>> potentialCoords = 
-    				mdp.getBucketedCandidateCoords(minefieldType, getBoard());    		    		
-    		
+
+            Map<Double, List<Coords>> potentialCoords =
+                  mdp.getBucketedCandidateCoords(minefieldType, getBoard());
+
     		// complicated loop:
     		// while we have mines to place (minesToPlace > 0)
-    		// AND we have buckets left with coordinates in them, place mines.    		
+            // AND we have buckets left with coordinates in them, place mines.
     		bucketloop:
     		for (double bucket : potentialCoords.keySet()) {
     			for (Coords coords : potentialCoords.get(bucket)) {
@@ -1518,10 +1518,10 @@ public abstract class BotClient extends Client {
 	    			// but hardly fair when players may be bound by scenario restrictions
 	    			// while the bot is not
 	    			int density = Compute.randomIntInclusive(30) + 5;
-	    			
-	    			Minefield minefield;
-	    			
-	    			// vibrabombs require a "setting"
+
+                    Minefield minefield;
+
+                    // vibrabombs require a "setting"
 	    			if (minefieldType != Minefield.TYPE_VIBRABOMB) {
 	    				minefield = Minefield.createMinefield(coords,
 	    					getLocalPlayer().getId(),
@@ -1534,22 +1534,22 @@ public abstract class BotClient extends Client {
 	    						density,
 	    						mdp.getVibrabombSetting(),
 	    						false,
-	    						0);	    						
+                              0);
 	    			}
-	    			
-	    			deployedMinefields.add(minefield);
+
+                    deployedMinefields.add(minefield);
 	    			mdp.markMinePlacement(coords);
-	    			
-	    			minesToPlace--;
-	    			
-	    			// if we run out of mines to place, break out of both loops
+
+                    minesToPlace--;
+
+                    // if we run out of mines to place, break out of both loops
 	    			if (minesToPlace == 0) {
 	    				break bucketloop;
 	    			}
     			}
     		}
     	}
-    	
+
         performMinefieldDeployment(deployedMinefields);
     }
 
@@ -1581,7 +1581,7 @@ public abstract class BotClient extends Client {
     public String receiveReport(List<Report> reports) {
         return "";
     }
-    
+
     /**
      * In addition to handling the entity update normally, the bot needs to decide
      * if it should activate its hidden units
@@ -1589,20 +1589,20 @@ public abstract class BotClient extends Client {
     @Override
     protected void receiveEntityUpdate(Packet packet) throws InvalidPacketDataException {
     	super.receiveEntityUpdate(packet);
-    	
-    	if (this.getGame().getPhase() == GamePhase.MOVEMENT) {
+
+        if (this.getGame().getPhase() == GamePhase.MOVEMENT) {
     		int entityIndex = packet.getIntValue(0);
     		revealEntities(entityIndex);
     	}
     }
-    
+
     /**
      * Given an entity that just moved, decide if I should reveal any entities in response
      */
     protected void revealEntities(int movedEntityID) {
     	// default does nothing
     }
-    
+
     /**
      * Let the bot decide whether to reroll initiative based on report info
      *

--- a/megamek/src/megamek/client/ui/clientGUI/CommanderGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/CommanderGUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 The MegaMek Team. All Rights Reserved.
+ * Copyright (C) 2025-2026 The MegaMek Team. All Rights Reserved.
  *
  * This file is part of MegaMek.
  *

--- a/megamek/src/megamek/client/ui/clientGUI/CommanderGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/CommanderGUI.java
@@ -60,6 +60,7 @@ import megamek.common.Configuration;
 import megamek.common.enums.GamePhase;
 import megamek.common.event.GameListenerAdapter;
 import megamek.common.event.GamePhaseChangeEvent;
+import megamek.common.event.GameVictoryEvent;
 import megamek.common.event.player.GamePlayerChatEvent;
 import megamek.common.units.Entity;
 import megamek.logging.MMLogger;
@@ -223,6 +224,7 @@ public class CommanderGUI extends Thread implements IClientGUI, ILocalBots {
                 if (e.getNewPhase() == GamePhase.VICTORY) {
                     audioService.playSound(SoundType.BING_MY_TURN);
                     buttonPanel.setMiscButton("Scenario Completed", "Click here to finish it", evt -> {
+                        deliverVictoryToListeners();
                         client.sendDone(true);
                         die();
                     });
@@ -279,6 +281,22 @@ public class CommanderGUI extends Thread implements IClientGUI, ILocalBots {
         // and no modal dialog is showing, so pressing space in a MekHQ window does not pause the running scenario.
         // See issue #8888.
         return !frame.isActive() || UIUtil.isModalDialogDisplayed();
+    }
+
+    /**
+     * Delivers the game result to the game's listeners (notably MekHQ) directly from the snapshot captured when the
+     * VICTORY phase began, rather than relying on the {@code GAME_VICTORY_EVENT} packet. That packet is only sent once
+     * the VICTORY phase ends, which can stall indefinitely on bot disconnects, leaving MekHQ uninformed. MekHQ's
+     * {@code gameVictory} guards against double-processing, so the packet is harmlessly ignored if it later arrives.
+     * See issue #8889.
+     */
+    private void deliverVictoryToListeners() {
+        if (client instanceof HeadlessClient headlessClient) {
+            GameVictoryEvent snapshot = headlessClient.getVictorySnapshot();
+            if (snapshot != null) {
+                client.getGame().processGameEvent(snapshot);
+            }
+        }
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/clientGUI/CommanderGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/CommanderGUI.java
@@ -186,6 +186,9 @@ public class CommanderGUI extends Thread implements IClientGUI, ILocalBots {
             @Override
             public void windowClosing(WindowEvent e) {
                 if (getClient().getGame().getPhase() == GamePhase.VICTORY) {
+                    // The game is already over, so no confirmation is needed, but we must still close the client
+                    // connection.
+                    getClient().die();
                     die();
                 } else {
                     int closePrompt = JOptionPane.showConfirmDialog(null,

--- a/megamek/src/megamek/client/ui/clientGUI/CommanderGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/CommanderGUI.java
@@ -274,7 +274,11 @@ public class CommanderGUI extends Thread implements IClientGUI, ILocalBots {
 
     @Override
     public boolean shouldIgnoreHotKeys() {
-        return false;
+        // The key dispatcher is registered application-wide, but this window is embedded in MekHQ alongside other
+        // windows. Only honor hotkeys (notably the space-bar pause) while this Commander window is the active window
+        // and no modal dialog is showing, so pressing space in a MekHQ window does not pause the running scenario.
+        // See issue #8888.
+        return !frame.isActive() || UIUtil.isModalDialogDisplayed();
     }
 
     @Override

--- a/megamek/src/megamek/client/ui/clientGUI/CommanderGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/CommanderGUI.java
@@ -37,6 +37,7 @@ import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
@@ -68,7 +69,7 @@ import megamek.logging.MMLogger;
 /**
  * @author Luana Coppio
  */
-public class CommanderGUI extends Thread implements IClientGUI, ILocalBots {
+public class CommanderGUI implements IClientGUI, ILocalBots {
     private static final MMLogger logger = MMLogger.create(CommanderGUI.class);
     private final Client client;
     private final MegaMekController controller;
@@ -77,10 +78,11 @@ public class CommanderGUI extends Thread implements IClientGUI, ILocalBots {
     private BoardViewLessMinimapPanel minimap;
     private boolean isLoading;
     private JProgressBar progressBar;
-    private boolean alive = true;
     private final AudioService audioService;
     private BotCommandsPanel buttonPanel;
     private JPanel centerPanel;
+    private String serverPassword = "";
+    private volatile boolean readyRequested = false;
 
     private final TreeMap<Integer, String> splashImages = new TreeMap<>();
 
@@ -99,53 +101,50 @@ public class CommanderGUI extends Thread implements IClientGUI, ILocalBots {
         this.audioService = new SoundManager();
         this.audioService.loadSoundFiles();
         frame = new JFrame(Messages.getString("ClientGUI.mini.title"));
-        frame.setMinimumSize(new Dimension(800, 800));
     }
 
-    @Override
-    public void run() {
-        initialize();
-        loop();
-    }
-
-    private static final long targetFrameTimeNanos = 1_000_000_000 / 60;
-
-    private void loop() {
-        long previousNanos = System.nanoTime() - 16_000_000; // artificially say it has passed 1 FPS in the first loop
-        long currentNanos;
-        long awaitMillis;
-        long elapsedNanos;
-        while (alive) {
-            currentNanos = System.nanoTime();
-            elapsedNanos = currentNanos - previousNanos;
-            // keeps around 60fps, not that it is important now, but anyway
-            tick(elapsedNanos / 1_000_000);
-            previousNanos = currentNanos;
-            awaitMillis = (targetFrameTimeNanos - elapsedNanos) / 1_000_000;
-            try {
-                Thread.sleep(Math.max(1, awaitMillis));
-            } catch (InterruptedException e) {
-                logger.error("Interrupted while waiting for next frame", e);
-                alive = false;
-            }
+    /**
+     * Sets the server password so the "Request Victory" button can authenticate its {@code /victory} command. MekHQ's
+     * Host dialog pre-fills the last password, and {@code VictoryCommand} rejects a passwordless request on a
+     * passworded server. See issue #8891.
+     *
+     * @param serverPassword the server password, or empty/{@code null} when the server has none
+     */
+    public void setServerPassword(String serverPassword) {
+        this.serverPassword = (serverPassword == null) ? "" : serverPassword;
+        if (buttonPanel != null) {
+            buttonPanel.setServerPassword(this.serverPassword);
         }
-    }
-
-    @SuppressWarnings("unused")
-    private void tick(long deltaTime) {
-        // nothing to do here for now
     }
 
     @Override
     public void initialize() {
+        // The whole window is built and shown on the EDT. This is invoked from the MekHQ game thread, so hop over with
+        // invokeAndWait; building Swing off the EDT is what made the window unreliable. See issue #8891.
+        if (SwingUtilities.isEventDispatchThread()) {
+            buildAndShow();
+        } else {
+            try {
+                SwingUtilities.invokeAndWait(this::buildAndShow);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.error("Interrupted while building the Commander window", e);
+            } catch (InvocationTargetException e) {
+                logger.error("Failed to build the Commander window", e);
+            }
+        }
+    }
+
+    private void buildAndShow() {
+        frame.setMinimumSize(UIUtil.scaleForGUI(800, 800));
         JPanel mainPanel = new JPanel(new BorderLayout());
 
         // Center: Splash image with progress bar
         centerPanel = new JPanel(new BorderLayout());
         RawImagePanel splashImage = UIUtil.createSplashComponent(splashImages, getFrame());
         MiniReportDisplayPanel miniReportDisplayPanel = new MiniReportDisplayPanel(this);
-        miniReportDisplayPanel.setMinimumSize(new Dimension(600, 600));
-        miniReportDisplayPanel.setPreferredSize(new Dimension(600, 600));
+        miniReportDisplayPanel.setMinimumSize(UIUtil.scaleForGUI(600, 600));
+        miniReportDisplayPanel.setPreferredSize(UIUtil.scaleForGUI(600, 600));
 
         progressBar = new JProgressBar(0, 100);
         progressBar.setIndeterminate(true);
@@ -159,7 +158,8 @@ public class CommanderGUI extends Thread implements IClientGUI, ILocalBots {
 
         // Right: List of current entities with their status
         JPanel rightPanel = new JPanel(new BorderLayout());
-        rightPanel.setMinimumSize(new Dimension(600, frame.getHeight()));
+        // Height is left to the layout: frame.getHeight() is still 0 before pack(), so a fixed value here was junk.
+        rightPanel.setMinimumSize(new Dimension(UIUtil.scaleForGUI(600), 0));
 
         JPanel entityListEntries = new JPanel();
         JLabel entitiesHeader = new JLabel("Entities in game");
@@ -167,10 +167,11 @@ public class CommanderGUI extends Thread implements IClientGUI, ILocalBots {
         entityListEntries.setLayout(new BoxLayout(entityListEntries, BoxLayout.Y_AXIS));
         buttonPanel = new BotCommandsPanel(this.client, audioService, controller);
         buttonPanel.useSpaceForPauseUnpause();
+        buttonPanel.setServerPassword(serverPassword);
 
         var jScroll = new JScrollPane(entityListEntries);
-        jScroll.setMinimumSize(new Dimension(-1, 20));
-        jScroll.setPreferredSize(new Dimension(-1, 300));
+        jScroll.setMinimumSize(new Dimension(-1, UIUtil.scaleForGUI(20)));
+        jScroll.setPreferredSize(new Dimension(-1, UIUtil.scaleForGUI(300)));
 
         rightPanel.add(jScroll, BorderLayout.NORTH);
         rightPanel.add(miniReportDisplayPanel, BorderLayout.CENTER);
@@ -249,7 +250,11 @@ public class CommanderGUI extends Thread implements IClientGUI, ILocalBots {
                           " (Crippled)" :
                           "");
                     JLabel entityLabel = new JLabel(entityLabelText);
-                    entityLabel.setForeground(entity.getOwner().getColour().getColour());
+                    // Owners are removed at resetGame(), so a late repaint can see a null owner. See issue #8891.
+                    var owner = entity.getOwner();
+                    if (owner != null) {
+                        entityLabel.setForeground(owner.getColour().getColour());
+                    }
                     entityListEntries.add(entityLabel);
                 });
                 entityListEntries.revalidate();
@@ -257,6 +262,9 @@ public class CommanderGUI extends Thread implements IClientGUI, ILocalBots {
             }
         });
         frame.setVisible(true);
+
+        // The launcher may have called enableReady() before the panel existed; apply it now that it does.
+        applyReadyIfRequested();
     }
 
     private void setupMinimap() {
@@ -329,8 +337,23 @@ public class CommanderGUI extends Thread implements IClientGUI, ILocalBots {
         return localBots;
     }
 
+    /**
+     * Requests that the Ready button be wired up. This may be called by the MekHQ launcher before {@link #initialize()}
+     * has finished building the panel; if so the request is remembered and applied at the end of {@code initialize()}
+     * rather than silently dropped (which left the Ready button dead and preparation stalled). See issue #8891.
+     */
     public void enableReady() {
-        if (buttonPanel != null) {
+        readyRequested = true;
+        applyReadyIfRequested();
+    }
+
+    private void applyReadyIfRequested() {
+        if (!readyRequested || (buttonPanel == null)) {
+            // Not yet buildable; buildAndShow() calls this again once the panel exists.
+            return;
+        }
+        Runnable apply = () -> {
+            logger.info("Commander GUI: wiring the Ready button");
             buttonPanel.setMiscButton(
                   Messages.getString("BotCommandPanel.Ready.title"),
                   Messages.getString("BotCommandPanel.Ready.tooltip"),
@@ -339,6 +362,11 @@ public class CommanderGUI extends Thread implements IClientGUI, ILocalBots {
                       client.sendDone(true);
                   });
             setupMinimap();
+        };
+        if (SwingUtilities.isEventDispatchThread()) {
+            apply.run();
+        } else {
+            SwingUtilities.invokeLater(apply);
         }
     }
 }

--- a/megamek/src/megamek/client/ui/clientGUI/CommanderGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/CommanderGUI.java
@@ -226,6 +226,11 @@ public class CommanderGUI implements IClientGUI, ILocalBots {
                     audioService.playSound(SoundType.BING_MY_TURN);
                     buttonPanel.setMiscButton("Scenario Completed", "Click here to finish it", evt -> {
                         deliverVictoryToListeners();
+                        // Clear any lingering pause first: while the server is paused it parks DONE in its
+                        // pausedWaitingList (CLOSE_CONNECTION and UNPAUSE are the ones handled immediately), so a DONE
+                        // sent here could sit unprocessed after the window closes and re-strand the hand-off. UNPAUSE
+                        // is idempotent when not paused. See issues #8888/#8891.
+                        client.sendUnpause();
                         client.sendDone(true);
                         die();
                     });

--- a/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
+++ b/megamek/src/megamek/client/ui/clientGUI/MegaMekGUI.java
@@ -321,9 +321,15 @@ public class MegaMekGUI implements IPreferenceChangeListener {
     }
 
     public void createController() {
+        KeyboardFocusManager keyboardFocusManager = KeyboardFocusManager.getCurrentKeyboardFocusManager();
+        // Remove any previously registered controller first. Each call to this method (e.g. once per MekHQ scenario)
+        // otherwise adds another dispatcher to the global KeyboardFocusManager that is never removed, leaking
+        // dispatchers that keep catching key events for games that have already ended. See issue #8888.
+        if (controller != null) {
+            keyboardFocusManager.removeKeyEventDispatcher(controller);
+        }
         controller = new MegaMekController();
         controller.megaMekGUI = this;
-        KeyboardFocusManager keyboardFocusManager = KeyboardFocusManager.getCurrentKeyboardFocusManager();
         keyboardFocusManager.addKeyEventDispatcher(controller);
         KeyBindParser.parseKeyBindings(controller);
     }

--- a/megamek/src/megamek/client/ui/dialogs/BotCommands/BotCommandsPanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/BotCommands/BotCommandsPanel.java
@@ -1479,6 +1479,11 @@ public class BotCommandsPanel extends JPanel {
 
     private boolean canBePaused() {
         var game = client.getGame();
+        // The game is already over at victory, so pausing here would only freeze the server while it waits to be
+        // unpaused, blocking a clean hand-off back to MekHQ. See issue #8888.
+        if (game.getPhase().isVictory()) {
+            return false;
+        }
         List<Player> nonBots = game.getPlayersList().stream().filter(p -> !p.isBot()).toList();
         boolean liveUnitsRemaining = nonBots.stream().anyMatch(p -> game.getEntitiesOwnedBy(p) > 0);
         return !liveUnitsRemaining;

--- a/megamek/src/megamek/client/ui/dialogs/BotCommands/BotCommandsPanel.java
+++ b/megamek/src/megamek/client/ui/dialogs/BotCommands/BotCommandsPanel.java
@@ -81,6 +81,7 @@ import megamek.common.equipment.WeaponMounted;
 import megamek.common.equipment.WeaponType;
 import megamek.common.event.GameListenerAdapter;
 import megamek.common.event.GamePhaseChangeEvent;
+import megamek.common.game.IGame;
 import megamek.common.game.InGameObject;
 import megamek.common.options.OptionsConstants;
 import megamek.common.units.Entity;
@@ -100,6 +101,7 @@ public class BotCommandsPanel extends JPanel {
     private final AudioService audioService;
     private final MegaMekController controller;
     private final ClientGUI clientGUI;
+    private String serverPassword = "";
     private final MegaMekButton miscButton =
           new MegaMekButton("", SkinSpecification.UIComponents.PhaseDisplayButton.getComp());
     // This latch is used only to change the state of the button from pause to continue and back
@@ -286,7 +288,35 @@ public class BotCommandsPanel extends JPanel {
         setMiscButton(
               Messages.getString("BotCommandPanel.Victory.title"),
               Messages.getString("BotCommandPanel.Victory.tooltip"),
-              evt -> client.sendChat("/victory"));
+              evt -> client.sendChat(victoryCommand()));
+    }
+
+    /**
+     * @return the {@code /victory} chat command, including the server password when one is set. {@code VictoryCommand}
+     *       rejects a passwordless request on a passworded server, and MekHQ's Host dialog pre-fills the last password.
+     *       See issue #8891.
+     */
+    private String victoryCommand() {
+        return buildVictoryCommand(serverPassword);
+    }
+
+    /**
+     * @param serverPassword the server password, possibly empty/{@code null}
+     *
+     * @return the {@code /victory} chat command, with the password appended when one is present
+     */
+    static String buildVictoryCommand(String serverPassword) {
+        return ((serverPassword == null) || serverPassword.isBlank()) ? "/victory" : ("/victory " + serverPassword);
+    }
+
+    /**
+     * Sets the server password used to authenticate the "Request Victory" command. Pass empty or {@code null} when the
+     * server has no password.
+     *
+     * @param serverPassword the server password
+     */
+    public void setServerPassword(String serverPassword) {
+        this.serverPassword = (serverPassword == null) ? "" : serverPassword;
     }
 
     /**
@@ -1478,9 +1508,19 @@ public class BotCommandsPanel extends JPanel {
     }
 
     private boolean canBePaused() {
-        var game = client.getGame();
-        // The game is already over at victory, so pausing here would only freeze the server while it waits to be
-        // unpaused, blocking a clean hand-off back to MekHQ. See issue #8888.
+        return isGamePausable(client.getGame());
+    }
+
+    /**
+     * Pausing is only meaningful while a bot-only game is still being watched. It is refused once the game has been
+     * decided - at victory, pausing would only freeze the server waiting to be unpaused and block the hand-off back to
+     * MekHQ (issue #8888) - and whenever a human player still owns units.
+     *
+     * @param game the game to test
+     *
+     * @return {@code true} if the game may be paused right now
+     */
+    static boolean isGamePausable(IGame game) {
         if (game.getPhase().isVictory()) {
             return false;
         }

--- a/megamek/src/megamek/common/units/EntityListFile.java
+++ b/megamek/src/megamek/common/units/EntityListFile.java
@@ -803,6 +803,27 @@ public class EntityListFile {
      * @throws IOException is thrown on any error.
      */
     public static void saveTo(File file, Client client, Player localPlayer) throws IOException {
+        saveTo(file, client, localPlayer, false);
+    }
+
+    /**
+     * Save the entities from the game of client to the given file, as {@link #saveTo(File, Client, Player)} does, but
+     * optionally treating the local player's whole team as "the player".
+     *
+     * <p>When {@code teamAsLiving} is {@code true}, every unit belonging to a player on the local player's team - not
+     * only the units the local player owns directly - is written to the survivors and retreated sections instead of the
+     * allies section. PACAR hands the player's units off to an "@AI" bot on the player's own team, so after the game
+     * the human player owns nothing and the force can only be recovered by team. See issue #8890.</p>
+     *
+     * @param file         - The current contents of the file will be discarded and all
+     *                     <code>Entity</code>s in the list will be written to the file.
+     * @param client       - a <code>Client</code> containing the <code>Game</code>s to be used
+     * @param localPlayer  - What player should we treat as "the" player?
+     * @param teamAsLiving - when {@code true}, the local player's whole team counts as the player's own units
+     *
+     * @throws IOException is thrown on any error.
+     */
+    public static void saveTo(File file, Client client, Player localPlayer, boolean teamAsLiving) throws IOException {
         if (null == client.getGame() || !client.playerExists(localPlayer.getId())) {
             return;
         }
@@ -824,7 +845,7 @@ public class EntityListFile {
         // Sort entities into player's, enemies, and allies and add to survivors,
         // salvage, and allies.
         for (Entity entity : client.getGame().inGameTWEntities()) {
-            if (entity.getOwner().getId() == localPlayer.getId()) {
+            if (countsAsPlayerOwn(entity.getOwner(), localPlayer, teamAsLiving)) {
                 living.add(entity);
             } else if (entity.getOwner().isEnemyOf(localPlayer)) {
                 if (!entity.canEscape()) {
@@ -840,7 +861,7 @@ public class EntityListFile {
         // sections
         for (Enumeration<Entity> iter = client.getGame().getRetreatedEntities(); iter.hasMoreElements(); ) {
             Entity ent = iter.nextElement();
-            if (ent.getOwner().getId() == localPlayer.getId()) {
+            if (countsAsPlayerOwn(ent.getOwner(), localPlayer, teamAsLiving)) {
                 living.add(ent);
             } else if (!ent.getOwner().isEnemyOf(localPlayer)) {
                 allied.add(ent);
@@ -925,6 +946,20 @@ public class EntityListFile {
         output.write("</" + MULParser.ELE_RECORD + ">\n");
         output.flush();
         output.close();
+    }
+
+    /**
+     * @param owner        the owner of a unit being classified
+     * @param localPlayer  the player treated as "the" player
+     * @param teamAsLiving when {@code true}, any owner on the local player's team counts, not only the local player
+     *
+     * @return {@code true} if the unit should be written as one of the player's own (survivors/retreated)
+     */
+    static boolean countsAsPlayerOwn(Player owner, Player localPlayer, boolean teamAsLiving) {
+        if (owner.getId() == localPlayer.getId()) {
+            return true;
+        }
+        return teamAsLiving && (owner.getTeam() == localPlayer.getTeam());
     }
 
     private static void writeKills(Writer output, Hashtable<String, String> kills) throws IOException {

--- a/megamek/src/megamek/server/totalWarfare/TWGameManager.java
+++ b/megamek/src/megamek/server/totalWarfare/TWGameManager.java
@@ -2399,6 +2399,14 @@ public class TWGameManager extends AbstractGameManager {
                 break;
             case VICTORY:
                 datasetLogger.requestNewLogFile();
+                // Mark every bot done as we enter VICTORY. Bots disconnect rather than acknowledging this phase, so
+                // without this the readiness check can wait forever on a bot whose disconnect has not yet been
+                // processed, and MekHQ is never told the game ended. See issue #8889.
+                for (Player victoryPlayer : game.getPlayersList()) {
+                    if (victoryPlayer.isBot()) {
+                        victoryPlayer.setDone(true);
+                    }
+                }
                 break;
             default:
                 break;

--- a/megamek/unittests/megamek/client/ui/dialogs/BotCommands/BotCommandsPanelStaticsTest.java
+++ b/megamek/unittests/megamek/client/ui/dialogs/BotCommands/BotCommandsPanelStaticsTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.client.ui.dialogs.BotCommands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import megamek.common.Player;
+import megamek.common.enums.GamePhase;
+import megamek.common.game.IGame;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for the static helpers of {@link BotCommandsPanel}:
+ * <ul>
+ *     <li>{@code buildVictoryCommand} - the "Request Victory" button must send the server password so
+ *     {@code VictoryCommand} accepts it on a passworded server (issue #8891).</li>
+ *     <li>{@code isGamePausable} - pausing must be refused at victory (issue #8888) and while a human owns units.</li>
+ * </ul>
+ */
+class BotCommandsPanelStaticsTest {
+
+    // region buildVictoryCommand (#8891)
+
+    @Test
+    void victoryCommandWithoutPasswordIsBare() {
+        assertEquals("/victory", BotCommandsPanel.buildVictoryCommand(""));
+    }
+
+    @Test
+    void victoryCommandWithNullPasswordIsBare() {
+        assertEquals("/victory", BotCommandsPanel.buildVictoryCommand(null));
+    }
+
+    @Test
+    void victoryCommandWithBlankPasswordIsBare() {
+        assertEquals("/victory", BotCommandsPanel.buildVictoryCommand("   "));
+    }
+
+    @Test
+    void victoryCommandWithPasswordAppendsIt() {
+        assertEquals("/victory hunter2", BotCommandsPanel.buildVictoryCommand("hunter2"));
+    }
+
+    // endregion
+
+    // region isGamePausable (#8888)
+
+    private static Player bot() {
+        Player player = mock(Player.class);
+        when(player.isBot()).thenReturn(true);
+        return player;
+    }
+
+    private static Player human() {
+        Player player = mock(Player.class);
+        when(player.isBot()).thenReturn(false);
+        return player;
+    }
+
+    private static IGame gameInPhase(GamePhase phase, List<Player> players) {
+        IGame game = mock(IGame.class);
+        when(game.getPhase()).thenReturn(phase);
+        when(game.getPlayersList()).thenReturn(players);
+        return game;
+    }
+
+    @Test
+    void botOnlyGameInPlayCanBePaused() {
+        IGame game = gameInPhase(GamePhase.MOVEMENT, List.of(bot(), bot()));
+        assertTrue(BotCommandsPanel.isGamePausable(game));
+    }
+
+    @Test
+    void gameAtVictoryCannotBePaused() {
+        // Even a bot-only game must not be paused once it is over: pausing there freezes the server and blocks the
+        // hand-off back to MekHQ. See issue #8888.
+        IGame game = gameInPhase(GamePhase.VICTORY, List.of(bot(), bot()));
+        assertFalse(BotCommandsPanel.isGamePausable(game));
+    }
+
+    @Test
+    void gameWithAHumanOwningUnitsCannotBePaused() {
+        Player human = human();
+        IGame game = gameInPhase(GamePhase.MOVEMENT, List.of(human, bot()));
+        when(game.getEntitiesOwnedBy(human)).thenReturn(3);
+        assertFalse(BotCommandsPanel.isGamePausable(game));
+    }
+
+    @Test
+    void gameWithAHumanOwningNoUnitsCanBePaused() {
+        Player human = human();
+        IGame game = gameInPhase(GamePhase.MOVEMENT, List.of(human, bot()));
+        when(game.getEntitiesOwnedBy(human)).thenReturn(0);
+        assertTrue(BotCommandsPanel.isGamePausable(game));
+    }
+
+    // endregion
+}

--- a/megamek/unittests/megamek/common/units/EntityListFileTeamClassificationTest.java
+++ b/megamek/unittests/megamek/common/units/EntityListFileTeamClassificationTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.units;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import megamek.client.Client;
+import megamek.common.Player;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.game.Game;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Regression tests for issue #8890: PACAR transfers the player's units to an "@AI" bot on the player's own team, so the
+ * player's real force must be gathered by team, not by exact owner, when the end-of-game MUL is written. The
+ * {@code teamAsLiving} overload of {@link EntityListFile#saveTo} and its {@code countsAsPlayerOwn} predicate carry that
+ * classification.
+ */
+class EntityListFileTeamClassificationTest {
+
+    private static final int LOCAL_ID = 0;
+    private static final int AI_BOT_ID = 1;
+    private static final int ENEMY_ID = 2;
+    private static final int PLAYER_TEAM = 1;
+    private static final int ENEMY_TEAM = 2;
+
+    /** A survivor-side chassis and an enemy-side chassis, chosen distinct so each can be found by name in the MUL. */
+    private static final String SURVIVOR_UNIT = "Atlas AS7-CM";
+    private static final String ENEMY_UNIT = "Archer ARC-2R";
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    private Player localPlayer;
+    private Player aiBot;
+    private Player enemy;
+
+    @BeforeEach
+    void setUp() {
+        localPlayer = new Player(LOCAL_ID, "Commander");
+        localPlayer.setTeam(PLAYER_TEAM);
+        aiBot = new Player(AI_BOT_ID, "Commander@AI");
+        aiBot.setTeam(PLAYER_TEAM);
+        enemy = new Player(ENEMY_ID, "Pirates");
+        enemy.setTeam(ENEMY_TEAM);
+    }
+
+    // region countsAsPlayerOwn predicate
+
+    @Test
+    void ownUnitCountsRegardlessOfFlag() {
+        assertTrue(EntityListFile.countsAsPlayerOwn(localPlayer, localPlayer, false));
+        assertTrue(EntityListFile.countsAsPlayerOwn(localPlayer, localPlayer, true));
+    }
+
+    @Test
+    void teammateCountsOnlyWhenTeamAsLiving() {
+        assertFalse(EntityListFile.countsAsPlayerOwn(aiBot, localPlayer, false),
+              "without teamAsLiving the @AI teammate is not the player's own");
+        assertTrue(EntityListFile.countsAsPlayerOwn(aiBot, localPlayer, true),
+              "with teamAsLiving the @AI teammate counts as the player's own");
+    }
+
+    @Test
+    void enemyNeverCounts() {
+        assertFalse(EntityListFile.countsAsPlayerOwn(enemy, localPlayer, false));
+        assertFalse(EntityListFile.countsAsPlayerOwn(enemy, localPlayer, true));
+    }
+
+    // endregion
+
+    // region saveTo section placement
+
+    @Test
+    void teamAsLivingPutsTheAiTeammateInSurvivorsAndEnemyInSalvage() throws Exception {
+        Game game = gameWith(unit(SURVIVOR_UNIT, aiBot), unit(ENEMY_UNIT, enemy));
+        String mul = writeMul(game, true);
+
+        assertTrue(sectionOf(mul, "survivors").contains("Atlas"),
+              "the @AI teammate's unit should be a survivor: " + mul);
+        assertTrue(sectionOf(mul, "salvage").contains("Archer"),
+              "the enemy unit should be salvage: " + mul);
+    }
+
+    @Test
+    void withoutTeamAsLivingTheAiTeammateIsNotASurvivor() throws Exception {
+        Game game = gameWith(unit(SURVIVOR_UNIT, aiBot), unit(ENEMY_UNIT, enemy));
+        String mul = writeMul(game, false);
+
+        assertFalse(sectionOf(mul, "survivors").contains("Atlas"),
+              "without teamAsLiving the teammate's unit must not be listed as one of the player's own survivors");
+        assertTrue(sectionOf(mul, "allies").contains("Atlas"),
+              "instead it belongs in the allies section: " + mul);
+    }
+
+    // endregion
+
+    // region helpers
+
+    private Entity unit(String unitName, Player owner) throws Exception {
+        Entity entity = new megamek.common.loaders.MekFileParser(
+              new File("testresources/data/mekfiles/" + unitName + ".mtf")).getEntity();
+        entity.setOwner(owner);
+        return entity;
+    }
+
+    private Game gameWith(Entity... entities) {
+        Game game = new Game();
+        game.addPlayer(LOCAL_ID, localPlayer);
+        game.addPlayer(AI_BOT_ID, aiBot);
+        game.addPlayer(ENEMY_ID, enemy);
+        for (Entity entity : entities) {
+            entity.setGame(game);
+            entity.setId(game.getNextEntityId());
+            game.addEntity(entity);
+        }
+        return game;
+    }
+
+    private String writeMul(Game game, boolean teamAsLiving) throws Exception {
+        Client client = mock(Client.class);
+        when(client.getGame()).thenReturn(game);
+        when(client.playerExists(anyInt())).thenReturn(true);
+        File file = tempDir.resolve("victory-" + teamAsLiving + ".mul").toFile();
+        EntityListFile.saveTo(file, client, localPlayer, teamAsLiving);
+        return Files.readString(file.toPath());
+    }
+
+    /** Returns the text between {@code <section ...>} and {@code </section>}, or "" when the section is absent. */
+    private static String sectionOf(String mul, String section) {
+        int open = mul.indexOf('<' + section);
+        int close = mul.indexOf("</" + section + '>');
+        if ((open < 0) || (close < 0)) {
+            return "";
+        }
+        return mul.substring(open, close);
+    }
+
+    // endregion
+}


### PR DESCRIPTION
# Required by https://github.com/MegaMek/mekhq/pull/9980

Fix #7284
Fix #8888
Fix #8889
Fix #8890
Fix #8891

## What this changes

This PR fixes many PACAR bugs. Most largely resolving around the handing off process from PACAR to MekHQ (via MegaMek).

## Testing

- Manual testing
- AI authored tests

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result