### PR TITLE
Fix #8936: Princess crashed when no unit was eligible to fire

### DIFF
--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1492,9 +1492,27 @@ public class Princess extends BotClient {
             // get the first entity that can act this turn make sure weapons
             // are loaded
             shooter = getEntityToFire(fireControlState);
-        } catch (Exception e) {
+        } catch (Exception exception) {
             // If we fail to get the shooter, literally nothing can be done.
-            LOGGER.error(e.getMessage(), e);
+            LOGGER.error(exception.getMessage(), exception);
+            return;
+        }
+
+        if (shooter == null) {
+            // getEntityToFire does not throw when nothing is eligible; it falls back to the game's first
+            // eligible entity, which is itself null when the turn list and the fire control state disagree about
+            // which units can still act. Without this guard the next line dereferences that null, and the
+            // handler at the end of the method then dereferences it a second time, so the bot sends nothing at
+            // all and stands mute for the rest of the phase.
+            int firstEntityId = getGame().getFirstEntityNum(getMyTurn());
+            if (firstEntityId == Entity.NONE) {
+                LOGGER.warn("No entity is eligible to fire this turn and the game has none to fall back on; "
+                      + "skipping the firing turn.");
+                return;
+            }
+            LOGGER.warn("No entity is eligible to fire this turn; sending an empty attack for entity ID {} so "
+                  + "the turn is not lost.", firstEntityId);
+            sendAttackData(firstEntityId, new Vector<>());
             return;
         }
 
