### PR TITLE
Give Advanced Buildings a crew field and the minimum crew table (TO:AR p. 130)

### DIFF
--- a/megamek/src/megamek/common/compute/Compute.java
+++ b/megamek/src/megamek/common/compute/Compute.java
@@ -7667,6 +7667,9 @@ public class Compute {
             return getAeroCrewNeeds(entity) + getTotalGunnerNeeds(entity) + getAdditionalNonGunner(entity);
         } else if (entity.isSuperHeavy() || entity.isTripodMek()) {
             return getTotalDriverNeeds(entity) + getTotalGunnerNeeds(entity) + getAdditionalNonGunner(entity);
+        } else if (entity instanceof AbstractBuildingEntity building) {
+            // The crew from the unit file or the Advanced Building Minimum Crew Table, plus any bay personnel
+            return building.getNCrew() + building.getBayPersonnel();
         } else {
             return 1;
         }

--- a/megamek/src/megamek/common/loaders/BLKFile.java
+++ b/megamek/src/megamek/common/loaders/BLKFile.java
@@ -656,7 +656,7 @@ public class BLKFile {
         if (dataFile.exists("originalBuildYear")) {
             e.setOriginalBuildYear(dataFile.getDataAsInt("originalBuildYear")[0]);
         }
-        
+
         if (!dataFile.exists("type")) {
             throw new EntityLoadingException("Could not find type block.");
         }
@@ -1244,6 +1244,9 @@ public class BLKFile {
                 blk.writeBlockData("building_type", abstractBuildingEntity.getBuildingType().getTypeValue());
                 blk.writeBlockData("height", abstractBuildingEntity.getInternalBuilding().getBuildingHeight());
                 blk.writeBlockData("cf", abstractBuildingEntity.getInternalBuilding().getCurrentCF(CubeCoords.ZERO));
+                if (abstractBuildingEntity.hasExplicitCrewCount()) {
+                    blk.writeBlockData("crew", abstractBuildingEntity.getNCrew());
+                }
 
                 blk.writeBlockData("coords",
                       abstractBuildingEntity.getInternalBuilding().getCoordsList().toArray(new CubeCoords[0]));

--- a/megamek/src/megamek/common/loaders/BLKStructureFile.java
+++ b/megamek/src/megamek/common/loaders/BLKStructureFile.java
@@ -34,6 +34,7 @@
 package megamek.common.loaders;
 
 import megamek.common.board.CubeCoords;
+import megamek.common.compute.Compute;
 import megamek.common.enums.BasementType;
 import megamek.common.enums.BuildingType;
 import megamek.common.equipment.Engine;
@@ -41,8 +42,11 @@ import megamek.common.units.AbstractBuildingEntity;
 import megamek.common.units.BuildingEntity;
 import megamek.common.units.Entity;
 import megamek.common.util.BuildingBlock;
+import megamek.logging.MMLogger;
 
 public class BLKStructureFile extends BLKFile implements IMekLoader {
+    private static final MMLogger LOGGER = MMLogger.create(BLKStructureFile.class);
+
     public BLKStructureFile(BuildingBlock block) {
         dataFile = block;
     }
@@ -103,6 +107,10 @@ public class BLKStructureFile extends BLKFile implements IMekLoader {
         }
         be.setYear(dataFile.getDataAsInt("year")[0]);
 
+        if (dataFile.exists("crew")) {
+            be.setCrewCount(dataFile.getDataAsInt("crew")[0]);
+        }
+
 
         be.refreshLocations();
         be.refreshAdditionalLocations();
@@ -127,8 +135,24 @@ public class BLKStructureFile extends BLKFile implements IMekLoader {
 
         // Reset our armor type & tech level now that we have all our locations set up
         be.recalculateTechAdvancement();
+        sizeCrewToHeadCount(be);
 
 
         return be;
+    }
+
+    /**
+     * Gives the building's crew object the head-count the building actually has, so anything that counts or
+     * removes people, an infantry action inside the building for one, works on the real crew rather than the single
+     * commander slot the crew type provides.
+     */
+    private static void sizeCrewToHeadCount(AbstractBuildingEntity building) {
+        int headCount = Compute.getFullCrewSize(building);
+        building.getCrew().setSize(headCount);
+        building.getCrew().setCurrentSize(headCount);
+        LOGGER.debug("[BuildingCrew] {}: crew {} ({}), {} bay personnel, crew object sized to {}",
+              building.getShortName(), building.getNCrew(),
+              building.hasExplicitCrewCount() ? "from the unit file" : "Advanced Building Minimum Crew Table",
+              building.getBayPersonnel(), headCount);
     }
 }

--- a/megamek/src/megamek/common/units/AbstractBuildingEntity.java
+++ b/megamek/src/megamek/common/units/AbstractBuildingEntity.java
@@ -55,8 +55,10 @@ import megamek.common.enums.BuildingType;
 import megamek.common.equipment.AmmoMounted;
 import megamek.common.equipment.IArmorState;
 import megamek.common.equipment.MiscMounted;
+import megamek.common.equipment.MiscType;
 import megamek.common.equipment.Mounted;
 import megamek.common.equipment.WeaponMounted;
+import megamek.common.equipment.WeaponType;
 import megamek.common.exceptions.LocationFullException;
 import megamek.common.rolls.PilotingRollData;
 import megamek.logging.MMLogger;
@@ -1447,80 +1449,130 @@ public abstract class AbstractBuildingEntity extends Entity implements IBuilding
         }
     }
 
