### PR TITLE
Fix: LA Required Officers

### DIFF
--- a/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
+++ b/megamek/src/megamek/common/verifier/TestAdvancedAerospace.java
@@ -333,12 +333,12 @@ public class TestAdvancedAerospace extends TestAero {
     }
 
     /**
-     * Returns the number of required officers of the vessel.
+     * Returns the number of required officers of the vessel from total base crew and gunners.
      * @param vessel The vessel
      * @return The number of required officers
      */
     public static int requiredOfficers(Jumpship vessel) {
-        return (int) Math.ceil((minimumBaseCrew(vessel) + requiredGunners(vessel)) / 6.0);
+        return (int) Math.ceil((vessel.getNCrew() - vessel.getBayPersonnel()) / 6.0);
     }
 
     public TestAdvancedAerospace(Jumpship vessel, TestEntityOption option, String fs) {

--- a/megamek/src/megamek/common/verifier/TestSmallCraft.java
+++ b/megamek/src/megamek/common/verifier/TestSmallCraft.java
@@ -323,7 +323,7 @@ public class TestSmallCraft extends TestAero {
     }
 
     /**
-     * Returns the number of required officers of the SmallCraft.
+     * Returns the number of required officers of the SmallCraft from minimum base crew and gunners.
      * @param smallCraft The SmallCraft
      * @return The number of required officers
      */


### PR DESCRIPTION
## What this changes

Fix advanced aerospace required officers calc to use total base crew + total gunners instead of min base crew + min gunners like with SmallCraft/DropShips

## Testing

Tested on build: loaded WarShip build in MML with too few officers, got a warning pop-up for invalid officers on load, then corrected cabins and overall tonnage
---

- [x] This PR is focused on one issue or RFE. Large refactoring or accessibility work is in its own PR
- [x] Every file in the diff has a deliberate change (no stray formatting, no unrelated files)
- [ ] Tests added or updated, if this implements a rule or changes game state
- [ ] Javadoc literals use `{@code true}` / `{@code null}` rather than bare or quoted text
- [ ] Dev team only: if AI tools were used, the **AI Assisted Development** label is applied, and I can
      explain and have verified the result