@@ -1750,6 +1768,13 @@ public class Princess extends BotClient {
     @Override
     protected void calculateTargetingOffBoardTurn() {
         Entity entityToFire = getGame().getFirstEntity(getMyTurn());
+
+        if (entityToFire == null) {
+            // Same hole as calculateFiringTurn: the game can legitimately report no eligible entity, and every
+            // use below dereferences this one.
+            LOGGER.warn("No entity is eligible for the targeting turn; skipping it.");
+            return;
+        }
 
         // if we're crippled, off-board and can do so, disengage
         if (entityToFire.isOffBoard() &&
@@ -5070,35 +5095,35 @@ public class Princess extends BotClient {
     	// then send the reveal command for that entity
     	if (getGame().getOptions().booleanOption(OptionsConstants.ADVANCED_HIDDEN_UNITS)) {
     		Entity target = getGame().getEntity(movedEntityID);
-    		
+
     		// if the target is not hostile/destroyed/abandoned/"broken", we don't bother considering it
     		// also, don't bother if the target can still move after this update
-    		if (target == null || target.isDestroyed() || target.isAbandoned() 
+    		if (target == null || target.isDestroyed() || target.isAbandoned()
     				|| (target.turnWasInterrupted() && !target.isDone())
     				|| !target.getOwner().isEnemyOf(getLocalPlayer())
     				|| getHonorUtil().isEnemyBroken(movedEntityID, target.getOwnerId(), getForcedWithdrawal())) {
     			return;
     		}
-    		
+
     		for (Entity shooter : getGame().getEntitiesVector()) {
     			// if the shooter is hidden, owned by me, on the board and not already activating
-                if (shooter.isHidden() && shooter.getOwnerId() == getLocalPlayerNumber() && 
-                		(shooter.getPosition() != null) && 
+                if (shooter.isHidden() && shooter.getOwnerId() == getLocalPlayerNumber() &&
+                		(shooter.getPosition() != null) &&
                 		(shooter.getHiddenActivationPhase() == GamePhase.UNKNOWN)) {
                 	final Map<WeaponMounted, Double> ammoConservation = calcAmmoConservation(shooter);
-                	
-                	double maxDamage = FireControl.getMaxDamageAtRange(shooter, 
+
+                	double maxDamage = FireControl.getMaxDamageAtRange(shooter,
                 			target.getPosition().distance(shooter.getPosition()), false, false);
-                	
+
                 	// if we're not going to do any damage, don't reveal
                 	if (maxDamage <= 0) {
                 		continue;
                 	}
-                	
+
                 	FiringPlan firingPlan = getFireControl(shooter).getBestFiringPlan(shooter, target, getGame(), ammoConservation);
-                	
+
                 	double percentage = firingPlan.getExpectedDamage() / maxDamage;
-                	
+
                 	// if the expected damage (% of max possible damage at that range)
                 	// is higher than our aggression value (e.g. aggression 7 means we tolerate 30%)
                 	// then reveal
@@ -5109,7 +5134,7 @@ public class Princess extends BotClient {
     		}
         }
     }
-    
+
     /**
      * Determines whether Princess should reroll initiative using the Tactical Genius special ability.
      *

--- a/megamek/src/megamek/client/bot/princess/Princess.java
+++ b/megamek/src/megamek/client/bot/princess/Princess.java
@@ -1493,8 +1493,8 @@ public class Princess extends BotClient {
             // are loaded
             shooter = getEntityToFire(fireControlState);
         } catch (Exception exception) {
-            // If we fail to get the shooter, literally nothing can be done.
             LOGGER.error(exception.getMessage(), exception);
+            clearFiringTurnWithoutShooter("Failed to determine which entity should fire");
             return;
         }
 
@@ -1504,15 +1504,7 @@ public class Princess extends BotClient {
             // which units can still act. Without this guard the next line dereferences that null, and the
             // handler at the end of the method then dereferences it a second time, so the bot sends nothing at
             // all and stands mute for the rest of the phase.
-            int firstEntityId = getGame().getFirstEntityNum(getMyTurn());
-            if (firstEntityId == Entity.NONE) {
-                LOGGER.warn("No entity is eligible to fire this turn and the game has none to fall back on; "
-                      + "skipping the firing turn.");
-                return;
-            }
-            LOGGER.warn("No entity is eligible to fire this turn; sending an empty attack for entity ID {} so "
-                  + "the turn is not lost.", firstEntityId);
-            sendAttackData(firstEntityId, new Vector<>());
+            clearFiringTurnWithoutShooter("No entity is eligible to fire this turn");
             return;
         }
 
@@ -1763,6 +1755,30 @@ public class Princess extends BotClient {
     }
 
     /**
+     * Ends a firing turn that has no shooter to declare for. A plain {@code return} is treated as success by
+     * {@link BotClient#calculateMyTurnWorker(boolean)}, so without an empty attack the turn is never resolved and
+     * the bot falls silent. Mirrors what {@code calculateMyTurnWorker} already does for the physical phase.
+     *
+     * @param reason why no shooter could be determined, for the log
+     */
+    private void clearFiringTurnWithoutShooter(String reason) {
+        int firstEntityId = Entity.NONE;
+        try {
+            firstEntityId = getGame().getFirstEntityNum(getMyTurn());
+        } catch (Exception exception) {
+            LOGGER.error(exception, "Could not find a fallback entity to clear the firing turn with.");
+        }
+
+        if (firstEntityId == Entity.NONE) {
+            LOGGER.warn("{}, and the game has no entity to fall back on; skipping the firing turn.", reason);
+            return;
+        }
+
+        LOGGER.warn("{}; sending an empty attack for entity ID {} so the turn is not lost.", reason, firstEntityId);
+        sendAttackData(firstEntityId, new Vector<>());
+    }
+
+    /**
      * Calculates the targeting/ off board turn This includes firing TAG and non-direct-fire artillery
      */
     @Override
@@ -1771,8 +1787,10 @@ public class Princess extends BotClient {
 
         if (entityToFire == null) {
             // Same hole as calculateFiringTurn: the game can legitimately report no eligible entity, and every
-            // use below dereferences this one.
-            LOGGER.warn("No entity is eligible for the targeting turn; skipping it.");
+            // use below dereferences this one. The turn still has to be declared done, exactly as the normal
+            // path does at the end of this method, or the targeting phase never advances.
+            LOGGER.warn("No entity is eligible for the targeting turn; declaring it done without acting.");
+            sendDone(true);
             return;
         }
 

--- a/megamek/unittests/megamek/client/bot/princess/PrincessNoEligibleShooterTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessNoEligibleShooterTest.java
@@ -121,5 +121,30 @@ class PrincessNoEligibleShooterTest {
         assertDoesNotThrow(princess::calculateTargetingOffBoardTurn);
 
         verify(princess, never()).sendAttackData(anyInt(), nullable(Vector.class));
+        verify(princess).sendDone(true);
+    }
+
+    /**
+     * {@code getEntityToFire} can also throw. A plain return there is treated as success by
+     * {@code BotClient.calculateMyTurnWorker}, so the turn has to be cleared the same way.
+     */
+    @Test
+    void firingTurnWhereFindingAShooterThrowsStillClearsTheTurn() {
+        Princess princess = mock(Princess.class);
+        Game game = mock(Game.class);
+        GameTurn turn = mock(GameTurn.class);
+
+        doCallRealMethod().when(princess).calculateFiringTurn();
+        when(princess.getEntityToFire(nullable(FireControlState.class)))
+              .thenThrow(new IllegalStateException("no fire control state"));
+        when(princess.getGame()).thenReturn(game);
+        when(princess.getMyTurn()).thenReturn(turn);
+        when(game.getFirstEntityNum(turn)).thenReturn(FALLBACK_ENTITY_ID);
+
+        assertDoesNotThrow(princess::calculateFiringTurn);
+
+        ArgumentCaptor<Vector<EntityAction>> attacks = ArgumentCaptor.forClass(Vector.class);
+        verify(princess).sendAttackData(eq(FALLBACK_ENTITY_ID), attacks.capture());
+        assertTrue(attacks.getValue().isEmpty(), "the turn must be cleared with an empty attack");
     }
 }

--- a/megamek/unittests/megamek/client/bot/princess/PrincessNoEligibleShooterTest.java
+++ b/megamek/unittests/megamek/client/bot/princess/PrincessNoEligibleShooterTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2026 The MegaMek Team. All Rights Reserved.
+ *
+ * This file is part of MegaMek.
+ *
+ * MegaMek is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License (GPL),
+ * version 3 or (at your option) any later version,
+ * as published by the Free Software Foundation.
+ *
+ * MegaMek is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty
+ * of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * A copy of the GPL should have been included with this project;
+ * if not, see <https://www.gnu.org/licenses/>.
+ *
+ * NOTICE: The MegaMek organization is a non-profit group of volunteers
+ * creating free software for the BattleTech community.
+ *
+ * MechWarrior, BattleMech, `Mech and AeroTech are registered trademarks
+ * of The Topps Company, Inc. All Rights Reserved.
+ *
+ * Catalyst Game Labs and the Catalyst Game Labs logo are trademarks of
+ * InMediaRes Productions, LLC.
+ *
+ * MechWarrior Copyright Microsoft Corporation. MegaMek was created under
+ * Microsoft's "Game Content Usage Rules"
+ * <https://www.xbox.com/en-US/developers/rules> and it is not endorsed by or
+ * affiliated with Microsoft.
+ */
+
+package megamek.client.bot.princess;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Vector;
+
+import megamek.common.actions.EntityAction;
+import megamek.common.game.Game;
+import megamek.common.game.GameTurn;
+import megamek.common.units.Entity;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Princess used to throw when nothing was eligible to fire, and the handler meant to recover from that threw on
+ * the same null, so the bot sent no attack data at all and stood mute for the rest of the phase (issue #8936).
+ * {@code getEntityToFire} never throws: it falls back to the game's first eligible entity, which is itself
+ * {@code null} when the turn list and the fire control state disagree about which units can still act.
+ */
+class PrincessNoEligibleShooterTest {
+
+    private static final int FALLBACK_ENTITY_ID = 7;
+
+    @Test
+    void firingTurnWithNoEligibleShooterSendsAnEmptyAttack() {
+        Princess princess = mock(Princess.class);
+        Game game = mock(Game.class);
+        GameTurn turn = mock(GameTurn.class);
+
+        doCallRealMethod().when(princess).calculateFiringTurn();
+        when(princess.getEntityToFire(nullable(FireControlState.class))).thenReturn(null);
+        when(princess.getGame()).thenReturn(game);
+        when(princess.getMyTurn()).thenReturn(turn);
+        when(game.getFirstEntityNum(turn)).thenReturn(FALLBACK_ENTITY_ID);
+
+        assertDoesNotThrow(princess::calculateFiringTurn);
+
+        ArgumentCaptor<Vector<EntityAction>> attacks = ArgumentCaptor.forClass(Vector.class);
+        verify(princess).sendAttackData(eq(FALLBACK_ENTITY_ID), attacks.capture());
+        assertTrue(attacks.getValue().isEmpty(), "the turn must be cleared with an empty attack");
+    }
+
+    /**
+     * When the game has no entity to fall back on either, there is nothing to clear the turn with, so the bot
+     * must simply skip the turn rather than send an attack for {@link Entity#NONE}.
+     */
+    @Test
+    void firingTurnWithNoFallbackEntitySendsNothing() {
+        Princess princess = mock(Princess.class);
+        Game game = mock(Game.class);
+        GameTurn turn = mock(GameTurn.class);
+
+        doCallRealMethod().when(princess).calculateFiringTurn();
+        when(princess.getEntityToFire(nullable(FireControlState.class))).thenReturn(null);
+        when(princess.getGame()).thenReturn(game);
+        when(princess.getMyTurn()).thenReturn(turn);
+        when(game.getFirstEntityNum(turn)).thenReturn(Entity.NONE);
+
+        assertDoesNotThrow(princess::calculateFiringTurn);
+
+        verify(princess, never()).sendAttackData(anyInt(), nullable(Vector.class));
+    }
+
+    /**
+     * The targeting turn had the same shape with no guard at all, dereferencing the game's first entity straight
+     * away.
+     */
+    @Test
+    void targetingTurnWithNoEligibleEntityIsSkipped() {
+        Princess princess = mock(Princess.class);
+        Game game = mock(Game.class);
+        GameTurn turn = mock(GameTurn.class);
+
+        doCallRealMethod().when(princess).calculateTargetingOffBoardTurn();
+        when(princess.getGame()).thenReturn(game);
+        when(princess.getMyTurn()).thenReturn(turn);
+        when(game.getFirstEntity(turn)).thenReturn(null);
+
+        assertDoesNotThrow(princess::calculateTargetingOffBoardTurn);
+
+        verify(princess, never()).sendAttackData(anyInt(), nullable(Vector.class));
+    }
+}


### PR DESCRIPTION
## What this changes

A Princess bot no longer freezes up when none of its units can fire. It used to crash, crash again in its own recovery path, send nothing, and then stand mute for the rest of the phase. Now it clears the turn and says why in the log.

The same missing check in the targeting phase is fixed too.

Fixes #8936

## Testing

New `PrincessNoEligibleShooterTest`, three tests, all passing, and all three fail with the fix reverted. They cover the firing turn with a fallback entity, the firing turn with none, and the targeting turn.

Full suite: 16,692 tests, 4 failures, all pre-existing and unrelated. Three are in `CommonSettingsDialogTest` and one in `SettingsFormPanelTest`, both Swing layout assertions that fail on unmodified `main` too. `checkstyleMain`, `spotlessCheck` and `javadoc` all pass.

## Both bots

This lands in `Princess`, and `Caspar` overrides neither `calculateFiringTurn` nor `calculateTargetingOffBoardTurn`, so CASPAR inherits the fix.

## What is not proven yet

The crash was never reproduced on demand. It depends on the turn list and the fire control state disagreeing about which units can still act, which is the deeper bug and is not addressed here. The tests drive the null directly.

Whether an empty attack is the right way to clear the turn is taken from the existing precedent in `BotClient.calculateMyTurnWorker`, which does exactly this for the physical phase. It was not confirmed against a live server.

## Note on the diff

Spotless stripped trailing whitespace from pre-existing lines in `Princess.java`. Its ratchet requires every touched file to be format-clean, so this is CI-mandated rather than a stray edit.

---
- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
