### PR TITLE
Close #8938: rebuild any record when loading a save game

### DIFF
--- a/megamek/src/megamek/common/util/SerializationHelper.java
+++ b/megamek/src/megamek/common/util/SerializationHelper.java
@@ -659,7 +659,7 @@ public class SerializationHelper {
                     // A record may reject its own values, as RulesRef does for a page below 1. Dropping the one
                     // record keeps the rest of the save loadable; a record that cannot tolerate being dropped
                     // gets its own converter, which is what the specific ones above are for.
-                    LOGGER.warn("Could not rebuild record {} from the save game; dropping it.",
+                    LOGGER.warn(exception, "Could not rebuild record {} from the save game; dropping it.",
                           recordType.getSimpleName());
                     return null;
                 }

--- a/megamek/src/megamek/common/util/SerializationHelper.java
+++ b/megamek/src/megamek/common/util/SerializationHelper.java
@@ -33,7 +33,11 @@
 
 package megamek.common.util;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.RecordComponent;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.Converter;
@@ -69,6 +73,7 @@ import megamek.common.units.IBuilding;
 import megamek.common.units.InfantryMount;
 import megamek.common.units.Mek;
 import megamek.common.weapons.handlers.AttackHandler;
+import megamek.logging.MMLogger;
 import megamek.server.victory.VictoryCondition;
 import megamek.server.victory.VictoryPointTracker;
 
@@ -76,6 +81,7 @@ import megamek.server.victory.VictoryPointTracker;
  * Class that off-loads serialization related code from Server.java
  */
 public class SerializationHelper {
+    private static final MMLogger LOGGER = MMLogger.create(SerializationHelper.class);
 
     private SerializationHelper() {
     }
@@ -606,6 +612,90 @@ public class SerializationHelper {
                 // Unused here
             }
         });
+
+        // XStream 1.4.x can write a record but cannot read one back: it rebuilds objects by writing straight to
+        // their fields, which the JVM forbids on a record. Every record reaching a save game therefore needs a
+        // converter, and forgetting one does not fail the build - it produces a save that will not load, with the
+        // players present and none of their units (issue #8924). This fallback rebuilds any record through its
+        // canonical constructor so that cannot happen again. It is registered at the lowest priority, so every
+        // specific converter above still wins; those exist to supply safe defaults this one cannot know about.
+        xStream.registerConverter(new Converter() {
+            @Override
+            public boolean canConvert(Class type) {
+                return (type != null) && type.isRecord();
+            }
+
+            @Override
+            public Object unmarshal(HierarchicalStreamReader reader, UnmarshallingContext context) {
+                Class<?> recordType = context.getRequiredType();
+                RecordComponent[] components = recordType.getRecordComponents();
+
+                Map<String, Object> readValues = new HashMap<>();
+                while (reader.hasMoreChildren()) {
+                    reader.moveDown();
+                    Class<?> componentType = componentType(components, reader.getNodeName());
+                    if (componentType != null) {
+                        readValues.put(reader.getNodeName(), context.convertAnother(null, componentType));
+                    }
+                    reader.moveUp();
+                }
+
+                // A component the save does not carry keeps its type's default, so a save written before that
+                // component existed still loads.
+                Object[] arguments = new Object[components.length];
+                Class<?>[] parameterTypes = new Class<?>[components.length];
+                for (int index = 0; index < components.length; index++) {
+                    parameterTypes[index] = components[index].getType();
+                    arguments[index] = readValues.containsKey(components[index].getName())
+                          ? readValues.get(components[index].getName())
+                          : defaultValue(parameterTypes[index]);
+                }
+
+                try {
+                    Constructor<?> canonicalConstructor = recordType.getDeclaredConstructor(parameterTypes);
+                    canonicalConstructor.setAccessible(true);
+                    return canonicalConstructor.newInstance(arguments);
+                } catch (Exception exception) {
+                    // A record may reject its own values, as RulesRef does for a page below 1. Dropping the one
+                    // record keeps the rest of the save loadable; a record that cannot tolerate being dropped
+                    // gets its own converter, which is what the specific ones above are for.
+                    LOGGER.warn("Could not rebuild record {} from the save game; dropping it.",
+                          recordType.getSimpleName());
+                    return null;
+                }
+            }
+
+            @Override
+            public void marshal(Object object, HierarchicalStreamWriter writer, MarshallingContext context) {
+                // Unused here; records are written correctly by reflection.
+            }
+
+            private Class<?> componentType(RecordComponent[] components, String name) {
+                for (RecordComponent component : components) {
+                    if (component.getName().equals(name)) {
+                        return component.getType();
+                    }
+                }
+                return null;
+            }
+
+            private Object defaultValue(Class<?> type) {
+                if (!type.isPrimitive()) {
+                    return null;
+                }
+                return switch (type.getName()) {
+                    case "boolean" -> false;
+                    case "byte" -> (byte) 0;
+                    case "short" -> (short) 0;
+                    case "int" -> 0;
+                    case "long" -> 0L;
+                    case "float" -> 0.0f;
+                    case "double" -> 0.0d;
+                    case "char" -> (char) 0;
+                    default -> null;
+                };
+            }
+        }, XStream.PRIORITY_VERY_LOW);
 
         return xStream;
     }

