### PR TITLE
Fix #8924: in-battle saves would not load after a crew ejected

### DIFF
--- a/megamek/src/megamek/common/util/SerializationHelper.java
+++ b/megamek/src/megamek/common/util/SerializationHelper.java
@@ -33,6 +33,8 @@
 
 package megamek.common.util;
 
+import java.util.ArrayList;
+
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.Converter;
 import com.thoughtworks.xstream.converters.MarshallingContext;
@@ -40,10 +42,11 @@ import com.thoughtworks.xstream.converters.UnmarshallingContext;
 import com.thoughtworks.xstream.converters.collections.CollectionConverter;
 import com.thoughtworks.xstream.io.HierarchicalStreamReader;
 import com.thoughtworks.xstream.io.HierarchicalStreamWriter;
+import megamek.common.RulesRef;
+import megamek.common.SourceBookCode;
 import megamek.common.TargetRollModifier;
 import megamek.common.board.Board;
 import megamek.common.board.BoardLocation;
-import megamek.server.victory.VictoryPointTracker;
 import megamek.common.board.Coords;
 import megamek.common.board.CubeCoords;
 import megamek.common.equipment.INarcPod;
@@ -67,8 +70,7 @@ import megamek.common.units.InfantryMount;
 import megamek.common.units.Mek;
 import megamek.common.weapons.handlers.AttackHandler;
 import megamek.server.victory.VictoryCondition;
