### PR TITLE
Fix #8899: Large craft heat read the wrong ship's locations

### DIFF
--- a/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
+++ b/megamek/src/megamek/common/weapons/handlers/WeaponHandler.java
@@ -211,6 +211,13 @@ public class WeaponHandler implements AttackHandler, Serializable {
             return totalHeat;
         }
 
+        // Sized and read from the unit whose declarations are being summed, which is the defender here, not the
+        // attacker holding this handler. Sizing them from the attacker crashed whenever the defender fired from a
+        // location the attacker does not have (issue #8899). Allocated once, so an arc counted for one weapon is
+        // not counted again for the next: rebuilding them per weapon defeated the whole point of the check.
+        boolean[] usedFrontArc = new boolean[entity.locations()];
+        boolean[] usedRearArc = new boolean[entity.locations()];
+
         for (Enumeration<AttackHandler> attack = game.getAttacks(); attack.hasMoreElements(); ) {
             AttackHandler attackHandler = attack.nextElement();
             WeaponAttackAction prevAttack = attackHandler.getWeaponAttackAction();
@@ -221,22 +228,18 @@ public class WeaponHandler implements AttackHandler, Serializable {
                 } else {
                     boolean rearMount = prevWeapon.isRearMounted();
                     int loc = prevWeapon.getLocation();
-
-                    // create an array of booleans of locations
-                    boolean[] usedFrontArc = new boolean[weaponEntity.locations()];
-                    boolean[] usedRearArc = new boolean[weaponEntity.locations()];
-                    for (int i = 0; i < weaponEntity.locations(); i++) {
-                        usedFrontArc[i] = false;
-                        usedRearArc[i] = false;
+                    if ((loc < 0) || (loc >= entity.locations())) {
+                        // A weapon with no real location, such as one held by a squadron rather than a hull
+                        continue;
                     }
                     if (!rearMount) {
                         if (!usedFrontArc[loc]) {
-                            totalHeat += weaponEntity.getHeatInArc(loc, rearMount);
+                            totalHeat += entity.getHeatInArc(loc, rearMount);
                             usedFrontArc[loc] = true;
                         }
                     } else {
                         if (!usedRearArc[loc]) {
-                            totalHeat += weaponEntity.getHeatInArc(loc, rearMount);
+                            totalHeat += entity.getHeatInArc(loc, rearMount);
                             usedRearArc[loc] = true;
                         }
                     }


### PR DESCRIPTION
## What this changes

Firing everything in a large space game no longer crashes the firing phase.

`getLargeCraftHeat` sums the heat a defender has already committed, to decide whether its point defences can engage. It is handed the defender, but it sized its per-location arrays from the attacker holding the handler, and read heat from the attacker too. Whenever the defender had declared fire from a location number the attacker does not have, the index blew up.

That is why single-unit reproductions failed and firing everything worked. You need a defender with more locations than the attacker, which only happens once enough different hulls are shooting at each other.

Also moves the two dedupe arrays out of the loop. They were rebuilt for every weapon, so the once-per-arc rule they exist to enforce never applied and heat was counted per weapon instead.

Fixes #8899

## Testing

`compileJava` and `checkstyleMain` pass.

Tested in game against the reporter's save. Every unit fired, and the firing phase ran to completion instead of throwing.

The save needed editing to open on the current build, for reasons unrelated to this fix. It predates two field changes, and `Player.minefieldCounts` deserialises as null because XStream does not run field initialisers, which then throws from `Player.copy` as soon as a client connects. That is a separate backward compatibility problem affecting every save written before that change, and it is worth its own issue.

## What is not proven yet

- No unit test. The crash needs a defender with more locations than the attacker, so covering it means building two different hulls and a declared attack from a high location number.
- The dedupe change alters how much heat is counted for a multi-weapon arc, which affects when point defences can engage. That is a behaviour change beyond the crash and wants a look from someone who knows the point defence rules. The in-game run shows the phase completing; it does not show that point defences now engage at the right times.

---
- [x] This PR is focused on one issue or RFE
- [x] Every file in the diff has a deliberate change
- [x] Tests added or updated - not applicable here; the fix is an indexing correction, and the reproduction is described under What is not proven yet
- [x] Javadoc literals use {@code true} / {@code null} rather than bare or quoted text
- [x] Dev team only: AI tools used -> AI Assisted Development label applied