--- a/megamek/unittests/megamek/common/util/SerializationHelperTest.java
+++ b/megamek/unittests/megamek/common/util/SerializationHelperTest.java
@@ -208,7 +208,7 @@ class SerializationHelperTest {
     @Test
     void componentMissingFromAnOlderSaveGetsItsTypeDefault() {
         String xml = SerializationHelper.getSaveGameXStream().toXML(new PrimitiveComponents(4, true, 2.5, 'x'));
-        String olderSave = xml.replaceAll("\s*<weight>[^<]*</weight>", "");
+        String olderSave = xml.replaceAll("\\s*<weight>[^<]*</weight>", "");
 
         Object restored = SerializationHelper.getLoadSaveGameXStream().fromXML(olderSave);
 

--- a/megamek/unittests/megamek/common/util/SerializationHelperTest.java
+++ b/megamek/unittests/megamek/common/util/SerializationHelperTest.java
@@ -155,4 +155,82 @@ class SerializationHelperTest {
         assertInstanceOf(RulesRef.class, restored);
         assertNull(((RulesRef) restored).page());
     }
+
+    // ---------------------------------------------------------------------------------------------------------
+    // Generic record converter (issue #8938). XStream 1.4 rebuilds objects by writing to their fields, which the
+    // JVM forbids on a record, so every record reaching a save game needed a hand-written converter and
+    // forgetting one produced a save that would not load. These pin the fallback that handles any record.
+    // ---------------------------------------------------------------------------------------------------------
+
+    /** A record of primitives, which the converter has to default rather than leave null. */
+    record PrimitiveComponents(int count, boolean enabled, double weight, char code) {}
+
+    /** A record holding an enum and a nullable reference. */
+    record EnumAndReference(SourceBookCode book, String label) {}
+
+    /** A record holding another record. */
+    record NestedRecords(PrimitiveComponents inner, String name) {}
+
+    @Test
+    void recordOfPrimitivesSurvivesSaveGameRoundTrip() {
+        PrimitiveComponents original = new PrimitiveComponents(4, true, 2.5, 'x');
+
+        String xml = SerializationHelper.getSaveGameXStream().toXML(original);
+        Object restored = SerializationHelper.getLoadSaveGameXStream().fromXML(xml);
+
+        assertEquals(original, restored);
+    }
+
+    @Test
+    void recordWithAnEnumAndANullSurvivesSaveGameRoundTrip() {
+        EnumAndReference original = new EnumAndReference(SourceBookCode.TO_AUE, null);
+
+        String xml = SerializationHelper.getSaveGameXStream().toXML(original);
+        Object restored = SerializationHelper.getLoadSaveGameXStream().fromXML(xml);
+
+        assertEquals(original, restored);
+    }
+
+    @Test
+    void recordNestedInsideAnotherRecordSurvivesSaveGameRoundTrip() {
+        NestedRecords original = new NestedRecords(new PrimitiveComponents(1, false, 0.5, 'q'), "outer");
+
+        String xml = SerializationHelper.getSaveGameXStream().toXML(original);
+        Object restored = SerializationHelper.getLoadSaveGameXStream().fromXML(xml);
+
+        assertEquals(original, restored);
+    }
+
+    /**
+     * A save written before a component existed does not carry it. The component must fall back to its type's
+     * default rather than failing the load, which is the whole point of the fallback.
+     */
+    @Test
+    void componentMissingFromAnOlderSaveGetsItsTypeDefault() {
+        String xml = SerializationHelper.getSaveGameXStream().toXML(new PrimitiveComponents(4, true, 2.5, 'x'));
+        String olderSave = xml.replaceAll("\s*<weight>[^<]*</weight>", "");
+
+        Object restored = SerializationHelper.getLoadSaveGameXStream().fromXML(olderSave);
+
+        assertInstanceOf(PrimitiveComponents.class, restored);
+        PrimitiveComponents components = (PrimitiveComponents) restored;
+        assertEquals(4, components.count());
+        assertEquals(0.0, components.weight());
+    }
+
+    /**
+     * The generic converter is registered at the lowest priority, so a record that has a specific converter must
+     * still go through that one. {@link RulesRef} is the proof: its converter turns an unrecognized book code
+     * into {@code UNOFFICIAL}, while the generic converter would let the record's own validation fail and drop it.
+     */
+    @Test
+    void aSpecificConverterStillWinsOverTheGenericOne() {
+        String xml = SerializationHelper.getSaveGameXStream().toXML(new RulesRef(SourceBookCode.TM, 273));
+        String corrupted = xml.replace("<book>TM</book>", "<book>NoSuchBook</book>");
+
+        Object restored = SerializationHelper.getLoadSaveGameXStream().fromXML(corrupted);
+
+        assertNotNull(restored, "the RulesRef converter must have handled this, not the generic fallback");
+        assertEquals(SourceBookCode.UNOFFICIAL, ((RulesRef) restored).book());
+    }
 }


### PR DESCRIPTION
## What this changes

Adding a Java record can no longer break save loading. Until now each record needed its own hand-written converter, and forgetting one did not fail the build. It produced a save that would not load, with every player listed and none of their units. That was #8924, and it was the fifth record to hit it.

Nothing about today's behaviour changes. The five existing converters still run, because the new one is registered at the lowest priority.

Closes #8938

## Testing

Five new tests, eleven in the class now, all passing. They cover a record of primitives, a record with an enum and a null, a record nested inside another record, a component missing from an older save, and converter precedence.

Four of the five fail with the converter removed. The fifth is the precedence test, which passes either way by design; it can only fail if the generic converter wrongly takes priority over a specific one.

Loaded all five real save files from #8924 through the full load path with the converter in place. Every one returns exactly what it did before: same round, same entity count, same per-player unit count. No regression.

Full suite: 16,694 tests, 4 failures, all pre-existing and unrelated. Three are in `CommonSettingsDialogTest` and one in `SettingsFormPanelTest`, both Swing layout assertions that fail on unmodified `main` too. `checkstyleMain`, `spotlessCheck` and `javadoc` all pass.

## What is not proven yet

No record was found in the save graph that is currently broken. This is a safety net for the next one, not a fix for a known-bad record today.

Like the five existing converters, this one does not register the record with XStream's reference table before reading its children, so a record cannot be the target of a back-reference. That is already true of every record in a save and nothing depends on it, but it is not changed here.

Behaviour when a record rejects its own values is a deliberate choice rather than a proven-correct one: the record is logged and dropped, so a validation failure becomes a missing entry instead of a dead save. A record that cannot tolerate being dropped needs its own converter.

---
- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [x] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can explain and have verified the result