-
-import java.util.ArrayList;
+import megamek.server.victory.VictoryPointTracker;
 
 /**
  * Class that off-loads serialization related code from Server.java
@@ -124,7 +126,7 @@ public class SerializationHelper {
         xStream.omitField(Mek.class, "sinksOnNextRound");
         xStream.aliasField("pendingCharges", Game.class, "pendingDisplacementAttacks");
         xStream.aliasField("pilotRolls", Game.class, "pilotingRolls");
-        
+
         xStream.registerLocalConverter(Game.class, "pilotingRolls", new CollectionConverter(xStream.getMapper(),
               ArrayList.class));
 
@@ -553,6 +555,50 @@ public class SerializationHelper {
                     reader.moveUp();
                 }
                 return new HeatBreakdown.HeatContribution(count, totalHeat);
+            }
+
+            @Override
+            public void marshal(Object object, HierarchicalStreamWriter writer, MarshallingContext context) {
+                // Unused here
+            }
+        });
+
+        // Necessary because XStream 1.4.x cannot deserialize records natively. RulesRef is the sourcebook
+        // reference held by every EquipmentType, and an ejected crew serializes its infantry weapon (and so that
+        // weapon's whole EquipmentType) inline, so without this converter any save taken after a crew ejects
+        // fails to load.
+        xStream.registerConverter(new Converter() {
+            @Override
+            public boolean canConvert(Class type) {
+                return (type == RulesRef.class);
+            }
+
+            @Override
+            public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+                SourceBookCode book = null;
+                Integer page = null;
+                while (reader.hasMoreChildren()) {
+                    reader.moveDown();
+                    try {
+                        switch (reader.getNodeName()) {
+                            case "book" -> book = SourceBookCode.valueOf(reader.getValue());
+                            case "page" -> page = Integer.parseInt(reader.getValue());
+                        }
+                    } catch (IllegalArgumentException exception) {
+                        // Keep the default for this field on a value this version no longer recognizes.
+                    }
+                    reader.moveUp();
+                }
+                // Never return null and never let the record's own validation throw: a null entry in
+                // EquipmentType.rulesRefs would NPE in TechAdvancement.guessStaticTechLevel, and the compact
+                // constructor rejects a non-positive page.
+                if (book == null) {
+                    book = SourceBookCode.UNOFFICIAL;
+                }
+                if ((page != null) && (page < 1)) {
+                    page = null;
+                }
+                return new RulesRef(book, page);
             }
 
             @Override

--- a/megamek/unittests/megamek/common/util/SerializationHelperTest.java
+++ b/megamek/unittests/megamek/common/util/SerializationHelperTest.java
@@ -35,8 +35,11 @@ package megamek.common.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.thoughtworks.xstream.XStream;
+import megamek.common.RulesRef;
+import megamek.common.SourceBookCode;
 import megamek.common.units.HeatBreakdown;
 import org.junit.jupiter.api.Test;
 
@@ -80,5 +83,76 @@ class SerializationHelperTest {
         HeatBreakdown.HeatContribution contribution = (HeatBreakdown.HeatContribution) restored;
         assertEquals(3, contribution.count());
         assertEquals(0, contribution.totalHeat());
+    }
+
+    /**
+     * {@link RulesRef} is the sourcebook reference on every {@code EquipmentType}. An ejected crew serializes its
+     * infantry weapon inline, so without a converter every save taken after a crew ejects fails to load and the
+     * game comes back with its players present but no units (issue #8924). This pins the converter.
+     */
+    @Test
+    void rulesRefRecordSurvivesSaveGameRoundTrip() {
+        RulesRef original = new RulesRef(SourceBookCode.TM, 273);
+
+        XStream saveXStream = SerializationHelper.getSaveGameXStream();
+        String xml = saveXStream.toXML(original);
+
+        XStream loadXStream = SerializationHelper.getLoadSaveGameXStream();
+        Object restored = loadXStream.fromXML(xml);
+
+        assertEquals(original, restored);
+    }
+
+    /**
+     * A page-less reference is valid, so the missing {@code page} element must come back as {@code null} rather
+     * than tripping the record's own validation.
+     */
+    @Test
+    void pagelessRulesRefSurvivesSaveGameRoundTrip() {
+        RulesRef original = new RulesRef(SourceBookCode.TO_AR, null);
+
+        XStream saveXStream = SerializationHelper.getSaveGameXStream();
+        String xml = saveXStream.toXML(original);
+
+        XStream loadXStream = SerializationHelper.getLoadSaveGameXStream();
+        Object restored = loadXStream.fromXML(xml);
+
+        assertEquals(original, restored);
+    }
+
+    /**
+     * A book code this version no longer knows must not produce a {@code null} list entry: {@code
+     * TechAdvancement.guessStaticTechLevel} maps {@code RulesRef::book} over the list and would NPE.
+     */
+    @Test
+    void unknownBookCodeDeserializesToNonNullReference() {
+        XStream saveXStream = SerializationHelper.getSaveGameXStream();
+        String xml = saveXStream.toXML(new RulesRef(SourceBookCode.TM, 273));
+        String corrupted = xml.replace("<book>TM</book>", "<book>NoSuchBook</book>");
+
+        XStream loadXStream = SerializationHelper.getLoadSaveGameXStream();
+        Object restored = loadXStream.fromXML(corrupted);
+
+        assertNotNull(restored);
+        assertInstanceOf(RulesRef.class, restored);
+        assertEquals(SourceBookCode.UNOFFICIAL, ((RulesRef) restored).book());
+    }
+
+    /**
+     * The record's compact constructor rejects a page below 1, so a corrupted page must be dropped rather than
+     * thrown from inside the load.
+     */
+    @Test
+    void nonPositivePageDeserializesToNoPage() {
+        XStream saveXStream = SerializationHelper.getSaveGameXStream();
+        String xml = saveXStream.toXML(new RulesRef(SourceBookCode.TM, 273));
+        String corrupted = xml.replace("<page>273</page>", "<page>0</page>");
+
+        XStream loadXStream = SerializationHelper.getLoadSaveGameXStream();
+        Object restored = loadXStream.fromXML(corrupted);
+
+        assertNotNull(restored);
+        assertInstanceOf(RulesRef.class, restored);
+        assertNull(((RulesRef) restored).page());
     }
 }


### PR DESCRIPTION
## What this changes

Saves taken during a battle could not be loaded once any crew had ejected. The game came back with its players listed and none of their units, positions or damage. Nothing was ever lost from the save file. The load failed before it could attach a single unit to a player, and this restores it.

Fixes #8924

## Testing

Loaded all five save files attached to the issue through the real load path. Every one now returns its units: the reporter's eight units at round 10 in one game, and eight at round 7 in the other. All five fail with the fix reverted, throwing the exact error from the bug report.

Four new unit tests cover the round trip, a reference with no page, an unrecognized book code, and a corrupted page. All four fail with the fix reverted. The two tests already in the file keep passing.

Full suite: 16,580 tests, 4 failures. All four are pre-existing Swing layout assertions in `CommonSettingsDialogTest` and `SettingsFormPanelTest`, and they fail on unmodified `main` too. `checkstyleMain` and `javadoc` both pass.

## What is not proven yet

No game was played through to an ejection in the MegaMek user interface to save and reload by hand. The five real saves were driven through the load code directly instead.

---
- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