+    /** A {@link #crewCount} of this value means the crew is derived from the Advanced Building Minimum Crew Table. */
+    public static final int CREW_FROM_MINIMUM_CREW_TABLE = -1;
+
+    /** Gunners a capital-scale weapon needs (TO:AR p. 130). */
+    private static final int GUNNERS_PER_CAPITAL_WEAPON = 7;
+    /** Tons of heavy weapon one gunner serves (TO:AR p. 130): gunners are the weapon's tons divided by this, rounded up. */
+    private static final double HEAVY_WEAPON_TONS_PER_GUNNER = 5.0;
+    /** Non-gunners a field kitchen needs (TO:AR p. 130). */
+    private static final int CREW_PER_FIELD_KITCHEN = 3;
+    /** Non-gunners each MASH operating theater needs (TO:AR p. 130). */
+    private static final int CREW_PER_MASH_THEATER = 5;
+    /** Non-gunners a mobile field base needs (TO:AR p. 130). */
+    private static final int CREW_PER_MOBILE_FIELD_BASE = 5;
+    /** The largest non-officer crew that a single officer commands (TO:AR p. 130). */
+    private static final int LARGEST_CREW_WITH_ONE_OFFICER = 9;
+    /** Crew per officer once the crew is larger than {@link #LARGEST_CREW_WITH_ONE_OFFICER} (TO:AR p. 130). */
+    private static final double CREW_PER_OFFICER = 10.0;
+
     /**
-     * Calculate building crew based on Advanced Building Minimum Crew Table (TO:AUE). Crew = Non-Gunners + Gunners +
-     * Officers
+     * The crew this building was built with, from the {@code crew} block of its unit file, or
+     * {@link #CREW_FROM_MINIMUM_CREW_TABLE} when the file has none and the crew is the table minimum.
+     */
+    private int crewCount = CREW_FROM_MINIMUM_CREW_TABLE;
+
+    /**
+     * Sets the crew this building was built with. The unit file's {@code crew} block sets it; a value of
+     * {@link #CREW_FROM_MINIMUM_CREW_TABLE} returns to the Advanced Building Minimum Crew Table.
      *
-     * @return total crew count
+     * @param crewCount the crew, or {@link #CREW_FROM_MINIMUM_CREW_TABLE}
+     */
+    public void setCrewCount(int crewCount) {
+        this.crewCount = crewCount;
+    }
+
+    /**
+     * @return {@code true} when the crew comes from the unit file rather than the minimum crew table
+     */
+    public boolean hasExplicitCrewCount() {
+        return crewCount != CREW_FROM_MINIMUM_CREW_TABLE;
+    }
+
+    /**
+     * The building's crew: the unit file's {@code crew} block when it has one, otherwise the Advanced Building
+     * Minimum Crew Table (TO:AR p. 130). Bay personnel are separate; see {@link #getBayPersonnel()}.
+     *
+     * @return the crew count
      */
     @Override
     public int getNCrew() {
+        if (hasExplicitCrewCount()) {
+            return crewCount;
+        }
+        return calculateMinimumCrew();
+    }
+
+    /**
+     * The Advanced Building Minimum Crew Table (TO:AR p. 130): non-gunners for the equipment that needs them, one
+     * gunner per light or medium weapon, one per five tons (rounded up) of each heavy weapon, seven per capital
+     * weapon, and officers for the whole.
+     *
+     * @return the minimum crew for this building's equipment
+     */
+    public int calculateMinimumCrew() {
         int nonGunners = calculateNonGunnerCrew();
         int gunners = calculateGunnerCrew();
         int officers = calculateOfficerCrew(nonGunners + gunners);
-
         return nonGunners + gunners + officers;
     }
 
     /**
-     * Calculate non-gunner crew based on building equipment. Does NOT include bay personnel - those are counted
-     * separately via getBayPersonnel().
-     *
-     * @return non-gunner crew count
+     * Non-gunners from the table's equipment rows that exist in MegaMek: one per ton of communications equipment,
+     * three per field kitchen, five per MASH theater and five per mobile field base. Flight decks, landing decks,
+     * helipads and modular structure linkages are not equipment yet and add nothing.
      */
     private int calculateNonGunnerCrew() {
-        int crew = 0;
-
-        // TODO: Implement equipment-based crew calculation when equipment system is available
-        // (Field Kitchens, Helipads, Landing Decks, etc.)
-        // For now, return 0 - bay personnel are counted separately
-
-        return crew;
+        int nonGunners = 0;
+        for (MiscMounted mounted : getMisc()) {
+            MiscType miscType = mounted.getType();
+            if (miscType.hasFlag(MiscType.F_COMMUNICATIONS)) {
+                nonGunners += (int) Math.ceil(mounted.getTonnage());
+            } else if (miscType.hasFlag(MiscType.F_FIELD_KITCHEN)) {
+                nonGunners += CREW_PER_FIELD_KITCHEN;
+            } else if (miscType.hasFlag(MiscType.F_MASH)) {
+                nonGunners += CREW_PER_MASH_THEATER * Math.max(1, (int) mounted.getSize());
+            } else if (miscType.hasFlag(MiscType.F_MOBILE_FIELD_BASE)) {
+                nonGunners += CREW_PER_MOBILE_FIELD_BASE;
+            }
+        }
+        return nonGunners;
     }
 
     /**
-     * Calculate gunner crew based on mounted weapons. - Light Weapon: 1 gunner - Medium Weapon: 1 gunner - Heavy
-     * Weapon: Weapon Tons ÷ 5 (round up) - Capital Weapon: 7 gunners
-     *
-     * @return gunner crew count
+     * Gunners for the mounted weapons. Light and medium weapons are the conventional infantry weapons and take one
+     * gunner each; every other non-capital weapon is a heavy weapon and takes one gunner per five tons, rounded up;
+     * a capital weapon takes seven (TO:AR pp. 129 to 130).
      */
     private int calculateGunnerCrew() {
         int gunners = 0;
-
-        for (megamek.common.equipment.Mounted<?> mounted : getWeaponList()) {
-            if (mounted.getType() instanceof megamek.common.equipment.WeaponType weapon) {
-                // Determine weapon size and calculate gunners
-                double weaponTonnage = weapon.getTonnage(this);
-
-                if (weapon.isCapital()) {
-                    gunners += 7;  // Capital weapon
-                } else if (weaponTonnage >= 10) {
-                    gunners += (int) Math.ceil(weaponTonnage / 5.0);  // Heavy weapon
-                } else {
-                    gunners += 1;  // Light or Medium weapon
-                }
+        for (WeaponMounted mounted : getWeaponList()) {
+            WeaponType weaponType = mounted.getType();
+            if (weaponType.isCapital()) {
+                gunners += GUNNERS_PER_CAPITAL_WEAPON;
+            } else if (weaponType.hasFlag(WeaponType.F_INFANTRY)) {
+                gunners += 1;
+            } else {
+                gunners += (int) Math.ceil(mounted.getTonnage() / HEAVY_WEAPON_TONS_PER_GUNNER);
             }
         }
-
         return gunners;
     }
 
     /**
-     * Calculate officer crew based on total non-officer crew. - 1-9 crew: 1 officer - 10+ crew: Total Crew ÷ 10 (round
-     * up)
+     * Officers for a crew: none for an empty crew, one for up to nine, otherwise one per ten rounded up.
      *
-     * @param nonOfficerCrew total non-officer crew
-     *
-     * @return officer crew count
+     * @param nonOfficerCrew the non-gunners and gunners together
      */
     private int calculateOfficerCrew(int nonOfficerCrew) {
         if (nonOfficerCrew == 0) {
             return 0;
-        } else if (nonOfficerCrew <= 9) {
-            return 1;
-        } else {
-            return (int) Math.ceil(nonOfficerCrew / 10.0);
         }
+        if (nonOfficerCrew <= LARGEST_CREW_WITH_ONE_OFFICER) {
+            return 1;
+        }
+        return (int) Math.ceil(nonOfficerCrew / CREW_PER_OFFICER);
     }
 
     @Override

--- a/megamek/src/megamek/common/units/AbstractBuildingEntity.java
+++ b/megamek/src/megamek/common/units/AbstractBuildingEntity.java
@@ -1475,12 +1475,13 @@ public abstract class AbstractBuildingEntity extends Entity implements IBuilding
 
     /**
      * Sets the crew this building was built with. The unit file's {@code crew} block sets it; a value of
-     * {@link #CREW_FROM_MINIMUM_CREW_TABLE} returns to the Advanced Building Minimum Crew Table.
+     * {@link #CREW_FROM_MINIMUM_CREW_TABLE} returns to the Advanced Building Minimum Crew Table, and so does any
+     * other negative value, since a negative crew is not a crew.
      *
      * @param crewCount the crew, or {@link #CREW_FROM_MINIMUM_CREW_TABLE}
      */
     public void setCrewCount(int crewCount) {
-        this.crewCount = crewCount;
+        this.crewCount = Math.max(crewCount, CREW_FROM_MINIMUM_CREW_TABLE);
     }
 
     /**
@@ -1541,9 +1542,10 @@ public abstract class AbstractBuildingEntity extends Entity implements IBuilding
     }
 
     /**
-     * Gunners for the mounted weapons. Light and medium weapons are the conventional infantry weapons and take one
-     * gunner each; every other non-capital weapon is a heavy weapon and takes one gunner per five tons, rounded up;
-     * a capital weapon takes seven (TO:AR pp. 129 to 130).
+     * Gunners for the mounted weapons (TO:AR pp. 129 to 130). The table's light and medium weapons are the
+     * conventional infantry weapons of the TechManual, and take one gunner each. Every weapon of 0.25 tons or more
+     * that a Mek or vehicle can mount, a machine gun or a medium laser included, is a heavy weapon and takes one
+     * gunner per five tons rounded up, which is one gunner up to five tons. A capital weapon takes seven.
      */
     private int calculateGunnerCrew() {
         int gunners = 0;

--- a/megamek/unittests/megamek/common/units/AdvancedBuildingCrewTest.java
+++ b/megamek/unittests/megamek/common/units/AdvancedBuildingCrewTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+package megamek.common.units;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import megamek.common.compute.Compute;
+import megamek.common.enums.BuildingType;
+import megamek.common.equipment.EquipmentType;
+import megamek.common.equipment.MiscMounted;
+import megamek.common.equipment.MiscType;
+import megamek.common.equipment.WeaponMounted;
+import megamek.common.equipment.WeaponType;
+import megamek.common.loaders.MekFileParser;
+import megamek.common.weapons.autoCannons.innerSphere.ISAC2;
+import megamek.common.weapons.capitalWeapons.naval.NL35Weapon;
+import megamek.common.weapons.gaussRifles.innerSphere.ISGaussRifle;
+import megamek.common.weapons.infantry.rifle.InfantryRifleAutoRifleWeapon;
+import megamek.common.weapons.lasers.innerSphere.medium.ISLaserMedium;
+import megamek.common.weapons.mgs.innerSphere.ISMG;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * The Advanced Building Minimum Crew Table (TO:AR p. 130) and the {@code crew} block of a building unit file.
+ */
+@DisplayName("Advanced Building crew")
+class AdvancedBuildingCrewTest {
+
+    private static final String LIGHT_LASER_EMPLACEMENT_WITH_CREW = """
+          <UnitType>
+          BuildingEntity
+          </UnitType>
+          <Name>
+          Crew Test Emplacement
+          </Name>
+          <Model>
+          (Test)
+          </Model>
+          <year>
+          2300
+          </year>
+          <type>
+          IS Level 2
+          </type>
+          <motion_type>
+          None
+          </motion_type>
+          <cruiseMP>
+          0
+          </cruiseMP>
+          <armor>
+          20
+          </armor>
+          <Level 0 0.0,0.0,0.0 Equipment>
+          Medium Laser(ST)
+          Medium Laser(ST)
+          Small Laser(ST)
+          Small Laser(ST)
+          Searchlight(ST)
+          FUSION PowerGenerator:SIZE:4.0
+          </Level 0 0.0,0.0,0.0 Equipment>
+          <height>
+          1
+          </height>
+          <building_class>
+          3
+          </building_class>
+          <building_type>
+          1
+          </building_type>
+          <cf>
+          30
+          </cf>
+          <crew>
+          %s
+          </crew>
+          <coords>
+          0.0,0.0,0.0
+          </coords>
+          """;
+
+    @BeforeAll
+    static void initializeEquipment() {
+        EquipmentType.initializeTypes();
+    }
+
+    private static BuildingEntity emplacement() {
+        return new BuildingEntity(BuildingType.LIGHT, IBuilding.GUN_EMPLACEMENT);
+    }
+
+    private static void mount(BuildingEntity building, WeaponType weaponType) throws Exception {
+        building.addEquipment(new WeaponMounted(building, weaponType), 0, false);
+    }
+
+    private static void mount(BuildingEntity building, MiscType miscType, double size) throws Exception {
+        MiscMounted mounted = new MiscMounted(building, miscType);
+        mounted.setSize(size);
+        building.addEquipment(mounted, 0, false);
+    }
+
+    @Test
+    @DisplayName("An unarmed, unequipped building needs no crew")
+    void emptyBuildingNeedsNobody() {
+        assertEquals(0, emplacement().getNCrew());
+    }
+
+    @Test
+    @DisplayName("A heavy weapon under five tons takes one gunner, plus one officer")
+    void lightHeavyWeaponsTakeOneGunnerEach() throws Exception {
+        BuildingEntity building = emplacement();
+        mount(building, new ISMG());          // 0.5 tons
+        mount(building, new ISLaserMedium()); // 1 ton
+        assertEquals(2 + 1, building.getNCrew(), "two gunners and one officer");
+    }
+
+    @Test
+    @DisplayName("A six-ton autocannon takes two gunners, a fifteen-ton Gauss rifle three")
+    void heavyWeaponsTakeOneGunnerPerFiveTonsRoundedUp() throws Exception {
+        BuildingEntity building = emplacement();
+        mount(building, new ISAC2());        // 6 tons -> 2
+        mount(building, new ISGaussRifle()); // 15 tons -> 3
+        assertEquals(5 + 1, building.getNCrew(), "five gunners and one officer");
+    }
+
+    @Test
+    @DisplayName("A capital weapon takes seven gunners")
+    void capitalWeaponTakesSevenGunners() throws Exception {
+        BuildingEntity building = emplacement();
+        mount(building, new NL35Weapon());
+        assertEquals(7 + 1, building.getNCrew(), "seven gunners and one officer");
+    }
+
+    @Test
+    @DisplayName("A conventional infantry weapon takes one gunner whatever it weighs")
+    void infantryWeaponTakesOneGunner() throws Exception {
+        BuildingEntity building = emplacement();
+        mount(building, new InfantryRifleAutoRifleWeapon());
+        assertEquals(1 + 1, building.getNCrew(), "one gunner and one officer");
+    }
+
+    @Test
+    @DisplayName("Ten or more non-officer crew need one officer per ten, rounded up")
+    void largeCrewsNeedMoreOfficers() throws Exception {
+        BuildingEntity building = emplacement();
+        for (int weapon = 0; weapon < 4; weapon++) {
+            mount(building, new ISGaussRifle()); // 3 gunners each, 12 gunners in all
+        }
+        assertEquals(12 + 2, building.getNCrew(), "twelve gunners and two officers");
+    }
+
+    @Test
+    @DisplayName("Communications equipment takes one non-gunner per ton")
+    void communicationsEquipmentTakesOneNonGunnerPerTon() throws Exception {
+        BuildingEntity building = emplacement();
+        mount(building, (MiscType) EquipmentType.get("Communications Equipment"), 7.0);
+        assertEquals(7 + 1, building.getNCrew(), "seven non-gunners and one officer");
+    }
+
+    @Test
+    @DisplayName("A field kitchen takes three non-gunners, a mobile field base five")
+    void supportEquipmentTakesItsListedCrew() throws Exception {
+        BuildingEntity building = emplacement();
+        mount(building, (MiscType) EquipmentType.get("FieldKitchen"), 1.0);
+        mount(building, (MiscType) EquipmentType.get("ISMobileFieldBase"), 1.0);
+        assertEquals(3 + 5 + 1, building.getNCrew(), "eight non-gunners and one officer");
+    }
+
+    @Test
+    @DisplayName("An explicit crew count from the unit file replaces the table")
+    void explicitCrewCountReplacesTheTable() throws Exception {
+        BuildingEntity building = emplacement();
+        mount(building, new ISMG());
+        assertFalse(building.hasExplicitCrewCount());
+        building.setCrewCount(12);
+        assertTrue(building.hasExplicitCrewCount());
+        assertEquals(12, building.getNCrew());
+        building.setCrewCount(AbstractBuildingEntity.CREW_FROM_MINIMUM_CREW_TABLE);
+        assertEquals(2, building.getNCrew(), "back to the table: one gunner and one officer");
+    }
+
+    @Test
+    @DisplayName("The full crew size of a building is its crew plus bay personnel")
+    void fullCrewSizeIsCrewPlusBayPersonnel() throws Exception {
+        BuildingEntity building = emplacement();
+        building.setCrewCount(9);
+        assertEquals(9 + building.getBayPersonnel(), Compute.getFullCrewSize(building));
+    }
+
+    @Test
+    @DisplayName("A unit file's crew block sets the crew and sizes the crew object to match")
+    void unitFileCrewBlockSetsCrewAndSizesCrewObject() throws Exception {
+        AbstractBuildingEntity building = load(LIGHT_LASER_EMPLACEMENT_WITH_CREW.formatted("9"));
+        assertTrue(building.hasExplicitCrewCount());
+        assertEquals(9, building.getNCrew());
+        assertEquals(9, building.getCrew().getSize(), "crew object sized to the head-count");
+        assertEquals(9, building.getCrew().getCurrentSize());
+    }
+
+    @Test
+    @DisplayName("Without a crew block the crew is the table minimum, and the crew object matches it")
+    void unitFileWithoutCrewBlockUsesTheTable() throws Exception {
+        String withoutCrewBlock = LIGHT_LASER_EMPLACEMENT_WITH_CREW.replace("<crew>\n%s\n</crew>\n", "");
+        AbstractBuildingEntity building = load(withoutCrewBlock);
+        assertFalse(building.hasExplicitCrewCount());
+        assertEquals(4 + 1, building.getNCrew(), "four one-ton-or-less lasers and one officer");
+        assertEquals(5, building.getCrew().getCurrentSize());
+    }
+
+    private static AbstractBuildingEntity load(String unitFile) throws Exception {
+        InputStream stream = new ByteArrayInputStream(unitFile.getBytes(StandardCharsets.UTF_8));
+        Entity entity = new MekFileParser(stream, "crew-test.blk").getEntity();
+        return assertInstanceOf(AbstractBuildingEntity.class, entity);
+    }
+}

--- a/megamek/unittests/megamek/common/units/AdvancedBuildingCrewTest.java
+++ b/megamek/unittests/megamek/common/units/AdvancedBuildingCrewTest.java
@@ -218,6 +218,16 @@ class AdvancedBuildingCrewTest {
     }
 
     @Test
+    @DisplayName("A negative crew count from a hand-edited file falls back to the table")
+    void negativeCrewCountFallsBackToTheTable() throws Exception {
+        BuildingEntity building = emplacement();
+        mount(building, new ISMG());
+        building.setCrewCount(-5);
+        assertFalse(building.hasExplicitCrewCount());
+        assertEquals(2, building.getNCrew(), "one gunner and one officer from the table");
+    }
+
+    @Test
     @DisplayName("The full crew size of a building is its crew plus bay personnel")
     void fullCrewSizeIsCrewPlusBayPersonnel() throws Exception {
         BuildingEntity building = emplacement();


### PR DESCRIPTION
## What this changes

Advanced Buildings read their crew from a `crew` block in the unit file, and without one use the Advanced Building Minimum Crew Table (TO:AR p. 130): one gunner per five tons of a heavy weapon rounded up, non-gunners for communications and support equipment, and officers. The loader sizes the building's crew object to that head-count, so an infantry action inside the building can thin the crew instead of only wiping it out.

## Testing

- Unit tests: each row of the table, officers at both scales, the file value overriding the table, the MUL crew size, and a unit file with and without the block.
- Spotless, checkstyle and javadoc green; building and infantry action suites green.
- Played hotseat 8 September: a five-crew emplacement lost three crew and took four crew hits on a 71 percent result, where before it lost nobody.

## What is not proven yet

- Flight decks, landing decks, helipads and structure linkages are not equipment, so their table rows do nothing.
- The Marine Points score still uses the crew count rather than the surviving crew; that follows in the score-table pull request.
- Adding the block to the 106 building files is a separate mm-data pull request.

---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result
