### PR TITLE
Fix: Carried Munitions dropdowns clipped the widest ammo name

### DIFF
--- a/megamek/src/megamek/client/ui/comboBoxes/SearchableComboBox.java
+++ b/megamek/src/megamek/client/ui/comboBoxes/SearchableComboBox.java
@@ -33,6 +33,8 @@
 package megamek.client.ui.comboBoxes;
 
 import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FontMetrics;
 import java.awt.event.ActionEvent;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
@@ -59,6 +61,7 @@ import javax.swing.plaf.basic.BasicComboBoxEditor;
 import javax.swing.plaf.basic.ComboPopup;
 
 import megamek.client.ui.Messages;
+import megamek.client.ui.util.UIUtil;
 import megamek.common.annotations.Nullable;
 
 /**
@@ -81,6 +84,9 @@ import megamek.common.annotations.Nullable;
  * @param <E> the type of item held by the combo box
  */
 public class SearchableComboBox<E> extends JComboBox<E> {
+
+    /** Unscaled pixels added beside the widest entry so its text does not sit against the drop-down arrow. */
+    private static final int WIDTH_BREATHING_ROOM = 12;
 
     private static final String ACTION_ACCEPT_SEARCH = "acceptSearch";
     private static final String ACTION_CANCEL_SEARCH = "cancelSearch";
@@ -150,12 +156,30 @@ public class SearchableComboBox<E> extends JComboBox<E> {
     /**
      * Sizes the box for its widest entry, so narrowing the list while typing does not make the box shrink and
      * grow with every keystroke.
+     *
+     * <p>Width is measured in pixels rather than in characters. Character count is a poor stand-in for width in a
+     * proportional font, and it picks the wrong entry often enough to matter: for machine gun ammo it chooses
+     * "Machine Gun [Full]" over the wider "Machine Gun [Half]", and for LRMs it is short by 13 pixels, which clips
+     * the name that is actually the longest.</p>
      */
     private void keepWidthOfWidestEntry() {
+        FontMetrics fontMetrics = getFontMetrics(getFont());
         Optional<E> widestEntry = filteredModel.getAllItems()
               .stream()
-              .max(Comparator.comparingInt(item -> filteredModel.getDisplayText(item).length()));
+              .max(Comparator.comparingInt(item -> fontMetrics.stringWidth(filteredModel.getDisplayText(item))));
         widestEntry.ifPresent(this::setPrototypeDisplayValue);
+    }
+
+    /**
+     * Adds a little breathing room to the width the prototype entry asks for.
+     *
+     * <p>Sizing to the widest entry alone leaves the text touching the drop-down arrow, which reads as clipped even
+     * when every character is present. The gap scales with the GUI scale setting, like every other spacing value.</p>
+     */
+    @Override
+    public Dimension getPreferredSize() {
+        Dimension preferredSize = super.getPreferredSize();
+        return new Dimension(preferredSize.width + UIUtil.scaleForGUI(WIDTH_BREATHING_ROOM), preferredSize.height);
     }
 
     /**

--- a/megamek/unittests/megamek/client/ui/comboBoxes/SearchableComboBoxTest.java
+++ b/megamek/unittests/megamek/client/ui/comboBoxes/SearchableComboBoxTest.java
@@ -36,13 +36,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.awt.FontMetrics;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import javax.swing.JTextField;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -196,4 +199,26 @@ class SearchableComboBoxTest {
         assertEquals("LRM 20 Thunder-Inferno", editorText(comboBox));
         assertEquals(3, comboBox.getSelectedIndex());
     }
+
+    @Test
+    @DisplayName("The box is sized for the widest entry measured in pixels, not in characters")
+    void theBoxIsSizedForTheWidestEntryInPixels() {
+        // "Machine Gun [Full]" has the same character count as "Machine Gun [Half]" but renders narrower, and
+        // real MegaMek ammo lists contain pairs exactly like it. Picking by character count therefore sizes the
+        // box too small and clips the entry that is genuinely the widest.
+        Munition full = new Munition("MG-F", "Machine Gun [Full]");
+        Munition half = new Munition("MG-H", "Machine Gun [Half]");
+        List<Munition> munitions = List.of(full, half);
+
+        SearchableComboBox<Munition> comboBox = new SearchableComboBox<>("mg", munitions, Munition::label);
+        FontMetrics fontMetrics = comboBox.getFontMetrics(comboBox.getFont());
+        assumeTrue(fontMetrics.stringWidth(half.label()) > fontMetrics.stringWidth(full.label()),
+              "This font must render the two labels at different widths for the test to mean anything");
+
+        Object prototype = comboBox.getPrototypeDisplayValue();
+
+        assertEquals(half, prototype,
+              "The prototype must be the entry that renders widest, not the first one with the most characters");
+    }
+
 }


### PR DESCRIPTION
## What this changes

The dropdowns in the lobby's Carried Munitions section fit their text properly.

They sized themselves to whichever entry had the most **characters**. In a proportional font that is not the same as the widest entry, so the box could come out narrower than the name it has to show, and clip it. Across every ammo family MegaMek ships, 15 of them picked a prototype that was too narrow, by up to 13 pixels.

Two examples. Machine gun ammo sized itself to "Machine Gun [Full]" when "Machine Gun [Half]" renders 3 pixels wider. LRM ammo sized itself to "Follow The Leader w/ Incendiary" when "Thunder-Augmented w/ Incendiary" renders 13 pixels wider.

The box now measures its entries in pixels. It also leaves a small gap beside the widest one, because sizing to the text exactly puts it against the drop-down arrow and reads as clipped even when nothing is cut off. That gap scales with the GUI scale setting.

This affects both searchable dropdowns: Carried Munitions and Munitions Loaded at Start.

No issue number. Reported directly with a screenshot of the Carried Munitions section.

## Testing

`compileJava`, `checkstyleMain`, `javadoc` and `SearchableComboBoxTest` all pass.

One new test, `theBoxIsSizedForTheWidestEntryInPixels`, uses the real machine gun ammo pair that exposed this. **Verified by reverting the fix, where it fails.**

The pixel shortfall figures above come from measuring every ammo family through the same display-name function the dropdown uses.

Checked in the lobby. The Carried Munitions dropdowns now read correctly.

## What is not proven yet

- The gap beside the text is a visual tuning value and is **not** covered by a test. I tried to test it against a plain combo box and that baseline was wrong, since this widget has its own editor and renderer, so I removed the test rather than leave one that could not fail.
- Only looked at on the default GUI scale. The gap is scaled, but no other scale has been eyeballed.
- Munitions Loaded at Start uses the same widget and gets the same fix, but was not looked at directly.

---
- [x] This PR is focused on one issue or RFE
- [x] Every file in the diff has a deliberate change
- [x] Tests added or updated, if this implements a rule or changes game state
- [x] Javadoc literals use {@code true} / {@code null} rather than bare or quoted text
- [x] Dev team only: AI tools used -> AI Assisted Development label applied
